### PR TITLE
dist 目录清理问题

### DIFF
--- a/packages/weapp-vite/src/context/services/BuildService.ts
+++ b/packages/weapp-vite/src/context/services/BuildService.ts
@@ -167,7 +167,8 @@ export class BuildService {
     if (this.configService.mpDistRoot) {
       const deletedFilePaths = await rimraf(
         [
-          path.resolve(this.configService.outDir, '**'),
+          path.resolve(this.configService.outDir, '*'),
+          path.resolve(this.configService.outDir, '.*')
         ],
         {
           glob: true,


### PR DESCRIPTION
**问题**
当 `dist` 目录为空的时候 使用 `rimraf` + `**` 通配符 会对 `dist` 目录本身进行删除?操作

**场景**
我在 vscode + devcontainer 中使用
`dist` 目录 mount 到 host
无法删除 `dist` 目录

**日志**
```shell
> weapp-vite build

node:internal/process/promises:394
    triggerUncaughtException(err, true /* fromPromise */);
    ^

[Error: EBUSY: resource busy or locked, rmdir '/workspace/example_mp/dist'] {
  errno: -16,
  code: 'EBUSY',
  syscall: 'rmdir',
  path: '/workspace/example_mp/dist'
}

Node.js v22.17.1
```