### PR TITLE
fix: 修复 web-apis 中 URL / Request / Response polyfill 兼容性问题

### DIFF
--- a/.changeset/old-peaches-rush.md
+++ b/.changeset/old-peaches-rush.md
@@ -1,0 +1,5 @@
+---
+'@wevu/web-apis': patch
+---
+
+修复 `@wevu/web-apis` 中 `URLPolyfill` 与 `RequestPolyfill` / `fetch` 直接组合时的兼容问题，统一 `URL`、`TextEncoder`、`TextDecoder` 构造器解析，并收敛 `Request` / `Response` 的 body 内部状态暴露，同时补充 `TextEncoderPolyfill` 与 `TextDecoderPolyfill` 的根入口导出。

--- a/e2e-apps/github-issues/package.json
+++ b/e2e-apps/github-issues/package.json
@@ -10,6 +10,7 @@
     "build:ui": "weapp-vite build --ui"
   },
   "dependencies": {
+    "@wevu/web-apis": "workspace:*",
     "camelcase": "^9.0.0",
     "dayjs": "catalog:",
     "merge": "catalog:",

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -225,6 +225,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-459/index",
+          "pathName": "pages/issue-459/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-385/index",
           "pathName": "pages/issue-385/index",
           "query": "",

--- a/e2e-apps/github-issues/src/pages/issue-459/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-459/index.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import {
+  RequestPolyfill,
+  ResponsePolyfill,
+  TextDecoderPolyfill,
+  TextEncoderPolyfill,
+  URLPolyfill,
+} from '@wevu/web-apis'
+
+definePageJson({
+  navigationBarTitleText: 'issue-459',
+})
+
+const request = new RequestPolyfill(new URLPolyfill('/abc', 'https://issue-459.invalid'))
+const response = new ResponsePolyfill('123')
+const requestUrl = request.url
+const requestHasOwnBody = Object.hasOwn(request, 'body')
+const responseHasOwnBody = Object.hasOwn(response, 'body')
+const responseHasOwnBodyValue = Object.hasOwn(response as Record<string, unknown>, 'bodyValue')
+const responseKeys = Object.keys(response).join(',')
+const textCodecRoundTrip = new TextDecoderPolyfill().decode(
+  new TextEncoderPolyfill().encode('issue-459'),
+)
+
+function _runE2E() {
+  return {
+    requestUrl,
+    requestHasOwnBody,
+    responseHasOwnBody,
+    responseHasOwnBodyValue,
+    responseKeys,
+    textCodecRoundTrip,
+  }
+}
+</script>
+
+<template>
+  <view class="issue459-page">
+    <text class="issue459-title">issue-459 web-apis polyfill compatibility</text>
+    <text class="issue459-line">requestUrl = {{ requestUrl }}</text>
+    <text class="issue459-line">requestOwnBody = {{ requestHasOwnBody }}</text>
+    <text class="issue459-line">responseOwnBody = {{ responseHasOwnBody }}</text>
+    <text class="issue459-line">responseOwnBodyValue = {{ responseHasOwnBodyValue }}</text>
+    <text class="issue459-line">responseKeys = {{ responseKeys }}</text>
+    <text class="issue459-line">textCodec = {{ textCodecRoundTrip }}</text>
+  </view>
+</template>
+
+<style scoped>
+.issue459-page {
+  padding: 32rpx;
+}
+
+.issue459-title,
+.issue459-line {
+  display: block;
+  margin-bottom: 24rpx;
+}
+</style>

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -187,6 +187,21 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageJs).toContain('get CustomEvent(){return l}')
   })
 
