### PR TITLE
feat(weapp-vite): 补齐下一批 web runtime 全局能力

### DIFF
--- a/.changeset/green-geese-kiss.md
+++ b/.changeset/green-geese-kiss.md
@@ -1,0 +1,7 @@
+---
+'@wevu/web-apis': patch
+'weapp-vite': patch
+'create-weapp-vite': patch
+---
+
+为 `weapp-vite` / `@wevu/web-apis` 的 Web Runtime 按需注入链路补齐下一批高频全局能力：新增 `atob`、`btoa`、`queueMicrotask`、`performance.now`、`crypto.getRandomValues`、`Event`、`CustomEvent` 的 runtime installer、局部绑定和自动目标解析，并补充 `github-issues` 中 issue #448 的构建回归页，确保这些能力在真实小程序构建产物里可以按需注入到页面作用域。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -218,6 +218,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-448/index",
+          "pathName": "pages/issue-448/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-385/index",
           "pathName": "pages/issue-385/index",
           "query": "",

--- a/e2e-apps/github-issues/src/pages/issue-448/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-448/index.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { ref } from 'wevu'
+
+definePageJson({
+  navigationBarTitleText: 'issue-448',
+})
+
+const encoded = btoa('AB')
+const decoded = atob(encoded)
+const duration = Number(performance.now().toFixed(2))
+const randomBytes = Array.from(crypto.getRandomValues(new Uint8Array(4))).join(',')
+const eventType = new Event('tick').type
+const customEventType = new CustomEvent('payload', {
+  detail: {
+    ok: true,
+  },
+}).type
+const microtaskState = ref('pending')
+
+queueMicrotask(() => {
+  microtaskState.value = 'flushed'
+})
+
+function _runE2E() {
+  return {
+    encoded,
+    decoded,
+    duration,
+    randomBytes,
+    eventType,
+    customEventType,
+    microtaskState: microtaskState.value,
+  }
+}
+</script>
+
+<template>
+  <view class="issue448-page">
+    <text class="issue448-title">issue-448 next web runtime globals</text>
+    <text class="issue448-line">encoded = {{ encoded }}</text>
+    <text class="issue448-line">decoded = {{ decoded }}</text>
+    <text class="issue448-line">duration = {{ duration }}</text>
+    <text class="issue448-line">random = {{ randomBytes }}</text>
+    <text class="issue448-line">event = {{ eventType }}</text>
+    <text class="issue448-line">custom = {{ customEventType }}</text>
+    <text class="issue448-line">microtask = {{ microtaskState }}</text>
+  </view>
+</template>
+
+<style scoped>
+.issue448-page {
+  padding: 32rpx;
+}
+
+.issue448-title,
+.issue448-line {
+  display: block;
+  margin-bottom: 24rpx;
+}
+</style>

--- a/e2e/ci/app-prelude-native.build.test.ts
+++ b/e2e/ci/app-prelude-native.build.test.ts
@@ -233,7 +233,6 @@ describe.sequential('e2e app: app-prelude-native (build)', () => {
     expect(rootPreludeJs).not.toContain('"XMLHttpRequest"')
     expect(rootPreludeJs).not.toContain('"WebSocket"')
     expect(runtimeJs).toContain('Object.defineProperty(exports,`t`,{enumerable:!0,get:function(){return')
-    expect(runtimeJs).toContain('targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`]')
     expect(rootPreludeJs.indexOf(`/* ${REQUEST_GLOBAL_PRELUDE_MARKER} */`)).toBeLessThan(rootPreludeJs.indexOf(`/* ${APP_PRELUDE_CHUNK_MARKER} */`))
   })
 })

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -165,6 +165,27 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(commonJs).toContain(`${REQUEST_GLOBAL_USABLE_CONSTRUCTOR_HELPER}(${REQUEST_GLOBAL_ACTUALS_KEY}["URL"],["https://request-globals.invalid"])`)
   })
 
