### PR TITLE
test(github-issues): 补充 issue 418 419 回归覆盖

### DIFF
--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -176,6 +176,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-418-419/index",
+          "pathName": "pages/issue-418-419/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-385/index",
           "pathName": "pages/issue-385/index",
           "query": "",

--- a/e2e-apps/github-issues/src/components/issue-418-419/NativeRefProbe/index.json
+++ b/e2e-apps/github-issues/src/components/issue-418-419/NativeRefProbe/index.json
@@ -1,0 +1,3 @@
+{
+  "component": true
+}

--- a/e2e-apps/github-issues/src/components/issue-418-419/NativeRefProbe/index.ts
+++ b/e2e-apps/github-issues/src/components/issue-418-419/NativeRefProbe/index.ts
@@ -1,0 +1,13 @@
+Component({
+  properties: {
+    label: {
+      type: String,
+      value: 'native-ref-probe',
+    },
+  },
+  methods: {
+    getLabel() {
+      return this.data.label
+    },
+  },
+})

--- a/e2e-apps/github-issues/src/components/issue-418-419/NativeRefProbe/index.wxml
+++ b/e2e-apps/github-issues/src/components/issue-418-419/NativeRefProbe/index.wxml
@@ -1,0 +1,3 @@
+<view class="native-ref-probe">
+  <text class="native-ref-probe__label">{{label}}</text>
+</view>

--- a/e2e-apps/github-issues/src/pages/issue-418-419/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-418-419/index.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, useTemplateRef } from 'wevu'
+
+definePageJson({
+  navigationBarTitleText: 'issue-418-419',
+  usingComponents: {
+    'native-ref-probe': '../../components/issue-418-419/NativeRefProbe/index',
+  },
+})
+
+const nativeButtonRef = useTemplateRef<Record<string, any>>('nativeButton')
+const mounted = ref(false)
+
+const nativeButtonReady = computed(() => Boolean(nativeButtonRef.value))
+const nativeButtonLabel = computed(() => {
+  const data = nativeButtonRef.value?.__data__
+  if (!data || typeof data !== 'object') {
+    return null
+  }
+  return typeof data.label === 'string' ? data.label : null
+})
+
+function inspectNativeRef() {
+  const currentPage = (getCurrentPages() as Array<Record<string, any>>).at(-1)
+
+  try {
+    const target = nativeButtonRef.value
+    if (!target || typeof target !== 'object') {
+      return {
+        ready: false,
+        ownKeysSample: [] as string[],
+        descriptorConfigurable: null as boolean | null,
+        hasDataObject: false,
+        errorMessage: null as string | null,
+      }
+    }
+
+    const ownKeysSample = Object.keys(target).slice(0, 8)
+    const descriptor = Object.getOwnPropertyDescriptor(target, '__data__')
+
+    return {
+      ready: true,
+      ownKeysSample,
+      descriptorConfigurable: descriptor?.configurable ?? null,
+      hasDataObject: Boolean(target.__data__ && typeof target.__data__ === 'object'),
+      errorMessage: null as string | null,
+    }
+  }
+  catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (currentPage) {
+      currentPage.__issue418419RuntimeError = message
+    }
+    return {
+      ready: false,
+      ownKeysSample: [] as string[],
+      descriptorConfigurable: null as boolean | null,
+      hasDataObject: false,
+      errorMessage: message,
+    }
+  }
+}
+
+onMounted(() => {
+  mounted.value = true
+})
+
+function _runE2E() {
+  const currentPage = (getCurrentPages() as Array<Record<string, any>>).at(-1)
+  const inspection = inspectNativeRef()
+
+  return {
+    ok: mounted.value && inspection.ready && inspection.errorMessage == null,
+    mounted: mounted.value,
+    nativeButtonReady: nativeButtonReady.value,
+    nativeButtonLabel: nativeButtonLabel.value,
+    descriptorConfigurable: inspection.descriptorConfigurable,
+    hasDataObject: inspection.hasDataObject,
+    ownKeysSample: inspection.ownKeysSample,
+    runtimeError: inspection.errorMessage ?? currentPage?.__issue418419RuntimeError ?? null,
+  }
+}
+</script>
+
+<template>
+  <view class="issue418419-page">
+    <text class="issue418419-title">
+      issue-418-419 template ref native component
+    </text>
+    <text class="issue418419-state">
+      mounted: {{ mounted ? 'yes' : 'no' }}
+    </text>
+    <text class="issue418419-state">
+      native ref ready: {{ nativeButtonReady ? 'yes' : 'no' }}
+    </text>
+    <text class="issue418419-state">
+      native label: {{ nativeButtonLabel || 'pending' }}
+    </text>
+    <native-ref-probe
+      ref="nativeButton"
+      label="issue-418-419"
+      class="issue418419-button"
+    />
+  </view>
+</template>
+
+<style scoped>
+.issue418419-page {
+  box-sizing: border-box;
+  min-height: 100vh;
+  padding: 32rpx;
+  background: #fff;
+}
+
+.issue418419-title,
+.issue418419-state {
+  display: block;
+}
+
+.issue418419-title {
+  margin-bottom: 20rpx;
+  font-size: 32rpx;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.issue418419-state {
+  margin-bottom: 16rpx;
+  font-size: 24rpx;
+  color: #334155;
+}
+
+.issue418419-button {
+  margin-top: 16rpx;
+}
+</style>

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -203,6 +203,25 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageJs).toContain('enableOnPageScroll')
   })
 