+  it('issue #459: keeps directly imported web-apis polyfills interoperable in github-issues app', async () => {
+    await runBuild()
+
+    const pageJsPath = path.join(DIST_ROOT, 'pages/issue-459/index.js')
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-459/index.wxml')
+    const pageJs = await fs.readFile(pageJsPath, 'utf-8')
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+
+    expect(pageWxml).toContain('issue-459 web-apis polyfill compatibility')
+    expect(pageJs).toContain('_runE2E')
+    expect(pageJs).toContain('`/abc`,`https://issue-459.invalid`')
+    expect(pageJs).toContain('`bodyValue`')
+    expect(pageJs).toContain('issue-459')
+  })
+
   it('issue #393: keeps path-mode devDependency chunks out of dist/node_modules', async () => {
     await runIssue393Build()
 

--- a/e2e/ide/github-issues.runtime.web-runtime.test.ts
+++ b/e2e/ide/github-issues.runtime.web-runtime.test.ts
@@ -42,6 +42,38 @@ async function waitForIssue448Runtime(page: any, timeoutMs = 20_000) {
   throw new Error(`Timed out waiting for issue-448 runtime: ${JSON.stringify(lastRuntime, null, 2)}`)
 }
 
+async function waitForIssue459Runtime(page: any, timeoutMs = 20_000) {
+  const startedAt = Date.now()
+  let lastRuntime: Record<string, any> | null = null
+
+  while (Date.now() - startedAt <= timeoutMs) {
+    try {
+      const runtime = await page.callMethod('_runE2E')
+      lastRuntime = runtime
+      if (
+        runtime?.requestUrl === 'https://issue-459.invalid/abc'
+        && runtime?.requestHasOwnBody === false
+        && runtime?.responseHasOwnBody === false
+        && runtime?.responseHasOwnBodyValue === false
+        && typeof runtime?.responseKeys === 'string'
+        && runtime?.textCodecRoundTrip === 'issue-459'
+      ) {
+        return runtime
+      }
+    }
+    catch {
+    }
+
+    try {
+      await page.waitFor(220)
+    }
+    catch {
+    }
+  }
+
+  throw new Error(`Timed out waiting for issue-459 runtime: ${JSON.stringify(lastRuntime, null, 2)}`)
+}
+
 function expectRandomBytesPayload(randomBytes: string) {
   const segments = randomBytes.split(',')
   expect(segments.length).toBe(4)
@@ -86,6 +118,40 @@ describe.sequential('github-issues runtime web runtime globals', () => {
       expect(pageWxml).toContain('class="issue448-page"')
       expect(pageWxml).toContain('class="issue448-title"')
       expect(pageWxml.match(/class="issue448-line"/g)?.length).toBe(7)
+    }
+    finally {
+      await releaseSharedMiniProgram(miniProgram)
+    }
+  })
+
+  it('issue #459: keeps directly imported web-apis polyfills interoperable in DevTools runtime', async (ctx) => {
+    const miniProgram = await getSharedMiniProgram(ctx)
+
+    try {
+      const page = await relaunchPage(
+        miniProgram,
+        '/pages/issue-459/index',
+        undefined,
+        20_000,
+      )
+      if (!page) {
+        throw new Error('Failed to launch issue-459 page')
+      }
+
+      const runtime = await waitForIssue459Runtime(page)
+      const pageWxml = await readPageWxml(page)
+
+      expect(runtime.requestUrl).toBe('https://issue-459.invalid/abc')
+      expect(runtime.requestHasOwnBody).toBe(false)
+      expect(runtime.responseHasOwnBody).toBe(false)
+      expect(runtime.responseHasOwnBodyValue).toBe(false)
+      expect(runtime.responseKeys.includes('body')).toBe(false)
+      expect(runtime.responseKeys.includes('bodyValue')).toBe(false)
+      expect(runtime.textCodecRoundTrip).toBe('issue-459')
+
+      expect(pageWxml).toContain('class="issue459-page"')
+      expect(pageWxml).toContain('class="issue459-title"')
+      expect(pageWxml.match(/class="issue459-line"/g)?.length).toBe(6)
     }
     finally {
       await releaseSharedMiniProgram(miniProgram)

--- a/packages-runtime/web-apis/README.md
+++ b/packages-runtime/web-apis/README.md
@@ -108,6 +108,7 @@ socket.onclose = (event) => {
 | `installAbortGlobals`                                      | 仅安装 `AbortController` / `AbortSignal`        |
 | `fetch`                                                    | 基于小程序请求能力适配的 `fetch` 实现           |
 | `HeadersPolyfill` / `RequestPolyfill` / `ResponsePolyfill` | HTTP 相关兼容类                                 |
+| `TextEncoderPolyfill` / `TextDecoderPolyfill`              | 文本编解码兼容类                                |
 | `URLPolyfill` / `URLSearchParamsPolyfill`                  | URL 相关兼容类                                  |
 | `WebSocketPolyfill`                                        | 基于小程序 `SocketTask` 的 `WebSocket` 兼容实现 |
 | `XMLHttpRequestPolyfill`                                   | XHR 兼容实现                                    |

--- a/packages-runtime/web-apis/src/constructors.ts
+++ b/packages-runtime/web-apis/src/constructors.ts
@@ -1,0 +1,41 @@
+import { URLPolyfill, URLSearchParamsPolyfill } from './url'
+
+export function resolveUrlConstructor() {
+  return typeof globalThis.URL === 'function'
+    ? globalThis.URL
+    : undefined
+}
+
+export function isUrlInstance(value: unknown): value is URL | URLPolyfill {
+  const HostUrl = resolveUrlConstructor()
+  return Boolean(
+    (HostUrl && value instanceof HostUrl)
+    || value instanceof URLPolyfill,
+  )
+}
+
+export function resolveUrlSearchParamsConstructor() {
+  return typeof globalThis.URLSearchParams === 'function'
+    ? globalThis.URLSearchParams
+    : undefined
+}
+
+export function isUrlSearchParamsInstance(value: unknown): value is URLSearchParams | URLSearchParamsPolyfill {
+  const HostUrlSearchParams = resolveUrlSearchParamsConstructor()
+  return Boolean(
+    (HostUrlSearchParams && value instanceof HostUrlSearchParams)
+    || value instanceof URLSearchParamsPolyfill,
+  )
+}
+
+export function resolveTextEncoderConstructor() {
+  return typeof globalThis.TextEncoder === 'function'
+    ? globalThis.TextEncoder
+    : undefined
+}
+
+export function resolveTextDecoderConstructor() {
+  return typeof globalThis.TextDecoder === 'function'
+    ? globalThis.TextDecoder
+    : undefined
+}

--- a/packages-runtime/web-apis/src/fetch.ts
+++ b/packages-runtime/web-apis/src/fetch.ts
@@ -1,4 +1,6 @@
+import type { URLPolyfill } from './url'
 import { wpi } from '@wevu/api'
+import { isUrlInstance, isUrlSearchParamsInstance } from './constructors'
 import { HeadersPolyfill, ResponsePolyfill } from './http'
 import { cloneArrayBuffer, cloneArrayBufferView, normalizeHeaderName } from './shared'
 
@@ -28,7 +30,7 @@ export interface RequestGlobalsFetchInit {
   [key: string]: unknown
 }
 
-type RequestGlobalsFetchInput = string | URL | RequestLikeInput
+type RequestGlobalsFetchInput = string | URL | URLPolyfill | RequestLikeInput
 type MiniProgramRequestMethod = NonNullable<WechatMiniprogram.RequestOption['method']>
 
 const REQUEST_METHODS: ReadonlyArray<MiniProgramRequestMethod> = [
@@ -46,10 +48,6 @@ const hasOwn = Object.prototype.hasOwnProperty
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
-}
-
-function isNativeUrlInstance(value: unknown): value is URL {
-  return typeof URL !== 'undefined' && value instanceof URL
 }
 
 function createAbortError() {
@@ -161,7 +159,7 @@ async function normalizeRequestBody(body: unknown, headers: HeaderMap) {
     }
     return body
   }
-  if (typeof URLSearchParams !== 'undefined' && body instanceof URLSearchParams) {
+  if (isUrlSearchParamsInstance(body)) {
     if (!hasHeader(headers, 'content-type')) {
       headers['content-type'] = 'application/x-www-form-urlencoded;charset=UTF-8'
     }
@@ -189,7 +187,7 @@ async function resolveRequestMeta(input: RequestGlobalsFetchInput, init: Request
   const requestInput = isRequestLikeInput(input) ? input : undefined
   const url = typeof input === 'string'
     ? input
-    : isNativeUrlInstance(input)
+    : isUrlInstance(input)
       ? input.toString()
       : requestInput?.url
 

--- a/packages-runtime/web-apis/src/http.ts
+++ b/packages-runtime/web-apis/src/http.ts
@@ -1,3 +1,5 @@
+import type { URLPolyfill } from './url'
+import { isUrlInstance } from './constructors'
 import {
   cloneArrayBuffer,
   cloneArrayBufferView,
@@ -15,10 +17,6 @@ function isIterableHeaders(input: unknown): input is Iterable<HeaderTuple> {
 
 function isHeaderObject(input: unknown): input is Record<string, unknown> {
   return typeof input === 'object' && input !== null
-}
-
-function isNativeUrlInstance(value: unknown): value is URL {
-  return typeof URL !== 'undefined' && value instanceof URL
 }
 
 export class HeadersPolyfill {
@@ -102,6 +100,10 @@ export class HeadersPolyfill {
 }
 
 type RequestBodyLike = string | ArrayBuffer | ArrayBufferView | Blob | null | undefined
+const requestBodyStore = new WeakMap<RequestPolyfill, RequestBodyLike>()
+const requestBodyUsedStore = new WeakMap<RequestPolyfill, boolean>()
+const responseBodyStore = new WeakMap<ResponsePolyfill, RequestBodyLike>()
+const responseBodyUsedStore = new WeakMap<ResponsePolyfill, boolean>()
 
 function normalizeBody(body: unknown): RequestBodyLike {
   if (body == null || typeof body === 'string' || body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
@@ -140,36 +142,51 @@ async function readBodyAsText(body: RequestBodyLike) {
   return decodeText(buffer)
 }
 
+function getRequestBodyValue(request?: RequestPolyfill) {
+  return request ? requestBodyStore.get(request) : undefined
+}
+
+function getResponseBodyValue(response: ResponsePolyfill) {
+  return responseBodyStore.get(response)
+}
+
 export class RequestPolyfill {
   readonly url: string
   readonly method: string
   readonly headers: HeadersPolyfill
   readonly signal: AbortSignal | null
   readonly [Symbol.toStringTag] = 'Request'
-  private readonly bodyValue: RequestBodyLike
-  bodyUsed = false
 
-  constructor(input: string | URL | RequestPolyfill, init: Record<string, any> = {}) {
+  constructor(input: string | URL | URLPolyfill | RequestPolyfill, init: Record<string, any> = {}) {
     const request = input instanceof RequestPolyfill ? input : undefined
     this.url = typeof input === 'string'
       ? input
-      : isNativeUrlInstance(input)
+      : isUrlInstance(input)
         ? input.toString()
         : request?.url ?? ''
     this.method = String(init.method ?? request?.method ?? 'GET').toUpperCase()
     this.headers = new HeadersPolyfill(init.headers ?? request?.headers)
     this.signal = init.signal ?? request?.signal ?? null
-    this.bodyValue = normalizeBody(init.body ?? request?.bodyValue)
+    requestBodyStore.set(this, normalizeBody(init.body ?? getRequestBodyValue(request)))
+    requestBodyUsedStore.set(this, false)
+  }
+
+  get body(): ReadableStream<Uint8Array> | null {
+    return null
+  }
+
+  get bodyUsed() {
+    return requestBodyUsedStore.get(this) === true
   }
 
   async arrayBuffer() {
-    this.bodyUsed = true
-    return readBodyAsArrayBuffer(this.bodyValue)
+    requestBodyUsedStore.set(this, true)
+    return readBodyAsArrayBuffer(getRequestBodyValue(this))
   }
 
   async text() {
-    this.bodyUsed = true
-    return readBodyAsText(this.bodyValue)
+    requestBodyUsedStore.set(this, true)
+    return readBodyAsText(getRequestBodyValue(this))
   }
 
   clone() {
@@ -177,7 +194,7 @@ export class RequestPolyfill {
       method: this.method,
       headers: this.headers,
       signal: this.signal,
-      body: this.bodyValue,
+      body: getRequestBodyValue(this),
     })
   }
 }
@@ -190,13 +207,11 @@ export class ResponsePolyfill {
   readonly url: string
   readonly redirected = false
   readonly type: ResponseType = 'basic'
-  readonly body: ReadableStream<Uint8Array> | null = null
   readonly [Symbol.toStringTag] = 'Response'
-  private readonly bodyValue: RequestBodyLike
-  bodyUsed = false
 
   constructor(body?: RequestBodyLike, init: Record<string, any> = {}) {
-    this.bodyValue = normalizeBody(body)
+    responseBodyStore.set(this, normalizeBody(body))
+    responseBodyUsedStore.set(this, false)
     this.status = Number.isFinite(init.status) ? init.status : 200
     this.statusText = init.statusText ?? ''
     this.ok = this.status >= 200 && this.status < 300
@@ -204,9 +219,17 @@ export class ResponsePolyfill {
     this.url = init.url ?? ''
   }
 
+  get body(): ReadableStream<Uint8Array> | null {
+    return null
+  }
+
+  get bodyUsed() {
+    return responseBodyUsedStore.get(this) === true
+  }
+
   async arrayBuffer() {
-    this.bodyUsed = true
-    return readBodyAsArrayBuffer(this.bodyValue)
+    responseBodyUsedStore.set(this, true)
+    return readBodyAsArrayBuffer(getResponseBodyValue(this))
   }
 
   async blob() {
@@ -225,12 +248,12 @@ export class ResponsePolyfill {
   }
 
   async text() {
-    this.bodyUsed = true
-    return readBodyAsText(this.bodyValue)
+    responseBodyUsedStore.set(this, true)
+    return readBodyAsText(getResponseBodyValue(this))
   }
 
   clone() {
-    return new ResponsePolyfill(this.bodyValue, {
+    return new ResponsePolyfill(getResponseBodyValue(this), {
       status: this.status,
       statusText: this.statusText,
       headers: this.headers,

--- a/packages-runtime/web-apis/src/index.ts
+++ b/packages-runtime/web-apis/src/index.ts
@@ -375,6 +375,8 @@ export {
   RequestGlobalsEventTarget,
   RequestPolyfill,
   ResponsePolyfill,
+  TextDecoderPolyfill,
+  TextEncoderPolyfill,
   URLPolyfill,
   URLSearchParamsPolyfill,
   WebSocketPolyfill,

--- a/packages-runtime/web-apis/src/shared.ts
+++ b/packages-runtime/web-apis/src/shared.ts
@@ -1,3 +1,5 @@
+import { resolveTextDecoderConstructor, resolveTextEncoderConstructor } from './constructors'
+
 export interface RequestGlobalsEventLike {
   type: string
   target?: unknown
@@ -119,8 +121,9 @@ export function encodeTextFallback(value: string) {
 }
 
 export function encodeText(value: string) {
-  if (typeof TextEncoder === 'function') {
-    return new TextEncoder().encode(value).buffer
+  const TextEncoderConstructor = resolveTextEncoderConstructor()
+  if (TextEncoderConstructor) {
+    return new TextEncoderConstructor().encode(value).buffer
   }
   return encodeTextFallback(value)
 }
@@ -140,8 +143,9 @@ export function decodeTextFallback(value: ArrayBuffer) {
 }
 
 export function decodeText(value: ArrayBuffer) {
-  if (typeof TextDecoder === 'function') {
-    return new TextDecoder().decode(value)
+  const TextDecoderConstructor = resolveTextDecoderConstructor()
+  if (TextDecoderConstructor) {
+    return new TextDecoderConstructor().decode(value)
   }
   return decodeTextFallback(value)
 }

--- a/packages-runtime/web-apis/src/websocket.ts
+++ b/packages-runtime/web-apis/src/websocket.ts
@@ -1,4 +1,5 @@
 import { wpi } from '@wevu/api'
+import { resolveUrlConstructor as resolveHostUrlConstructor, resolveTextEncoderConstructor } from './constructors'
 import { cloneArrayBuffer, cloneArrayBufferView, RequestGlobalsEventTarget } from './shared'
 import { URLPolyfill } from './url'
 import { BlobPolyfill } from './web'
@@ -45,8 +46,9 @@ function createDomLikeError(name: string, message: string) {
 }
 
 function encodeReasonLength(reason: string) {
-  if (typeof TextEncoder === 'function') {
-    return new TextEncoder().encode(reason).byteLength
+  const TextEncoderConstructor = resolveTextEncoderConstructor()
+  if (TextEncoderConstructor) {
+    return new TextEncoderConstructor().encode(reason).byteLength
   }
   return unescape(encodeURIComponent(reason)).length
 }
@@ -73,7 +75,7 @@ function normalizeCloseReason(reason?: string) {
 }
 
 function resolveUrlConstructor() {
-  return typeof URL === 'function' ? URL : URLPolyfill
+  return resolveHostUrlConstructor() ?? URLPolyfill
 }
 
 function normalizeProtocols(protocols?: string | string[]) {

--- a/packages-runtime/web-apis/test-d/index.test-d.ts
+++ b/packages-runtime/web-apis/test-d/index.test-d.ts
@@ -3,7 +3,14 @@ import type {
   WeappInjectRequestGlobalsTarget,
   WeappInjectWebRuntimeGlobalsTarget,
 } from '@wevu/web-apis'
-import { installRequestGlobals, installWebRuntimeGlobals } from '@wevu/web-apis'
+import {
+  installRequestGlobals,
+  installWebRuntimeGlobals,
+  RequestPolyfill,
+  TextDecoderPolyfill,
+  TextEncoderPolyfill,
+  URLPolyfill,
+} from '@wevu/web-apis'
 import { expectError, expectType } from 'tsd'
 
 const target: WeappInjectWebRuntimeGlobalsTarget = 'fetch'
@@ -21,6 +28,9 @@ expectType<void>(installWebRuntimeGlobals(options))
 expectType<void>(installWebRuntimeGlobals())
 expectType<void>(installRequestGlobals(options))
 expectType<void>(installRequestGlobals())
+expectType<RequestPolyfill>(new RequestPolyfill(new URLPolyfill('https://request-globals.invalid')))
+expectType<Uint8Array>(new TextEncoderPolyfill().encode('ok'))
+expectType<string>(new TextDecoderPolyfill().decode(new Uint8Array([111, 107])))
 
 expectError<WeappInjectWebRuntimeGlobalsTarget>('URL')
 expectError<InstallWebRuntimeGlobalsOptions>({

--- a/packages-runtime/web-apis/test/runtime.test.ts
+++ b/packages-runtime/web-apis/test/runtime.test.ts
@@ -352,6 +352,64 @@ describe('request globals runtime', () => {
     expect(searchParams.toString()).toBe('variables=%7B%22ok%22%3Atrue%7D')
   })
 
+  it('keeps directly imported web-apis polyfills interoperable', async () => {
+    wpiRequestMock.mockImplementation((options: Record<string, any>) => {
+      options.success?.({
+        data: 'ok',
+        statusCode: 200,
+        header: {
+          'content-type': 'text/plain;charset=UTF-8',
+        },
+      })
+      return {
+        abort: vi.fn(),
+      }
+    })
+
+    const {
+      RequestPolyfill,
+      ResponsePolyfill,
+      TextDecoderPolyfill,
+      TextEncoderPolyfill,
+      URLPolyfill,
+      fetch: requestGlobalsFetch,
+    } = await import('../src')
+
+    const request = new RequestPolyfill(
+      new URLPolyfill('/polyfill', 'https://request-globals.invalid'),
+      {
+        body: 'payload',
+        method: 'POST',
+      },
+    )
+    expect(request.url).toBe('https://request-globals.invalid/polyfill')
+    expect(request.body).toBeNull()
+    expect(Object.hasOwn(request, 'body')).toBe(false)
+    expect(Object.hasOwn(request, 'bodyUsed')).toBe(false)
+    expect(request.bodyUsed).toBe(false)
+    expect(await request.text()).toBe('payload')
+    expect(request.bodyUsed).toBe(true)
+
+    const response = new ResponsePolyfill('123')
+    expect(response.body).toBeNull()
+    expect(Object.hasOwn(response, 'body')).toBe(false)
+    expect(Object.hasOwn(response, 'bodyUsed')).toBe(false)
+    expect(Object.keys(response)).not.toContain('body')
+    expect(Object.keys(response)).not.toContain('bodyValue')
+    expect(await response.text()).toBe('123')
+
+    const fetchResponse = await requestGlobalsFetch(
+      new URLPolyfill('/polyfill', 'https://request-globals.invalid'),
+    )
+    expect(wpiRequestMock).toHaveBeenCalledWith(expect.objectContaining({
+      url: 'https://request-globals.invalid/polyfill',
+    }))
+    expect(await fetchResponse.text()).toBe('ok')
+
+    const bytes = new TextEncoderPolyfill().encode('你好, issue-459')
+    expect(new TextDecoderPolyfill().decode(bytes)).toBe('你好, issue-459')
+  })
+
   it('installs the next batch of web runtime globals with stable behavior', async () => {
     setGlobalValue('performance', undefined)
     setGlobalValue('crypto', undefined)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1296,6 +1296,9 @@ importers:
 
   e2e-apps/github-issues:
     dependencies:
+      '@wevu/web-apis':
+        specifier: workspace:*
+        version: link:../../packages-runtime/web-apis
       camelcase:
         specifier: ^9.0.0
         version: 9.0.0


### PR DESCRIPTION
## 关联问题

Closes #459

## 变更说明

- 修复 `@wevu/web-apis` 中 `URLPolyfill` 无法直接传入 `RequestPolyfill` / `fetch` 的兼容问题
- 统一 `URL`、`URLSearchParams`、`TextEncoder`、`TextDecoder` 的宿主构造器解析逻辑，避免直接依赖当前自由变量构造器
- 收敛 `RequestPolyfill` / `ResponsePolyfill` 的 body 内部状态存储，避免 `body` / `bodyValue` 以实例可枚举字段暴露
- 从 `@wevu/web-apis` 根入口补充导出 `TextEncoderPolyfill` 与 `TextDecoderPolyfill`
- 增加 `web-apis` 运行时测试与 `tsd` 类型回归测试
- 在 `e2e-apps/github-issues` 增加 issue-459 最小复现页，并补充定向构建 / IDE 运行时断言

## 验证

- `pnpm --filter @wevu/web-apis build`
- `pnpm --filter @wevu/web-apis typecheck`
- `pnpm --filter @wevu/web-apis test`
- `pnpm --filter @wevu/web-apis test:types`
- `pnpm vitest run -c ./e2e/vitest.e2e.ci.build-only.config.ts e2e/ci/github-issues.build.test.ts -t "issue #459"`

## 说明

- `pnpm vitest run -c ./e2e/vitest.e2e.devtools.config.ts e2e/ide/github-issues.runtime.web-runtime.test.ts -t "issue #459"` 在当前环境被正常跳过，原因是 WeChat DevTools 基础设施不可用，报错为 `listen EPERM`
