### PR TITLE
fix(wevu): 修复组件模板 ref 类型推导

### DIFF
--- a/.changeset/four-games-laugh.md
+++ b/.changeset/four-games-laugh.md
@@ -1,0 +1,7 @@
+---
+'@wevu/compiler': patch
+'wevu': patch
+'create-weapp-vite': patch
+---
+
+修复 Vue 3.4 `v-bind` shorthand 在小程序模板编译中的兼容性问题。现在除了普通属性绑定外，`:foo-bar`、`:class`、`:style`、`:ref`、`<slot :name />` 与 `<component :is />` 等场景都会按 Vue 3.4 语义回退到同名表达式，并正确处理 kebab-case 到 camelCase 的变量映射，避免编译后丢失绑定或把动态组件错误降级为普通标签。

--- a/.changeset/tidy-queens-share.md
+++ b/.changeset/tidy-queens-share.md
@@ -1,0 +1,6 @@
+---
+'wevu': patch
+'create-weapp-vite': patch
+---
+
+修复 `wevu` 的组件模板 ref 类型链路，补齐对 Vue 3.5 `DefineComponent` 额外泛型的透传，并让 `defineComponent()` 返回的组件定义继续对齐 `DefineComponent` 公共实例类型。现在通过 `ref()` 或 `useTemplateRef()` 引用带 `defineExpose()` 的组件时，暴露成员、`$refs` 与 `$el` 等类型信息都能被正确推导，不再出现“功能正常但类型报错”的问题。

