### PR TITLE
fix(web-runtime): 修复 tsdown 迁移后产物调试可读性退化

### DIFF
--- a/.changeset/bold-rivers-sleep.md
+++ b/.changeset/bold-rivers-sleep.md
@@ -1,0 +1,5 @@
+---
+"@weapp-vite/web": patch
+---
+
+修复 `@weapp-vite/web` 在迁移到 `tsdown` 后发布产物调试体验退化的问题。默认构建现已显式关闭压缩、开启 sourcemap、关闭 hash 文件名并启用 unbundle 输出，避免入口文件退化为短别名转发到 hash chunk，提升运行时排障与源码追踪可读性。同时补充构建产物回归测试，锁定入口可读性与 sourcemap 产出。

--- a/e2e/ci/web-runtime.package-output.test.ts
+++ b/e2e/ci/web-runtime.package-output.test.ts
@@ -1,0 +1,43 @@
+/* eslint-disable e18e/ban-dependencies -- e2e 测试需要 execa 驱动包构建。 */
+import { fs } from '@weapp-core/shared'
+import { execa } from 'execa'
+import path from 'pathe'
+import { describe, expect, it } from 'vitest'
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../..')
+const WEB_PACKAGE_ROOT = path.join(REPO_ROOT, 'packages-runtime/web')
+const DIST_ROOT = path.join(WEB_PACKAGE_ROOT, 'dist')
+
+async function runBuild() {
+  await fs.remove(DIST_ROOT)
+  await execa('pnpm', ['--filter', '@weapp-vite/web', 'build'], {
+    cwd: REPO_ROOT,
+  })
+}
+
+describe.sequential('e2e package: @weapp-vite/web (build output)', () => {
+  it('issue #456: keeps entry output readable and emits sourcemaps', async () => {
+    await runBuild()
+
+    const indexEntryPath = path.join(DIST_ROOT, 'index.mjs')
+    const runtimeEntryPath = path.join(DIST_ROOT, 'runtime/index.mjs')
+
+    expect(await fs.pathExists(indexEntryPath)).toBe(true)
+    expect(await fs.pathExists(runtimeEntryPath)).toBe(true)
+
+    const indexEntry = await fs.readFile(indexEntryPath, 'utf8')
+    const runtimeEntry = await fs.readFile(runtimeEntryPath, 'utf8')
+
+    expect(indexEntry).toContain('from "./runtime/style.mjs"')
+    expect(indexEntry).not.toMatch(/from "\.\/runtime-[^"]+\.mjs"/)
+    expect(indexEntry).not.toMatch(/from "\.\/plugin-[^"]+\.mjs"/)
+    expect(indexEntry.split('\n').length).toBeGreaterThan(10)
+
+    expect(runtimeEntry).toContain('from "./style.mjs"')
+    expect(runtimeEntry).not.toMatch(/from "\.\.\/runtime-[^"]+\.mjs"/)
+    expect(runtimeEntry.split('\n').length).toBeGreaterThan(10)
+
+    expect(await fs.pathExists(path.join(DIST_ROOT, 'runtime/polyfill/index.mjs.map'))).toBe(true)
+    expect(await fs.pathExists(path.join(DIST_ROOT, 'plugin/index.mjs.map'))).toBe(true)
+  })
+})

--- a/packages-runtime/web/src/plugin/path.ts
+++ b/packages-runtime/web/src/plugin/path.ts
@@ -66,8 +66,10 @@ export function toViteFsImport(absPath: string) {
 export function resolveRuntimePolyfillPath() {
   const currentDir = dirname(fileURLToPath(import.meta.url))
   const candidates = [
+    resolve(currentDir, '../runtime/index.mjs'),
     resolve(currentDir, './runtime/index.mjs'),
     resolve(currentDir, '../runtime/polyfill.ts'),
+    resolve(currentDir, '../runtime/index.ts'),
   ]
 
   for (const candidate of candidates) {

--- a/packages-runtime/web/tsdown.config.ts
+++ b/packages-runtime/web/tsdown.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
     onlyBundle: false,
   },
   format: ['esm'],
+  minify: false,
+  sourcemap: true,
+  hash: false,
+  unbundle: true,
   shims: true,
   tsconfig: './tsconfig.build.json',
   outExtensions() {


### PR DESCRIPTION
## 背景

close #456

`@weapp-vite/web` 迁移到 `tsdown` 后，入口产物退化为短别名转发 + hash chunk，且默认无 sourcemap，调试体验明显下降。

## 变更

- 在 `packages-runtime/web/tsdown.config.ts` 明确设置调试友好默认：
  - `minify: false`
  - `sourcemap: true`
  - `hash: false`
  - `unbundle: true`
- 新增 e2e 回归测试 `e2e/ci/web-runtime.package-output.test.ts`，锁定：
  - `dist/index.mjs` / `dist/runtime/index.mjs` 入口可读（非 hash chunk 跳转）
  - 关键 sourcemap 文件存在（例如 `runtime/polyfill/index.mjs.map`、`plugin/index.mjs.map`）
- 补充 changeset：`@weapp-vite/web` patch。

## 验证

- `pnpm --filter @weapp-vite/web build`
- `pnpm exec vitest run -c e2e/vitest.e2e.ci.config.ts e2e/ci/web-runtime.package-output.test.ts`
- `pnpm exec eslint packages-runtime/web/tsdown.config.ts e2e/ci/web-runtime.package-output.test.ts`