+  it('issue #418/#419: keeps native template refs stable for third-party components', async () => {
+    await runBuild()
+
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-418-419/index.wxml')
+    const pageJsPath = path.join(DIST_ROOT, 'pages/issue-418-419/index.js')
+    const pageJsonPath = path.join(DIST_ROOT, 'pages/issue-418-419/index.json')
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+    const pageJs = await fs.readFile(pageJsPath, 'utf-8')
+    const pageJson = await fs.readFile(pageJsonPath, 'utf-8')
+
+    expect(pageWxml).toContain('issue-418-419 template ref native component')
+    expect(pageWxml).toContain('<native-ref-probe')
+    expect(pageWxml).toContain('issue-418-419')
+    expect(pageJs).toContain('_runE2E')
+    expect(pageJs).toContain('nativeButtonRef')
+    expect(pageJs).toContain('descriptorConfigurable')
+    expect(pageJson).toContain('../../components/issue-418-419/NativeRefProbe/index')
+  })
+
   it('issue #289: compiles split pages with per-page controls and safe class bindings', async () => {
     await runBuild()
 

--- a/e2e/ide/github-issues.runtime.lifecycle.test.ts
+++ b/e2e/ide/github-issues.runtime.lifecycle.test.ts
@@ -170,6 +170,34 @@ async function waitForIssue404ScrollRuntime(page: any, timeoutMs = 20_000) {
   return null
 }
 
+async function waitForIssue418419Runtime(page: any, timeoutMs = 20_000) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt <= timeoutMs) {
+    try {
+      const runtime = await callPageMethodWithTimeout(page, '_runE2E')
+      if (
+        runtime?.ok
+        && runtime?.mounted
+        && runtime?.nativeButtonReady
+        && runtime?.descriptorConfigurable === true
+        && runtime?.hasDataObject
+      ) {
+        return runtime
+      }
+    }
+    catch {
+    }
+
+    try {
+      await page.waitFor(220)
+    }
+    catch {
+    }
+  }
+
+  return null
+}
+
 describe.sequential('e2e app: github-issues / lifecycle', () => {
   afterAll(async () => {
     await closeSharedMiniProgram()
@@ -436,6 +464,37 @@ describe.sequential('e2e app: github-issues / lifecycle', () => {
       expect(Array.isArray(runtimeResult?.scrollLogs)).toBe(true)
       expect(runtimeResult?.scrollLogs?.some((value: number) => value > 0)).toBe(true)
       expect(Number(runtimeResult?.latestScrollTop ?? -1)).toBeGreaterThan(0)
+    }
+    finally {
+      await releaseSharedMiniProgram(miniProgram)
+    }
+  })
+
+  it('issue #418/#419: keeps third-party component template refs available in DevTools runtime', async (ctx) => {
+    const issuePageWxmlPath = path.join(DIST_ROOT, 'pages/issue-418-419/index.wxml')
+    const issuePageJsPath = path.join(DIST_ROOT, 'pages/issue-418-419/index.js')
+    const issuePageJsonPath = path.join(DIST_ROOT, 'pages/issue-418-419/index.json')
+
+    expect(await fs.readFile(issuePageWxmlPath, 'utf-8')).toContain('issue-418-419 template ref native component')
+    expect(await fs.readFile(issuePageWxmlPath, 'utf-8')).toContain('native ref ready')
+    expect(await fs.readFile(issuePageJsPath, 'utf-8')).toContain('_runE2E')
+    expect(await fs.readFile(issuePageJsPath, 'utf-8')).toContain('descriptorConfigurable')
+    expect(await fs.readFile(issuePageJsonPath, 'utf-8')).toContain('../../components/issue-418-419/NativeRefProbe/index')
+
+    const miniProgram = await getSharedMiniProgram(ctx)
+    try {
+      const issuePage = await relaunchPage(miniProgram, '/pages/issue-418-419/index')
+      if (!issuePage) {
+        throw new Error('Failed to launch issue-418-419 page')
+      }
+
+      const runtimeResult = await waitForIssue418419Runtime(issuePage)
+      expect(runtimeResult?.ok).toBe(true)
+      expect(runtimeResult?.mounted).toBe(true)
+      expect(runtimeResult?.nativeButtonReady).toBe(true)
+      expect(runtimeResult?.descriptorConfigurable).toBe(true)
+      expect(runtimeResult?.hasDataObject).toBe(true)
+      expect(runtimeResult?.runtimeError).toBeNull()
     }
     finally {
       await releaseSharedMiniProgram(miniProgram)


### PR DESCRIPTION
## 摘要
- 为 `github-issues` 应用新增 `issue-418-419` 复现页，覆盖非 wevu 组件的 template ref 场景
- 新增 build 侧断言，确认页面产物与原生组件引用链路正确
- 新增 DevTools runtime 定向用例，确认第三方/原生组件 template ref 在运行时可用且不会再触发 #418/#419

## 验证
- `pnpm vitest run packages-runtime/wevu/test/runtime-template-refs.test.ts packages-runtime/wevu/test/runtime-setdata-scheduler.test.ts`
- `pnpm --filter wevu build`
- `pnpm vitest run -c e2e/vitest.e2e.ci.build-only.config.ts e2e/ci/github-issues.build.test.ts -t "issue #418/#419"`
- `pnpm vitest run -c e2e/vitest.e2e.devtools.config.ts e2e/ide/github-issues.runtime.lifecycle.test.ts -t "issue #418/#419"`

## 关联
- 关联 #418
- 关联 #419