### PR TITLE
test(github-issues): 补充 issue-466 主包 Dialog.confirm 场景

### DIFF
--- a/e2e-apps/github-issues/project.config.json
+++ b/e2e-apps/github-issues/project.config.json
@@ -11,8 +11,13 @@
     "uglifyFileName": false,
     "uploadWithSourceMap": true,
     "enhance": true,
-    "packNpmManually": false,
-    "packNpmRelationList": [],
+    "packNpmManually": true,
+    "packNpmRelationList": [
+      {
+        "packageJsonPath": "./package.json",
+        "miniprogramNpmDistDir": "./dist"
+      }
+    ],
     "minifyWXSS": true,
     "localPlugins": false,
     "disableUseStrict": false,

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -232,6 +232,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-466/index",
+          "pathName": "pages/issue-466/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-475/index",
           "pathName": "pages/issue-475/index",
           "query": "",

--- a/e2e-apps/github-issues/src/pages/issue-466/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-466/index.vue
@@ -1,0 +1,251 @@
+<script setup lang="ts">
+import Dialog from 'tdesign-miniprogram/dialog/index'
+import { getCurrentInstance, ref } from 'wevu'
+
+definePageJson({
+  navigationBarTitleText: 'issue-466-main',
+  usingComponents: {
+    't-dialog': 'tdesign-miniprogram/dialog/dialog',
+  },
+})
+
+type DialogOutcome = 'confirmed' | 'cancelled'
+type OpenTrigger = 'idle' | 'user-tap' | 'e2e'
+
+const mpContext = getCurrentInstance()
+const dialogModule = Dialog as Record<string, any>
+const confirmType = typeof dialogModule.confirm
+const defaultType = typeof dialogModule.default
+const defaultConfirmType = typeof dialogModule.default?.confirm
+
+const openCount = ref(0)
+const settleCount = ref(0)
+const dialogVisible = ref(false)
+const lastAction = ref('idle')
+const lastTrigger = ref<OpenTrigger>('idle')
+const lastError = ref('')
+const lastPayload = ref('')
+const lastTitle = ref('')
+const lastReturnedPromise = ref(false)
+
+let lastDialogPromise: Promise<DialogOutcome> | null = null
+
+function stringifyValue(value: unknown) {
+  if (typeof value === 'string') {
+    return value
+  }
+  if (value instanceof Error) {
+    return value.message || String(value)
+  }
+  if (value == null) {
+    return ''
+  }
+  try {
+    return JSON.stringify(value)
+  }
+  catch {
+    return String(value)
+  }
+}
+
+function resolveDialogHost() {
+  return (mpContext as any)?.selectComponent?.('#issue466-main-dialog') ?? null
+}
+
+function syncDialogState() {
+  const dialogHost = resolveDialogHost()
+  dialogVisible.value = Boolean(dialogHost?.data?.visible ?? dialogHost?.properties?.visible)
+  lastTitle.value = String(dialogHost?.data?.title ?? dialogHost?.properties?.title ?? '')
+  return dialogHost
+}
+
+function clearDialogHost() {
+  resolveDialogHost()?.setData?.({
+    cancelBtn: '',
+    confirmBtn: '',
+    content: '',
+    title: '',
+    visible: false,
+  })
+}
+
+function readRuntimeState() {
+  syncDialogState()
+  return {
+    confirmType,
+    defaultType,
+    defaultConfirmType,
+    openCount: openCount.value,
+    settleCount: settleCount.value,
+    dialogVisible: dialogVisible.value,
+    lastAction: lastAction.value,
+    lastTrigger: lastTrigger.value,
+    lastError: lastError.value,
+    lastPayload: lastPayload.value,
+    lastTitle: lastTitle.value,
+    lastReturnedPromise: lastReturnedPromise.value,
+  }
+}
+
+function resetLastStatus(trigger: OpenTrigger) {
+  lastAction.value = 'opening'
+  lastTrigger.value = trigger
+  lastError.value = ''
+  lastPayload.value = ''
+  lastReturnedPromise.value = false
+}
+
+function trackDialogPromise(dialogResult: Promise<unknown>) {
+  lastReturnedPromise.value = typeof dialogResult?.then === 'function'
+  lastDialogPromise = Promise.resolve(dialogResult)
+    .then((payload) => {
+      settleCount.value += 1
+      lastAction.value = 'confirmed'
+      lastPayload.value = stringifyValue(payload)
+      return 'confirmed' as const
+    })
+    .catch((error) => {
+      settleCount.value += 1
+      lastAction.value = 'cancelled'
+      lastError.value = stringifyValue(error)
+      lastPayload.value = stringifyValue(error)
+      return 'cancelled' as const
+    })
+    .finally(() => {
+      lastDialogPromise = null
+    })
+}
+
+async function openConfirmDialog(trigger: OpenTrigger) {
+  openCount.value += 1
+  resetLastStatus(trigger)
+
+  try {
+    const dialogResult = Dialog.confirm({
+      context: mpContext as any,
+      selector: '#issue466-main-dialog',
+      title: 'issue-466 main confirm title',
+      content: 'issue-466 main confirm content',
+      confirmBtn: '确定',
+      cancelBtn: '取消',
+    })
+
+    trackDialogPromise(dialogResult)
+    await Promise.resolve()
+    return readRuntimeState()
+  }
+  catch (error) {
+    lastAction.value = 'confirm-threw'
+    lastError.value = stringifyValue(error)
+    return readRuntimeState()
+  }
+}
+
+function handleOpenConfirmTap() {
+  void openConfirmDialog('user-tap')
+}
+
+function _runE2E() {
+  return readRuntimeState()
+}
+
+function _resetE2E() {
+  openCount.value = 0
+  settleCount.value = 0
+  dialogVisible.value = false
+  lastAction.value = 'idle'
+  lastTrigger.value = 'idle'
+  lastError.value = ''
+  lastPayload.value = ''
+  lastTitle.value = ''
+  lastReturnedPromise.value = false
+  lastDialogPromise = null
+  clearDialogHost()
+  return readRuntimeState()
+}
+
+async function _openDialogE2E() {
+  return await openConfirmDialog('e2e')
+}
+
+async function _confirmDialogE2E() {
+  const dialogHost = syncDialogState()
+
+  if (typeof dialogHost?.onConfirm === 'function') {
+    dialogHost.onConfirm()
+  }
+  else if (typeof dialogHost?._onConfirm === 'function') {
+    dialogHost._onConfirm({ trigger: 'confirm' })
+  }
+
+  if (lastDialogPromise) {
+    await lastDialogPromise
+  }
+
+  await Promise.resolve()
+  return readRuntimeState()
+}
+
+async function _cancelDialogE2E() {
+  const dialogHost = syncDialogState()
+
+  if (typeof dialogHost?.onCancel === 'function') {
+    dialogHost.onCancel()
+  }
+  else if (typeof dialogHost?._onCancel === 'function') {
+    dialogHost._onCancel({ trigger: 'cancel' })
+  }
+
+  if (lastDialogPromise) {
+    await lastDialogPromise
+  }
+
+  await Promise.resolve()
+  return readRuntimeState()
+}
+</script>
+
+<template>
+  <view class="issue466-main-page">
+    <text class="issue466-main-title">
+      issue-466 main-package tdesign Dialog.confirm
+    </text>
+    <text class="issue466-main-line">confirmType = {{ confirmType }}</text>
+    <text class="issue466-main-line">defaultConfirmType = {{ defaultConfirmType }}</text>
+    <text class="issue466-main-line">lastAction = {{ lastAction }}</text>
+    <text class="issue466-main-line">lastTrigger = {{ lastTrigger }}</text>
+    <text class="issue466-main-line">lastPayload = {{ lastPayload || 'none' }}</text>
+    <text class="issue466-main-line">lastError = {{ lastError || 'none' }}</text>
+    <text class="issue466-main-line">dialogVisible = {{ dialogVisible }}</text>
+    <text class="issue466-main-line">lastTitle = {{ lastTitle || 'none' }}</text>
+    <text class="issue466-main-line">counts = open {{ openCount }}, settle {{ settleCount }}</text>
+    <button id="issue466-main-open" class="issue466-main-button" @tap="handleOpenConfirmTap">
+      打开 confirm
+    </button>
+    <button class="issue466-main-button issue466-main-button--secondary" @tap="_resetE2E">
+      重置状态
+    </button>
+    <t-dialog id="issue466-main-dialog" />
+  </view>
+</template>
+
+<style scoped>
+.issue466-main-page {
+  padding: 32rpx;
+}
+
+.issue466-main-title,
+.issue466-main-line {
+  display: block;
+  margin-bottom: 24rpx;
+}
+
+.issue466-main-button {
+  margin-bottom: 16rpx;
+}
+
+.issue466-main-button--secondary {
+  color: #475569;
+  background: #e2e8f0;
+}
+</style>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -23,7 +23,9 @@ export default defineConfig({
     },
     npm: {
       mainPackage: {
-        dependencies: false,
+        dependencies: [
+          /^tdesign-miniprogram$/,
+        ],
       },
       subPackages: {
         'subpackages/issue-327': {

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -1115,7 +1115,7 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(await fs.pathExists(userRuntimePath)).toBe(true)
   })
 
-  it('issue #327: routes npm deps by mainPackage/subPackages config without emitting main-package npm output', async () => {
+  it('issue #327: routes npm deps by mainPackage/subPackages config and only emits configured main-package npm output', async () => {
     await runBuild()
 
     const issue327NpmRoot = path.join(DIST_ROOT, 'subpackages/issue-327/miniprogram_npm')
@@ -1139,10 +1139,10 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(await fs.pathExists(itemCamelCasePath)).toBe(true)
     expect(await fs.pathExists(userMergePath)).toBe(true)
     expect(await fs.pathExists(mainDayjsPath)).toBe(false)
-    expect(await fs.pathExists(mainTdesignPath)).toBe(false)
+    expect(await fs.pathExists(mainTdesignPath)).toBe(true)
     expect(await fs.pathExists(mainLodashPath)).toBe(false)
     expect(await fs.pathExists(mainMergePath)).toBe(false)
-    expect(await fs.pathExists(path.join(DIST_ROOT, 'miniprogram_npm'))).toBe(false)
+    expect(await fs.pathExists(path.join(DIST_ROOT, 'miniprogram_npm'))).toBe(true)
 
     expect(await fs.pathExists(path.join(issue327NpmRoot, 'camelcase/index.js'))).toBe(false)
     expect(await fs.pathExists(path.join(issue327NpmRoot, 'merge/index.js'))).toBe(false)

--- a/e2e/ide/github-issues.runtime.issue466.test.ts
+++ b/e2e/ide/github-issues.runtime.issue466.test.ts
@@ -2,7 +2,10 @@ import { afterAll, describe, expect, it } from 'vitest'
 import {
   closeSharedMiniProgram,
   getSharedMiniProgram,
+  readPageWxml,
+  relaunchPage,
   releaseSharedMiniProgram,
+  tapElement,
 } from './github-issues.runtime.shared'
 import { attachRuntimeErrorCollector } from './runtimeErrors'
 
@@ -64,9 +67,137 @@ async function waitForIssue466NativeRuntime(page: any, timeoutMs = 20_000) {
   throw new Error(`Timed out waiting for issue-466 native runtime: ${JSON.stringify(lastRuntime, null, 2)}`)
 }
 
+async function waitForIssue466MainRuntime(page: any, timeoutMs = 20_000) {
+  const startedAt = Date.now()
+  let lastRuntime: Record<string, any> | null = null
+
+  while (Date.now() - startedAt <= timeoutMs) {
+    try {
+      const runtime = await page.callMethod('_runE2E')
+      lastRuntime = runtime
+      if (runtime?.confirmType === 'function') {
+        return runtime
+      }
+    }
+    catch {
+    }
+
+    try {
+      await page.waitFor(220)
+    }
+    catch {
+    }
+  }
+
+  throw new Error(`Timed out waiting for issue-466 main runtime: ${JSON.stringify(lastRuntime, null, 2)}`)
+}
+
 describe.sequential('github-issues runtime issue-466', () => {
   afterAll(async () => {
     await closeSharedMiniProgram()
+  })
+
+  it('issue #466: keeps main-package tdesign Dialog.confirm callable through a user-facing page flow', async (ctx) => {
+    const miniProgram = await getSharedMiniProgram(ctx)
+    const collector = attachRuntimeErrorCollector(miniProgram)
+
+    try {
+      const page = await relaunchPage(
+        miniProgram,
+        '/pages/issue-466/index',
+        undefined,
+        20_000,
+      )
+      if (!page) {
+        throw new Error('Failed to launch main-package issue-466 page')
+      }
+
+      await waitForIssue466MainRuntime(page)
+
+      expect(await page.callMethod('_resetE2E')).toMatchObject({
+        confirmType: 'function',
+        openCount: 0,
+        settleCount: 0,
+        dialogVisible: false,
+        lastAction: 'idle',
+        lastTrigger: 'idle',
+        lastError: '',
+        lastPayload: '',
+        lastReturnedPromise: false,
+      })
+
+      const pageWxml = await readPageWxml(page)
+      expect(pageWxml).toContain('class="issue466-main-page"')
+      expect(pageWxml).toContain('id="issue466-main-open"')
+
+      const openMarker = collector.mark()
+      await tapElement(page, '#issue466-main-open')
+      const opened = await page.callMethod('_runE2E')
+      expect(opened).toMatchObject({
+        confirmType: 'function',
+        openCount: 1,
+        settleCount: 0,
+        dialogVisible: true,
+        lastAction: 'opening',
+        lastTrigger: 'user-tap',
+        lastError: '',
+        lastPayload: '',
+        lastTitle: 'issue-466 main confirm title',
+        lastReturnedPromise: true,
+      })
+      expect(collector.getSince(openMarker)).toEqual([])
+
+      const cancelMarker = collector.mark()
+      const cancelled = await page.callMethod('_cancelDialogE2E')
+      expect(cancelled).toMatchObject({
+        confirmType: 'function',
+        openCount: 1,
+        settleCount: 1,
+        dialogVisible: false,
+        lastAction: 'cancelled',
+        lastTrigger: 'user-tap',
+        lastError: '{"trigger":"cancel"}',
+        lastPayload: '{"trigger":"cancel"}',
+        lastTitle: 'issue-466 main confirm title',
+        lastReturnedPromise: true,
+      })
+      expect(collector.getSince(cancelMarker)).toEqual([])
+
+      const reopenMarker = collector.mark()
+      const reopened = await page.callMethod('_openDialogE2E')
+      expect(reopened).toMatchObject({
+        confirmType: 'function',
+        openCount: 2,
+        settleCount: 1,
+        dialogVisible: true,
+        lastAction: 'opening',
+        lastTrigger: 'e2e',
+        lastError: '',
+        lastPayload: '',
+        lastTitle: 'issue-466 main confirm title',
+        lastReturnedPromise: true,
+      })
+      expect(collector.getSince(reopenMarker)).toEqual([])
+
+      const confirmMarker = collector.mark()
+      const confirmed = await page.callMethod('_confirmDialogE2E')
+      expect(confirmed).toMatchObject({
+        confirmType: 'function',
+        openCount: 2,
+        settleCount: 2,
+        dialogVisible: false,
+        lastAction: 'confirmed',
+        lastTrigger: 'e2e',
+        lastError: '',
+        lastTitle: 'issue-466 main confirm title',
+        lastReturnedPromise: true,
+      })
+      expect(collector.getSince(confirmMarker)).toEqual([])
+    }
+    finally {
+      collector.dispose()
+      await releaseSharedMiniProgram(miniProgram)
+    }
   })
 
   it('issue #466: keeps imported tdesign Dialog methods callable in DevTools runtime', async (ctx) => {


### PR DESCRIPTION
## 摘要
补充 issue #466 在 `e2e-apps/github-issues` 主包中的正常用户使用场景，并新增对应 DevTools runtime e2e 覆盖。

## 改动
- 在 `e2e-apps/github-issues/src/pages/issue-466/index.vue` 新增主包页面，覆盖 `tdesign-miniprogram` 的命令式 `Dialog.confirm` 用法
- 调整 `e2e-apps/github-issues/weapp-vite.config.ts`，将 `tdesign-miniprogram` 纳入主包 npm 依赖配置
- 调整 `e2e-apps/github-issues/project.config.json`，让主包 npm 产物输出到 `dist/`，避免 DevTools 在主包页面解析不到 `t-dialog` 组件
- 更新 `e2e-apps/github-issues/project.private.config.json`，补充主包 issue-466 页面启动入口
- 扩展 `e2e/ide/github-issues.runtime.issue466.test.ts`，新增主包页面的用户流和 e2e 测试

## 验证
- `pnpm --filter e2e-app-github-issues build`
- `vitest run -c ./e2e/vitest.e2e.devtools.config.ts e2e/ide/github-issues.runtime.issue466.test.ts`

## 关联
Refs #466