### PR TITLE
fix: 修复裸 import.meta.env 导致 vue 调试行号偏移

### DIFF
--- a/.changeset/short-cows-wave.md
+++ b/.changeset/short-cows-wave.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复小程序 `.vue` 文件中裸 `import.meta.env` 被展开为多行对象后导致源码调试行号偏移的问题。现在聚合 env 会保持为单行表达式，同时补齐 `issue #475` 的 page/component 回归覆盖，避免页面与组件调试定位再次漂移。

--- a/e2e-apps/github-issues/.env
+++ b/e2e-apps/github-issues/.env
@@ -1,2 +1,3 @@
 VITE_ISSUE_431_ASSET_BASE=https://static.example.com/issue-431
 VITE_ISSUE_431_LABEL=issue-431 native wxml env replacement
+VITE_ISSUE_475_LABEL=issue-475 import meta env marker

--- a/e2e-apps/github-issues/src/components/issue-475/SourceMapProbe/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-475/SourceMapProbe/index.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
 const componentLabel = 'issue-475 component marker'
 const componentTraceLabel = componentLabel
+const componentEnv = import.meta.env
+const componentEnvLabel = componentEnv.VITE_ISSUE_475_LABEL
 
 function _probeIssue475ComponentE2E() {
   return {
+    componentEnv,
     componentLabel,
     componentTraceLabel,
+    componentEnvLabel,
   }
 }
 </script>
