### PR TITLE
fix: support --config/-c option for custom config files

### DIFF
--- a/packages/weapp-vite/src/context/services/ConfigService.ts
+++ b/packages/weapp-vite/src/context/services/ConfigService.ts
@@ -25,6 +25,7 @@ export interface LoadConfigOptions {
   isDev: boolean
   mode: string
   inlineConfig?: InlineConfig
+  configFile?: string
 }
 
 export interface LoadConfigResult {
@@ -90,7 +91,7 @@ export class ConfigService {
   }
 
   async loadConfig(opts: LoadConfigOptions) {
-    const { cwd, isDev, mode, inlineConfig } = opts
+    const { cwd, isDev, mode, inlineConfig, configFile } = opts
     const projectConfig = await getProjectConfig(cwd)
     const mpDistRoot = projectConfig.miniprogramRoot ?? projectConfig.srcMiniprogramRoot
     if (!mpDistRoot) {
@@ -107,10 +108,15 @@ export class ConfigService {
       packageJson = localPackageJson
     }
 
+    let resolvedConfigFile = configFile
+    if (resolvedConfigFile && !path.isAbsolute(resolvedConfigFile)) {
+      resolvedConfigFile = path.resolve(cwd, resolvedConfigFile)
+    }
+
     const loaded = await loadConfigFromFile({
       command: isDev ? 'serve' : 'build',
       mode,
-    }, undefined, cwd)
+    }, resolvedConfigFile, cwd)
 
     const loadedConfig = loaded?.config
 


### PR DESCRIPTION
- Add configFile parameter to loadConfig function
- Implement resolveConfigFile to handle both --config and -c options
- Pass configFile through createCompilerContext to ConfigService
- Resolve relative config paths to absolute in ConfigService
- Support custom config in generate command

This allows users to specify custom vite config files:
  weapp-vite build --config vite.config.weapp.ts
  weapp-vite dev -c custom.config.js