### PR TITLE
fix: 修复 issue #475 的 Vue sourcemap 调试偏移

### DIFF
--- a/.changeset/issue-475-vue-sourcemap.md
+++ b/.changeset/issue-475-vue-sourcemap.md
@@ -1,0 +1,7 @@
+---
+'weapp-vite': patch
+'@wevu/compiler': patch
+'create-weapp-vite': patch
+---
+
+修复 `weapp-vite` / `@wevu/compiler` 在 `.vue` 文件源码调试链路中丢失脚本 sourcemap 的问题。现在 Vue SFC 的 `compileScript`、wevu 脚本重写、页面特性注入、`setData.pick` 注入以及最终入口代码拼装会连续传递并组合 sourcemap，避免 `app.vue`、页面与组件在开发者工具里出现不同程度的断点行号偏移。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -232,6 +232,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-475/index",
+          "pathName": "pages/issue-475/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-459/index",
           "pathName": "pages/issue-459/index",
           "query": "",

--- a/e2e-apps/github-issues/src/components/issue-475/SourceMapProbe/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-475/SourceMapProbe/index.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+const componentLabel = 'issue-475 component marker'
+const componentTraceLabel = componentLabel
+
+function _probeIssue475ComponentE2E() {
+  return {
+    componentLabel,
+    componentTraceLabel,
+  }
+}
+</script>
+
+<template>
+  <view class="issue475-component">
+    <text class="issue475-component__title">{{ componentLabel }}</text>
+    <text class="issue475-component__trace">{{ componentTraceLabel }}</text>
+  </view>
+</template>
+
+<style scoped>
+.issue475-component {
+  padding: 16rpx;
+}
+
+.issue475-component__title {
+  display: block;
+}
+
+.issue475-component__trace {
+  display: block;
+}
+</style>

--- a/e2e-apps/github-issues/src/pages/issue-475/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-475/index.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import SourceMapProbe from '../../components/issue-475/SourceMapProbe/index.vue'
+
+definePageJson({
+  navigationBarTitleText: 'issue-475',
+})
+
+const pageLabel = 'issue-475 vue sourcemap debugging'
+const pageTraceLabel = 'issue-475 page marker'
+
+function _runE2E() {
+  return {
+    pageLabel,
+    pageTraceLabel,
+  }
+}
+</script>
+
+<template>
+  <view class="issue475-page">
+    <text class="issue475-page__title">{{ pageLabel }}</text>
+    <text class="issue475-page__trace">{{ pageTraceLabel }}</text>
+    <SourceMapProbe />
+  </view>
+</template>
+
+<style scoped>
+.issue475-page {
+  padding: 32rpx;
+}
+
+.issue475-page__title {
+  display: block;
+  margin-bottom: 24rpx;
+}
+
+.issue475-page__trace {
+  display: block;
+  margin-bottom: 24rpx;
+}
+</style>

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -4,7 +4,7 @@ import { execa } from 'execa'
 import { fdir } from 'fdir'
 import path from 'pathe'
 import { describe, expect, it } from 'vitest'
-import { runWeappViteBuildWithLogCapture } from '../utils/buildLog'
+import { runWeappViteBuildWithLogCapture, sanitizeBuildCommandEnv } from '../utils/buildLog'
 
 const CLI_PATH = path.resolve(import.meta.dirname, '../../packages/weapp-vite/bin/weapp-vite.js')
 const APP_ROOT = path.resolve(import.meta.dirname, '../../e2e-apps/github-issues')
@@ -21,6 +21,24 @@ async function runBuild() {
     cwd: APP_ROOT,
     label: 'ci:github-issues',
     skipNpm: true,
+  })
+}
+
+async function runBuildWithSourcemap() {
+  await fs.remove(DIST_ROOT)
+
+  await execa('node', [
+    CLI_PATH,
+    'build',
+    APP_ROOT,
+    '--platform',
+    'weapp',
+    '--sourcemap',
+  ], {
+    cwd: APP_ROOT,
+    extendEnv: false,
+    env: sanitizeBuildCommandEnv(),
+    stdio: 'inherit',
   })
 }
 
@@ -203,6 +221,26 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageJs).toContain('"btoa"')
     expect(pageJs).toContain('const encoded = btoa("issue-457");')
     expect(lineCount).toBeGreaterThan(5)
