### PR TITLE
fix: 奇怪的 Ref<Ref<...>> 类型

### DIFF
--- a/packages/wevu/src/store/storeToRefs.ts
+++ b/packages/wevu/src/store/storeToRefs.ts
@@ -1,9 +1,16 @@
 import type { Ref } from '../reactivity'
 import { computed, isRef } from '../reactivity'
 
-export function storeToRefs<T extends Record<string, any>>(store: T): {
-  [K in keyof T]: T[K] extends (...args: any[]) => any ? T[K] : Ref<T[K]>
-} {
+type StoreToRefsResult<T extends Record<string, any>> = {
+  [K in keyof T]:
+    T[K] extends (...args: any[]) => any
+      ? T[K]
+      : T[K] extends Ref<infer V>
+        ? Ref<V>
+        : Ref<T[K]>
+}
+
+export function storeToRefs<T extends Record<string, any>>(store: T): StoreToRefsResult<T> {
   const result: Record<string, any> = {}
   for (const key in store) {
     const value = (store as any)[key]
@@ -23,5 +30,5 @@ export function storeToRefs<T extends Record<string, any>>(store: T): {
       })
     }
   }
-  return result as any
+  return result as StoreToRefsResult<T>
 }


### PR DESCRIPTION
## 问题描述

修复 `storeToRefs` 函数的类型定义，避免当 store 中已经存在 `Ref` 类型的属性时，出现 `Ref<Ref<...>>` 嵌套类型的问题。

## 修复内容

- 提取 `StoreToRefsResult` 类型定义，使其更加清晰易读
- 添加对 `Ref` 类型的检查：`T[K] extends Ref<infer V> ? Ref<V> : Ref<T[K]>`
- 当属性已经是 `Ref` 类型时，直接返回 `Ref<V>`，而不是 `Ref<Ref<V>>`
- 改进返回类型断言，从 `as any` 改为 `as StoreToRefsResult<T>`

## 测试

- [x] 类型检查通过
- [x] 避免了嵌套 Ref 类型的问题