### PR TITLE
fix(wevu): skip proxying unsupported built-in objects

### DIFF
--- a/.changeset/smart-buses-film.md
+++ b/.changeset/smart-buses-film.md
@@ -1,0 +1,6 @@
+---
+'wevu': patch
+'create-weapp-vite': patch
+---
+
+修复 `wevu` 响应式系统对 `Date`、`Map`、`Set`、`WeakMap` 与 `WeakSet` 等内置对象的错误代理行为。现在 `reactive()` 与 `shallowReactive()` 会直接返回这些内置对象本身，不再生成不可靠的 Proxy；同时为集合类型保留后续引入专用 collection handlers 的扩展注释，避免当前出现“被代理但方法绑定异常”的半可用状态。

--- a/.changeset/smart-buses-film.md
+++ b/.changeset/smart-buses-film.md
@@ -3,4 +3,4 @@
 'create-weapp-vite': patch
 ---
 
-修复 `wevu` 响应式系统对 `Date`、`Map`、`Set`、`WeakMap` 与 `WeakSet` 等内置对象的错误代理行为。现在 `reactive()` 与 `shallowReactive()` 会直接返回这些内置对象本身，不再生成不可靠的 Proxy；同时为集合类型保留后续引入专用 collection handlers 的扩展注释，避免当前出现“被代理但方法绑定异常”的半可用状态。
+修复 `wevu` 响应式/只读包装对 `Date`、`Map`、`Set`、`WeakMap` 与 `WeakSet` 等内置对象的错误代理行为。现在 `reactive()`、`shallowReactive()`、`readonly()` 与 `shallowReadonly()` 会直接返回这些内置对象本身，不再生成不可靠的 Proxy；同时为集合类型保留后续引入专用 collection handlers 的扩展注释，避免当前出现“被代理但方法绑定异常”的半可用状态。

--- a/packages-runtime/wevu/src/reactivity/reactive.ts
+++ b/packages-runtime/wevu/src/reactivity/reactive.ts
@@ -14,7 +14,7 @@ import {
   removeParentLink,
   resolvePathToTarget,
 } from './reactive/patchState'
-import { isArrayIndexKey, isObject, ReactiveFlags, toRaw, VERSION_KEY } from './reactive/shared'
+import { getTargetType, isArrayIndexKey, isObject, ReactiveFlags, TargetType, toRaw, VERSION_KEY } from './reactive/shared'
 import { rawMap, reactiveMap } from './reactive/state'
 
 export { addMutationRecorder, removeMutationRecorder } from './reactive/mutation'