+  })
+
+  it('issue #475: keeps emitted github-issues js traceable back to vue page and component sources', async () => {
+    await runBuildWithSourcemap()
+
+    const pageJsPath = path.join(DIST_ROOT, 'pages/issue-475/index.js')
+    const componentJsPath = path.join(DIST_ROOT, 'components/issue-475/SourceMapProbe/index.js')
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-475/index.wxml')
+    const pageJs = await fs.readFile(pageJsPath, 'utf-8')
+    const componentJs = await fs.readFile(componentJsPath, 'utf-8')
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+
+    expect(pageWxml).toContain('class="issue475-page"')
+    expect(pageWxml).toContain('{{pageLabel}}')
+    expect(pageWxml).toContain('{{pageTraceLabel}}')
+    expect(pageWxml).toContain('<SourceMapProbe />')
+    expect(pageJs).toContain('//#region src/pages/issue-475/index.vue')
+    expect(pageJs).toContain('issue-475 page marker')
+    expect(componentJs).toContain('//#region src/components/issue-475/SourceMapProbe/index.vue')
+    expect(componentJs).toContain('issue-475 component marker')
   })
 
   it('issue #459: keeps directly imported web-apis polyfills interoperable in github-issues app', async () => {

--- a/packages-runtime/wevu-compiler/package.json
+++ b/packages-runtime/wevu-compiler/package.json
@@ -51,6 +51,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
+    "@jridgewell/remapping": "^2.3.5",
     "@vue/compiler-core": "catalog:",
     "@vue/compiler-dom": "catalog:",
     "@weapp-core/constants": "workspace:^",

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/index.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/index.ts
@@ -52,6 +52,7 @@ export async function compileVueFile(
     parsed.isAppFile,
   )
   result.script = scriptPhase.script
+  result.scriptMap = scriptPhase.scriptMap
 
   compileStylePhase(parsed.descriptor, filename, result)
 

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/script.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/script.ts
@@ -1,11 +1,13 @@
 import type { File as BabelFile } from '@weapp-vite/ast/babelTypes'
 import type { SFCDescriptor } from 'vue/compiler-sfc'
+import type { EncodedSourceMapLike } from '../../../../utils/sourcemap'
 import type { TemplateCompileResult } from '../../compiler/template'
 import type { AutoUsingComponentsOptions, CompileVueFileOptions } from './types'
 import { removeExtensionDeep } from '@weapp-core/shared'
 import * as t from '@weapp-vite/ast/babelTypes'
 import { compileScript } from 'vue/compiler-sfc'
 import { BABEL_TS_MODULE_PARSER_OPTIONS, parse as babelParse, traverse } from '../../../../utils/babel'
+import { composeSourceMaps } from '../../../../utils/sourcemap'
 import { collectVueTemplateTags, VUE_COMPONENT_TAG_RE } from '../../../../utils/vueTemplateTags'
 import { resolveWarnHandler } from '../../../../utils/warn'
 import { stripJsonMacroCallsFromCode } from '../jsonMacros'
@@ -15,6 +17,7 @@ const TYPE_ONLY_DEFINE_PROPS_RE = /\bdefineProps\s*</
 
 export interface ScriptPhaseResult {
   script?: string
+  scriptMap?: EncodedSourceMapLike | null
   autoUsingComponentsMap: Record<string, string>
   autoComponentMeta: Record<string, string>
 }
@@ -113,6 +116,7 @@ export async function compileScriptPhase(
   }
 
   let scriptCode: string | undefined
+  let scriptMap: EncodedSourceMapLike | null = null
   if (descriptor.script || descriptor.scriptSetup) {
     const scriptCompiled = compileScript(descriptorForCompile, {
       id: filename,
@@ -120,6 +124,9 @@ export async function compileScriptPhase(
     })
 
     scriptCode = scriptCompiled.content
+    scriptMap = scriptCompiled.map && typeof scriptCompiled.map === 'object'
+      ? scriptCompiled.map
+      : null
 
     if (
       scriptCode.includes('defineAppJson')
@@ -152,8 +159,13 @@ export async function compileScriptPhase(
       inlineExpressions: templateCompiled?.inlineExpressions,
       relaxStructuredTypeOnlyProps,
     })
-    return { script: transformed.code, autoUsingComponentsMap, autoComponentMeta }
+    return {
+      script: transformed.code,
+      scriptMap: composeSourceMaps(transformed.map ?? null, scriptMap),
+      autoUsingComponentsMap,
+      autoComponentMeta,
+    }
   }
 
-  return { script: scriptCode, autoUsingComponentsMap, autoComponentMeta }
+  return { script: scriptCode, scriptMap: null, autoUsingComponentsMap, autoComponentMeta }
 }

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/types.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/types.ts
@@ -1,6 +1,7 @@
 import type { AstEngineName } from '../../../../ast/types'
 import type { JsonConfig, JsonMergeStrategy } from '../../../../types/json'
 import type { WevuDefaults } from '../../../../types/wevu'
+import type { EncodedSourceMapLike } from '../../../../utils/sourcemap'
 import type { ResolveSfcBlockSrcOptions } from '../../../utils/vueSfc'
 import type { TemplateCompileOptions, TemplateCompileResult } from '../../compiler/template'
 
@@ -9,6 +10,7 @@ import type { TemplateCompileOptions, TemplateCompileResult } from '../../compil
  */
 export interface VueTransformResult {
   script?: string
+  scriptMap?: EncodedSourceMapLike | null
   template?: string
   style?: string
   config?: string

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/transformScript/index.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/transformScript/index.ts
@@ -73,10 +73,13 @@ export function transformScript(source: string, options?: TransformScriptOptions
 
   const generated = generate(ast, {
     retainLines: true,
-  })
+    sourceMaps: true,
+    sourceFileName: 'inline.ts',
+  }, source)
 
   return {
     code: generated.code,
+    map: generated.map as TransformResult['map'],
     transformed: state.transformed,
   }
 }

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/transformScript/utils.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/transformScript/utils.ts
@@ -1,5 +1,6 @@
 import type { NodePath } from '@weapp-vite/ast/babelTraverse'
 import type { WevuDefaults } from '../../../../types/wevu'
+import type { EncodedSourceMapLike } from '../../../../utils/sourcemap'
 import type { ClassStyleBinding, ClassStyleRuntime, InlineExpressionAsset, LayoutHostBinding, TemplateRefBinding } from '../../compiler/template/types'
 import * as t from '@weapp-vite/ast/babelTypes'
 
@@ -10,6 +11,7 @@ import * as t from '@weapp-vite/ast/babelTypes'
 export interface TransformResult {
   code: string
   transformed: boolean
+  map?: EncodedSourceMapLike | null
 }
 
 export interface TransformScriptOptions {

--- a/packages-runtime/wevu-compiler/src/plugins/wevu/pageFeatures/inject.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/wevu/pageFeatures/inject.ts
@@ -1,4 +1,5 @@
 import type { AstEngineName } from '../../../ast/types'
+import type { EncodedSourceMapLike } from '../../../utils/sourcemap'
 import type { ModuleAnalysis } from './analysis'
 import type { ModuleResolver, WevuPageFeatureFlag } from './types'
 import { collectWevuPageFeatureFlagsFromCode } from '../../../ast/operations/pageFeatures'
@@ -14,7 +15,7 @@ export function injectWevuPageFeaturesInJs(
   options?: {
     astEngine?: AstEngineName
   },
-): { code: string, transformed: boolean } {
+): { code: string, transformed: boolean, map?: EncodedSourceMapLike | null } {
   const enabled = collectWevuPageFeatureFlagsFromCode(source, options)
   if (!enabled.size) {
     return { code: source, transformed: false }
@@ -35,8 +36,12 @@ export function injectWevuPageFeaturesInJs(
     return { code: source, transformed: false }
   }
 
-  const generated = generate(ast, { retainLines: true })
-  return { code: generated.code, transformed: true }
+  const generated = generate(ast, {
+    retainLines: true,
+    sourceMaps: true,
+    sourceFileName: 'inline.js',
+  }, source)
+  return { code: generated.code, transformed: true, map: generated.map as EncodedSourceMapLike }
 }
 
 /**
@@ -45,7 +50,7 @@ export function injectWevuPageFeaturesInJs(
 export async function injectWevuPageFeaturesInJsWithResolver(
   source: string,
   options: { id: string, resolver: ModuleResolver, astEngine?: AstEngineName },
-): Promise<{ code: string, transformed: boolean }> {
+): Promise<{ code: string, transformed: boolean, map?: EncodedSourceMapLike | null }> {
   const preflight = collectTargetOptionsObjectsFromCode(source, options.id, {
     astEngine: options.astEngine,
   })
@@ -92,6 +97,10 @@ export async function injectWevuPageFeaturesInJsWithResolver(
     return { code: source, transformed: false }
   }
 
-  const generated = generate(ast, { retainLines: true })
-  return { code: generated.code, transformed: true }
+  const generated = generate(ast, {
+    retainLines: true,
+    sourceMaps: true,
+    sourceFileName: 'inline.js',
+  }, source)
+  return { code: generated.code, transformed: true, map: generated.map as EncodedSourceMapLike }
 }

--- a/packages-runtime/wevu-compiler/src/utils/sourcemap.ts
+++ b/packages-runtime/wevu-compiler/src/utils/sourcemap.ts
@@ -1,0 +1,38 @@
+import remapping from '@jridgewell/remapping'
+
+export interface EncodedSourceMapLike {
+  version: number | string
+  file?: string
+  names: string[]
+  sourceRoot?: string
+  sources: string[]
+  sourcesContent?: Array<string | null>
+  mappings: string
+}
+
+export function isEncodedSourceMapLike(value: unknown): value is EncodedSourceMapLike {
+  return Boolean(
+    value
+    && typeof value === 'object'
+    && 'version' in value
+    && 'mappings' in value
+    && 'names' in value
+    && 'sources' in value,
+  )
+}
+
+export function composeSourceMaps(
+  transformedMap: EncodedSourceMapLike | null | undefined,
+  originalMap: EncodedSourceMapLike | null | undefined,
+): EncodedSourceMapLike | null {
+  if (isEncodedSourceMapLike(transformedMap) && isEncodedSourceMapLike(originalMap)) {
+    return remapping([transformedMap as any, originalMap as any], () => null) as EncodedSourceMapLike
+  }
+  if (isEncodedSourceMapLike(transformedMap)) {
+    return transformedMap
+  }
+  if (isEncodedSourceMapLike(originalMap)) {
+    return originalMap
+  }
+  return null
+}

--- a/packages-runtime/wevu-compiler/test/index.test.ts
+++ b/packages-runtime/wevu-compiler/test/index.test.ts
@@ -99,4 +99,22 @@ export default {
       pages: [],
     })
   })
+
+  it('returns script sourcemap chained back to the original vue file', async () => {
+    const source = `
+<script setup lang="ts">
+const title = 'hello'
+console.log(title)
+</script>
+<template>
+  <view>{{ title }}</view>
+</template>
+    `.trim()
+
+    const result = await compileVueFile(source, '/project/src/pages/index/index.vue')
+
+    expect(result.scriptMap).toBeTruthy()
+    expect(result.scriptMap?.sources).toEqual(['/project/src/pages/index/index.vue'])
+    expect(result.scriptMap?.sourcesContent?.[0]).toBe(source)
+  })
 })

--- a/packages/weapp-vite/package.json
+++ b/packages/weapp-vite/package.json
@@ -108,6 +108,7 @@
     "sync": "cnpm sync weapp-vite"
   },
   "dependencies": {
+    "@jridgewell/remapping": "^2.3.5",
     "@vercel/detect-agent": "^1.2.3",
     "@volar/typescript": "^2.4.28",
     "@vue/language-core": "catalog:",

--- a/packages/weapp-vite/src/plugins/vue/transform/injectPageFeatures.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/injectPageFeatures.ts
@@ -1,3 +1,4 @@
+import type { EncodedSourceMapLike } from '../../../utils/sourcemap'
 import { injectWevuPageFeaturesInJsWithResolver } from 'wevu/compiler'
 import { readFile as readFileCached } from '../../utils/cache'
 import { createViteResolverAdapter } from '../../utils/viteResolverAdapter'
@@ -11,7 +12,7 @@ export async function injectWevuPageFeaturesInJsWithViteResolver(
   source: string,
   id: string,
   options?: { checkMtime?: boolean },
-): Promise<{ code: string, transformed: boolean }> {
+): Promise<{ code: string, transformed: boolean, map?: EncodedSourceMapLike | null }> {
   const checkMtime = options?.checkMtime ?? true
   return injectWevuPageFeaturesInJsWithResolver(source, {
     id,

--- a/packages/weapp-vite/src/plugins/vue/transform/injectSetDataPick.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/injectSetDataPick.ts
@@ -2,6 +2,7 @@ import type { NodePath } from '@weapp-vite/ast/babelTraverse'
 import type * as t from '@weapp-vite/ast/babelTypes'
 import type { AstEngineName } from '../../../ast'
 import type { WeappViteConfig } from '../../../types'
+import type { EncodedSourceMapLike } from '../../../utils/sourcemap'
 import { collectSetDataPickKeysFromTemplateCode } from '../../../ast'
 import { generate, parseJsLike, traverse } from '../../../utils/babel'
 import { isAutoSetDataPickEnabledWithPreset } from './wevuPreset'
@@ -213,7 +214,7 @@ export function collectSetDataPickKeysFromTemplate(
 export function injectSetDataPickInJs(
   source: string,
   pickKeys: string[],
-): { code: string, transformed: boolean } {
+): { code: string, transformed: boolean, map?: EncodedSourceMapLike | null } {
   if (!pickKeys.length) {
     return { code: source, transformed: false }
   }
@@ -248,6 +249,10 @@ export function injectSetDataPickInJs(
     return { code: source, transformed: false }
   }
 
-  const generated = generate(ast, { retainLines: true })
-  return { code: generated.code, transformed: true }
+  const generated = generate(ast, {
+    retainLines: true,
+    sourceMaps: true,
+    sourceFileName: 'inline.js',
+  }, source)
+  return { code: generated.code, transformed: true, map: generated.map as EncodedSourceMapLike }
 }

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin.astEngine.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin.astEngine.test.ts
@@ -244,10 +244,11 @@ describe('createVueTransformPlugin ast engine smoke', () => {
       addWatchFile: vi.fn(),
     } as any, '<template><view /></template>', '/project/src/components/empty-shell.vue')
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       code: 'Component({})',
-      map: null,
     })
+    expect(result?.map).toBeTruthy()
+    expect(result?.map?.sources).toEqual(['empty-shell.vue'])
     expect(readAndParseSfcMock).not.toHaveBeenCalled()
     expect(collectSetDataPickKeysFromTemplateMock).not.toHaveBeenCalled()
   })

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/shared.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/shared.test.ts
@@ -8,11 +8,13 @@ const emitNativeLayoutScriptChunkIfNeededMock = vi.hoisted(() => vi.fn(async () 
 const injectWevuPageFeaturesInJsWithViteResolverMock = vi.hoisted(() => vi.fn(async (_ctx: any, code: string) => ({
   transformed: false,
   code,
+  map: null,
 })))
 const collectSetDataPickKeysFromTemplateMock = vi.hoisted(() => vi.fn(() => ['count']))
 const injectSetDataPickInJsMock = vi.hoisted(() => vi.fn((code: string) => ({
   transformed: false,
   code,
+  map: null,
 })))
 const isAutoSetDataPickEnabledMock = vi.hoisted(() => vi.fn(() => false))
 const collectOnPageScrollPerformanceWarningsMock = vi.hoisted(() => vi.fn(() => []))
@@ -97,6 +99,7 @@ describe('vue transform plugin shared helpers', () => {
     injectWevuPageFeaturesInJsWithViteResolverMock.mockResolvedValue({
       transformed: false,
       code: 'Page({})',
+      map: null,
     })
     collectSetDataPickKeysFromTemplateMock.mockReset()
     collectSetDataPickKeysFromTemplateMock.mockReturnValue(['count'])
@@ -104,6 +107,7 @@ describe('vue transform plugin shared helpers', () => {
     injectSetDataPickInJsMock.mockImplementation((code: string) => ({
       transformed: false,
       code,
+      map: null,
     }))
     isAutoSetDataPickEnabledMock.mockReset()
     isAutoSetDataPickEnabledMock.mockReturnValue(false)
@@ -529,11 +533,25 @@ describe('vue transform plugin shared helpers', () => {
     injectWevuPageFeaturesInJsWithViteResolverMock.mockResolvedValue({
       transformed: true,
       code: 'Page({ enhanced: true })',
+      map: {
+        version: 3,
+        names: [],
+        sources: ['/project/src/pages/home/index.vue'],
+        sourcesContent: ['Page({ onPageScroll() {}, onReachBottom() {} })'],
+        mappings: 'AAAA',
+      },
     })
     isAutoSetDataPickEnabledMock.mockReturnValue(true)
     injectSetDataPickInJsMock.mockReturnValue({
       transformed: true,
       code: 'Page({ enhanced: true, __setDataPick: ["count"] })',
+      map: {
+        version: 3,
+        names: [],
+        sources: ['/project/src/pages/home/index.vue'],
+        sourcesContent: ['Page({ enhanced: true })'],
+        mappings: 'AAAA',
+      },
     })
 
     const result = await finalizeTransformEntryScript({
@@ -566,6 +584,13 @@ describe('vue transform plugin shared helpers', () => {
     injectSetDataPickInJsMock.mockReturnValue({
       transformed: true,
       code: 'Page({ __setDataPick: ["count"] })',
+      map: {
+        version: 3,
+        names: [],
+        sources: ['/project/src/pages/home/index.vue'],
+        sourcesContent: ['Page({})'],
+        mappings: 'AAAA',
+      },
     })
 
     const result = await finalizeTransformEntryScript({
@@ -616,7 +641,7 @@ describe('vue transform plugin shared helpers', () => {
   })
 
   it('finalizes transform entry code with style imports, scriptless stubs, and dev hashes', () => {
-    const code = finalizeTransformEntryCode({
+    const output = finalizeTransformEntryCode({
       result: {
         script: '',
         meta: {
@@ -632,19 +657,28 @@ describe('vue transform plugin shared helpers', () => {
     })
 
     expect(buildWeappVueStyleRequestMock).toHaveBeenCalledTimes(2)
-    expect(code).toContain('import "/project/src/pages/home/index.vue?style=0";')
-    expect(code).toContain('import "/project/src/pages/home/index.vue?style=1";')
-    expect(code).toContain('Page({})')
-    expect(code).toContain('__weappViteJsonMacroHash')
-    expect(code).toContain('"json-hash"')
-    expect(code).toContain('__weappViteDefineOptionsHash')
-    expect(code).toContain('"define-options-hash"')
+    expect(output.code).toContain('import "/project/src/pages/home/index.vue?style=0";')
+    expect(output.code).toContain('import "/project/src/pages/home/index.vue?style=1";')
+    expect(output.code).toContain('Page({})')
+    expect(output.code).toContain('__weappViteJsonMacroHash')
+    expect(output.code).toContain('"json-hash"')
+    expect(output.code).toContain('__weappViteDefineOptionsHash')
+    expect(output.code).toContain('"define-options-hash"')
+    expect(output.map).toBeTruthy()
+    expect(output.map?.sources).toEqual(['index.vue'])
   })
 
   it('returns original entry code when finalize transform entry code has nothing extra to inject', () => {
-    const code = finalizeTransformEntryCode({
+    const output = finalizeTransformEntryCode({
       result: {
         script: 'App({})',
+        scriptMap: {
+          version: 3,
+          names: [],
+          sources: ['/project/src/app.vue'],
+          sourcesContent: ['App({})'],
+          mappings: 'AAAA',
+        },
         meta: {
           jsonMacroHash: 'json-hash',
           defineOptionsHash: 'define-options-hash',
@@ -657,7 +691,8 @@ describe('vue transform plugin shared helpers', () => {
     })
 
     expect(buildWeappVueStyleRequestMock).not.toHaveBeenCalled()
-    expect(code).toBe('App({})')
+    expect(output.code).toBe('App({})')
+    expect(output.map?.sources).toEqual(['/project/src/app.vue'])
   })
 
   it('inlines auto routes imports and dynamic imports through shared helper', async () => {

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/shared/compile.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/shared/compile.ts
@@ -1,8 +1,11 @@
 import type { SFCStyleBlock } from 'vue/compiler-sfc'
 import type { VueTransformResult } from 'wevu/compiler'
 import type { CompilerContext } from '../../../../../context'
+import type { EncodedSourceMapLike } from '../../../../../utils/sourcemap'
+import MagicString from 'magic-string'
 import { resolveAstEngine } from '../../../../../ast'
 import logger from '../../../../../logger'
+import { composeSourceMaps } from '../../../../../utils/sourcemap'
 import { collectOnPageScrollPerformanceWarnings } from '../../../../performance/onPageScrollDiagnostics'
 import { injectWevuPageFeaturesInJsWithViteResolver } from '../../injectPageFeatures'
 import { collectSetDataPickKeysFromTemplate, injectSetDataPickInJs, isAutoSetDataPickEnabled } from '../../injectSetDataPick'
@@ -16,8 +19,12 @@ import {
   resolveScriptlessVueEntryStub,
 } from './state'
 
+type VueTransformResultWithScriptMap = VueTransformResult & {
+  scriptMap?: EncodedSourceMapLike | null
+}
+
 export async function finalizeTransformEntryScript(options: {
-  result: VueTransformResult
+  result: VueTransformResultWithScriptMap
   filename: string
   pluginCtx: any
   configService: NonNullable<CompilerContext['configService']>
@@ -41,6 +48,7 @@ export async function finalizeTransformEntryScript(options: {
       })
       if (injected.transformed) {
         result.script = injected.code
+        result.scriptMap = composeSourceMaps(injected.map as EncodedSourceMapLike | null | undefined, result.scriptMap)
       }
     }
   }
@@ -60,6 +68,7 @@ export async function finalizeTransformEntryScript(options: {
     const injectedPick = injectSetDataPickInJs(result.script, keys)
     if (injectedPick.transformed) {
       result.script = injectedPick.code
+      result.scriptMap = composeSourceMaps(injectedPick.map as EncodedSourceMapLike | null | undefined, result.scriptMap)
     }
   }
 
@@ -67,7 +76,7 @@ export async function finalizeTransformEntryScript(options: {
 }
 
 export function finalizeTransformEntryCode(options: {
-  result: VueTransformResult
+  result: VueTransformResultWithScriptMap
   filename: string
   styleBlocks?: SFCStyleBlock[]
   isPage: boolean
@@ -75,7 +84,9 @@ export function finalizeTransformEntryCode(options: {
   isDev: boolean
 }) {
   const { result, filename, styleBlocks, isPage, isApp, isDev } = options
-  let returnedCode = result.script ?? ''
+  const script = result.script ?? ''
+  const returned = new MagicString(script)
+  let hasMutation = false
 
   if (styleBlocks?.length) {
     const styleImports = styleBlocks
@@ -84,24 +95,40 @@ export function finalizeTransformEntryCode(options: {
         return `import ${JSON.stringify(request)};\n`
       })
       .join('')
-    returnedCode = styleImports + returnedCode
+    returned.prepend(styleImports)
+    hasMutation = true
   }
 
   if (!isApp && !result.script?.trim()) {
-    returnedCode += resolveScriptlessVueEntryStub(isPage)
+    returned.append(resolveScriptlessVueEntryStub(isPage))
+    hasMutation = true
   }
 
   const macroHash = result.meta?.jsonMacroHash
   if (macroHash && isDev) {
-    returnedCode += `\n;Object.defineProperty({}, '__weappViteJsonMacroHash', { value: ${JSON.stringify(macroHash)} })\n`
+    returned.append(`\n;Object.defineProperty({}, '__weappViteJsonMacroHash', { value: ${JSON.stringify(macroHash)} })\n`)
+    hasMutation = true
   }
 
   const defineOptionsHash = result.meta?.defineOptionsHash
   if (defineOptionsHash && isDev) {
-    returnedCode += `\n;Object.defineProperty({}, '__weappViteDefineOptionsHash', { value: ${JSON.stringify(defineOptionsHash)} })\n`
+    returned.append(`\n;Object.defineProperty({}, '__weappViteDefineOptionsHash', { value: ${JSON.stringify(defineOptionsHash)} })\n`)
+    hasMutation = true
   }
 
-  return returnedCode
+  const generatedMap = hasMutation
+    ? returned.generateMap({
+      hires: true,
+      includeContent: true,
+      source: filename,
+      file: filename,
+    }) as unknown as EncodedSourceMapLike
+    : null
+
+  return {
+    code: returned.toString(),
+    map: composeSourceMaps(generatedMap as EncodedSourceMapLike | null, result.scriptMap),
+  }
 }
 
 export async function compileTransformEntryResult(options: {
@@ -154,6 +181,7 @@ export async function finalizeTransformCompiledResult(options: {
     addWatchFile,
     emitScopedSlotChunks,
   } = options
+  const transformResult = result as VueTransformResultWithScriptMap
 
   if (isPage && result.template) {
     await handleTransformEntryPageLayoutFlow({
@@ -174,7 +202,7 @@ export async function finalizeTransformCompiledResult(options: {
   }
 
   await finalizeTransformEntryScript({
-    result,
+    result: transformResult,
     filename,
     pluginCtx,
     configService,
@@ -189,7 +217,7 @@ export async function finalizeTransformCompiledResult(options: {
     emitScopedSlotChunks(pluginCtx, relativeBase, result, scopedSlotModules, emittedScopedSlotChunks, configService.outputExtensions)
   }
 
-  return result
+  return transformResult
 }
 
 export function logTransformFileError(filename: string, error: unknown) {

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile.ts
@@ -142,8 +142,8 @@ export async function transformVueLikeFile(options: {
     reportTiming(filename, isPage)
 
     return {
-      code: returnedCode,
-      map: null,
+      code: returnedCode.code,
+      map: returnedCode.map,
     }
   }
   catch (error) {

--- a/packages/weapp-vite/src/utils/sourcemap.ts
+++ b/packages/weapp-vite/src/utils/sourcemap.ts
@@ -1,0 +1,38 @@
+import remapping from '@jridgewell/remapping'
+
+export interface EncodedSourceMapLike {
+  version: number
+  file?: string
+  names: string[]
+  sourceRoot?: string
+  sources: string[]
+  sourcesContent?: Array<string | null>
+  mappings: string
+}
+
+export function isEncodedSourceMapLike(value: unknown): value is EncodedSourceMapLike {
+  return Boolean(
+    value
+    && typeof value === 'object'
+    && 'version' in value
+    && 'mappings' in value
+    && 'names' in value
+    && 'sources' in value,
+  )
+}
+
+export function composeSourceMaps(
+  transformedMap: EncodedSourceMapLike | null | undefined,
+  originalMap: EncodedSourceMapLike | null | undefined,
+): EncodedSourceMapLike | null {
+  if (isEncodedSourceMapLike(transformedMap) && isEncodedSourceMapLike(originalMap)) {
+    return remapping([transformedMap as any, originalMap as any], () => null) as EncodedSourceMapLike
+  }
+  if (isEncodedSourceMapLike(transformedMap)) {
+    return transformedMap
+  }
+  if (isEncodedSourceMapLike(originalMap)) {
+    return originalMap
+  }
+  return null
+}

--- a/packages/weapp-vite/test/vue/transform-plugin.test.ts
+++ b/packages/weapp-vite/test/vue/transform-plugin.test.ts
@@ -145,7 +145,17 @@ describe('vue transform plugin', () => {
   }
 
   it('transform() resolves shared class style wxs path by default', async () => {
-    compileVueFileMock.mockResolvedValue({ script: 'export default {}', meta: {} })
+    compileVueFileMock.mockResolvedValue({
+      script: 'export default {}',
+      scriptMap: {
+        version: 3,
+        names: [],
+        sources: [vuePath!],
+        sourcesContent: ['export default {}'],
+        mappings: 'AAAA',
+      },
+      meta: {},
+    })
 
     const nestedVue = path.join(tmpDir!, 'pages/index/page.vue')
     await fs.ensureDir(path.dirname(nestedVue))
@@ -176,7 +186,17 @@ describe('vue transform plugin', () => {
   })
 
   it('transform() defaults classStyleRuntime to js even when wxs is available', async () => {
-    compileVueFileMock.mockResolvedValue({ script: 'export default {}', meta: {} })
+    compileVueFileMock.mockResolvedValue({
+      script: 'export default {}',
+      scriptMap: {
+        version: 3,
+        names: [],
+        sources: [vuePath!],
+        sourcesContent: ['export default {}'],
+        mappings: 'AAAA',
+      },
+      meta: {},
+    })
 
     const nestedVue = path.join(tmpDir!, 'pages/index/page.vue')
     await fs.ensureDir(path.dirname(nestedVue))
@@ -201,7 +221,17 @@ describe('vue transform plugin', () => {
   })
 
   it('transform() passes objectLiteralBindMode from config', async () => {
-    compileVueFileMock.mockResolvedValue({ script: 'export default {}', meta: {} })
+    compileVueFileMock.mockResolvedValue({
+      script: 'export default {}',
+      scriptMap: {
+        version: 3,
+        names: [],
+        sources: [vuePath!],
+        sourcesContent: ['export default {}'],
+        mappings: 'AAAA',
+      },
+      meta: {},
+    })
 
     const { createVueTransformPlugin } = await import('../../src/plugins/vue/transform/plugin')
     const ctx = createCtx({
@@ -228,7 +258,17 @@ describe('vue transform plugin', () => {
   })
 
   it('transform() passes mustacheInterpolation from config', async () => {
-    compileVueFileMock.mockResolvedValue({ script: 'export default {}', meta: {} })
+    compileVueFileMock.mockResolvedValue({
+      script: 'export default {}',
+      scriptMap: {
+        version: 3,
+        names: [],
+        sources: [vuePath!],
+        sourcesContent: ['export default {}'],
+        mappings: 'AAAA',
+      },
+      meta: {},
+    })
 
     const { createVueTransformPlugin } = await import('../../src/plugins/vue/transform/plugin')
     const ctx = createCtx({
@@ -252,6 +292,31 @@ describe('vue transform plugin', () => {
 
     const [, , options] = compileVueFileMock.mock.calls[0]!
     expect(options.template.mustacheInterpolation).toBe('spaced')
+  })
+
+  it('transform() preserves vue entry sourcemap after injecting style imports', async () => {
+    compileVueFileMock.mockResolvedValue({
+      script: 'export default {}',
+      scriptMap: {
+        version: 3,
+        names: [],
+        sources: [vuePath!],
+        sourcesContent: [await fs.readFile(vuePath!, 'utf8')],
+        mappings: 'AAAA',
+      },
+      meta: {},
+    })
+
+    const { createVueTransformPlugin } = await import('../../src/plugins/vue/transform/plugin')
+    const plugin = createVueTransformPlugin(createCtx() as any)
+
+    const result = await plugin.transform!.call({}, await fs.readFile(vuePath!, 'utf8'), vuePath!)
+
+    expect(result).toBeTruthy()
+    expect(result?.code).toContain('weapp-vite:vue-style:')
+    expect(result?.map).toBeTruthy()
+    expect(typeof result?.map).not.toBe('string')
+    expect((result?.map as any).sources).toEqual([vuePath!])
   })
 
   it('transform() uses local class style wxs path when sharing is disabled', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1799,6 +1799,9 @@ importers:
 
   packages-runtime/wevu-compiler:
     dependencies:
+      '@jridgewell/remapping':
+        specifier: ^2.3.5
+        version: 2.3.5
       '@vue/compiler-core':
         specifier: 'catalog:'
         version: 3.5.32
@@ -2011,6 +2014,9 @@ importers:
 
   packages/weapp-vite:
     dependencies:
+      '@jridgewell/remapping':
+        specifier: ^2.3.5
+        version: 2.3.5
       '@vercel/detect-agent':
         specifier: ^1.2.3
         version: 1.2.3


### PR DESCRIPTION
## 变更说明
- 修复 `weapp-vite` / `@wevu/compiler` 在 `.vue` 文件调试链路中丢失脚本 sourcemap 的问题，补齐 `compileScript -> wevu 脚本重写 -> 页面特性注入 -> setData.pick 注入 -> 入口代码拼装` 的 sourcemap 传递与组合。
- 新增 `github-issues` 中的 `issue-475` 最小复现页面与组件，并补充 CI build e2e，锁定最终产物仍能稳定追溯回原始 `.vue` 页面与组件源码。
- 补充 changeset，覆盖 `weapp-vite`、`@wevu/compiler`、`create-weapp-vite`。

## 验证
- `pnpm vitest run packages-runtime/wevu-compiler/test/index.test.ts packages/weapp-vite/src/plugins/vue/transform/plugin/shared.test.ts packages/weapp-vite/test/vue/transform-plugin.test.ts`
- `pnpm --filter @wevu/compiler typecheck`
- `pnpm --filter weapp-vite typecheck`
- `pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #475"`

Closes #475