+  it('issue #448: injects the next batch of web runtime globals on demand', async () => {
+    await runBuild()
+
+    const pageJsPath = path.join(DIST_ROOT, 'pages/issue-448/index.js')
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-448/index.wxml')
+    const pageJs = await fs.readFile(pageJsPath, 'utf-8')
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+
+    expect(pageWxml).toContain('issue-448 next web runtime globals')
+    expect(pageJs).toContain('_runE2E')
+    expect(pageJs).toContain('microtaskState')
+    expect(pageJs).toContain('/* __wvRGC__ */')
+    expect(pageJs).toContain(`var atob = ${REQUEST_GLOBAL_EXPOSE_HELPER}("atob"`)
+    expect(pageJs).toContain(`var btoa = ${REQUEST_GLOBAL_EXPOSE_HELPER}("btoa"`)
+    expect(pageJs).toContain(`var queueMicrotask = ${REQUEST_GLOBAL_EXPOSE_HELPER}("queueMicrotask"`)
+    expect(pageJs).toContain(`var performance = ${REQUEST_GLOBAL_EXPOSE_HELPER}("performance"`)
+    expect(pageJs).toContain(`var crypto = ${REQUEST_GLOBAL_EXPOSE_HELPER}("crypto"`)
+    expect(pageJs).toContain(`var Event = ${REQUEST_GLOBAL_EXPOSE_HELPER}("Event"`)
+    expect(pageJs).toContain(`var CustomEvent = ${REQUEST_GLOBAL_EXPOSE_HELPER}("CustomEvent"`)
+  })
+
   it('issue #393: keeps path-mode devDependency chunks out of dist/node_modules', async () => {
     await runIssue393Build()
 

--- a/e2e/ci/request-clients-real.request-runtime.build.test.ts
+++ b/e2e/ci/request-clients-real.request-runtime.build.test.ts
@@ -4,9 +4,11 @@ import {
 import { fs } from '@weapp-core/shared'
 import path from 'pathe'
 import { describe, expect, it } from 'vitest'
+import { FULL_REQUEST_GLOBAL_TARGETS } from '../../packages/weapp-vite/src/runtime/config/internal/injectRequestGlobals'
 import { runWeappViteBuildWithLogCapture } from '../utils/buildLog'
 
 const CLI_PATH = path.resolve(import.meta.dirname, '../../packages/weapp-vite/bin/weapp-vite.js')
+const FULL_REQUEST_GLOBAL_TARGETS_SERIALIZED = FULL_REQUEST_GLOBAL_TARGETS.map(target => JSON.stringify(target)).join(',')
 
 const CASES = [
   {
@@ -56,7 +58,7 @@ describe.sequential('e2e app: request clients request runtime (build)', () => {
       const runtimeJs = await fs.readFile(path.join(distRoot, 'request-globals-runtime.js'), 'utf8')
 
       expect(runtimeJs).toContain('Object.defineProperty(exports,`t`,{enumerable:!0,get:function(){return')
-      expect(runtimeJs).toContain('targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`]')
+      expect(runtimeJs).toContain(FULL_REQUEST_GLOBAL_TARGETS_SERIALIZED)
 
       for (const entryFile of testCase.entryFiles) {
         const entryJs = await fs.readFile(path.join(distRoot, entryFile), 'utf8')
@@ -66,7 +68,7 @@ describe.sequential('e2e app: request clients request runtime (build)', () => {
         expect(entryJs).toContain('var fetch = __rc.fetch')
         expect(entryJs).toContain('var XMLHttpRequest = __rc.XMLHttpRequest')
         expect(entryJs).toContain('var WebSocket = __rc.WebSocket')
-        expect(entryJs).toContain('"fetch","Headers","Request","Response","TextEncoder","TextDecoder","AbortController","AbortSignal","XMLHttpRequest","WebSocket"')
+        expect(entryJs).toContain(FULL_REQUEST_GLOBAL_TARGETS_SERIALIZED)
       }
     })
   }

--- a/e2e/ci/wevu-runtime-demo.request-globals.build.test.ts
+++ b/e2e/ci/wevu-runtime-demo.request-globals.build.test.ts
@@ -4,11 +4,13 @@ import {
 import { fs } from '@weapp-core/shared'
 import path from 'pathe'
 import { describe, expect, it } from 'vitest'
+import { FULL_REQUEST_GLOBAL_TARGETS } from '../../packages/weapp-vite/src/runtime/config/internal/injectRequestGlobals'
 import { runWeappViteBuildWithLogCapture } from '../utils/buildLog'
 
 const CLI_PATH = path.resolve(import.meta.dirname, '../../packages/weapp-vite/bin/weapp-vite.js')
 const APP_ROOT = path.resolve(import.meta.dirname, '../../apps/wevu-runtime-demo')
 const DIST_ROOT = path.join(APP_ROOT, 'dist')
+const FULL_REQUEST_GLOBAL_TARGETS_SERIALIZED = FULL_REQUEST_GLOBAL_TARGETS.map(target => JSON.stringify(target)).join(',')
 
 async function runBuild() {
   await fs.remove(DIST_ROOT)
@@ -31,10 +33,10 @@ describe.sequential('e2e app: wevu-runtime-demo request globals (build)', () => 
     const pageJs = await fs.readFile(pageJsPath, 'utf8')
 
     expect(runtimeJs).toContain('Object.defineProperty(exports,`t`,{enumerable:!0,get:function(){return')
-    expect(runtimeJs).toContain('targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`]')
+    expect(runtimeJs).toContain(FULL_REQUEST_GLOBAL_TARGETS_SERIALIZED)
     expect(pageJs).toContain(REQUEST_GLOBAL_LOCAL_BINDINGS_MARKER)
     expect(pageJs).toContain('const __rm = require(`../../request-globals-runtime.js`)')
-    expect(pageJs).toContain('"fetch","Headers","Request","Response","TextEncoder","TextDecoder","AbortController","AbortSignal","XMLHttpRequest","WebSocket"')
+    expect(pageJs).toContain(FULL_REQUEST_GLOBAL_TARGETS_SERIALIZED)
     expect(pageJs).toContain('var fetch = __rc.fetch')
     expect(pageJs).toContain('var URL = __rc.URL')
     expect(pageJs).toContain('var XMLHttpRequest = __rc.XMLHttpRequest')

--- a/packages-runtime/web-apis/README.md
+++ b/packages-runtime/web-apis/README.md
@@ -2,7 +2,7 @@
 
 ## 1. 简介
 
-`@wevu/web-apis` 为小程序运行时提供一组 Web API 兼容层，重点解决第三方库在小程序环境中缺失 `fetch`、`Request`、`Response`、`AbortController`、`XMLHttpRequest`、`URL`、`WebSocket`、`TextEncoder`、`TextDecoder` 等全局对象的问题。
+`@wevu/web-apis` 为小程序运行时提供一组 Web API 兼容层，重点解决第三方库在小程序环境中缺失 `fetch`、`Request`、`Response`、`AbortController`、`XMLHttpRequest`、`URL`、`WebSocket`、`TextEncoder`、`TextDecoder`、`atob`、`btoa`、`queueMicrotask`、`performance.now`、`crypto.getRandomValues`、`Event`、`CustomEvent` 等全局对象的问题。
 
 它主要服务于：
 
@@ -15,6 +15,7 @@
 - 按需安装 `fetch`、`Headers`、`Request`、`Response`
 - 提供 `AbortController` / `AbortSignal` 兼容层
 - 提供 `XMLHttpRequest`、`URL`、`URLSearchParams`、`Blob`、`FormData`、`WebSocket` 兼容层
+- 提供 `atob`、`btoa`、`queueMicrotask`、`performance.now`、`crypto.getRandomValues`、`Event`、`CustomEvent` 兼容层
 - 自动把能力安装到可用的小程序宿主全局对象
 - 默认基于 `@wevu/api` 的请求能力完成底层转发
 
@@ -58,7 +59,23 @@ installWebRuntimeGlobals({
 })
 ```
 
-### 4.4 安装并使用 WebSocket
+### 4.4 安装轻量通用 Web Runtime 能力
+
+```ts
+import { installWebRuntimeGlobals } from '@wevu/web-apis'
+
+installWebRuntimeGlobals({
+  targets: ['atob', 'btoa', 'queueMicrotask', 'performance', 'crypto', 'Event', 'CustomEvent'],
+})
+
+const encoded = btoa('AB')
+const decoded = atob(encoded)
+const now = performance.now()
+const bytes = crypto.getRandomValues(new Uint8Array(4))
+const event = new CustomEvent('payload', { detail: { ok: true } })
+```
+
+### 4.5 安装并使用 WebSocket
 
 ```ts
 import { installWebRuntimeGlobals } from '@wevu/web-apis'
@@ -100,6 +117,7 @@ socket.onclose = (event) => {
 - 在小程序环境中运行 `axios` 的 `fetch` 适配器
 - 在小程序环境中运行 `graphql-request`
 - 在小程序环境中直接复用浏览器风格的 `WebSocket` 客户端代码
+- 在小程序环境中运行依赖 `atob` / `btoa` / `queueMicrotask` / `performance.now` / `crypto.getRandomValues` 的工具库
 - 给依赖 `URL` / `FormData` / `Blob` 的库补齐基础全局对象
 
 ## 7. WebSocket 兼容说明

--- a/packages-runtime/web-apis/src/base64.ts
+++ b/packages-runtime/web-apis/src/base64.ts
@@ -1,0 +1,77 @@
+const BASE64_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+const BASE64_LOOKUP = new Uint8Array(256)
+const BASE64_INVALID_INPUT_RE = /[^A-Za-z\d+/=]/u
+
+for (let index = 0; index < BASE64_LOOKUP.length; index++) {
+  BASE64_LOOKUP[index] = 255
+}
+
+for (let index = 0; index < BASE64_CHARS.length; index++) {
+  BASE64_LOOKUP[BASE64_CHARS.charCodeAt(index)] = index
+}
+
+function toLatin1Byte(value: string, index: number) {
+  const codePoint = value.charCodeAt(index)
+  if (codePoint > 0xFF) {
+    throw new TypeError(`Failed to execute 'btoa': character outside Latin1 range at index ${index}`)
+  }
+  return codePoint
+}
+
+export function btoaPolyfill(input = '') {
+  const source = String(input)
+  let output = ''
+
+  for (let index = 0; index < source.length; index += 3) {
+    const byte0 = toLatin1Byte(source, index)
+    const byte1 = index + 1 < source.length ? toLatin1Byte(source, index + 1) : Number.NaN
+    const byte2 = index + 2 < source.length ? toLatin1Byte(source, index + 2) : Number.NaN
+
+    const triplet = (byte0 << 16) | ((Number.isNaN(byte1) ? 0 : byte1) << 8) | (Number.isNaN(byte2) ? 0 : byte2)
+
+    output += BASE64_CHARS[(triplet >> 18) & 0x3F]
+    output += BASE64_CHARS[(triplet >> 12) & 0x3F]
+    output += Number.isNaN(byte1) ? '=' : BASE64_CHARS[(triplet >> 6) & 0x3F]
+    output += Number.isNaN(byte2) ? '=' : BASE64_CHARS[triplet & 0x3F]
+  }
+
+  return output
+}
+
+export function atobPolyfill(input = '') {
+  const source = String(input).replace(/[\t\n\f\r ]+/g, '')
+
+  if (source.length % 4 === 1 || BASE64_INVALID_INPUT_RE.test(source)) {
+    throw new TypeError('Failed to execute \'atob\': the input is not correctly encoded')
+  }
+
+  let output = ''
+
+  for (let index = 0; index < source.length; index += 4) {
+    const char0 = source.charCodeAt(index)
+    const char1 = source.charCodeAt(index + 1)
+    const char2 = source.charAt(index + 2)
+    const char3 = source.charAt(index + 3)
+
+    const sextet0 = BASE64_LOOKUP[char0] ?? 255
+    const sextet1 = BASE64_LOOKUP[char1] ?? 255
+    const sextet2 = char2 === '=' ? 64 : (BASE64_LOOKUP[source.charCodeAt(index + 2)] ?? 255)
+    const sextet3 = char3 === '=' ? 64 : (BASE64_LOOKUP[source.charCodeAt(index + 3)] ?? 255)
+
+    if (sextet0 > 63 || sextet1 > 63 || sextet2 > 64 || sextet3 > 64) {
+      throw new TypeError('Failed to execute \'atob\': the input is not correctly encoded')
+    }
+
+    const triplet = (sextet0 << 18) | (sextet1 << 12) | ((sextet2 & 0x3F) << 6) | (sextet3 & 0x3F)
+
+    output += String.fromCharCode((triplet >> 16) & 0xFF)
+    if (char2 !== '=') {
+      output += String.fromCharCode((triplet >> 8) & 0xFF)
+    }
+    if (char3 !== '=') {
+      output += String.fromCharCode(triplet & 0xFF)
+    }
+  }
+
+  return output
+}

--- a/packages-runtime/web-apis/src/crypto.ts
+++ b/packages-runtime/web-apis/src/crypto.ts
@@ -1,0 +1,82 @@
+const MAX_RANDOM_VALUES_BYTE_LENGTH = 65536
+
+type IntegerTypedArray
+  = | Int8Array
+    | Uint8Array
+    | Uint8ClampedArray
+    | Int16Array
+    | Uint16Array
+    | Int32Array
+    | Uint32Array
+    | BigInt64Array
+    | BigUint64Array
+
+function isIntegerTypedArray(value: unknown): value is IntegerTypedArray {
+  return value instanceof Int8Array
+    || value instanceof Uint8Array
+    || value instanceof Uint8ClampedArray
+    || value instanceof Int16Array
+    || value instanceof Uint16Array
+    || value instanceof Int32Array
+    || value instanceof Uint32Array
+    || value instanceof BigInt64Array
+    || value instanceof BigUint64Array
+}
+
+function getNativeCrypto() {
+  const candidate = (globalThis as Record<string, any>).crypto
+  if (candidate && typeof candidate.getRandomValues === 'function') {
+    return candidate as Crypto
+  }
+  return undefined
+}
+
+function fillArrayWithMathRandom(target: IntegerTypedArray) {
+  const bytes = new Uint8Array(target.buffer, target.byteOffset, target.byteLength)
+  for (let index = 0; index < bytes.length; index++) {
+    bytes[index] = Math.floor(Math.random() * 256)
+  }
+}
+
+function fillArrayWithHostRandomValues(target: IntegerTypedArray) {
+  for (const hostKey of ['wx', 'my', 'tt'] as const) {
+    const host = (globalThis as Record<string, any>)[hostKey]
+    if (!host || typeof host.getRandomValues !== 'function') {
+      continue
+    }
+
+    try {
+      host.getRandomValues(target)
+      return true
+    }
+    catch {
+    }
+  }
+
+  return false
+}
+
+export function getRandomValuesPolyfill<T extends IntegerTypedArray>(typedArray: T) {
+  if (!isIntegerTypedArray(typedArray)) {
+    throw new TypeError('Failed to execute \'getRandomValues\': input must be an integer TypedArray')
+  }
+
+  if (typedArray.byteLength > MAX_RANDOM_VALUES_BYTE_LENGTH) {
+    throw new TypeError('Failed to execute \'getRandomValues\': byteLength exceeds 65536')
+  }
+
+  const nativeCrypto = getNativeCrypto()
+  if (nativeCrypto && nativeCrypto.getRandomValues !== getRandomValuesPolyfill) {
+    return nativeCrypto.getRandomValues(typedArray as never)
+  }
+
+  if (!fillArrayWithHostRandomValues(typedArray)) {
+    fillArrayWithMathRandom(typedArray)
+  }
+
+  return typedArray
+}
+
+export const cryptoPolyfill = {
+  getRandomValues: getRandomValuesPolyfill,
+}

--- a/packages-runtime/web-apis/src/events.ts
+++ b/packages-runtime/web-apis/src/events.ts
@@ -1,0 +1,56 @@
+interface EventInitPolyfill {
+  bubbles?: boolean
+  cancelable?: boolean
+  composed?: boolean
+}
+
+interface CustomEventInitPolyfill<T = any> extends EventInitPolyfill {
+  detail?: T
+}
+
+export class EventPolyfill {
+  readonly bubbles: boolean
+  readonly cancelable: boolean
+  readonly composed: boolean
+  readonly isTrusted = false
+  readonly timeStamp = Date.now()
+  readonly type: string
+  currentTarget: unknown = null
+  target: unknown = null
+  defaultPrevented = false
+  cancelBubble = false
+
+  constructor(type: string, init: EventInitPolyfill = {}) {
+    this.type = String(type)
+    this.bubbles = init.bubbles === true
+    this.cancelable = init.cancelable === true
+    this.composed = init.composed === true
+  }
+
+  composedPath() {
+    return this.target == null ? [] : [this.target]
+  }
+
+  preventDefault() {
+    if (this.cancelable) {
+      this.defaultPrevented = true
+    }
+  }
+
+  stopImmediatePropagation() {
+    this.cancelBubble = true
+  }
+
+  stopPropagation() {
+    this.cancelBubble = true
+  }
+}
+
+export class CustomEventPolyfill<T = any> extends EventPolyfill {
+  readonly detail: T | null
+
+  constructor(type: string, init: CustomEventInitPolyfill<T> = {}) {
+    super(type, init)
+    this.detail = init.detail ?? null
+  }
+}

--- a/packages-runtime/web-apis/src/index.ts
+++ b/packages-runtime/web-apis/src/index.ts
@@ -1,13 +1,18 @@
 import { REQUEST_GLOBAL_ACTUALS_KEY, REQUEST_GLOBAL_PLACEHOLDER_KEY } from '@weapp-core/constants'
 import { AbortControllerPolyfill, AbortSignalPolyfill } from './abort'
+import { atobPolyfill, btoaPolyfill } from './base64'
+import { cryptoPolyfill } from './crypto'
+import { CustomEventPolyfill, EventPolyfill } from './events'
 import { fetch as requestGlobalsFetch } from './fetch'
 import { HeadersPolyfill, RequestPolyfill, ResponsePolyfill } from './http'
+import { performancePolyfill } from './performance'
 import {
   installRequestGlobalBinding,
   RequestGlobalsEventTarget,
   resolveRequestGlobalsHost,
   resolveRequestGlobalsHosts,
 } from './shared'
+import { queueMicrotaskPolyfill } from './task'
 import { TextDecoderPolyfill, TextEncoderPolyfill } from './textCodec'
 import { URLPolyfill, URLSearchParamsPolyfill } from './url'
 import { BlobPolyfill, FormDataPolyfill } from './web'
@@ -25,6 +30,13 @@ export type WeappInjectWebRuntimeGlobalsTarget
     | 'AbortSignal'
     | 'XMLHttpRequest'
     | 'WebSocket'
+    | 'atob'
+    | 'btoa'
+    | 'queueMicrotask'
+    | 'performance'
+    | 'crypto'
+    | 'Event'
+    | 'CustomEvent'
 
 export type WeappInjectRequestGlobalsTarget = WeappInjectWebRuntimeGlobalsTarget
 
@@ -50,6 +62,9 @@ function resolveInstallTargets(targets: WeappInjectWebRuntimeGlobalsTarget[]) {
   const installTargets: WeappInjectWebRuntimeGlobalsTarget[] = [...targets]
   if (hasRequestRuntimeBinaryUsage(targets)) {
     installTargets.push('TextEncoder', 'TextDecoder')
+  }
+  if (targets.includes('CustomEvent')) {
+    installTargets.push('Event')
   }
   return [...new Set(installTargets)]
 }
@@ -162,6 +177,55 @@ function installSingleTarget(host: Record<string, any>, target: WeappInjectWebRu
     return
   }
 
+  if (target === 'atob') {
+    if (typeof host.atob !== 'function' || isPlaceholderRequestGlobal(host.atob)) {
+      assignHostGlobal(host, 'atob', atobPolyfill)
+    }
+    return
+  }
+
+  if (target === 'btoa') {
+    if (typeof host.btoa !== 'function' || isPlaceholderRequestGlobal(host.btoa)) {
+      assignHostGlobal(host, 'btoa', btoaPolyfill)
+    }
+    return
+  }
+
+  if (target === 'queueMicrotask') {
+    if (typeof host.queueMicrotask !== 'function' || isPlaceholderRequestGlobal(host.queueMicrotask)) {
+      assignHostGlobal(host, 'queueMicrotask', queueMicrotaskPolyfill)
+    }
+    return
+  }
+
+  if (target === 'performance') {
+    if (!host.performance || typeof host.performance.now !== 'function') {
+      assignHostGlobal(host, 'performance', performancePolyfill)
+    }
+    return
+  }
+
+  if (target === 'crypto') {
+    if (!host.crypto || typeof host.crypto.getRandomValues !== 'function') {
+      assignHostGlobal(host, 'crypto', cryptoPolyfill)
+    }
+    return
+  }
+
+  if (target === 'Event') {
+    if (typeof host.Event !== 'function' || isPlaceholderRequestGlobal(host.Event)) {
+      assignHostGlobal(host, 'Event', EventPolyfill)
+    }
+    return
+  }
+
+  if (target === 'CustomEvent') {
+    if (typeof host.CustomEvent !== 'function' || isPlaceholderRequestGlobal(host.CustomEvent)) {
+      assignHostGlobal(host, 'CustomEvent', CustomEventPolyfill)
+    }
+    return
+  }
+
   if (target === 'XMLHttpRequest' && (typeof host.XMLHttpRequest !== 'function' || isPlaceholderRequestGlobal(host.XMLHttpRequest))) {
     assignHostGlobal(host, 'XMLHttpRequest', XMLHttpRequestPolyfill)
   }
@@ -240,6 +304,13 @@ export function installWebRuntimeGlobals(options: InstallWebRuntimeGlobalsOption
     'AbortSignal',
     'XMLHttpRequest',
     'WebSocket',
+    'atob',
+    'btoa',
+    'queueMicrotask',
+    'performance',
+    'crypto',
+    'Event',
+    'CustomEvent',
   ])
   const hosts = resolveRequestGlobalsHosts()
   const primaryHost = resolveRequestGlobalsHost()
@@ -290,10 +361,17 @@ export function installAbortGlobals() {
 export {
   AbortControllerPolyfill,
   AbortSignalPolyfill,
+  atobPolyfill,
   BlobPolyfill,
+  btoaPolyfill,
+  cryptoPolyfill,
+  CustomEventPolyfill,
+  EventPolyfill,
   requestGlobalsFetch as fetch,
   FormDataPolyfill,
   HeadersPolyfill,
+  performancePolyfill,
+  queueMicrotaskPolyfill,
   RequestGlobalsEventTarget,
   RequestPolyfill,
   ResponsePolyfill,

--- a/packages-runtime/web-apis/src/performance.ts
+++ b/packages-runtime/web-apis/src/performance.ts
@@ -1,0 +1,50 @@
+const performanceTimeOrigin = Date.now()
+const PERFORMANCE_POLYFILL_MARKER = '__weappVitePerformancePolyfill'
+
+function resolveNativePerformance() {
+  const candidate = (globalThis as Record<string, any>).performance
+  if (
+    candidate
+    && candidate?.[PERFORMANCE_POLYFILL_MARKER] !== true
+    && typeof candidate.now === 'function'
+  ) {
+    return candidate
+  }
+
+  for (const hostKey of ['wx', 'my', 'tt'] as const) {
+    const host = (globalThis as Record<string, any>)[hostKey]
+    if (!host || typeof host.getPerformance !== 'function') {
+      continue
+    }
+
+    try {
+      const performance = host.getPerformance()
+      if (performance && typeof performance.now === 'function') {
+        return performance
+      }
+    }
+    catch {
+    }
+  }
+
+  return undefined
+}
+
+const performancePolyfill = {
+  [PERFORMANCE_POLYFILL_MARKER]: true,
+  now() {
+    const nativePerformance = resolveNativePerformance()
+    if (nativePerformance && nativePerformance !== performancePolyfill) {
+      try {
+        return Number(nativePerformance.now())
+      }
+      catch {
+      }
+    }
+
+    return Date.now() - performanceTimeOrigin
+  },
+  timeOrigin: performanceTimeOrigin,
+}
+
+export { performancePolyfill }

--- a/packages-runtime/web-apis/src/task.ts
+++ b/packages-runtime/web-apis/src/task.ts
@@ -1,0 +1,19 @@
+export function queueMicrotaskPolyfill(callback: () => void) {
+  if (typeof callback !== 'function') {
+    throw new TypeError('Failed to execute \'queueMicrotask\': callback must be a function')
+  }
+
+  const nativeQueueMicrotask = (globalThis as Record<string, any>).queueMicrotask
+  if (typeof nativeQueueMicrotask === 'function' && nativeQueueMicrotask !== queueMicrotaskPolyfill) {
+    nativeQueueMicrotask(callback)
+    return
+  }
+
+  Promise.resolve()
+    .then(callback)
+    .catch((error) => {
+      setTimeout(() => {
+        throw error
+      }, 0)
+    })
+}

--- a/packages-runtime/web-apis/test-d/index.test-d.ts
+++ b/packages-runtime/web-apis/test-d/index.test-d.ts
@@ -9,9 +9,12 @@ import { expectError, expectType } from 'tsd'
 const target: WeappInjectWebRuntimeGlobalsTarget = 'fetch'
 expectType<WeappInjectWebRuntimeGlobalsTarget>(target)
 expectType<WeappInjectRequestGlobalsTarget>(target)
+expectType<WeappInjectWebRuntimeGlobalsTarget>('performance')
+expectType<WeappInjectWebRuntimeGlobalsTarget>('crypto')
+expectType<WeappInjectWebRuntimeGlobalsTarget>('queueMicrotask')
 
 const options: InstallWebRuntimeGlobalsOptions = {
-  targets: ['fetch', 'Request', 'XMLHttpRequest'],
+  targets: ['fetch', 'Request', 'XMLHttpRequest', 'performance', 'crypto'],
 }
 expectType<WeappInjectWebRuntimeGlobalsTarget[] | undefined>(options.targets)
 expectType<void>(installWebRuntimeGlobals(options))

--- a/packages-runtime/web-apis/test/runtime.test.ts
+++ b/packages-runtime/web-apis/test/runtime.test.ts
@@ -82,6 +82,13 @@ describe('request globals runtime', () => {
     delete (globalThis as Record<string, any>).WebSocket
     delete (globalThis as Record<string, any>).Blob
     delete (globalThis as Record<string, any>).FormData
+    delete (globalThis as Record<string, any>).atob
+    delete (globalThis as Record<string, any>).btoa
+    delete (globalThis as Record<string, any>).queueMicrotask
+    delete (globalThis as Record<string, any>).performance
+    delete (globalThis as Record<string, any>).crypto
+    delete (globalThis as Record<string, any>).Event
+    delete (globalThis as Record<string, any>).CustomEvent
     delete (globalThis as Record<string, any>).wx
     delete (globalThis as Record<string, any>).global
     delete (globalThis as Record<string, any>).self
@@ -104,6 +111,13 @@ describe('request globals runtime', () => {
     expect(typeof globalThis.WebSocket).toBe('function')
     expect(typeof globalThis.TextEncoder).toBe('function')
     expect(typeof globalThis.TextDecoder).toBe('function')
+    expect(typeof globalThis.atob).toBe('function')
+    expect(typeof globalThis.btoa).toBe('function')
+    expect(typeof globalThis.queueMicrotask).toBe('function')
+    expect(typeof globalThis.performance.now).toBe('function')
+    expect(typeof globalThis.crypto.getRandomValues).toBe('function')
+    expect(typeof globalThis.Event).toBe('function')
+    expect(typeof globalThis.CustomEvent).toBe('function')
   })
 
   it('supports fetch through @wevu/api request bridge without requiring wevu/fetch', async () => {
@@ -336,6 +350,48 @@ describe('request globals runtime', () => {
     const searchParams = new URLSearchParamsPolyfill()
     searchParams.append('variables', '{"ok":true}')
     expect(searchParams.toString()).toBe('variables=%7B%22ok%22%3Atrue%7D')
+  })
+
+  it('installs the next batch of web runtime globals with stable behavior', async () => {
+    setGlobalValue('performance', undefined)
+    setGlobalValue('crypto', undefined)
+    ;(globalThis as Record<string, any>).wx = {
+      getPerformance: () => ({
+        now: () => 321.5,
+      }),
+      getRandomValues: (typedArray: Uint8Array) => {
+        typedArray.set([1, 2, 3, 4].slice(0, typedArray.length))
+        return typedArray
+      },
+    }
+
+    const { installWebRuntimeGlobals } = await import('../src')
+    installWebRuntimeGlobals({
+      targets: ['atob', 'btoa', 'queueMicrotask', 'performance', 'crypto', 'Event', 'CustomEvent'],
+    })
+
+    expect(globalThis.btoa('AB')).toBe('QUI=')
+    expect(globalThis.atob('QUI=')).toBe('AB')
+    expect(globalThis.performance.now()).toBe(321.5)
+
+    const bytes = globalThis.crypto.getRandomValues(new Uint8Array(4))
+    expect([...bytes]).toEqual([1, 2, 3, 4])
+
+    const microtaskSpy = vi.fn()
+    globalThis.queueMicrotask(microtaskSpy)
+    await Promise.resolve()
+    expect(microtaskSpy).toHaveBeenCalledTimes(1)
+
+    const event = new globalThis.Event('tick')
+    const customEvent = new globalThis.CustomEvent('payload', {
+      detail: { ok: true },
+      cancelable: true,
+    })
+    customEvent.preventDefault()
+
+    expect(event.type).toBe('tick')
+    expect(customEvent.detail).toEqual({ ok: true })
+    expect(customEvent.defaultPrevented).toBe(true)
   })
 
   it('supports mini-program SocketTask through the injected WebSocket bridge', async () => {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts
@@ -17,6 +17,7 @@ import {
   REQUEST_GLOBAL_USABLE_CONSTRUCTOR_HELPER,
 } from '@weapp-core/constants'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { FULL_REQUEST_GLOBAL_TARGETS } from '../../../runtime/config/internal/injectRequestGlobals'
 import { normalizeWatchPath } from '../../../utils/path'
 import { createGenerateBundleHook, createRenderStartHook } from './emit'
 
@@ -35,6 +36,7 @@ const refreshSharedChunkImportersMock = vi.hoisted(() => vi.fn())
 const removeImplicitPagePreloadsMock = vi.hoisted(() => vi.fn())
 const loggerInfoMock = vi.hoisted(() => vi.fn())
 const loggerWarnMock = vi.hoisted(() => vi.fn())
+const FULL_REQUEST_GLOBAL_TARGETS_LITERAL = JSON.stringify(FULL_REQUEST_GLOBAL_TARGETS)
 
 vi.mock('../../../runtime/chunkStrategy', () => ({
   DEFAULT_SHARED_CHUNK_STRATEGY: 'copy',
@@ -1319,7 +1321,7 @@ describe('core lifecycle emit hook extra branches', () => {
 
     const appCode = bundle['app.js'].code
     expect(appCode).toContain(`/* ${REQUEST_GLOBAL_PRELUDE_MARKER} */`)
-    expect(appCode).toContain('require("./common.js")["At"]({ targets: ["fetch","Headers","Request","Response","TextEncoder","TextDecoder","AbortController","AbortSignal","XMLHttpRequest","WebSocket"] }) || globalThis')
+    expect(appCode).toContain(`require("./common.js")["At"]({ targets: ${FULL_REQUEST_GLOBAL_TARGETS_LITERAL} }) || globalThis`)
     expect(appCode.indexOf(`/* ${REQUEST_GLOBAL_PRELUDE_MARKER} */`)).toBeLessThan(appCode.indexOf(`/* ${APP_PRELUDE_CHUNK_MARKER} */`))
   })
 
@@ -1389,7 +1391,7 @@ describe('core lifecycle emit hook extra branches', () => {
     expect(bundle['app.js'].code).toContain('require("./app.prelude.js")')
     expect(bundle['app.js'].code).not.toContain(`/* ${REQUEST_GLOBAL_PRELUDE_MARKER} */`)
     expect(String(bundle['app.prelude.js'].source)).toContain(`/* ${REQUEST_GLOBAL_PRELUDE_MARKER} */`)
-    expect(String(bundle['app.prelude.js'].source)).toContain('require("./common.js")["At"]({ targets: ["fetch","Headers","Request","Response","TextEncoder","TextDecoder","AbortController","AbortSignal","XMLHttpRequest","WebSocket"] }) || globalThis')
+    expect(String(bundle['app.prelude.js'].source)).toContain(`require("./common.js")["At"]({ targets: ${FULL_REQUEST_GLOBAL_TARGETS_LITERAL} }) || globalThis`)
     expect(String(bundle['app.prelude.js'].source).indexOf(`/* ${REQUEST_GLOBAL_PRELUDE_MARKER} */`)).toBeLessThan(String(bundle['app.prelude.js'].source).indexOf(`/* ${APP_PRELUDE_CHUNK_MARKER} */`))
   })
 

--- a/packages/weapp-vite/src/plugins/core/lifecycle/load.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/load.test.ts
@@ -9,11 +9,13 @@ import {
 import { parseSync } from 'oxc-parser'
 import path from 'pathe'
 import { describe, expect, it, vi } from 'vitest'
+import { FULL_REQUEST_GLOBAL_TARGETS } from '../../../runtime/config/internal/injectRequestGlobals'
 import { createLoadHook, createOptionsHook } from './load'
 
 const resolveWeappLibEntriesMock = vi.hoisted(() => vi.fn())
 const findJsEntryMock = vi.hoisted(() => vi.fn())
 const findVueEntryMock = vi.hoisted(() => vi.fn())
+const FULL_REQUEST_GLOBAL_TARGETS_SERIALIZED = FULL_REQUEST_GLOBAL_TARGETS.map(target => JSON.stringify(target)).join(',')
 
 vi.mock('../../../runtime/lib', () => ({
   resolveWeappLibEntries: resolveWeappLibEntriesMock,
@@ -273,7 +275,7 @@ describe('core lifecycle load hook injectWeapi', () => {
     const code = result && typeof result === 'object' && 'code' in result ? result.code : ''
 
     expect(code).toContain('installWebRuntimeGlobals')
-    expect(code).toContain('"fetch","Headers","Request","Response","TextEncoder","TextDecoder","AbortController","AbortSignal","XMLHttpRequest","WebSocket"')
+    expect(code).toContain(FULL_REQUEST_GLOBAL_TARGETS_SERIALIZED)
     expect(code).toContain(`var WebSocket = ${REQUEST_GLOBAL_INSTALLER_HOST_REF}.WebSocket`)
     expect(code).toContain(`var URL = ${REQUEST_GLOBAL_INSTALLER_HOST_REF}.URL`)
   })

--- a/packages/weapp-vite/src/runtime/config/internal/injectRequestGlobals.test.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/injectRequestGlobals.test.ts
@@ -17,6 +17,26 @@ import {
 } from './injectRequestGlobals'
 
 describe('injectRequestGlobals helpers', () => {
+  const fullWebRuntimeTargets = [
+    'fetch',
+    'Headers',
+    'Request',
+    'Response',
+    'TextEncoder',
+    'TextDecoder',
+    'AbortController',
+    'AbortSignal',
+    'XMLHttpRequest',
+    'WebSocket',
+    'atob',
+    'btoa',
+    'queueMicrotask',
+    'performance',
+    'crypto',
+    'Event',
+    'CustomEvent',
+  ] as const
+
   it('enables auto injection when matching dependencies are present', () => {
     expect(resolveInjectRequestGlobalsOptions(undefined, {
       dependencies: {
@@ -25,18 +45,7 @@ describe('injectRequestGlobals helpers', () => {
     })).toEqual({
       mode: 'auto',
       prelude: false,
-      targets: [
-        'fetch',
-        'Headers',
-        'Request',
-        'Response',
-        'TextEncoder',
-        'TextDecoder',
-        'AbortController',
-        'AbortSignal',
-        'XMLHttpRequest',
-        'WebSocket',
-      ],
+      targets: [...fullWebRuntimeTargets],
     })
   })
 
@@ -48,18 +57,7 @@ describe('injectRequestGlobals helpers', () => {
     })).toEqual({
       mode: 'auto',
       prelude: false,
-      targets: [
-        'fetch',
-        'Headers',
-        'Request',
-        'Response',
-        'TextEncoder',
-        'TextDecoder',
-        'AbortController',
-        'AbortSignal',
-        'XMLHttpRequest',
-        'WebSocket',
-      ],
+      targets: [...fullWebRuntimeTargets],
     })
   })
 
@@ -114,18 +112,7 @@ describe('injectRequestGlobals helpers', () => {
     })).toEqual({
       mode: 'auto',
       prelude: true,
-      targets: [
-        'fetch',
-        'Headers',
-        'Request',
-        'Response',
-        'TextEncoder',
-        'TextDecoder',
-        'AbortController',
-        'AbortSignal',
-        'XMLHttpRequest',
-        'WebSocket',
-      ],
+      targets: [...fullWebRuntimeTargets],
     })
   })
 
@@ -142,18 +129,7 @@ describe('injectRequestGlobals helpers', () => {
       mode: 'explicit',
       dependencyPatterns: ['axios', 'graphql-request', 'socket.io-client', 'engine.io-client'],
       prelude: true,
-      targets: [
-        'fetch',
-        'Headers',
-        'Request',
-        'Response',
-        'TextEncoder',
-        'TextDecoder',
-        'AbortController',
-        'AbortSignal',
-        'XMLHttpRequest',
-        'WebSocket',
-      ],
+      targets: [...fullWebRuntimeTargets],
     })
   })
 
@@ -330,6 +306,20 @@ describe('injectRequestGlobals helpers', () => {
     expect(code).not.toContain(`${REQUEST_GLOBAL_INSTALLER_HOST_REF}.fetch`)
   })
 
+  it('creates passive bindings for the next web runtime batch', () => {
+    const code = createInjectRequestGlobalsCode(['atob', 'btoa', 'queueMicrotask', 'performance', 'crypto', 'Event', 'CustomEvent'], {
+      passiveLocalBindings: true,
+    })
+
+    expect(code).toContain(`var atob = ${REQUEST_GLOBAL_EXPOSE_HELPER}("atob"`)
+    expect(code).toContain(`var btoa = ${REQUEST_GLOBAL_EXPOSE_HELPER}("btoa"`)
+    expect(code).toContain(`var queueMicrotask = ${REQUEST_GLOBAL_EXPOSE_HELPER}("queueMicrotask"`)
+    expect(code).toContain(`var performance = ${REQUEST_GLOBAL_EXPOSE_HELPER}("performance"`)
+    expect(code).toContain(`var crypto = ${REQUEST_GLOBAL_EXPOSE_HELPER}("crypto"`)
+    expect(code).toContain(`var Event = ${REQUEST_GLOBAL_EXPOSE_HELPER}("Event"`)
+    expect(code).toContain(`var CustomEvent = ${REQUEST_GLOBAL_EXPOSE_HELPER}("CustomEvent"`)
+  })
+
   it('can create a valid sfc injection block', () => {
     const code = createInjectRequestGlobalsSfcCode(['fetch'], {
       localBindings: true,
@@ -348,6 +338,39 @@ describe('injectRequestGlobals helpers', () => {
         return new TextDecoder().decode(payload)
       }
     `, ['TextDecoder', 'TextEncoder', 'fetch'])).toEqual(['TextDecoder'])
+  })
+
+  it('resolves direct next-batch references in auto mode without pulling request runtime group', () => {
+    expect(resolveAutoRequestGlobalsTargets(`
+      export function createRuntimeSnapshot() {
+        queueMicrotask(() => {})
+        return [
+          btoa("A"),
+          atob("QQ=="),
+          performance.now(),
+          crypto.getRandomValues(new Uint8Array(1))[0],
+          new Event("tick").type,
+          new CustomEvent("payload").type,
+        ]
+      }
+    `, [
+      'atob',
+      'btoa',
+      'queueMicrotask',
+      'performance',
+      'crypto',
+      'Event',
+      'CustomEvent',
+      'fetch',
+    ])).toEqual([
+      'atob',
+      'btoa',
+      'queueMicrotask',
+      'performance',
+      'crypto',
+      'Event',
+      'CustomEvent',
+    ])
   })
 
   it('injects into existing normal script before falling back to a new block', () => {
@@ -391,18 +414,7 @@ describe('injectRequestGlobals helpers', () => {
     expect(resolveManualRequestGlobalsTargets([
       'import { installRequestGlobals } from "@wevu/web-apis"',
       'installRequestGlobals()',
-    ].join('\n'))).toEqual([
-      'fetch',
-      'Headers',
-      'Request',
-      'Response',
-      'TextEncoder',
-      'TextDecoder',
-      'AbortController',
-      'AbortSignal',
-      'XMLHttpRequest',
-      'WebSocket',
-    ])
+    ].join('\n'))).toEqual([...fullWebRuntimeTargets])
   })
 
   it('detects manual installAbortGlobals usage from compatibility imports', () => {

--- a/packages/weapp-vite/src/runtime/config/internal/injectRequestGlobals.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/injectRequestGlobals.ts
@@ -33,6 +33,13 @@ export const FULL_REQUEST_GLOBAL_TARGETS: WeappInjectWebRuntimeGlobalsTarget[] =
   'AbortSignal',
   'XMLHttpRequest',
   'WebSocket',
+  'atob',
+  'btoa',
+  'queueMicrotask',
+  'performance',
+  'crypto',
+  'Event',
+  'CustomEvent',
 ]
 
 export const ABORT_REQUEST_GLOBAL_TARGETS: WeappInjectWebRuntimeGlobalsTarget[] = [
@@ -317,6 +324,10 @@ export function resolveRequestGlobalsBindingTargets(targets: WeappInjectRequestG
     bindingTargets.push('URL', 'URLSearchParams', 'Blob', 'FormData')
   }
 
+  if (targets.includes('CustomEvent')) {
+    bindingTargets.push('Event')
+  }
+
   return [...new Set(bindingTargets)].filter(target => REQUEST_GLOBAL_FREE_BINDING_TARGETS.has(target))
 }
 
@@ -340,16 +351,35 @@ export function createRequestGlobalsPassiveBindingsCode(targets: WeappInjectRequ
     `function ${REQUEST_GLOBAL_MARK_PLACEHOLDER_HELPER}(value){try{Object.defineProperty(value,${JSON.stringify(REQUEST_GLOBAL_PLACEHOLDER_KEY)},{value:true,configurable:true})}catch{value[${JSON.stringify(REQUEST_GLOBAL_PLACEHOLDER_KEY)}]=true}return value}`,
     `function ${REQUEST_GLOBAL_LAZY_FUNCTION_HELPER}(name){const placeholder=function(...args){const actual=${REQUEST_GLOBAL_ACTUALS_KEY}[name];if(typeof actual!=="function"){throw new Error(name+" is not initialized")}return actual.apply(this,args)};return ${REQUEST_GLOBAL_MARK_PLACEHOLDER_HELPER}(placeholder)}`,
     `function ${REQUEST_GLOBAL_LAZY_CONSTRUCTOR_HELPER}(name){const placeholder=function(...args){const actual=${REQUEST_GLOBAL_ACTUALS_KEY}[name];if(typeof actual!=="function"){throw new Error(name+" is not initialized")}return Reflect.construct(actual,args)};return ${REQUEST_GLOBAL_MARK_PLACEHOLDER_HELPER}(placeholder)}`,
+    `function __weappViteRequestGlobalsLazyObject(name,keys){const placeholder=Object.create(null);for(const key of keys){placeholder[key]=function(...args){const actual=${REQUEST_GLOBAL_ACTUALS_KEY}[name];const actualValue=actual?.[key];if(typeof actualValue!=="function"){throw new Error(name+"."+key+" is not initialized")}return actualValue.apply(actual,args)}}return ${REQUEST_GLOBAL_MARK_PLACEHOLDER_HELPER}(placeholder)}`,
     `function ${REQUEST_GLOBAL_USABLE_CONSTRUCTOR_HELPER}(value,args){if(typeof value!=="function"||value?.[${JSON.stringify(REQUEST_GLOBAL_PLACEHOLDER_KEY)}]===true){return false}try{return Reflect.construct(value,args),true}catch{return false}}`,
-    `function ${REQUEST_GLOBAL_EXPOSE_HELPER}(name,value){if(value==null){return value}const current=globalThis[name];if(current===value){return value}if(typeof current!=="function"||current?.[${JSON.stringify(REQUEST_GLOBAL_PLACEHOLDER_KEY)}]===true){try{globalThis[name]=value}catch{}}return value}`,
+    `function ${REQUEST_GLOBAL_EXPOSE_HELPER}(name,value){if(value==null){return value}const current=globalThis[name];if(current===value){return value}if((typeof current!=="function"&&typeof current!=="object")||current?.[${JSON.stringify(REQUEST_GLOBAL_PLACEHOLDER_KEY)}]===true){try{globalThis[name]=value}catch{}}return value}`,
   ].join(';')
   const bindingCode = bindingTargets.map((target) => {
     if (target === 'fetch') {
       return `var fetch = ${REQUEST_GLOBAL_EXPOSE_HELPER}("fetch",typeof ${REQUEST_GLOBAL_ACTUALS_KEY}["fetch"]==="function"&&${REQUEST_GLOBAL_ACTUALS_KEY}["fetch"]?.[${JSON.stringify(REQUEST_GLOBAL_PLACEHOLDER_KEY)}]!==true?${REQUEST_GLOBAL_ACTUALS_KEY}["fetch"]:typeof globalThis.fetch==="function"&&globalThis.fetch?.[${JSON.stringify(REQUEST_GLOBAL_PLACEHOLDER_KEY)}]!==true?globalThis.fetch:${REQUEST_GLOBAL_LAZY_FUNCTION_HELPER}("fetch"))`
     }
 
+    if (target === 'atob') {
+      return `var atob = ${REQUEST_GLOBAL_EXPOSE_HELPER}("atob",typeof ${REQUEST_GLOBAL_ACTUALS_KEY}["atob"]==="function"&&${REQUEST_GLOBAL_ACTUALS_KEY}["atob"]?.[${JSON.stringify(REQUEST_GLOBAL_PLACEHOLDER_KEY)}]!==true?${REQUEST_GLOBAL_ACTUALS_KEY}["atob"]:typeof globalThis.atob==="function"&&globalThis.atob?.[${JSON.stringify(REQUEST_GLOBAL_PLACEHOLDER_KEY)}]!==true?globalThis.atob:${REQUEST_GLOBAL_LAZY_FUNCTION_HELPER}("atob"))`
+    }
+
+    if (target === 'btoa') {
+      return `var btoa = ${REQUEST_GLOBAL_EXPOSE_HELPER}("btoa",typeof ${REQUEST_GLOBAL_ACTUALS_KEY}["btoa"]==="function"&&${REQUEST_GLOBAL_ACTUALS_KEY}["btoa"]?.[${JSON.stringify(REQUEST_GLOBAL_PLACEHOLDER_KEY)}]!==true?${REQUEST_GLOBAL_ACTUALS_KEY}["btoa"]:typeof globalThis.btoa==="function"&&globalThis.btoa?.[${JSON.stringify(REQUEST_GLOBAL_PLACEHOLDER_KEY)}]!==true?globalThis.btoa:${REQUEST_GLOBAL_LAZY_FUNCTION_HELPER}("btoa"))`
+    }
+
+    if (target === 'queueMicrotask') {
+      return `var queueMicrotask = ${REQUEST_GLOBAL_EXPOSE_HELPER}("queueMicrotask",typeof ${REQUEST_GLOBAL_ACTUALS_KEY}["queueMicrotask"]==="function"&&${REQUEST_GLOBAL_ACTUALS_KEY}["queueMicrotask"]?.[${JSON.stringify(REQUEST_GLOBAL_PLACEHOLDER_KEY)}]!==true?${REQUEST_GLOBAL_ACTUALS_KEY}["queueMicrotask"]:typeof globalThis.queueMicrotask==="function"&&globalThis.queueMicrotask?.[${JSON.stringify(REQUEST_GLOBAL_PLACEHOLDER_KEY)}]!==true?globalThis.queueMicrotask:${REQUEST_GLOBAL_LAZY_FUNCTION_HELPER}("queueMicrotask"))`
+    }
+
     const placeholderFactory = `${REQUEST_GLOBAL_LAZY_CONSTRUCTOR_HELPER}(${JSON.stringify(target)})`
     const actualRef = `${REQUEST_GLOBAL_ACTUALS_KEY}[${JSON.stringify(target)}]`
+    if (target === 'performance') {
+      return `var performance = ${REQUEST_GLOBAL_EXPOSE_HELPER}("performance",${actualRef}&&typeof ${actualRef}.now==="function"&&${actualRef}?.[${JSON.stringify(REQUEST_GLOBAL_PLACEHOLDER_KEY)}]!==true?${actualRef}:globalThis.performance&&typeof globalThis.performance.now==="function"&&globalThis.performance?.[${JSON.stringify(REQUEST_GLOBAL_PLACEHOLDER_KEY)}]!==true?globalThis.performance:__weappViteRequestGlobalsLazyObject("performance",["now"]))`
+    }
+    if (target === 'crypto') {
+      return `var crypto = ${REQUEST_GLOBAL_EXPOSE_HELPER}("crypto",${actualRef}&&typeof ${actualRef}.getRandomValues==="function"&&${actualRef}?.[${JSON.stringify(REQUEST_GLOBAL_PLACEHOLDER_KEY)}]!==true?${actualRef}:globalThis.crypto&&typeof globalThis.crypto.getRandomValues==="function"&&globalThis.crypto?.[${JSON.stringify(REQUEST_GLOBAL_PLACEHOLDER_KEY)}]!==true?globalThis.crypto:__weappViteRequestGlobalsLazyObject("crypto",["getRandomValues"]))`
+    }
     if (target === 'URL') {
       return `var URL = ${REQUEST_GLOBAL_EXPOSE_HELPER}("URL",${REQUEST_GLOBAL_USABLE_CONSTRUCTOR_HELPER}(${actualRef},["https://request-globals.invalid"])?${actualRef}:${REQUEST_GLOBAL_USABLE_CONSTRUCTOR_HELPER}(globalThis.URL,["https://request-globals.invalid"])?globalThis.URL:${placeholderFactory})`
     }

--- a/packages/weapp-vite/src/types/config/features.ts
+++ b/packages/weapp-vite/src/types/config/features.ts
@@ -148,6 +148,13 @@ export type WeappInjectWebRuntimeGlobalsTarget
     | 'AbortSignal'
     | 'XMLHttpRequest'
     | 'WebSocket'
+    | 'atob'
+    | 'btoa'
+    | 'queueMicrotask'
+    | 'performance'
+    | 'crypto'
+    | 'Event'
+    | 'CustomEvent'
 
 export type WeappInjectRequestGlobalsTarget = WeappInjectWebRuntimeGlobalsTarget
 

--- a/packages/weapp-vite/test-d/config-define-config/index.d.ts
+++ b/packages/weapp-vite/test-d/config-define-config/index.d.ts
@@ -16,19 +16,19 @@ export interface WeappViteConfig {
     mode?: 'inline' | 'entry' | 'require'
     webRuntime?: boolean | {
       enabled?: boolean
-      targets?: ('fetch' | 'Headers' | 'Request' | 'Response' | 'TextEncoder' | 'TextDecoder' | 'AbortController' | 'AbortSignal' | 'XMLHttpRequest' | 'WebSocket')[]
+      targets?: ('fetch' | 'Headers' | 'Request' | 'Response' | 'TextEncoder' | 'TextDecoder' | 'AbortController' | 'AbortSignal' | 'XMLHttpRequest' | 'WebSocket' | 'atob' | 'btoa' | 'queueMicrotask' | 'performance' | 'crypto' | 'Event' | 'CustomEvent')[]
       dependencies?: (string | RegExp)[]
     }
   }
   injectWebRuntimeGlobals?: boolean | {
     enabled?: boolean
-    targets?: ('fetch' | 'Headers' | 'Request' | 'Response' | 'TextEncoder' | 'TextDecoder' | 'AbortController' | 'AbortSignal' | 'XMLHttpRequest' | 'WebSocket')[]
+    targets?: ('fetch' | 'Headers' | 'Request' | 'Response' | 'TextEncoder' | 'TextDecoder' | 'AbortController' | 'AbortSignal' | 'XMLHttpRequest' | 'WebSocket' | 'atob' | 'btoa' | 'queueMicrotask' | 'performance' | 'crypto' | 'Event' | 'CustomEvent')[]
     dependencies?: (string | RegExp)[]
     prelude?: boolean
   }
   injectRequestGlobals?: boolean | {
     enabled?: boolean
-    targets?: ('fetch' | 'Headers' | 'Request' | 'Response' | 'TextEncoder' | 'TextDecoder' | 'AbortController' | 'AbortSignal' | 'XMLHttpRequest' | 'WebSocket')[]
+    targets?: ('fetch' | 'Headers' | 'Request' | 'Response' | 'TextEncoder' | 'TextDecoder' | 'AbortController' | 'AbortSignal' | 'XMLHttpRequest' | 'WebSocket' | 'atob' | 'btoa' | 'queueMicrotask' | 'performance' | 'crypto' | 'Event' | 'CustomEvent')[]
     dependencies?: (string | RegExp)[]
     prelude?: boolean
   }

--- a/packages/weapp-vite/test-d/config-define-config/index.test-d.ts
+++ b/packages/weapp-vite/test-d/config-define-config/index.test-d.ts
@@ -39,13 +39,13 @@ expectType<boolean | {
   mode?: 'inline' | 'entry' | 'require'
   webRuntime?: boolean | {
     enabled?: boolean
-    targets?: ('fetch' | 'Headers' | 'Request' | 'Response' | 'TextEncoder' | 'TextDecoder' | 'AbortController' | 'AbortSignal' | 'XMLHttpRequest' | 'WebSocket')[]
+    targets?: ('fetch' | 'Headers' | 'Request' | 'Response' | 'TextEncoder' | 'TextDecoder' | 'AbortController' | 'AbortSignal' | 'XMLHttpRequest' | 'WebSocket' | 'atob' | 'btoa' | 'queueMicrotask' | 'performance' | 'crypto' | 'Event' | 'CustomEvent')[]
     dependencies?: (string | RegExp)[]
   }
 } | undefined>(objectConfig.weapp?.appPrelude)
 expectType<boolean | {
   enabled?: boolean
-  targets?: ('fetch' | 'Headers' | 'Request' | 'Response' | 'TextEncoder' | 'TextDecoder' | 'AbortController' | 'AbortSignal' | 'XMLHttpRequest' | 'WebSocket')[]
+  targets?: ('fetch' | 'Headers' | 'Request' | 'Response' | 'TextEncoder' | 'TextDecoder' | 'AbortController' | 'AbortSignal' | 'XMLHttpRequest' | 'WebSocket' | 'atob' | 'btoa' | 'queueMicrotask' | 'performance' | 'crypto' | 'Event' | 'CustomEvent')[]
   dependencies?: (string | RegExp)[]
   prelude?: boolean
 } | undefined>(objectConfig.weapp?.injectWebRuntimeGlobals)

--- a/packages/weapp-vite/test-d/internal-src-types/index.d.ts
+++ b/packages/weapp-vite/test-d/internal-src-types/index.d.ts
@@ -37,7 +37,7 @@ export declare function createSidecarWatchOptions(
   input: SidecarWatchOptionsInput,
 ): ChokidarWatchOptions
 
-export type WeappInjectRequestGlobalsTarget = 'fetch' | 'Headers' | 'Request' | 'Response' | 'AbortController' | 'AbortSignal' | 'XMLHttpRequest' | 'WebSocket'
+export type WeappInjectRequestGlobalsTarget = 'fetch' | 'Headers' | 'Request' | 'Response' | 'TextEncoder' | 'TextDecoder' | 'AbortController' | 'AbortSignal' | 'XMLHttpRequest' | 'WebSocket' | 'atob' | 'btoa' | 'queueMicrotask' | 'performance' | 'crypto' | 'Event' | 'CustomEvent'
 
 export type RequestGlobalBindingTarget = WeappInjectRequestGlobalsTarget | 'URL' | 'URLSearchParams' | 'Blob' | 'FormData'
 


### PR DESCRIPTION
## 摘要
补齐 weapp-vite / @wevu/web-apis 下一批高频 Web Runtime 全局能力，覆盖 atob、btoa、queueMicrotask、performance.now、crypto.getRandomValues、Event、CustomEvent 的按需注入、局部绑定与 runtime installer。

## 变更
- 在 @wevu/web-apis 新增上述能力的轻量 polyfill 与安装逻辑
- 在 weapp-vite 扩展 Web Runtime target 类型、自动目标解析与被动/局部绑定代码生成
- 为 github-issues 增加 issue-448 构建回归页与定向断言
- 补充 tsd、runtime 单测与构建回归覆盖，并添加 changeset

## 测试
- pnpm --filter @wevu/web-apis build
- pnpm --filter @wevu/web-apis test
- pnpm --filter @wevu/web-apis typecheck
- pnpm --filter @wevu/web-apis test:types
- pnpm --filter weapp-vite build
- pnpm --filter weapp-vite typecheck
- pnpm --filter weapp-vite test:types
- pnpm exec vitest run packages/weapp-vite/src/runtime/config/internal/injectRequestGlobals.test.ts
- pnpm exec vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #448"
- pnpm exec eslint --fix packages-runtime/web-apis/src/index.ts packages-runtime/web-apis/src/base64.ts packages-runtime/web-apis/src/crypto.ts packages-runtime/web-apis/src/events.ts packages-runtime/web-apis/src/performance.ts packages-runtime/web-apis/src/task.ts packages-runtime/web-apis/test/runtime.test.ts packages-runtime/web-apis/test-d/index.test-d.ts packages/weapp-vite/src/runtime/config/internal/injectRequestGlobals.ts packages/weapp-vite/src/runtime/config/internal/injectRequestGlobals.test.ts packages/weapp-vite/src/types/config/features.ts packages/weapp-vite/test-d/config-define-config/index.d.ts packages/weapp-vite/test-d/config-define-config/index.test-d.ts packages/weapp-vite/test-d/internal-src-types/index.d.ts e2e/ci/github-issues.build.test.ts e2e-apps/github-issues/src/pages/issue-448/index.vue
- pnpm exec stylelint e2e-apps/github-issues/src/pages/issue-448/index.vue

Closes #448
