### PR TITLE
fix(wevu): 修复非 wevu 组件 template ref 异常

### DIFF
--- a/.changeset/sixty-radios-lie.md
+++ b/.changeset/sixty-radios-lie.md
@@ -1,0 +1,6 @@
+---
+'create-weapp-vite': patch
+'wevu': patch
+---
+
+修复 `wevu` 在 `useTemplateRef()` 引用非 wevu 组件实例时的两个运行时问题：一是模板 ref 包装代理对原生实例不可配置属性返回了不符合 Proxy 规范的描述符，导致访问 `__data__` 等字段时抛错；二是 `shallowRef(null)` 初始值在后续参与 setData token 比较时缺少空值守卫，触发 `Object.hasOwn(null, ...)` 异常。

--- a/packages-runtime/wevu/src/runtime/app/setData/scheduler.ts
+++ b/packages-runtime/wevu/src/runtime/app/setData/scheduler.ts
@@ -130,7 +130,9 @@ export function createSetDataScheduler(options: {
       || !Object.hasOwn(right as object, 'raw')
     ) {
       if (
-        typeof left === 'object'
+        left
+        && right
+        && typeof left === 'object'
         && typeof right === 'object'
         && Object.hasOwn(left as object, 'snapshot')
         && Object.hasOwn(right as object, 'snapshot')

--- a/packages-runtime/wevu/src/runtime/templateRefs/helpers.ts
+++ b/packages-runtime/wevu/src/runtime/templateRefs/helpers.ts
@@ -102,7 +102,14 @@ function mergeComponentRefValue(
       if (Reflect.has(target, key)) {
         return Object.getOwnPropertyDescriptor(target, key)
       }
-      return Object.getOwnPropertyDescriptor(source, key)
+      const descriptor = Object.getOwnPropertyDescriptor(source, key)
+      if (!descriptor) {
+        return descriptor
+      }
+      return {
+        ...descriptor,
+        configurable: true,
+      }
     },
   })
   return markNoSetData(merged)

--- a/packages-runtime/wevu/test/runtime-setdata-scheduler.test.ts
+++ b/packages-runtime/wevu/test/runtime-setdata-scheduler.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import { shallowRef } from '@/reactivity'
+import { createSetDataScheduler } from '@/runtime/app/setData/scheduler'
+
+describe('runtime: setData scheduler', () => {
+  it('handles shallowRef null transitions when comparing value tokens', () => {
+    const current = shallowRef<any>(null)
+    const setData = vi.fn()
+    const scheduler = createSetDataScheduler({
+      state: { current },
+      computedRefs: {},
+      dirtyComputedKeys: new Set(),
+      includeComputed: false,
+      setDataStrategy: 'diff',
+      computedCompare: 'reference',
+      computedCompareMaxDepth: 2,
+      computedCompareMaxKeys: 20,
+      currentAdapter: { setData },
+      shouldIncludeKey: () => true,
+      maxPatchKeys: 20,
+      maxPayloadBytes: 1024 * 32,
+      mergeSiblingThreshold: 4,
+      mergeSiblingMaxInflationRatio: 2,
+      mergeSiblingMaxParentBytes: 1024 * 8,
+      mergeSiblingSkipArray: false,
+      elevateTopKeyThreshold: 8,
+      toPlainMaxDepth: 4,
+      toPlainMaxKeys: 50,
+      debug: undefined,
+      debugWhen: 'fallback',
+      debugSampleRate: 1,
+      runTracker: () => {},
+      isMounted: () => true,
+    })
+
+    expect(() => scheduler.job({})).not.toThrow()
+    expect(setData).toHaveBeenCalledWith({ current: null })
+
+    current.value = { id: 'native-ref' }
+
+    expect(() => scheduler.job({})).not.toThrow()
+    expect(setData).toHaveBeenLastCalledWith({ current: { id: 'native-ref' } })
+  })
+})

--- a/packages-runtime/wevu/test/runtime-template-refs.test.ts
+++ b/packages-runtime/wevu/test/runtime-template-refs.test.ts
@@ -245,6 +245,34 @@ describe('runtime: template refs', () => {
     expect(onConfirm).toHaveBeenCalledWith('ok')
   })
 
+  it('keeps native component property descriptors proxy-safe', () => {
+    const componentInstance: any = {}
+    Object.defineProperty(componentInstance, '__data__', {
+      value: { text: 'hello' },
+      configurable: false,
+      enumerable: true,
+      writable: false,
+    })
+
+    const instance: any = {
+      __wevuReadyCalled: true,
+      __wevu: { state: {}, proxy: {} },
+      selectComponent: vi.fn(() => componentInstance),
+      __wevuTemplateRefs: [
+        { selector: '.native', inFor: false, name: 'native', kind: 'component' },
+      ],
+    }
+
+    updateTemplateRefs(instance)
+
+    const refs = instance.__wevu.state.$refs
+    expect(() => Object.keys(refs.native)).not.toThrow()
+    const descriptor = Object.getOwnPropertyDescriptor(refs.native, '__data__')
+    expect(descriptor?.configurable).toBe(true)
+    expect(descriptor?.enumerable).toBe(true)
+    expect(descriptor?.value).toEqual({ text: 'hello' })
+  })
+
   it('scheduleTemplateRefUpdate batches updates', async () => {
     const resolver: QueryResolver = (selector) => {
       if (selector === '.batched') {


### PR DESCRIPTION
## 背景
- 修复 #418 中 `useTemplateRef()` 引用非 wevu 组件时的 Proxy `getOwnPropertyDescriptor` 不变量问题
- 修复 #419 中 `shallowRef(null)` 初始值在 setData token 比较时触发的空值异常

## 变更
- 对模板 ref 合并代理返回的 source 描述符统一转为 `configurable: true`，避免原生实例不可配置属性破坏 Proxy 规范
- 为 `isSameToken` 的 snapshot 分支补充 `null` 守卫
- 新增 2 条回归测试，分别覆盖原生组件实例描述符场景和 `shallowRef(null) -> object` 的 setData 调度场景
- 补充 changeset，发布 `wevu` 与 `create-weapp-vite` patch 版本

## 验证
- `./node_modules/.bin/vitest run packages-runtime/wevu/test/runtime-template-refs.test.ts packages-runtime/wevu/test/runtime-setdata-scheduler.test.ts`
- `./node_modules/.bin/eslint packages-runtime/wevu/src/runtime/templateRefs/helpers.ts packages-runtime/wevu/src/runtime/app/setData/scheduler.ts packages-runtime/wevu/test/runtime-template-refs.test.ts packages-runtime/wevu/test/runtime-setdata-scheduler.test.ts`
- `pnpm --filter wevu build`

Closes #418
Closes #419
