### PR TITLE
fix(weapp-vite): 修复 github-issues 首次编译误把共享脚本识别为页面

### DIFF
--- a/.changeset/bright-trains-visit.md
+++ b/.changeset/bright-trains-visit.md
@@ -1,0 +1,6 @@
+---
+'weapp-vite': patch
+'create-weapp-vite': patch
+---
+
+修复 `autoRoutes` 在无 `pages/` 目录的分包根目录下误把共享脚本模块识别为页面的问题。现在像 `subpackages/item/issue-340-shared.ts` 这类仅供其他页面复用的裸脚本文件，不会再被写入 `dist/app.json` 或自动路由类型定义，从而避免 `pnpm dev:open` / 首次编译时微信开发者工具因为找不到对应 `.wxml` 页面文件而报错。

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -608,8 +608,10 @@ describe.sequential('e2e app: github-issues (build)', () => {
   it('issue #340: keeps cross-subpackage source imports runnable for item/login-required and user/register/form', async () => {
     await runBuild()
 
+    const appJsonPath = path.join(DIST_ROOT, 'app.json')
     const itemPageJsPath = path.join(DIST_ROOT, 'subpackages/item/login-required/index.js')
     const userPageJsPath = path.join(DIST_ROOT, 'subpackages/user/register/form.js')
+    const invalidSharedPageWxmlPath = path.join(DIST_ROOT, 'subpackages/item/issue-340-shared.wxml')
     const rootCommonPath = path.join(DIST_ROOT, 'common.js')
     const itemSharedPath = path.join(DIST_ROOT, 'subpackages/item/weapp-shared/common.js')
     const userSharedPath = path.join(DIST_ROOT, 'subpackages/user/weapp-shared/common.js')
@@ -621,10 +623,12 @@ describe.sequential('e2e app: github-issues (build)', () => {
     const itemRuntimePath = path.join(DIST_ROOT, 'subpackages/item/rolldown-runtime.js')
     const userRuntimePath = path.join(DIST_ROOT, 'subpackages/user/rolldown-runtime.js')
 
+    const appJson = JSON.parse(await fs.readFile(appJsonPath, 'utf-8'))
     const itemPageJs = await fs.readFile(itemPageJsPath, 'utf-8')
     const userPageJs = await fs.readFile(userPageJsPath, 'utf-8')
     const itemShared = await fs.readFile(itemSharedPath, 'utf-8')
     const userShared = await fs.readFile(userSharedPath, 'utf-8')
+    const itemSubPackage = (appJson.subPackages ?? appJson.subpackages ?? []).find((entry: any) => entry?.root === 'subpackages/item')
 
     expect(itemPageJs).toContain('item-login-required:issue-340:shared')
     expect(userPageJs).toContain('user-register-form:issue-340:shared')
@@ -646,6 +650,11 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(itemShared).not.toMatch(/vendors(?:\.\d+)?\.js/)
     expect(userShared).not.toMatch(/vendors(?:\.\d+)?\.js/)
 
+    expect(itemSubPackage?.pages).toEqual([
+      'index',
+      'login-required/index',
+    ])
+    expect(await fs.pathExists(invalidSharedPageWxmlPath)).toBe(false)
     expect(await fs.pathExists(rootCommonPath)).toBe(true)
     expect(await fs.pathExists(itemInvalidCommonPath)).toBe(false)
     expect(await fs.pathExists(userInvalidCommonPath)).toBe(false)

--- a/packages/weapp-vite/src/runtime/autoRoutesPlugin/routes/scan.test.ts
+++ b/packages/weapp-vite/src/runtime/autoRoutesPlugin/routes/scan.test.ts
@@ -41,27 +41,61 @@ describe('auto routes scan helpers', () => {
 
   it('decides whether scan candidates should be included', () => {
     expect(shouldIncludeScanCandidate({
+      files: new Set(['/project/src/pages/home/index.ts']),
       hasScript: false,
       hasTemplate: false,
       jsonPath: '/project/src/pages/home/index.json',
     }, undefined)).toBe(false)
 
     expect(shouldIncludeScanCandidate({
+      files: new Set(['/project/src/pages/home/index.ts']),
       hasScript: true,
       hasTemplate: false,
       jsonPath: '/project/src/pages/home/index.json',
     }, { component: true })).toBe(false)
 
     expect(shouldIncludeScanCandidate({
+      files: new Set(['/project/src/pages/home/index.ts']),
       hasScript: true,
       hasTemplate: false,
       jsonPath: '/project/src/pages/home/index.json',
     }, {})).toBe(true)
 
     expect(shouldIncludeScanCandidate({
+      files: new Set(['/project/src/pages/home/index.ts']),
       hasScript: false,
       hasTemplate: false,
       jsonPath: undefined,
     }, undefined)).toBe(false)
+
+    expect(shouldIncludeScanCandidate({
+      files: new Set(['/project/src/subpackages/item/issue-340-shared.ts']),
+      hasScript: true,
+      hasTemplate: false,
+      jsonPath: undefined,
+    }, undefined, {
+      root: 'subpackages/item',
+      pagePath: 'issue-340-shared',
+    })).toBe(false)
+
+    expect(shouldIncludeScanCandidate({
+      files: new Set(['/project/src/subpackages/item/index.ts']),
+      hasScript: true,
+      hasTemplate: false,
+      jsonPath: undefined,
+    }, undefined, {
+      root: 'subpackages/item',
+      pagePath: 'index',
+    })).toBe(true)
+
+    expect(shouldIncludeScanCandidate({
+      files: new Set(['/project/src/subpackages/user/register/form.vue']),
+      hasScript: true,
+      hasTemplate: false,
+      jsonPath: undefined,
+    }, undefined, {
+      root: 'subpackages/user',
+      pagePath: 'register/form',
+    })).toBe(true)
   })
 })

--- a/packages/weapp-vite/src/runtime/autoRoutesPlugin/routes/scan.ts
+++ b/packages/weapp-vite/src/runtime/autoRoutesPlugin/routes/scan.ts
@@ -42,14 +42,29 @@ function ensureSubPackage(map: Map<string, Set<string>>, root: string) {
 }
 
 function shouldIncludeScanCandidate(
-  candidate: Pick<CandidateEntry, 'hasScript' | 'hasTemplate' | 'jsonPath'>,
+  candidate: Pick<CandidateEntry, 'files' | 'hasScript' | 'hasTemplate' | 'jsonPath'>,
   json: Record<string, any> | undefined,
+  route?: { pagePath: string, root?: string },
 ) {
   if (candidate.jsonPath && json === undefined) {
     return false
   }
   if (json && typeof json === 'object' && json.component === true) {
     return false
+  }
+
+  if (
+    route?.root
+    && !route.pagePath.startsWith('pages/')
+    && candidate.hasScript
+    && !candidate.hasTemplate
+    && !candidate.jsonPath
+  ) {
+    const hasVueEntry = [...candidate.files].some(file => file.endsWith('.vue'))
+    const isIndexEntry = path.basename(route.pagePath) === 'index'
+    if (!hasVueEntry && !isIndexEntry) {
+      return false
+    }
   }
 
   return candidate.hasScript || candidate.hasTemplate || Boolean(candidate.jsonPath)
@@ -107,7 +122,7 @@ export async function scanRoutes(
     watchDirs.add(path.dirname(candidate.base))
 
     const json = jsonMap.get(candidate)
-    if (!shouldIncludeScanCandidate(candidate, json)) {
+    if (!shouldIncludeScanCandidate(candidate, json, route)) {
       continue
     }
 


### PR DESCRIPTION
## 摘要
修复 e2e-apps/github-issues 在首次 pnpm dev:open / 首次编译时，autoRoutes 将 subpackages/item/issue-340-shared.ts 误识别为页面并写入 dist/app.json，导致微信开发者工具报 app.json 文件内容错误 的问题。

## 根因
autoRoutes 在无 pages/ 目录的分包根目录 fallback 扫描中，会把分包根下的裸脚本候选也当作页面入口。
e2e-apps/github-issues/src/subpackages/item/issue-340-shared.ts 是跨页面复用的共享模块，不应进入自动路由，但旧逻辑会把它生成到：
- dist/app.json
- .weapp-vite/typed-router.d.ts

这会让 DevTools 在首次打开时尝试加载不存在的 subpackages/item/issue-340-shared.wxml。

## 变更
- 在 packages/weapp-vite/src/runtime/autoRoutesPlugin/routes/scan.ts 调整默认分包 fallback 扫描规则
- 保留无 pages/ 目录时的分包根目录直出页面能力
- 排除仅作为共享模块存在的裸脚本 helper，例如 issue-340-shared.ts
- 为 scan 逻辑补充单测，覆盖共享脚本、index.ts 页面和嵌套 .vue 页面三类情况
- 为 e2e/ci/github-issues.build.test.ts 补充断言，锁定 dist/app.json 中 subpackages/item.pages 不再包含 issue-340-shared

## 验证
- pnpm vitest run packages/weapp-vite/src/runtime/autoRoutesPlugin/routes/scan.test.ts
- pnpm --filter weapp-vite build
- pnpm vitest run -c e2e/vitest.e2e.config.ts e2e/ci/github-issues.build.test.ts -t "issue #340"

## 结果
修复后，e2e-apps/github-issues/dist/app.json 中 subpackages/item.pages 仅包含：
- index
- login-required/index

首次编译不再生成错误的 issue-340-shared 页面入口。