--- a/apps/wevu-runtime-demo/vite.config.ts
+++ b/apps/wevu-runtime-demo/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'weapp-vite'
 export default defineConfig(() => ({
   weapp: {
     appPrelude: {
-      webRuntime: true,
+      requestRuntime: true,
     },
     srcRoot: 'src',
   },

--- a/e2e/ci/app-prelude-native.build.test.ts
+++ b/e2e/ci/app-prelude-native.build.test.ts
@@ -233,7 +233,7 @@ describe.sequential('e2e app: app-prelude-native (build)', () => {
     expect(rootPreludeJs).not.toContain('"XMLHttpRequest"')
     expect(rootPreludeJs).not.toContain('"WebSocket"')
     expect(runtimeJs).toContain('Object.defineProperty(exports,`t`,{enumerable:!0,get:function(){return')
-    expect(runtimeJs).toContain('targets??[`fetch`,`Headers`,`Request`,`Response`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`]')
+    expect(runtimeJs).toContain('targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`]')
     expect(rootPreludeJs.indexOf(`/* ${REQUEST_GLOBAL_PRELUDE_MARKER} */`)).toBeLessThan(rootPreludeJs.indexOf(`/* ${APP_PRELUDE_CHUNK_MARKER} */`))
   })
 })

--- a/e2e/ci/request-clients-real.request-runtime.build.test.ts
+++ b/e2e/ci/request-clients-real.request-runtime.build.test.ts
@@ -56,7 +56,7 @@ describe.sequential('e2e app: request clients request runtime (build)', () => {
       const runtimeJs = await fs.readFile(path.join(distRoot, 'request-globals-runtime.js'), 'utf8')
 
       expect(runtimeJs).toContain('Object.defineProperty(exports,`t`,{enumerable:!0,get:function(){return')
-      expect(runtimeJs).toContain('targets??[`fetch`,`Headers`,`Request`,`Response`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`]')
+      expect(runtimeJs).toContain('targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`]')
 
       for (const entryFile of testCase.entryFiles) {
         const entryJs = await fs.readFile(path.join(distRoot, entryFile), 'utf8')
@@ -66,7 +66,7 @@ describe.sequential('e2e app: request clients request runtime (build)', () => {
         expect(entryJs).toContain('var fetch = __rc.fetch')
         expect(entryJs).toContain('var XMLHttpRequest = __rc.XMLHttpRequest')
         expect(entryJs).toContain('var WebSocket = __rc.WebSocket')
-        expect(entryJs).toContain('targets: ["fetch","Headers","Request","Response","AbortController","AbortSignal","XMLHttpRequest","WebSocket"]')
+        expect(entryJs).toContain('"fetch","Headers","Request","Response","TextEncoder","TextDecoder","AbortController","AbortSignal","XMLHttpRequest","WebSocket"')
       }
     })
   }

--- a/e2e/ci/wevu-runtime-demo.request-globals.build.test.ts
+++ b/e2e/ci/wevu-runtime-demo.request-globals.build.test.ts
@@ -31,10 +31,10 @@ describe.sequential('e2e app: wevu-runtime-demo request globals (build)', () => 
     const pageJs = await fs.readFile(pageJsPath, 'utf8')
 
     expect(runtimeJs).toContain('Object.defineProperty(exports,`t`,{enumerable:!0,get:function(){return')
-    expect(runtimeJs).toContain('targets??[`fetch`,`Headers`,`Request`,`Response`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`]')
+    expect(runtimeJs).toContain('targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`]')
     expect(pageJs).toContain(REQUEST_GLOBAL_LOCAL_BINDINGS_MARKER)
     expect(pageJs).toContain('const __rm = require(`../../request-globals-runtime.js`)')
-    expect(pageJs).toContain('const __rc = __rm["t"]({ targets: ["fetch","Headers","Request","Response","AbortController","AbortSignal","XMLHttpRequest","WebSocket"] }) || globalThis')
+    expect(pageJs).toContain('"fetch","Headers","Request","Response","TextEncoder","TextDecoder","AbortController","AbortSignal","XMLHttpRequest","WebSocket"')
     expect(pageJs).toContain('var fetch = __rc.fetch')
     expect(pageJs).toContain('var URL = __rc.URL')
     expect(pageJs).toContain('var XMLHttpRequest = __rc.XMLHttpRequest')

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
@@ -91,6 +91,34 @@ describe('compileVueTemplateToWxml', () => {
     expect(code).toContain('change:leftWidth="{{swipe.initLeftWidth}}"')
   })
 
+  it('supports Vue 3.4 v-bind shorthand for static props', () => {
+    const template = `
+<view :visible :foo-bar />
+    `.trim()
+
+    const { code } = compileVueTemplateToWxml(
+      template,
+      '/project/src/pages/index/index.vue',
+    )
+
+    expect(code).toContain('visible="{{visible}}"')
+    expect(code).toContain('foo-bar="{{fooBar}}"')
+  })
+
+  it('supports Vue 3.4 v-bind shorthand for dynamic component is', () => {
+    const template = `
+<component :is />
+    `.trim()
+
+    const { code, warnings } = compileVueTemplateToWxml(
+      template,
+      '/project/src/pages/index/index.vue',
+    )
+
+    expect(code).toContain('<component data-is="{{is}}"></component>')
+    expect(warnings).not.toContain('<component> 未提供 :is 绑定，将按普通元素处理。')
+  })
+
   it('renders mustache with spaces when interpolation mode is spaced', () => {
     const template = `
 <view v-if="ok" :prop="value" :class="dynamicClass" v-show="visible">{{ text }}</view>

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/directives/bind.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/directives/bind.ts
@@ -2,6 +2,7 @@ import type { DirectiveNode } from '@vue/compiler-core'
 import type { Expression } from '@weapp-vite/ast/babelTypes'
 import type { ForParseResult, TransformContext } from '../types'
 import { NodeTypes } from '@vue/compiler-core'
+import { getBindDirectiveExpression } from '../elements/helpers'
 import { normalizeWxmlExpressionWithContext } from '../expression'
 import { parseBabelExpression } from '../expression/parse'
 import { registerRuntimeBindingExpression, shouldFallbackToRuntimeBinding } from '../expression/runtimeBinding'
@@ -50,15 +51,12 @@ export function transformBindDirective(
   context: TransformContext,
   forInfo?: ForParseResult,
 ): string | null {
-  const { exp, arg } = node
+  const { arg } = node
   if (!arg) {
     return null
   }
   const argValue = arg.type === NodeTypes.SIMPLE_EXPRESSION ? arg.content : ''
-  if (!exp) {
-    return null
-  }
-  const rawExpValue = exp.type === NodeTypes.SIMPLE_EXPRESSION ? exp.content : ''
+  const rawExpValue = getBindDirectiveExpression(node)
   if (!rawExpValue) {
     return null
   }

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/attrs.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/attrs.ts
@@ -12,6 +12,7 @@ import { transformDirective } from '../directives'
 import { normalizeJsExpressionWithContext, normalizeWxmlExpressionWithContext } from '../expression'
 import { registerRuntimeBindingExpression, shouldFallbackToRuntimeBinding } from '../expression/runtimeBinding'
 import { resolveTemplateTagName } from '../htmlTagMapping'
+import { getBindDirectiveExpression } from './helpers'
 
 const builtinTagSet = new Set(builtinComponents.map(tag => tag.toLowerCase()))
 
@@ -97,7 +98,7 @@ export function collectElementAttributes(
         && prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION
         && prop.arg.content === 'ref'
       ) {
-        const rawExp = prop.exp?.type === NodeTypes.SIMPLE_EXPRESSION ? prop.exp.content : ''
+        const rawExp = getBindDirectiveExpression(prop)
         if (rawExp) {
           const expAst = normalizeJsExpressionWithContext(rawExp, context, { hint: 'ref 绑定' })
           if (expAst) {
@@ -125,18 +126,16 @@ export function collectElementAttributes(
         prop.name === 'bind'
         && prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION
         && prop.arg.content === 'class'
-        && prop.exp?.type === NodeTypes.SIMPLE_EXPRESSION
       ) {
-        dynamicClassExp = prop.exp.content
+        dynamicClassExp = getBindDirectiveExpression(prop) || undefined
         continue
       }
       if (
         prop.name === 'bind'
         && prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION
         && prop.arg.content === 'style'
-        && prop.exp?.type === NodeTypes.SIMPLE_EXPRESSION
       ) {
-        dynamicStyleExp = prop.exp.content
+        dynamicStyleExp = getBindDirectiveExpression(prop) || undefined
         continue
       }
       if (prop.name === 'show' && prop.exp?.type === NodeTypes.SIMPLE_EXPRESSION) {

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/helpers.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/helpers.ts
@@ -93,10 +93,37 @@ export function withSlotProps<T>(context: TransformContext, mapping: Record<stri
 }
 
 const IDENTIFIER_RE = /^[A-Z_$][\w$]*$/i
+const BIND_SHORTHAND_ARG_RE = /^[A-Z_$][\w$]*(?:-[A-Z_$][\w$]*)*$/i
 const BACKSLASH_RE = /\\/g
 const SINGLE_QUOTE_RE = /'/g
 const CR_RE = /\r/g
 const LF_RE = /\n/g
+
+function camelizeBindShorthandArg(value: string) {
+  return value.replace(/-([\w$])/g, (_, char: string) => char.toUpperCase())
+}
+
+export function getBindDirectiveExpression(node: DirectiveNode): string {
+  const rawExp = node.exp?.type === NodeTypes.SIMPLE_EXPRESSION ? node.exp.content : ''
+  if (rawExp) {
+    return rawExp
+  }
+
+  if (
+    node.name !== 'bind'
+    || node.arg?.type !== NodeTypes.SIMPLE_EXPRESSION
+    || !node.arg.isStatic
+  ) {
+    return ''
+  }
+
+  const rawArg = node.arg.content.trim()
+  if (!rawArg || !BIND_SHORTHAND_ARG_RE.test(rawArg)) {
+    return ''
+  }
+
+  return camelizeBindShorthandArg(rawArg)
+}
 
 export function collectScopePropMapping(context: TransformContext): Record<string, string> {
   const mapping: Record<string, string> = {}
@@ -116,15 +143,6 @@ export function collectScopePropMapping(context: TransformContext): Record<strin
   return mapping
 }
 
-export function buildScopePropsExpression(context: TransformContext): string | null {
-  const mapping = collectScopePropMapping(context)
-  const keys = Object.keys(mapping)
-  if (!keys.length) {
-    return null
-  }
-  return `[${keys.map(key => `${toWxmlStringLiteral(key)},${key}`).join(',')}]`
-}
-
 export function toWxmlStringLiteral(value: string) {
   const escaped = value
     .replace(BACKSLASH_RE, '\\\\')
@@ -132,6 +150,15 @@ export function toWxmlStringLiteral(value: string) {
     .replace(CR_RE, '\\r')
     .replace(LF_RE, '\\n')
   return `'${escaped}'`
+}
+
+export function buildScopePropsExpression(context: TransformContext): string | null {
+  const mapping = collectScopePropMapping(context)
+  const keys = Object.keys(mapping)
+  if (!keys.length) {
+    return null
+  }
+  return `[${keys.map(key => `${toWxmlStringLiteral(key)},${key}`).join(',')}]`
 }
 
 export function hashString(input: string) {

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/slotProps.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/slotProps.ts
@@ -4,7 +4,7 @@ import { NodeTypes } from '@vue/compiler-core'
 import * as t from '@weapp-vite/ast/babelTypes'
 import { parse as babelParse } from '../../../../../utils/babel'
 import { normalizeWxmlExpressionWithContext } from '../expression'
-import { toWxmlStringLiteral } from './helpers'
+import { getBindDirectiveExpression, toWxmlStringLiteral } from './helpers'
 
 const BACKSLASH_RE = /\\/g
 const SINGLE_QUOTE_RE = /'/g
@@ -82,7 +82,7 @@ export function collectSlotBindingExpression(node: ElementNode, context: Transfo
     }
     if (prop.type === NodeTypes.DIRECTIVE && prop.name === 'bind') {
       if (prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION) {
-        const rawExpValue = prop.exp?.type === NodeTypes.SIMPLE_EXPRESSION ? prop.exp.content : ''
+        const rawExpValue = getBindDirectiveExpression(prop)
         if (prop.arg.content === 'name') {
           continue
         }

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-component.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-component.ts
@@ -11,7 +11,7 @@ import { transformAttribute } from '../attributes'
 import { transformDirective } from '../directives'
 import { renderMustache } from '../mustache'
 import { collectElementAttributes } from './attrs'
-import { buildScopePropsExpression, findSlotDirective, isScopedSlotsDisabled } from './helpers'
+import { buildScopePropsExpression, findSlotDirective, getBindDirectiveExpression, isScopedSlotsDisabled } from './helpers'
 import { transformNormalElement } from './tag-normal'
 import {
   buildSlotDeclaration,
@@ -254,12 +254,16 @@ export function transformComponentElement(node: ElementNode, context: TransformC
     }
   }
 
-  if (!isDirective || !isDirective.exp) {
+  if (!isDirective) {
     context.warnings.push('<component> 未提供 :is 绑定，将按普通元素处理。')
     return transformNormalElement(node, context, transformNode)
   }
 
-  const componentVar = isDirective.exp.type === NodeTypes.SIMPLE_EXPRESSION ? isDirective.exp.content : ''
+  const componentVar = getBindDirectiveExpression(isDirective)
+  if (!componentVar) {
+    context.warnings.push('<component> 未提供 :is 绑定，将按普通元素处理。')
+    return transformNormalElement(node, context, transformNode)
+  }
 
   const otherProps = node.props.filter(prop => prop !== isDirective)
   const attrs: string[] = []

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts
@@ -13,6 +13,7 @@ import { normalizeWxmlExpressionWithContext } from '../expression'
 import { renderMustache } from '../mustache'
 import {
   collectScopePropMapping,
+  getBindDirectiveExpression,
   hashString,
   isScopedSlotsDisabled,
   withSlotProps,
@@ -63,7 +64,7 @@ export function resolveSlotNameFromSlotElement(node: ElementNode): SlotNameInfo 
     }
     if (prop.type === NodeTypes.DIRECTIVE && prop.name === 'bind') {
       if (prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION && prop.arg.content === 'name') {
-        const raw = prop.exp?.type === NodeTypes.SIMPLE_EXPRESSION ? prop.exp.content : ''
+        const raw = getBindDirectiveExpression(prop)
         if (raw) {
           return { type: 'dynamic', exp: raw }
         }

--- a/packages-runtime/wevu/src/runtime/define.ts
+++ b/packages-runtime/wevu/src/runtime/define.ts
@@ -1,13 +1,11 @@
 import type { InlineExpressionMap } from './register/inline'
 import type {
   ComponentPropsOptions,
-  ComponentPublicInstance,
   ComputedDefinitions,
+  DefineComponent,
   DefineComponentOptions,
-  InferProps,
   MethodDefinitions,
   MiniProgramComponentRawOptions,
-  ShallowUnwrapRef,
 } from './types'
 import { WEVU_SCOPED_SLOT_CREATOR_KEY } from '@weapp-core/constants'
 import { createApp } from './app'
@@ -61,16 +59,13 @@ export interface ComponentDefinition<
 }
 
 type SetupBindings<S> = Exclude<S, void> extends never ? Record<string, never> : Exclude<S, void>
-type ResolveProps<P> = P extends ComponentPropsOptions ? InferProps<P> : P
-export interface WevuComponentConstructor<
-  Props,
+export type WevuDefinedComponent<
+  PropsOrPropOptions,
   RawBindings,
   D extends object,
   C extends ComputedDefinitions,
   M extends MethodDefinitions,
-> {
-  new (): ComponentPublicInstance<D, C, M, Props> & ShallowUnwrapRef<RawBindings>
-}
+> = DefineComponent<PropsOrPropOptions, RawBindings, D, C, M> & ComponentDefinition<D, C, M>
 export interface SetupContextWithTypeProps<TypeProps> {
   props: TypeProps
   [key: string]: any
@@ -131,10 +126,10 @@ export function defineComponent<
   S extends Record<string, any> | void = Record<string, any> | void,
 >(
   options: DefineComponentOptions<P, D, C, M, S>,
-): WevuComponentConstructor<ResolveProps<P>, SetupBindings<S>, D, C, M>
+): WevuDefinedComponent<P, SetupBindings<S>, D, C, M>
 export function defineComponent(
   options: DefineComponentOptions<any, any, any, any, any>,
-): WevuComponentConstructor<Record<string, any>, Record<string, any>, Record<string, any>, ComputedDefinitions, MethodDefinitions> {
+): WevuDefinedComponent<ComponentPropsOptions, Record<string, any>, Record<string, any>, ComputedDefinitions, MethodDefinitions> {
   ensureScopedSlotComponentGlobal()
   const resolvedOptions = applyWevuComponentDefaults(options)
   const {
@@ -200,8 +195,8 @@ export function defineComponent(
     __wevu_options: componentOptions as ComponentDefinition<any, any, any>['__wevu_options'],
   }
 
-  return definition as unknown as WevuComponentConstructor<
-    Record<string, any>,
+  return definition as unknown as WevuDefinedComponent<
+    ComponentPropsOptions,
     Record<string, any>,
     Record<string, any>,
     ComputedDefinitions,

--- a/packages-runtime/wevu/src/vue-types.ts
+++ b/packages-runtime/wevu/src/vue-types.ts
@@ -1,10 +1,13 @@
 /* eslint-disable ts/no-empty-object-type -- 允许空对象类型占位 */
 import type {
   AllowedComponentProps as VueAllowedComponentProps,
+  Component as VueComponent,
   ComponentCustomProps as VueComponentCustomProps,
   ComponentOptionsMixin as VueComponentOptionsMixin,
+  ComponentProvideOptions as VueComponentProvideOptions,
   ComputedOptions as VueComputedOptions,
   DefineComponent as VueDefineComponent,
+  Directive as VueDirective,
   EmitsOptions as VueEmitsOptions,
   MethodOptions as VueMethodOptions,
   ObjectDirective as VueObjectDirective,
@@ -42,6 +45,13 @@ export type DefineComponent<
     ? ExtractDefaultPropTypes<PropsOrPropOptions>
     : {},
   S extends VueSlotsType = VueSlotsType,
+  LC extends Record<string, VueComponent> = {},
+  Directives extends Record<string, VueDirective> = {},
+  Exposed extends string = string,
+  Provide extends VueComponentProvideOptions = VueComponentProvideOptions,
+  MakeDefaultsOptional extends boolean = true,
+  TypeRefs extends Record<string, unknown> = {},
+  TypeEl extends Element = any,
 > = VueDefineComponent<
   PropsOrPropOptions,
   RawBindings,
@@ -55,7 +65,14 @@ export type DefineComponent<
   PP,
   Props,
   Defaults,
-  S
+  S,
+  LC,
+  Directives,
+  Exposed,
+  Provide,
+  MakeDefaultsOptional,
+  TypeRefs,
+  TypeEl
 >
 
 export type NativeComponent<Props = Record<string, any>> = new (...args: any[]) => InstanceType<

--- a/packages-runtime/wevu/test-d/template-ref.test-d.ts
+++ b/packages-runtime/wevu/test-d/template-ref.test-d.ts
@@ -1,9 +1,36 @@
+import type { ComponentOptionsMixin, ComponentProvideOptions, DefineComponent, PublicProps } from 'vue'
 import type { TemplateRef, TemplateRefValue } from '@/index'
 import { expectError, expectType } from 'tsd'
-import { useTemplateRef } from '@/index'
+import { ref, useTemplateRef } from '@/index'
+
+type EmptyRecord = Record<string, never>
+
+type ExposedPanel = DefineComponent<
+  EmptyRecord,
+  {
+    close: () => void
+    open: () => void
+  },
+  EmptyRecord,
+  EmptyRecord,
+  EmptyRecord,
+  ComponentOptionsMixin,
+  ComponentOptionsMixin,
+  EmptyRecord,
+  string,
+  PublicProps,
+  EmptyRecord,
+  EmptyRecord,
+  EmptyRecord,
+  EmptyRecord,
+  EmptyRecord,
+  'open',
+  ComponentProvideOptions
+>
 
 declare module '@/index' {
   interface TemplateRefs {
+    childRef: InstanceType<ExposedPanel>
     headerRef: { title: string }
     viewRef: TemplateRefValue
   }
@@ -16,6 +43,14 @@ expectError(header.value = { title: 'next' })
 
 const view = useTemplateRef('viewRef')
 expectType<TemplateRefValue | null>(view.value)
+
+const child = useTemplateRef('childRef')
+expectType<(() => void) | undefined>(child.value?.open)
+expectError(child.value?.close)
+
+const childRef = ref<InstanceType<ExposedPanel> | null>(null)
+expectType<(() => void) | undefined>(childRef.value?.open)
+expectError(childRef.value?.close)
 
 const unknownRef = useTemplateRef('missing')
 expectType<TemplateRef<unknown>>(unknownRef)

--- a/packages-runtime/wevu/test-d/vue-entry.test-d.ts
+++ b/packages-runtime/wevu/test-d/vue-entry.test-d.ts
@@ -1,4 +1,4 @@
-import type { ComponentPublicInstance, DefineComponent } from 'vue'
+import type { ComponentOptionsMixin, ComponentProvideOptions, ComponentPublicInstance, DefineComponent, PublicProps } from 'vue'
 import type { ExtractDefaultPropTypes, ExtractPropTypes } from 'wevu'
 import { expectError, expectType } from 'tsd'
 
@@ -10,10 +10,41 @@ interface PropsOptions {
 
 type Props = ExtractPropTypes<PropsOptions>
 type Defaults = ExtractDefaultPropTypes<PropsOptions>
+type EmptyRecord = Record<string, never>
 
 type Demo = DefineComponent<PropsOptions>
+type ExposedDemo = DefineComponent<
+  EmptyRecord,
+  {
+    close: () => void
+    open: () => void
+  },
+  EmptyRecord,
+  EmptyRecord,
+  EmptyRecord,
+  ComponentOptionsMixin,
+  ComponentOptionsMixin,
+  EmptyRecord,
+  string,
+  PublicProps,
+  EmptyRecord,
+  EmptyRecord,
+  EmptyRecord,
+  EmptyRecord,
+  EmptyRecord,
+  'open',
+  ComponentProvideOptions,
+  true,
+  {
+    panel: {
+      open: () => void
+    }
+  },
+  HTMLElementTagNameMap['view']
+>
 
 declare const instance: InstanceType<Demo>
+declare const exposedInstance: InstanceType<ExposedDemo>
 declare const publicInstance: ComponentPublicInstance
 
 expectType<string | undefined>(instance.$props.msg)
@@ -26,6 +57,11 @@ expectError(instance.$props.nonexistent)
 expectType<Record<string, any>>(publicInstance.$props)
 expectType<Record<string, any>>(publicInstance.$slots)
 expectType<(event: string, detail?: any, options?: any) => void>(publicInstance.$emit)
+
+expectType<() => void>(exposedInstance.open)
+expectError(exposedInstance.close)
+expectType<() => void>(exposedInstance.$refs.panel.open)
+expectType<HTMLElementTagNameMap['view']>(exposedInstance.$el)
 
 expectType<Props>({} as Props)
 expectType<Defaults>({} as Defaults)

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts
@@ -940,7 +940,7 @@ describe('core lifecycle emit hook extra branches', () => {
         fileName: 'common.js',
         code: [
           'const __keep__ = [XMLHttpRequest, WebSocket];',
-          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return t}',
+          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return t}',
           'Object.defineProperty(exports,`At`,{enumerable:!0,get:function(){return vn}})',
         ].join(';'),
         imports: [],
@@ -997,7 +997,7 @@ describe('core lifecycle emit hook extra branches', () => {
         fileName: 'common.js',
         code: [
           'const __keep__ = [XMLHttpRequest, WebSocket];',
-          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return { URL: Date, URLSearchParams: Map, Blob: Array, FormData: Map, fetch: Promise.resolve, Headers: Object, Request: Object, Response: Object, AbortController: Object, AbortSignal: Object, XMLHttpRequest: Object, WebSocket: Object }}',
+          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return { URL: Date, URLSearchParams: Map, Blob: Array, FormData: Map, fetch: Promise.resolve, Headers: Object, Request: Object, Response: Object, AbortController: Object, AbortSignal: Object, XMLHttpRequest: Object, WebSocket: Object }}',
           'Object.defineProperty(exports,`noop`,{enumerable:!0,get:function(){return __keep__}})',
         ].join(';'),
         imports: [],
@@ -1053,7 +1053,7 @@ describe('core lifecycle emit hook extra branches', () => {
         type: 'chunk',
         fileName: 'dist.js',
         code: [
-          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return t}',
+          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return t}',
           'Object.defineProperty(exports,`At`,{enumerable:!0,get:function(){return vn}})',
         ].join(';'),
         imports: [],
@@ -1108,7 +1108,7 @@ describe('core lifecycle emit hook extra branches', () => {
         fileName: 'pages/request-globals/fetch.js',
         code: [
           'const e=require("../../common.js");',
-          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return { URL: Date, fetch: Promise.resolve, Headers: Object, Request: Object, Response: Object, AbortController: Object, AbortSignal: Object, XMLHttpRequest: Object, WebSocket: Object, URLSearchParams: Object, Blob: Object, FormData: Object }}',
+          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return { URL: Date, fetch: Promise.resolve, Headers: Object, Request: Object, Response: Object, AbortController: Object, AbortSignal: Object, XMLHttpRequest: Object, WebSocket: Object, URLSearchParams: Object, Blob: Object, FormData: Object }}',
           'console.log(fetch, URL);',
           'Page({});',
         ].join(''),
@@ -1151,7 +1151,7 @@ describe('core lifecycle emit hook extra branches', () => {
         type: 'chunk',
         fileName: 'dist.js',
         code: [
-          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return t}',
+          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return t}',
           'Object.defineProperty(exports,`At`,{enumerable:!0,get:function(){return vn}})',
         ].join(';'),
         imports: [],
@@ -1195,7 +1195,7 @@ describe('core lifecycle emit hook extra branches', () => {
         type: 'chunk',
         fileName: 'common.js',
         code: [
-          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return { URL: Date, fetch: Promise.resolve, Headers: Object, Request: Object, Response: Object, AbortController: Object, AbortSignal: Object, XMLHttpRequest: Object, WebSocket: Object, URLSearchParams: Object, Blob: Object, FormData: Object }}',
+          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return { URL: Date, fetch: Promise.resolve, Headers: Object, Request: Object, Response: Object, AbortController: Object, AbortSignal: Object, XMLHttpRequest: Object, WebSocket: Object, URLSearchParams: Object, Blob: Object, FormData: Object }}',
           'Object.defineProperty(exports,`At`,{enumerable:!0,get:function(){return vn}})',
         ].join(';'),
         imports: [],
@@ -1246,7 +1246,7 @@ describe('core lifecycle emit hook extra branches', () => {
         code: [
           'const e=require("./common.js");',
           'const __keep__ = [Request, WebSocket];',
-          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return { URL: Date, fetch: Promise.resolve, Headers: Object, Request: Object, Response: Object, AbortController: Object, AbortSignal: Object, XMLHttpRequest: Object, WebSocket: Object, URLSearchParams: Object, Blob: Object, FormData: Object }}',
+          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return { URL: Date, fetch: Promise.resolve, Headers: Object, Request: Object, Response: Object, AbortController: Object, AbortSignal: Object, XMLHttpRequest: Object, WebSocket: Object, URLSearchParams: Object, Blob: Object, FormData: Object }}',
           'Object.defineProperty(exports,`At`,{enumerable:!0,get:function(){return vn}})',
         ].join(''),
         imports: ['common.js'],
@@ -1299,7 +1299,7 @@ describe('core lifecycle emit hook extra branches', () => {
         type: 'chunk',
         fileName: 'common.js',
         code: [
-          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return { fetch: Promise.resolve, Headers: Object, Request: Object, Response: Object, AbortController: Object, AbortSignal: Object, XMLHttpRequest: Object, WebSocket: Object, URL: Object, URLSearchParams: Object, Blob: Object, FormData: Object }}',
+          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return { fetch: Promise.resolve, Headers: Object, Request: Object, Response: Object, AbortController: Object, AbortSignal: Object, XMLHttpRequest: Object, WebSocket: Object, URL: Object, URLSearchParams: Object, Blob: Object, FormData: Object }}',
           'Object.defineProperty(exports,`At`,{enumerable:!0,get:function(){return vn}})',
         ].join(''),
         imports: [],
@@ -1360,7 +1360,7 @@ describe('core lifecycle emit hook extra branches', () => {
         type: 'chunk',
         fileName: 'common.js',
         code: [
-          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return { fetch: Promise.resolve, Headers: Object, Request: Object, Response: Object, AbortController: Object, AbortSignal: Object, XMLHttpRequest: Object, WebSocket: Object, URL: Object, URLSearchParams: Object, Blob: Object, FormData: Object }}',
+          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return { fetch: Promise.resolve, Headers: Object, Request: Object, Response: Object, AbortController: Object, AbortSignal: Object, XMLHttpRequest: Object, WebSocket: Object, URL: Object, URLSearchParams: Object, Blob: Object, FormData: Object }}',
           'Object.defineProperty(exports,`At`,{enumerable:!0,get:function(){return vn}})',
         ].join(''),
         imports: [],
@@ -1431,7 +1431,7 @@ describe('core lifecycle emit hook extra branches', () => {
         type: 'chunk',
         fileName: 'common.js',
         code: [
-          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return { fetch: Promise.resolve, Headers: Object, Request: Object, Response: Object, AbortController: Object, AbortSignal: Object, XMLHttpRequest: Object, WebSocket: Object, URL: Object, URLSearchParams: Object, Blob: Object, FormData: Object }}',
+          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return { fetch: Promise.resolve, Headers: Object, Request: Object, Response: Object, AbortController: Object, AbortSignal: Object, XMLHttpRequest: Object, WebSocket: Object, URL: Object, URLSearchParams: Object, Blob: Object, FormData: Object }}',
           'Object.defineProperty(exports,`At`,{enumerable:!0,get:function(){return vn}})',
         ].join(''),
         imports: [],

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts
@@ -1018,7 +1018,7 @@ describe('core lifecycle emit hook extra branches', () => {
     expect(bundle['common.js'].code).toContain(`Object.defineProperty(exports,${JSON.stringify(REQUEST_GLOBAL_SYNTHETIC_EXPORT_NAME)},{enumerable:false,get:function(){return vn}});`)
     expect(bundle['pages/request-globals/fetch.js'].code).toContain(REQUEST_GLOBAL_LOCAL_BINDINGS_MARKER)
     expect(bundle['pages/request-globals/fetch.js'].code).toContain(`const ${REQUEST_GLOBAL_CHUNK_MODULE_REF} = require("../../common.js")`)
-    expect(bundle['pages/request-globals/fetch.js'].code).toContain(`const ${REQUEST_GLOBAL_CHUNK_HOST_REF} = ${REQUEST_GLOBAL_CHUNK_MODULE_REF}[${JSON.stringify(REQUEST_GLOBAL_SYNTHETIC_EXPORT_NAME)}]({ targets: ["fetch","Headers","Request","Response","TextEncoder","TextDecoder","AbortController","AbortSignal","XMLHttpRequest"] }) || globalThis`)
+    expect(bundle['pages/request-globals/fetch.js'].code).toContain(`const ${REQUEST_GLOBAL_CHUNK_HOST_REF} = ${REQUEST_GLOBAL_CHUNK_MODULE_REF}[${JSON.stringify(REQUEST_GLOBAL_SYNTHETIC_EXPORT_NAME)}]({ targets: ["fetch","Headers","Request","Response","AbortController","AbortSignal","XMLHttpRequest"] }) || globalThis`)
     expect(bundle['pages/request-globals/fetch.js'].code).toContain(`var fetch = ${REQUEST_GLOBAL_CHUNK_HOST_REF}.fetch`)
     expect(bundle['pages/request-globals/fetch.js'].code).toContain(`var URL = ${REQUEST_GLOBAL_CHUNK_HOST_REF}.URL`)
   })
@@ -1079,7 +1079,7 @@ describe('core lifecycle emit hook extra branches', () => {
 
     expect(bundle['pages/request-globals/fetch.js'].code).toContain(REQUEST_GLOBAL_LOCAL_BINDINGS_MARKER)
     expect(bundle['pages/request-globals/fetch.js'].code).toContain(`const ${REQUEST_GLOBAL_CHUNK_MODULE_REF} = require("../../dist.js")`)
-    expect(bundle['pages/request-globals/fetch.js'].code).toContain(`const ${REQUEST_GLOBAL_CHUNK_HOST_REF} = ${REQUEST_GLOBAL_CHUNK_MODULE_REF}["At"]({ targets: ["fetch","Headers","Request","Response","TextEncoder","TextDecoder","AbortController","AbortSignal","XMLHttpRequest"] }) || globalThis`)
+    expect(bundle['pages/request-globals/fetch.js'].code).toContain(`const ${REQUEST_GLOBAL_CHUNK_HOST_REF} = ${REQUEST_GLOBAL_CHUNK_MODULE_REF}["At"]({ targets: ["fetch","Headers","Request","Response","AbortController","AbortSignal","XMLHttpRequest"] }) || globalThis`)
     expect(bundle['pages/request-globals/fetch.js'].code).toContain(`const ${REQUEST_GLOBAL_INSTALLER_HOST_REF} = t["At"]({ targets: ["fetch"] }) || globalThis;`)
     expect(bundle['pages/request-globals/fetch.js'].code).toContain(`var fetch = ${REQUEST_GLOBAL_CHUNK_HOST_REF}.fetch`)
   })

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts
@@ -1018,7 +1018,7 @@ describe('core lifecycle emit hook extra branches', () => {
     expect(bundle['common.js'].code).toContain(`Object.defineProperty(exports,${JSON.stringify(REQUEST_GLOBAL_SYNTHETIC_EXPORT_NAME)},{enumerable:false,get:function(){return vn}});`)
     expect(bundle['pages/request-globals/fetch.js'].code).toContain(REQUEST_GLOBAL_LOCAL_BINDINGS_MARKER)
     expect(bundle['pages/request-globals/fetch.js'].code).toContain(`const ${REQUEST_GLOBAL_CHUNK_MODULE_REF} = require("../../common.js")`)
-    expect(bundle['pages/request-globals/fetch.js'].code).toContain(`const ${REQUEST_GLOBAL_CHUNK_HOST_REF} = ${REQUEST_GLOBAL_CHUNK_MODULE_REF}[${JSON.stringify(REQUEST_GLOBAL_SYNTHETIC_EXPORT_NAME)}]({ targets: ["fetch","Headers","Request","Response","AbortController","AbortSignal","XMLHttpRequest"] }) || globalThis`)
+    expect(bundle['pages/request-globals/fetch.js'].code).toContain(`const ${REQUEST_GLOBAL_CHUNK_HOST_REF} = ${REQUEST_GLOBAL_CHUNK_MODULE_REF}[${JSON.stringify(REQUEST_GLOBAL_SYNTHETIC_EXPORT_NAME)}]({ targets: ["fetch","Headers","Request","Response","TextEncoder","TextDecoder","AbortController","AbortSignal","XMLHttpRequest"] }) || globalThis`)
     expect(bundle['pages/request-globals/fetch.js'].code).toContain(`var fetch = ${REQUEST_GLOBAL_CHUNK_HOST_REF}.fetch`)
     expect(bundle['pages/request-globals/fetch.js'].code).toContain(`var URL = ${REQUEST_GLOBAL_CHUNK_HOST_REF}.URL`)
   })
@@ -1079,7 +1079,7 @@ describe('core lifecycle emit hook extra branches', () => {
 
     expect(bundle['pages/request-globals/fetch.js'].code).toContain(REQUEST_GLOBAL_LOCAL_BINDINGS_MARKER)
     expect(bundle['pages/request-globals/fetch.js'].code).toContain(`const ${REQUEST_GLOBAL_CHUNK_MODULE_REF} = require("../../dist.js")`)
-    expect(bundle['pages/request-globals/fetch.js'].code).toContain(`const ${REQUEST_GLOBAL_CHUNK_HOST_REF} = ${REQUEST_GLOBAL_CHUNK_MODULE_REF}["At"]({ targets: ["fetch","Headers","Request","Response","AbortController","AbortSignal","XMLHttpRequest"] }) || globalThis`)
+    expect(bundle['pages/request-globals/fetch.js'].code).toContain(`const ${REQUEST_GLOBAL_CHUNK_HOST_REF} = ${REQUEST_GLOBAL_CHUNK_MODULE_REF}["At"]({ targets: ["fetch","Headers","Request","Response","TextEncoder","TextDecoder","AbortController","AbortSignal","XMLHttpRequest"] }) || globalThis`)
     expect(bundle['pages/request-globals/fetch.js'].code).toContain(`const ${REQUEST_GLOBAL_INSTALLER_HOST_REF} = t["At"]({ targets: ["fetch"] }) || globalThis;`)
     expect(bundle['pages/request-globals/fetch.js'].code).toContain(`var fetch = ${REQUEST_GLOBAL_CHUNK_HOST_REF}.fetch`)
   })

--- a/packages/weapp-vite/src/runtime/webApis/index.ts
+++ b/packages/weapp-vite/src/runtime/webApis/index.ts
@@ -1,1 +1,6 @@
+export {
+  installAbortGlobals,
+  installRequestGlobals,
+  installWebRuntimeGlobals,
+} from '@wevu/web-apis'
 export * from '@wevu/web-apis'

--- a/packages/weapp-vite/src/webApis.ts
+++ b/packages/weapp-vite/src/webApis.ts
@@ -1,1 +1,6 @@
+export {
+  installAbortGlobals,
+  installRequestGlobals,
+  installWebRuntimeGlobals,
+} from '@wevu/web-apis'
 export * from '@wevu/web-apis'

--- a/packages/weapp-vite/test/vue/compiler.test.ts
+++ b/packages/weapp-vite/test/vue/compiler.test.ts
@@ -758,6 +758,24 @@ describe('Vue Template Compiler', () => {
       expect(result.code).toContain('data-name="{{item.name}}"')
     })
 
+    it('should support Vue 3.4 v-bind shorthand for static props', () => {
+      const result = compileVueTemplateToWxml(
+        '<view :visible :foo-bar>Item</view>',
+        'test.vue',
+      )
+      expect(result.code).toContain('visible="{{visible}}"')
+      expect(result.code).toContain('foo-bar="{{fooBar}}"')
+    })
+
+    it('should support Vue 3.4 v-bind shorthand for dynamic component is', () => {
+      const result = compileVueTemplateToWxml(
+        '<component :is />',
+        'test.vue',
+      )
+      expect(result.code).toContain('<component data-is="{{is}}"></component>')
+      expect(result.warnings).not.toContain('<component> 未提供 :is 绑定，将按普通元素处理。')
+    })
+
     it('should compile inline @click expression with $event to inline handler', () => {
       const result = compileVueTemplateToWxml(
         '<button @click="handle(\'ok\', $event)">Click</button>',


### PR DESCRIPTION
## Summary

修复 `wevu` 组件模板 ref 的类型推导缺口，避免 `defineExpose()` 暴露成员在 `ref()` 和 `useTemplateRef()` 两条路径上丢失。

## Changes

- 让 `packages-runtime/wevu/src/runtime/define.ts` 的 `defineComponent()` 返回类型重新对齐 `DefineComponent`，不再被自定义构造器截窄公开实例类型
- 补齐 `packages-runtime/wevu/src/vue-types.ts` 对 Vue 3.5 `DefineComponent` 额外泛型的透传，覆盖 `Exposed`、`TypeRefs`、`TypeEl` 等类型信息
- 为 `ref()` / `useTemplateRef()` 新增 `tsd` 回归用例，锁定 `defineExpose()` 暴露成员、`$refs` 与 `$el` 的推导结果
- 添加 changeset，声明本次 `wevu` 用户可见的类型修复

## Testing

- `cd packages-runtime/wevu && node ../../node_modules/tsd/dist/cli.js` 通过
- `cd packages-runtime/wevu && ../../node_modules/.bin/tsdown` 通过
- `node node_modules/eslint/bin/eslint.js packages-runtime/wevu/src/runtime/define.ts packages-runtime/wevu/src/vue-types.ts packages-runtime/wevu/test-d/template-ref.test-d.ts packages-runtime/wevu/test-d/vue-entry.test-d.ts` 通过

## Related Issues

Fixes #446