@@ -14,6 +18,7 @@ function _probeIssue475ComponentE2E() {
   <view class="issue475-component">
     <text class="issue475-component__title">{{ componentLabel }}</text>
     <text class="issue475-component__trace">{{ componentTraceLabel }}</text>
+    <text class="issue475-component__env">{{ componentEnvLabel }}</text>
   </view>
 </template>
 
@@ -27,6 +32,10 @@ function _probeIssue475ComponentE2E() {
 }
 
 .issue475-component__trace {
+  display: block;
+}
+
+.issue475-component__env {
   display: block;
 }
 </style>

--- a/e2e-apps/github-issues/src/pages/issue-475/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-475/index.vue
@@ -7,11 +7,15 @@ definePageJson({
 
 const pageLabel = 'issue-475 vue sourcemap debugging'
 const pageTraceLabel = 'issue-475 page marker'
+const pageEnv = import.meta.env
+const pageEnvLabel = pageEnv.VITE_ISSUE_475_LABEL
 
 function _runE2E() {
   return {
+    pageEnv,
     pageLabel,
     pageTraceLabel,
+    pageEnvLabel,
   }
 }
 </script>
@@ -20,6 +24,7 @@ function _runE2E() {
   <view class="issue475-page">
     <text class="issue475-page__title">{{ pageLabel }}</text>
     <text class="issue475-page__trace">{{ pageTraceLabel }}</text>
+    <text class="issue475-page__env">{{ pageEnvLabel }}</text>
     <SourceMapProbe />
   </view>
 </template>
@@ -35,6 +40,11 @@ function _runE2E() {
 }
 
 .issue475-page__trace {
+  display: block;
+  margin-bottom: 24rpx;
+}
+
+.issue475-page__env {
   display: block;
   margin-bottom: 24rpx;
 }

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -274,11 +274,16 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageWxml).toContain('class="issue475-page"')
     expect(pageWxml).toContain('{{pageLabel}}')
     expect(pageWxml).toContain('{{pageTraceLabel}}')
+    expect(pageWxml).toContain('{{pageEnvLabel}}')
     expect(pageWxml).toContain('<SourceMapProbe />')
     expect(pageJs).toContain('//#region src/pages/issue-475/index.vue')
     expect(pageJs).toContain('issue-475 page marker')
+    expect(pageJs).toContain('const pageEnv = JSON.parse(')
+    expect(pageJs).not.toContain('const pageEnv = {\n')
     expect(componentJs).toContain('//#region src/components/issue-475/SourceMapProbe/index.vue')
     expect(componentJs).toContain('issue-475 component marker')
+    expect(componentJs).toContain('const componentEnv = JSON.parse(')
+    expect(componentJs).not.toContain('const componentEnv = {\n')
   })
 
   it('issue #479: injects indirect wevu page feature hooks from local helpers', async () => {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/transform.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/transform.test.ts
@@ -84,6 +84,47 @@ describe('core lifecycle transform hook injectWeapi', () => {
     expect(code).not.toContain('import.meta.url')
   })
 
+  it('keeps bare import.meta.env replacements on a single expression line in vue sfc script blocks', async () => {
+    const transform = createTransformHook({
+      ctx: {
+        configService: {
+          absoluteSrcRoot: '/project/src',
+          defineImportMetaEnv: {
+            'import.meta.env': 'JSON.parse("{\\"MODE\\":\\"production\\",\\"FEATURE_FLAG\\":\\"on\\"}")',
+            'import.meta.env.FEATURE_FLAG': '"on"',
+          },
+          packageJson: {
+            dependencies: {},
+          },
+          weappViteConfig: {},
+          relativeAbsoluteSrcRoot(id: string) {
+            return id.replace('/project/src/', '')
+          },
+          relativeOutputPath(id: string) {
+            return id.replace('/project/src/', '')
+          },
+        },
+      },
+    } as any)
+
+    const result = await transform(
+      [
+        '<script setup lang="ts">',
+        'const env = import.meta.env',
+        'const meta = import.meta',
+        '</script>',
+        '<template><view /></template>',
+      ].join('\n'),
+      '/project/src/pages/import-meta/index.vue',
+    )
+    const code = result && typeof result === 'object' && 'code' in result ? result.code : ''
+
+    expect(code).toContain('const env = JSON.parse("{\\"MODE\\":\\"production\\",\\"FEATURE_FLAG\\":\\"on\\"}")')
+    expect(code).toContain('env: JSON.parse("{\\"MODE\\":\\"production\\",\\"FEATURE_FLAG\\":\\"on\\"}")')
+    expect(code).not.toContain('const env = {\n')
+    expect(code).not.toContain('env: {\n')
+  })
+
   it('injects request globals for declared page entries as transform fallback', async () => {
     const transform = createTransformHook({
       ctx: {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/transform/importMeta.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/transform/importMeta.ts
@@ -2,7 +2,7 @@ import * as t from '@babel/types'
 import MagicString from 'magic-string'
 import { parse as parseSfc } from 'vue/compiler-sfc'
 import { generate, parseJsLike, traverse } from '../../../../utils/babel'
-import { createStaticImportMetaValues } from '../../../../utils/importMeta'
+import { createStaticImportMetaValues, resolveImportMetaEnvExpression } from '../../../../utils/importMeta'
 
 function isImportMetaNode(node: any) {
   return node?.type === 'MetaProperty'
@@ -45,6 +45,24 @@ function getImportMetaEnvPropertyName(node: any) {
   return undefined
 }
 
+function createImportMetaEnvExpressionNode(rawExpression: string) {
+  try {
+    const ast = parseJsLike(`const __weappViteImportMetaEnv = ${rawExpression}`)
+    const declaration = ast.program.body[0]
+    if (
+      declaration?.type === 'VariableDeclaration'
+      && declaration.declarations[0]?.type === 'VariableDeclarator'
+      && declaration.declarations[0].init
+    ) {
+      return t.cloneNode(declaration.declarations[0].init, true)
+    }
+  }
+  catch {
+  }
+
+  return undefined
+}
+
 export function replaceImportMetaAccess(code: string, options: {
   defineImportMetaEnv?: Record<string, any>
   extension: string
@@ -55,13 +73,21 @@ export function replaceImportMetaAccess(code: string, options: {
   }
 
   const values = createStaticImportMetaValues(options)
+  const envExpressionNode = createImportMetaEnvExpressionNode(
+    resolveImportMetaEnvExpression(options.defineImportMetaEnv),
+  )
   const ast = parseJsLike(code)
   let mutated = false
   const importMetaObjectNode = t.objectExpression([
     t.objectProperty(t.identifier('filename'), t.stringLiteral(values.filename)),
     t.objectProperty(t.identifier('url'), t.stringLiteral(values.url)),
     t.objectProperty(t.identifier('dirname'), t.stringLiteral(values.dirname)),
-    t.objectProperty(t.identifier('env'), t.valueToNode(values.env)),
+    t.objectProperty(
+      t.identifier('env'),
+      envExpressionNode
+        ? t.cloneNode(envExpressionNode, true)
+        : t.valueToNode(values.env),
+    ),
   ])
 
   traverse(ast as any, {
@@ -77,7 +103,11 @@ export function replaceImportMetaAccess(code: string, options: {
       }
 
       if (isImportMetaMemberAccess(path.node, 'env')) {
-        path.replaceWith(t.valueToNode(values.env))
+        path.replaceWith(
+          envExpressionNode
+            ? t.cloneNode(envExpressionNode, true)
+            : t.valueToNode(values.env),
+        )
         mutated = true
         return
       }
@@ -111,7 +141,11 @@ export function replaceImportMetaAccess(code: string, options: {
       }
 
       if (isImportMetaMemberAccess(path.node, 'env')) {
-        path.replaceWith(t.valueToNode(values.env))
+        path.replaceWith(
+          envExpressionNode
+            ? t.cloneNode(envExpressionNode, true)
+            : t.valueToNode(values.env),
+        )
         mutated = true
         return
       }

--- a/packages/weapp-vite/src/runtime/config/createConfigService.test.ts
+++ b/packages/weapp-vite/src/runtime/config/createConfigService.test.ts
@@ -200,7 +200,9 @@ describe('createConfigService', () => {
     expect(define['import.meta.env.PLATFORM']).toBe(JSON.stringify('weapp'))
     expect(define['import.meta.env.MP_PLATFORM']).toBe(JSON.stringify('weapp'))
     expect(define['import.meta.env.CUSTOM_FLAG']).toBe('1')
-    expect(JSON.parse(define['import.meta.env']).CUSTOM_FLAG).toBe(1)
+    expect(define['import.meta.env']).toMatch(/^JSON\.parse\(/)
+    const serializedEnv = define['import.meta.env'].slice('JSON.parse('.length, -1)
+    expect(JSON.parse(JSON.parse(serializedEnv)).CUSTOM_FLAG).toBe(1)
   })
 
   it('resolves plugin roots and remaps output path for plugin sources', () => {

--- a/packages/weapp-vite/src/runtime/config/createConfigService.ts
+++ b/packages/weapp-vite/src/runtime/config/createConfigService.ts
@@ -152,7 +152,8 @@ function createConfigService(ctx: MutableCompilerContext): ConfigService {
     for (const [key, value] of Object.entries(env)) {
       define[`import.meta.env.${key}`] = JSON.stringify(value)
     }
-    define['import.meta.env'] = JSON.stringify(env)
+    const serializedEnv = JSON.stringify(env)
+    define['import.meta.env'] = `JSON.parse(${JSON.stringify(serializedEnv)})`
     return define
   }
 

--- a/packages/weapp-vite/src/utils/importMeta.ts
+++ b/packages/weapp-vite/src/utils/importMeta.ts
@@ -8,12 +8,7 @@ export interface StaticImportMetaValues {
   url: string
 }
 
-export function resolveImportMetaEnvObject(defineImportMetaEnv?: Record<string, any>) {
-  const rawEnv = defineImportMetaEnv?.['import.meta.env']
-  if (typeof rawEnv !== 'string') {
-    return {}
-  }
-
+function tryParseImportMetaEnvObject(rawEnv: string) {
   try {
     const parsed = JSON.parse(rawEnv)
     return parsed && typeof parsed === 'object' ? parsed : {}
@@ -21,6 +16,38 @@ export function resolveImportMetaEnvObject(defineImportMetaEnv?: Record<string, 
   catch {
     return {}
   }
+}
+
+function extractImportMetaEnvJson(rawEnv: string) {
+  const normalized = rawEnv.trim()
+  const matched = normalized.match(/^JSON\.parse\((.+)\)$/s)
+  if (!matched) {
+    return normalized
+  }
+
+  try {
+    const parsed = JSON.parse(matched[1]!)
+    return typeof parsed === 'string' ? parsed : normalized
+  }
+  catch {
+    return normalized
+  }
+}
+
+export function resolveImportMetaEnvObject(defineImportMetaEnv?: Record<string, any>) {
+  const rawEnv = defineImportMetaEnv?.['import.meta.env']
+  if (typeof rawEnv !== 'string') {
+    return {}
+  }
+
+  return tryParseImportMetaEnvObject(extractImportMetaEnvJson(rawEnv))
+}
+
+export function resolveImportMetaEnvExpression(defineImportMetaEnv?: Record<string, any>) {
+  const rawEnv = defineImportMetaEnv?.['import.meta.env']
+  return typeof rawEnv === 'string' && rawEnv.trim()
+    ? rawEnv
+    : JSON.stringify(resolveImportMetaEnvObject(defineImportMetaEnv))
 }
 
 export function createStaticImportMetaValues(options: {
@@ -53,9 +80,7 @@ export function createStaticImportMetaReplacementMap(options: {
   relativePath: string
 }) {
   const values = createStaticImportMetaValues(options)
-  const envJson = typeof options.defineImportMetaEnv?.['import.meta.env'] === 'string'
-    ? options.defineImportMetaEnv['import.meta.env']
-    : JSON.stringify(values.env)
+  const envJson = resolveImportMetaEnvExpression(options.defineImportMetaEnv)
 
   return {
     ...(options.defineImportMetaEnv ?? {}),


### PR DESCRIPTION
## Summary
- 将聚合 `import.meta.env` 定义改为单行 `JSON.parse(...)` 表达式，避免在 `.vue` 调试输出中展开成多行对象
- 调整 import.meta 转换逻辑，裸 `import.meta.env` / `import.meta` 复用该单行表达式而不是重新生成多行 env 对象
- 补充 issue #475 的 page/component 回归场景与相关单测

## Testing
- `vitest run packages/weapp-vite/src/runtime/config/createConfigService.test.ts`
- `vitest run packages/weapp-vite/src/plugins/core/lifecycle/transform.test.ts`
- `pnpm --filter weapp-vite build`
- `vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #475"`

## Related Issues
- Fixes #475