@@ -208,11 +208,14 @@ export function reactive<T extends object>(target: T): T {
   if (!isObject(target)) {
     return target
   }
+  if ((target as any)[ReactiveFlags.IS_REACTIVE]) {
+    return target
+  }
   const existingProxy = reactiveMap.get(target)
   if (existingProxy) {
     return existingProxy
   }
-  if ((target as any)[ReactiveFlags.IS_REACTIVE]) {
+  if (getTargetType(target) === TargetType.INVALID) {
     return target
   }
   const proxy = new Proxy(target, mutableHandlers)

--- a/packages-runtime/wevu/src/reactivity/reactive/shallow.ts
+++ b/packages-runtime/wevu/src/reactivity/reactive/shallow.ts
@@ -1,6 +1,6 @@
 import { track, trigger } from '../core'
 import { bumpRawVersion, rawVersionMap } from './patchState'
-import { isObject, ReactiveFlags, toRaw, VERSION_KEY } from './shared'
+import { getTargetType, isObject, ReactiveFlags, TargetType, toRaw, VERSION_KEY } from './shared'
 import { rawMap, shallowReactiveMap } from './state'
 
 const shallowHandlers: ProxyHandler<any> = {
@@ -64,11 +64,14 @@ export function shallowReactive<T extends object>(target: T): T {
   if (!isObject(target)) {
     return target
   }
+  if ((target as any)[ReactiveFlags.IS_REACTIVE]) {
+    return target
+  }
   const existingProxy = shallowReactiveMap.get(target)
   if (existingProxy) {
     return existingProxy
   }
-  if ((target as any)[ReactiveFlags.IS_REACTIVE]) {
+  if (getTargetType(target) === TargetType.INVALID) {
     return target
   }
   const proxy = new Proxy(target, shallowHandlers)

--- a/packages-runtime/wevu/src/reactivity/reactive/shared.ts
+++ b/packages-runtime/wevu/src/reactivity/reactive/shared.ts
@@ -35,7 +35,7 @@ function targetTypeMap(rawType: string) {
 }
 
 export function getTargetType(value: object) {
-  return (value as any)[ReactiveFlags.SKIP] || !Object.isExtensible(value)
+  return (value as any)[ReactiveFlags.SKIP]
     ? TargetType.INVALID
     : targetTypeMap(toRawType(value))
 }

--- a/packages-runtime/wevu/src/reactivity/reactive/shared.ts
+++ b/packages-runtime/wevu/src/reactivity/reactive/shared.ts
@@ -5,8 +5,39 @@ export enum ReactiveFlags {
   SKIP = '__r_skip', // 标记此对象无需转换为响应式（用于 markRaw）
 }
 
+export enum TargetType {
+  INVALID = 0,
+  COMMON = 1,
+}
+
 export function isObject(value: unknown): value is object {
   return typeof value === 'object' && value !== null
+}
+
+export function toRawType(value: unknown) {
+  return Object.prototype.toString.call(value).slice(8, -1)
+}
+
+function targetTypeMap(rawType: string) {
+  switch (rawType) {
+    case 'Object':
+    case 'Array':
+      return TargetType.COMMON
+    case 'Map':
+    case 'Set':
+    case 'WeakMap':
+    case 'WeakSet':
+      // TODO: 后续如需支持集合响应式，需要引入专门的 collection handlers。
+      return TargetType.INVALID
+    default:
+      return TargetType.INVALID
+  }
+}
+
+export function getTargetType(value: object) {
+  return (value as any)[ReactiveFlags.SKIP] || !Object.isExtensible(value)
+    ? TargetType.INVALID
+    : targetTypeMap(toRawType(value))
 }
 
 // 版本键（VERSION_KEY）表示“任意字段发生变化”，用于订阅整体版本避免深度遍历跟踪

--- a/packages-runtime/wevu/src/reactivity/readonly.ts
+++ b/packages-runtime/wevu/src/reactivity/readonly.ts
@@ -1,6 +1,6 @@
 import type { Ref } from './ref'
 import { isObject, isReactive } from './reactive'
-import { ReactiveFlags } from './reactive/shared'
+import { getTargetType, ReactiveFlags, TargetType } from './reactive/shared'
 import { isRef, markAsRef } from './ref'
 
 function createReadonlyWrapper(target: any): any {
@@ -27,6 +27,9 @@ function createReadonlyWrapper(target: any): any {
     return readonlyRef
   }
   if (!isObject(target)) {
+    return target
+  }
+  if (getTargetType(target as object) === TargetType.INVALID) {
     return target
   }
   return new Proxy(target as object, {

--- a/packages-runtime/wevu/test/reactivity-mutation.test.ts
+++ b/packages-runtime/wevu/test/reactivity-mutation.test.ts
@@ -4,6 +4,7 @@ import type {
 import { describe, expect, it } from 'vitest'
 import {
   addMutationRecorder,
+  isReactive,
   markRaw,
   prelinkReactiveTree,
   reactive,
@@ -96,6 +97,11 @@ describe('reactive mutation tracking', () => {
     expect(shallowReactive(base)).toBe(proxy)
     expect(shallowReactive(proxy)).toBe(proxy)
     expect(isShallowReactive(proxy)).toBe(true)
+    const date = new Date('2024-01-01')
+    expect(shallowReactive(date)).toBe(date)
+    const map = new Map()
+    expect(shallowReactive(map)).toBe(map)
+    expect(isReactive(shallowReactive(map))).toBe(false)
 
     delete (proxy as any).missing
   })

--- a/packages-runtime/wevu/test/reactivity-mutation.test.ts
+++ b/packages-runtime/wevu/test/reactivity-mutation.test.ts
@@ -102,6 +102,16 @@ describe('reactive mutation tracking', () => {
     const map = new Map()
     expect(shallowReactive(map)).toBe(map)
     expect(isReactive(shallowReactive(map))).toBe(false)
+    const set = new Set([1, 2, 3])
+    expect(shallowReactive(set)).toBe(set)
+    const weakMap = new WeakMap<object, string>()
+    const weakMapKey = {}
+    weakMap.set(weakMapKey, 'value')
+    expect(shallowReactive(weakMap)).toBe(weakMap)
+    const weakSet = new WeakSet<object>()
+    const weakSetValue = {}
+    weakSet.add(weakSetValue)
+    expect(shallowReactive(weakSet)).toBe(weakSet)
 
     delete (proxy as any).missing
   })

--- a/packages-runtime/wevu/test/reactivity-reactive-extended.test.ts
+++ b/packages-runtime/wevu/test/reactivity-reactive-extended.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { effect } from '@/reactivity/core'
 import { convertToReactive, isReactive, reactive, toRaw, touchReactive } from '@/reactivity/reactive'
+import { ref } from '@/reactivity/ref'
 
 describe('reactive - edge cases and boundary values', () => {
   describe('reactive on primitives', () => {
@@ -497,6 +498,12 @@ describe('reactive - edge cases and boundary values', () => {
       expect(observed).toBe(weakSet)
       expect(isReactive(observed)).toBe(false)
       expect(toRaw(observed)).toBe(weakSet)
+    })
+
+    it('should keep Date methods usable when wrapped by ref', () => {
+      const dateRef = ref(new Date('2024-01-01T00:00:00.000Z'))
+
+      expect(dateRef.value.valueOf()).toBe(new Date('2024-01-01T00:00:00.000Z').valueOf())
     })
 
     it('should handle deeply nested structures', () => {

--- a/packages-runtime/wevu/test/reactivity-reactive-extended.test.ts
+++ b/packages-runtime/wevu/test/reactivity-reactive-extended.test.ts
@@ -450,30 +450,53 @@ describe('reactive - edge cases and boundary values', () => {
       expect(effectCount).toBe(2)
     })
 
-    it('should handle Date objects', () => {
+    it('should not proxy Date objects', () => {
       const date = new Date('2024-01-01')
-      const proxy = reactive(date)
+      const observed = reactive(date)
 
-      expect(isReactive(proxy)).toBe(true)
-      // 说明：Date 对象在 Proxy 下存在兼容性问题，这里只验证其为 reactive
-      expect(toRaw(proxy)).toBe(date)
+      expect(observed).toBe(date)
+      expect(isReactive(observed)).toBe(false)
+      expect(toRaw(observed)).toBe(date)
     })
 
-    it('should handle Map objects', () => {
+    it('should not proxy Map objects', () => {
       const map = new Map([['key', 'value']])
-      const proxy = reactive(map)
+      const observed = reactive(map)
 
-      expect(isReactive(proxy)).toBe(true)
-      // 说明：Map/Set 在 Proxy 下存在方法绑定问题，这里只验证其为 reactive
-      expect(toRaw(proxy)).toBe(map)
+      expect(observed).toBe(map)
+      expect(isReactive(observed)).toBe(false)
+      expect(toRaw(observed)).toBe(map)
     })
 
-    it('should handle Set objects', () => {
+    it('should not proxy Set objects', () => {
       const set = new Set([1, 2, 3])
-      const proxy = reactive(set)
+      const observed = reactive(set)
 
-      expect(isReactive(proxy)).toBe(true)
-      expect(toRaw(proxy)).toBe(set)
+      expect(observed).toBe(set)
+      expect(isReactive(observed)).toBe(false)
+      expect(toRaw(observed)).toBe(set)
+    })
+
+    it('should not proxy WeakMap objects', () => {
+      const weakMap = new WeakMap<object, string>()
+      const key = {}
+      weakMap.set(key, 'value')
+      const observed = reactive(weakMap)
+
+      expect(observed).toBe(weakMap)
+      expect(isReactive(observed)).toBe(false)
+      expect(toRaw(observed)).toBe(weakMap)
+    })
+
+    it('should not proxy WeakSet objects', () => {
+      const weakSet = new WeakSet<object>()
+      const value = {}
+      weakSet.add(value)
+      const observed = reactive(weakSet)
+
+      expect(observed).toBe(weakSet)
+      expect(isReactive(observed)).toBe(false)
+      expect(toRaw(observed)).toBe(weakSet)
     })
 
     it('should handle deeply nested structures', () => {

--- a/packages-runtime/wevu/test/reactivity-readonly.test.ts
+++ b/packages-runtime/wevu/test/reactivity-readonly.test.ts
@@ -172,6 +172,7 @@ describe('readonly - edge cases and boundary values', () => {
       expect(ro).toBe(date)
       expect(ro.valueOf()).toBe(date.valueOf())
       expect(isReadonly(ro)).toBe(false)
+      expect(isProxy(ro)).toBe(false)
     })
 
     it('should return Map as-is', () => {
@@ -181,6 +182,7 @@ describe('readonly - edge cases and boundary values', () => {
       expect(ro).toBe(map)
       expect(ro.get('key')).toBe('value')
       expect(isReadonly(ro)).toBe(false)
+      expect(isProxy(ro)).toBe(false)
     })
 
     it('should return Set as-is', () => {
@@ -190,9 +192,13 @@ describe('readonly - edge cases and boundary values', () => {
       expect(ro).toBe(set)
       expect(ro.has(2)).toBe(true)
       expect(isReadonly(ro)).toBe(false)
+      expect(isProxy(ro)).toBe(false)
     })
 
     it('should keep shallowReadonly aligned for unsupported built-ins', () => {
+      const date = new Date('2024-01-01T00:00:00.000Z')
+      const map = new Map([['key', 'value']])
+      const set = new Set([1, 2, 3])
       const weakMap = new WeakMap<object, string>()
       const key = {}
       weakMap.set(key, 'value')
@@ -200,6 +206,9 @@ describe('readonly - edge cases and boundary values', () => {
       const value = {}
       weakSet.add(value)
 
+      expect(shallowReadonly(date)).toBe(date)
+      expect(shallowReadonly(map)).toBe(map)
+      expect(shallowReadonly(set)).toBe(set)
       expect(shallowReadonly(weakMap)).toBe(weakMap)
       expect(shallowReadonly(weakSet)).toBe(weakSet)
     })

--- a/packages-runtime/wevu/test/reactivity-readonly.test.ts
+++ b/packages-runtime/wevu/test/reactivity-readonly.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { reactive } from '@/reactivity/reactive'
-import { isProxy, isReadonly, readonly } from '@/reactivity/readonly'
+import { isProxy, isReadonly, readonly, shallowReadonly } from '@/reactivity/readonly'
 import { ref } from '@/reactivity/ref'
 
 describe('readonly - edge cases and boundary values', () => {
@@ -161,6 +161,47 @@ describe('readonly - edge cases and boundary values', () => {
       // 嵌套数组不是 readonly
       ro[0][0] = 100
       expect(ro[0][0]).toBe(100)
+    })
+  })
+
+  describe('readonly on unsupported built-ins', () => {
+    it('should return Date as-is', () => {
+      const date = new Date('2024-01-01T00:00:00.000Z')
+      const ro = readonly(date)
+
+      expect(ro).toBe(date)
+      expect(ro.valueOf()).toBe(date.valueOf())
+      expect(isReadonly(ro)).toBe(false)
+    })
+
+    it('should return Map as-is', () => {
+      const map = new Map([['key', 'value']])
+      const ro = readonly(map)
+
+      expect(ro).toBe(map)
+      expect(ro.get('key')).toBe('value')
+      expect(isReadonly(ro)).toBe(false)
+    })
+
+    it('should return Set as-is', () => {
+      const set = new Set([1, 2, 3])
+      const ro = readonly(set)
+
+      expect(ro).toBe(set)
+      expect(ro.has(2)).toBe(true)
+      expect(isReadonly(ro)).toBe(false)
+    })
+
+    it('should keep shallowReadonly aligned for unsupported built-ins', () => {
+      const weakMap = new WeakMap<object, string>()
+      const key = {}
+      weakMap.set(key, 'value')
+      const weakSet = new WeakSet<object>()
+      const value = {}
+      weakSet.add(value)
+
+      expect(shallowReadonly(weakMap)).toBe(weakMap)
+      expect(shallowReadonly(weakSet)).toBe(weakSet)
     })
   })
 

--- a/packages-runtime/wevu/test/reactivity.test.ts
+++ b/packages-runtime/wevu/test/reactivity.test.ts
@@ -64,6 +64,14 @@ describe('reactivity (root version)', () => {
     expect(isReactive({})).toBe(false)
   })
 
+  it('keeps frozen plain objects reactive', () => {
+    const frozen = Object.freeze({ n: 1 })
+    const observed = reactive(frozen)
+
+    expect(observed).not.toBe(frozen)
+    expect(isReactive(observed)).toBe(true)
+  })
+
   it('effect onStop is called and lazy option', () => {
     let cleaned = 0
     const runner = effect(() => {}, {


### PR DESCRIPTION
## 背景

当前 `wevu` 在做响应式转换与只读包装时，会对所有 object 值继续尝试代理，但实际上现在只真正适配了普通对象和数组。

对于 `Map`、`Set`、`WeakMap`、`WeakSet`，目前既没有完整的 collection handlers，也没有排除处理；对于 `Date` 等其他内置对象，也没有提前跳过。这样会导致一些内置对象被错误转换成 Proxy，进而触发方法调用时的 `this` 绑定问题。

例如：

```ts
const d = ref(new Date())
console.log(d.value.valueOf())
```

这类用法在当前实现下会报错。只读包装也存在同类问题，例如 `readonly(new Map()).get(...)` 或 `readonly(new Date()).valueOf()`。

## 改动

本 PR 调整了 `reactive()` / `shallowReactive()` / `readonly()` / `shallowReadonly()` 的目标类型判断逻辑：

- 仅继续代理 `Object` 和 `Array`
- 将 `Map`、`Set`、`WeakMap`、`WeakSet` 视为不受支持类型，直接跳过
- 同时对 `Date` 等其他未支持的内置对象也直接跳过，不再错误转换为 Proxy
- 为集合类型后续如需支持专用响应式处理保留了 `TODO`
- 保持普通 `Object` / `Array` 的既有语义，不额外扩展到新的 non-extensible 行为变化

## 这样处理的原因

这次没有尝试直接补齐 `Map` / `Set` 的响应式支持，是因为这部分需要单独的 collection handlers，以及配套的依赖追踪、迭代器、`size`、只读/浅响应式等语义补全，改动面会明显扩大。

在当前实现尚未真正支持这些内置对象的前提下，先统一跳过会更安全，也更符合预期，能够避免出现“被代理了，但其实不能正确使用”的半可用状态。

## 验证

- 补充并更新了 `Date`、`Map`、`Set`、`WeakMap`、`WeakSet` 的相关测试
- 验证 `reactive()`、`shallowReactive()`、`readonly()` 与 `shallowReadonly()` 对这些内置对象都会直接返回原值
- 补充 `ref(new Date()).value.valueOf()` 回归测试，确认方法调用不再因错误代理而报错
- 补充 frozen plain object 回归测试，锁定本次没有引入额外的 non-extensible 语义变化
- 验证相关 `wevu` 定向测试通过