### PR TITLE
fix(weapp-vite): 修复 autoImportComponents 布尔默认输出缺失

### DIFF
--- a/.changeset/fair-crabs-develop.md
+++ b/.changeset/fair-crabs-develop.md
@@ -1,0 +1,6 @@
+---
+'create-weapp-vite': patch
+'weapp-vite': patch
+---
+
+修复 `weapp.autoImportComponents: true` 的默认展开行为。现在该布尔开关除了启用组件目录扫描外，还会默认开启 `auto-import-components.json`、`typed-components.d.ts`、`mini-program.html-data.json` 和 `vueComponents` 等辅助产物输出，避免模板项目只写 `true` 时缺少 IDE 补全与清单文件。

--- a/packages/weapp-vite/src/plugins/autoImport.test.ts
+++ b/packages/weapp-vite/src/plugins/autoImport.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line e18e/ban-dependencies
 import fs from 'fs-extra'
 import path from 'pathe'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -12,11 +13,6 @@ vi.mock('chokidar', () => ({
 }))
 
 describe('autoImport plugin', () => {
-  beforeEach(() => {
-    chokidarWatchMock.mockReset()
-    chokidarWatchMock.mockReturnValue(createMockSidecarWatcher())
-  })
-
   function createMockSidecarWatcher() {
     const listeners = new Map<string, (filePath: string) => void>()
     const watcher = {
@@ -32,6 +28,11 @@ describe('autoImport plugin', () => {
 
     return watcher
   }
+
+  beforeEach(() => {
+    chokidarWatchMock.mockReset()
+    chokidarWatchMock.mockReturnValue(createMockSidecarWatcher())
+  })
 
   it('bootstraps outputs without globs', async () => {
     const reset = vi.fn()
@@ -50,6 +51,42 @@ describe('autoImport plugin', () => {
             vueComponents: true,
           },
         },
+      },
+      autoImportService: {
+        reset,
+        awaitManifestWrites,
+        filter: () => false,
+        registerPotentialComponent: vi.fn(),
+        removePotentialComponent: vi.fn(),
+        resolve: vi.fn(),
+        getRegisteredLocalComponents: vi.fn(),
+      },
+    } as any
+
+    const plugin = autoImport(ctx)[0]
+    plugin.configResolved?.({ build: { outDir: 'dist' } } as any)
+
+    await plugin.buildStart?.()
+    expect(reset).toHaveBeenCalledTimes(1)
+
+    await plugin.closeBundle?.()
+    expect(awaitManifestWrites).toHaveBeenCalledTimes(1)
+  })
+
+  it('bootstraps generated outputs when auto import is enabled with boolean true', async () => {
+    const reset = vi.fn()
+    const awaitManifestWrites = vi.fn().mockResolvedValue(undefined)
+
+    const ctx = {
+      configService: {
+        cwd: '/project',
+        absoluteSrcRoot: '/project/src',
+        relativeCwd: (p: string) => p,
+        relativeAbsoluteSrcRoot: (p: string) => p,
+        weappViteConfig: {
+          autoImportComponents: true,
+        },
+        packageJson: {},
       },
       autoImportService: {
         reset,

--- a/packages/weapp-vite/src/runtime/__tests__/autoImportConfig.test.ts
+++ b/packages/weapp-vite/src/runtime/__tests__/autoImportConfig.test.ts
@@ -187,7 +187,9 @@ describe('autoImport config helpers', () => {
           'packages/order/components/**/*.vue',
         ]),
       )
+      expect(config?.output).toBe(true)
       expect(config?.typedComponents).toBe(true)
+      expect(config?.htmlCustomData).toBe(true)
       expect(config?.vueComponents).toBe(true)
       expect(config?.vueComponentsModule).toBe('wevu')
     })
@@ -207,6 +209,9 @@ describe('autoImport config helpers', () => {
           'packages/order/components/**/*.wxml',
         ]),
       )
+      expect(config?.output).toBe(true)
+      expect(config?.typedComponents).toBe(true)
+      expect(config?.htmlCustomData).toBe(true)
       expect(config?.globs).not.toContain('components/**/*.vue')
       expect(config?.globs).not.toContain('packages/order/components/**/*.vue')
       expect(config?.vueComponents).toBe(true)

--- a/packages/weapp-vite/src/runtime/autoImport/config/defaults.ts
+++ b/packages/weapp-vite/src/runtime/autoImport/config/defaults.ts
@@ -62,7 +62,9 @@ function createEnabledAutoImportComponents(
   return {
     ...defaults,
     globs: [...globs],
+    output: true,
     typedComponents: true,
+    htmlCustomData: true,
     vueComponents: true,
     vueComponentsModule: hasWevuDependency(configService) ? 'wevu' : undefined,
   }

--- a/website/guide/auto-import.md
+++ b/website/guide/auto-import.md
@@ -31,6 +31,8 @@ keywords:
 > - 引入第三方 UI Resolver / 生成自定义输出
 >
 > 时才需要手动配置 `autoImportComponents`。
+>
+> 当你显式写成 `autoImportComponents: true` 时，除了扫描组件目录，还会默认开启 `.weapp-vite/auto-import-components.json`、`.weapp-vite/typed-components.d.ts`、`.weapp-vite/mini-program.html-data.json` 与 `vueComponents` 输出。
 
 ## 适用场景
 


### PR DESCRIPTION
## 摘要
- 调整 weapp.autoImportComponents: true 的默认展开行为
- 默认同时开启 auto-import-components.json、typed-components.d.ts、mini-program.html-data.json 和 vueComponents 输出
- 补充配置解析与插件自举回归测试，并更新自动导入文档说明

## 验证
- vitest run src/runtime/__tests__/autoImportConfig.test.ts src/plugins/autoImport.test.ts
- eslint src/runtime/autoImport/config/defaults.ts src/runtime/__tests__/autoImportConfig.test.ts src/plugins/autoImport.test.ts

## 关联 Issue
- Fixes #377
