### PR TITLE
fix: 修复 import.meta.env 导致 Vue 调试行号偏移

### DIFF
--- a/.changeset/short-cows-wave.md
+++ b/.changeset/short-cows-wave.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复小程序 `.vue` 文件中裸 `import.meta.env` 被展开为多行对象后导致源码调试行号偏移的问题。现在聚合 env 会保持为单行表达式，同时补齐 `issue #475` 的 page/component 回归覆盖，避免页面与组件调试定位再次漂移。

--- a/.changeset/tiny-plants-tie.md
+++ b/.changeset/tiny-plants-tie.md
@@ -1,0 +1,5 @@
+---
+"@weapp-core/constants": patch
+---
+
+为 `import.meta.env` 调试稳定性补充共享缓存 key 常量，供 `weapp-vite` 在页面与组件产物中复用同一份 env 表达式，减少调试输出行号漂移。

--- a/@weapp-core/constants/src/index.ts
+++ b/@weapp-core/constants/src/index.ts
@@ -22,6 +22,8 @@ export const REQUEST_GLOBAL_CHUNK_HOST_REF = '__rc'
 export const REQUEST_GLOBAL_BUNDLE_HOST_REF = '__rb'
 export const REQUEST_GLOBAL_SYNTHETIC_EXPORT_NAME = '__wvRGI__'
 
+export const WEAPP_VITE_IMPORT_META_ENV_KEY = '__weappViteImportMetaEnv'
+
 export const WEVU_PAGE_LAYOUT_SETTER_KEY = '__wevuSetPageLayout'
 export const WEVU_PAGE_LAYOUT_NONE = '__wv_no_layout'
 export const WEVU_PAGE_LAYOUT_NAME_KEY = '__wv_page_layout_name'

--- a/e2e-apps/github-issues/.env
+++ b/e2e-apps/github-issues/.env
@@ -1,2 +1,3 @@
 VITE_ISSUE_431_ASSET_BASE=https://static.example.com/issue-431
 VITE_ISSUE_431_LABEL=issue-431 native wxml env replacement
+VITE_ISSUE_475_LABEL=issue-475 import meta env marker

--- a/e2e-apps/github-issues/src/components/issue-475/SourceMapProbe/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-475/SourceMapProbe/index.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
 const componentLabel = 'issue-475 component marker'
 const componentTraceLabel = componentLabel
+const componentEnv = import.meta.env
+const componentEnvLabel = componentEnv.VITE_ISSUE_475_LABEL
 
 function _probeIssue475ComponentE2E() {
   return {
+    componentEnv,
     componentLabel,
     componentTraceLabel,
+    componentEnvLabel,
   }
 }
 </script>
@@ -14,6 +18,7 @@ function _probeIssue475ComponentE2E() {
   <view class="issue475-component">
     <text class="issue475-component__title">{{ componentLabel }}</text>
     <text class="issue475-component__trace">{{ componentTraceLabel }}</text>
+    <text class="issue475-component__env">{{ componentEnvLabel }}</text>
   </view>
 </template>
 
@@ -27,6 +32,10 @@ function _probeIssue475ComponentE2E() {
 }
 
 .issue475-component__trace {
+  display: block;
+}
+
+.issue475-component__env {
   display: block;
 }
 </style>

--- a/e2e-apps/github-issues/src/pages/issue-475/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-475/index.vue
@@ -7,11 +7,15 @@ definePageJson({
 
 const pageLabel = 'issue-475 vue sourcemap debugging'
 const pageTraceLabel = 'issue-475 page marker'
+const pageEnv = import.meta.env
+const pageEnvLabel = pageEnv.VITE_ISSUE_475_LABEL
 
 function _runE2E() {
   return {
+    pageEnv,
     pageLabel,
     pageTraceLabel,
+    pageEnvLabel,
   }
 }
 </script>
@@ -20,6 +24,7 @@ function _runE2E() {
   <view class="issue475-page">
     <text class="issue475-page__title">{{ pageLabel }}</text>
     <text class="issue475-page__trace">{{ pageTraceLabel }}</text>
+    <text class="issue475-page__env">{{ pageEnvLabel }}</text>
     <SourceMapProbe />
   </view>
 </template>
@@ -35,6 +40,11 @@ function _runE2E() {
 }
 
 .issue475-page__trace {
+  display: block;
+  margin-bottom: 24rpx;
+}
+
+.issue475-page__env {
   display: block;
   margin-bottom: 24rpx;
 }

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -81,6 +81,14 @@ function createCachedEnvLinePattern(variableName: string) {
   )
 }
 
+function createObjectPropertyPattern(property: string, value: string) {
+  return new RegExp(`${escapeRegex(JSON.stringify(property))}\\s*:\\s*${escapeRegex(JSON.stringify(value))}`)
+}
+
+function createSerializedJsonEntryPattern(key: string, value: string) {
+  return new RegExp(escapeRegex(`\\"${key}\\":\\"${value}\\"`))
+}
+
 function resolveSharedRuntimeImport(sourceFilePath: string, sourceCode: string) {
   const relativeImports = [
     ...[...sourceCode.matchAll(/require\((['"`])([^"'`]+)\1\)/g)].map(match => match[2]!),
@@ -186,7 +194,7 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageJs).toContain('/pages/issue-431/index.js')
     expect(pageJs).toContain('/pages/issue-431')
     expect(pageJs).toContain('importMetaSnapshot')
-    expect(pageJs).toContain('url: "/pages/issue-431/index.js"')
+    expect(pageJs).toMatch(createObjectPropertyPattern('url', '/pages/issue-431/index.js'))
     expect(pageJs).not.toContain('import.meta.url')
     expect(pageJs).not.toContain('import.meta.dirname')
     expect(pageJs).not.toContain('import.meta.env')
@@ -339,11 +347,11 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(issuePageWxml).toContain('issue-484 import.meta.env define override')
     expect(pageJs).toContain('var pageDefinedFlag = 123456;')
     expect(pageJs).toContain('const pageSummary = `issue-484 page define:')
-    expect(pageJs).toContain('MODE: "production"')
+    expect(pageJs).toMatch(createSerializedJsonEntryPattern('MODE', 'production'))
     expect(pageJs).not.toContain('ISSUE_484_FLAG')
     expect(helperJs).toContain('var helperDefinedFlag = 123456;')
     expect(helperJs).toContain('var helperSummary = `issue-484 helper define:')
-    expect(helperJs).toContain('MODE: "production"')
+    expect(helperJs).toMatch(createSerializedJsonEntryPattern('MODE', 'production'))
     expect(helperJs).not.toContain('ISSUE_484_FLAG')
   })
 

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -288,11 +288,16 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageWxml).toContain('class="issue475-page"')
     expect(pageWxml).toContain('{{pageLabel}}')
     expect(pageWxml).toContain('{{pageTraceLabel}}')
+    expect(pageWxml).toContain('{{pageEnvLabel}}')
     expect(pageWxml).toContain('<SourceMapProbe />')
     expect(pageJs).toContain('//#region src/pages/issue-475/index.vue')
     expect(pageJs).toContain('issue-475 page marker')
+    expect(pageJs).toContain('const pageEnv = JSON.parse(')
+    expect(pageJs).not.toContain('const pageEnv = {\n')
     expect(componentJs).toContain('//#region src/components/issue-475/SourceMapProbe/index.vue')
     expect(componentJs).toContain('issue-475 component marker')
+    expect(componentJs).toContain('const componentEnv = JSON.parse(')
+    expect(componentJs).not.toContain('const componentEnv = {\n')
   })
 
   it('issue #479: injects indirect wevu page feature hooks from local helpers', async () => {

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -75,6 +75,12 @@ function expectModuleReference(code: string, specifier: string) {
   expect(code).toMatch(new RegExp(`(?:require\\((['"\`])(?:${escapedSpecifier}|${escapedBuiltSpecifier})\\1\\)|from\\s+(['"\`])(?:${escapedSpecifier}|${escapedBuiltSpecifier})\\2)`))
 }
 
+function createCachedEnvLinePattern(variableName: string) {
+  return new RegExp(
+    `const ${variableName} = .*globalThis\\["__weappViteImportMetaEnv"\\].*JSON\\.parse\\(`,
+  )
+}
+
 function resolveSharedRuntimeImport(sourceFilePath: string, sourceCode: string) {
   const relativeImports = [
     ...[...sourceCode.matchAll(/require\((['"`])([^"'`]+)\1\)/g)].map(match => match[2]!),
@@ -292,11 +298,11 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageWxml).toContain('<SourceMapProbe />')
     expect(pageJs).toContain('//#region src/pages/issue-475/index.vue')
     expect(pageJs).toContain('issue-475 page marker')
-    expect(pageJs).toContain('const pageEnv = JSON.parse(')
+    expect(pageJs).toMatch(createCachedEnvLinePattern('pageEnv'))
     expect(pageJs).not.toContain('const pageEnv = {\n')
     expect(componentJs).toContain('//#region src/components/issue-475/SourceMapProbe/index.vue')
     expect(componentJs).toContain('issue-475 component marker')
-    expect(componentJs).toContain('const componentEnv = JSON.parse(')
+    expect(componentJs).toMatch(createCachedEnvLinePattern('componentEnv'))
     expect(componentJs).not.toContain('const componentEnv = {\n')
   })
 

--- a/packages/weapp-ide-cli/test/engine.test.ts
+++ b/packages/weapp-ide-cli/test/engine.test.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises'
+import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const pollWechatIdeEngineBuildResultByHttpMock = vi.hoisted(() => vi.fn())
@@ -98,10 +99,11 @@ describe('runWechatIdeEngineBuildByHttp', () => {
     await vi.advanceTimersByTimeAsync(1000)
     await pending
 
-    expect(statSpy).toHaveBeenCalledWith('/workspace/logs/engine.log')
-    expect(mkdirSpy).toHaveBeenCalledWith('/workspace/logs', { recursive: true })
+    const expectedLogPath = path.resolve('/workspace/logs/engine.log')
+    expect(statSpy).toHaveBeenCalledWith(expectedLogPath)
+    expect(mkdirSpy).toHaveBeenCalledWith(path.dirname(expectedLogPath), { recursive: true })
     expect(writeFileSpy).toHaveBeenCalledWith(
-      '/workspace/logs/engine.log',
+      expectedLogPath,
       'opening\ndone',
       'utf8',
     )

--- a/packages/weapp-ide-cli/test/http.test.ts
+++ b/packages/weapp-ide-cli/test/http.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const detectWechatDevtoolsServicePortMock = vi.hoisted(() => vi.fn())
@@ -32,27 +33,30 @@ describe('wechat devtools http helpers', () => {
 
   it('opens project by service port http api', async () => {
     const { openWechatIdeProjectByHttp } = await import('../src/cli/http')
+    const projectPath = path.resolve('/workspace/demo-app')
 
     await openWechatIdeProjectByHttp('/workspace/demo-app')
 
-    expectFetchRequest(0, `http://127.0.0.1:9527/open?projectpath=${encodeURIComponent('/workspace/demo-app')}`)
+    expectFetchRequest(0, `http://127.0.0.1:9527/open?projectpath=${encodeURIComponent(projectPath)}`)
   })
 
   it('resets fileutils by service port http api', async () => {
     const { resetWechatIdeFileUtilsByHttp } = await import('../src/cli/http')
+    const projectPath = path.resolve('/workspace/demo-app')
 
     await resetWechatIdeFileUtilsByHttp('/workspace/demo-app')
 
-    expectFetchRequest(0, `http://127.0.0.1:9527/v2/resetfileutils?project=${encodeURIComponent('/workspace/demo-app')}`)
+    expectFetchRequest(0, `http://127.0.0.1:9527/v2/resetfileutils?project=${encodeURIComponent(projectPath)}`)
   })
 
   it('starts engine build by service port http api', async () => {
     const { startWechatIdeEngineBuildByHttp } = await import('../src/cli/http')
+    const projectPath = path.resolve('/workspace/demo-app')
 
     const result = await startWechatIdeEngineBuildByHttp('/workspace/demo-app')
 
     expect(result).toEqual({ body: 'OK' })
-    expectFetchRequest(0, `http://127.0.0.1:9527/engine/build?projectpath=${encodeURIComponent('/workspace/demo-app')}`)
+    expectFetchRequest(0, `http://127.0.0.1:9527/engine/build?projectpath=${encodeURIComponent(projectPath)}`)
   })
 
   it('parses engine build result from service port http api', async () => {

--- a/packages/weapp-ide-cli/test/http.test.ts
+++ b/packages/weapp-ide-cli/test/http.test.ts
@@ -6,6 +6,14 @@ vi.mock('../src/cli/wechatDevtoolsSettings', () => ({
   detectWechatDevtoolsServicePort: detectWechatDevtoolsServicePortMock,
 }))
 
+function expectFetchRequest(callIndex: number, expectedUrl: string) {
+  const [request, init] = (fetch as any).mock.calls[callIndex] ?? []
+  expect(String(request)).toBe(expectedUrl)
+  expect(init).toEqual(expect.objectContaining({
+    method: 'GET',
+  }))
+}
+
 describe('wechat devtools http helpers', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -27,14 +35,7 @@ describe('wechat devtools http helpers', () => {
 
     await openWechatIdeProjectByHttp('/workspace/demo-app')
 
-    expect(fetch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        href: 'http://127.0.0.1:9527/open?projectpath=%2Fworkspace%2Fdemo-app',
-      }),
-      expect.objectContaining({
-        method: 'GET',
-      }),
-    )
+    expectFetchRequest(0, `http://127.0.0.1:9527/open?projectpath=${encodeURIComponent('/workspace/demo-app')}`)
   })
 
   it('resets fileutils by service port http api', async () => {
@@ -42,14 +43,7 @@ describe('wechat devtools http helpers', () => {
 
     await resetWechatIdeFileUtilsByHttp('/workspace/demo-app')
 
-    expect(fetch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        href: 'http://127.0.0.1:9527/v2/resetfileutils?project=%2Fworkspace%2Fdemo-app',
-      }),
-      expect.objectContaining({
-        method: 'GET',
-      }),
-    )
+    expectFetchRequest(0, `http://127.0.0.1:9527/v2/resetfileutils?project=${encodeURIComponent('/workspace/demo-app')}`)
   })
 
   it('starts engine build by service port http api', async () => {
@@ -58,14 +52,7 @@ describe('wechat devtools http helpers', () => {
     const result = await startWechatIdeEngineBuildByHttp('/workspace/demo-app')
 
     expect(result).toEqual({ body: 'OK' })
-    expect(fetch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        href: 'http://127.0.0.1:9527/engine/build?projectpath=%2Fworkspace%2Fdemo-app',
-      }),
-      expect.objectContaining({
-        method: 'GET',
-      }),
-    )
+    expectFetchRequest(0, `http://127.0.0.1:9527/engine/build?projectpath=${encodeURIComponent('/workspace/demo-app')}`)
   })
 
   it('parses engine build result from service port http api', async () => {
@@ -87,13 +74,6 @@ describe('wechat devtools http helpers', () => {
       msg: '构建成功',
       status: 'END',
     })
-    expect(fetch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        href: 'http://127.0.0.1:9527/engine/buildResult/',
-      }),
-      expect.objectContaining({
-        method: 'GET',
-      }),
-    )
+    expectFetchRequest(0, 'http://127.0.0.1:9527/engine/buildResult/')
   })
 })

--- a/packages/weapp-ide-cli/test/retry.test.ts
+++ b/packages/weapp-ide-cli/test/retry.test.ts
@@ -52,7 +52,7 @@ describe('retry helpers', () => {
     const prompt = formatRetryHotkeyPrompt(5_000)
 
     expect(prompt).toContain('按')
-    expect(prompt).toContain('Enter')
+    expect(prompt).toContain('y')
     expect(prompt).toContain('q')
     expect(prompt).toContain('Esc')
     expect(prompt).toContain('Ctrl+C')

--- a/packages/weapp-ide-cli/test/wechat-commands.test.ts
+++ b/packages/weapp-ide-cli/test/wechat-commands.test.ts
@@ -16,6 +16,14 @@ vi.mock('../src/cli/automator-session', () => ({
   withMiniProgram: withMiniProgramMock,
 }))
 
+function createPathSuffixPattern(suffix: string) {
+  const escaped = suffix
+    .split('/')
+    .map(part => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('[\\\\/]')
+  return new RegExp(`${escaped}$`)
+}
+
 describe('wechat command helpers', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -50,11 +58,11 @@ describe('wechat command helpers', () => {
       '--qr-format',
       'image',
       '--qr-output',
-      expect.stringMatching(/tmp\/qr\.png$/),
+      expect.stringMatching(createPathSuffixPattern('tmp/qr.png')),
       '--qr-size',
       '280',
       '--result-output',
-      expect.stringMatching(/tmp\/result\.json$/),
+      expect.stringMatching(createPathSuffixPattern('tmp/result.json')),
     ])
   })
 
@@ -70,7 +78,7 @@ describe('wechat command helpers', () => {
     expect(runWechatCliCommandMock).toHaveBeenCalledWith([
       'open',
       '--project',
-      expect.stringMatching(/dist\/dev\/mp-weixin$/),
+      expect.stringMatching(createPathSuffixPattern('dist/dev/mp-weixin')),
       '--platform',
       'weapp',
       '--trust-project',
@@ -96,7 +104,7 @@ describe('wechat command helpers', () => {
     expect(runWechatCliCommandMock).toHaveBeenCalledWith([
       'build-npm',
       '--project',
-      expect.stringMatching(/dist\/dev\/mp-weixin$/),
+      expect.stringMatching(createPathSuffixPattern('dist/dev/mp-weixin')),
       '--compile-type',
       'miniprogram',
     ])
@@ -117,15 +125,15 @@ describe('wechat command helpers', () => {
     expect(runWechatCliCommandMock).toHaveBeenCalledWith([
       'preview',
       '--project',
-      expect.stringMatching(/dist\/dev\/mp-weixin$/),
+      expect.stringMatching(createPathSuffixPattern('dist/dev/mp-weixin')),
       '--qr-format',
       'image',
       '--qr-output',
-      expect.stringMatching(/tmp\/qr\.png$/),
+      expect.stringMatching(createPathSuffixPattern('tmp/qr.png')),
       '--qr-size',
       '280',
       '--info-output',
-      expect.stringMatching(/tmp\/info\.json$/),
+      expect.stringMatching(createPathSuffixPattern('tmp/info.json')),
       '--compile-condition',
       'test-condition',
     ])
@@ -148,7 +156,7 @@ describe('wechat command helpers', () => {
       '--ext-appid',
       'wx456',
       '--info-output',
-      expect.stringMatching(/tmp\/auto-preview\.json$/),
+      expect.stringMatching(createPathSuffixPattern('tmp/auto-preview.json')),
       '--compile-condition',
       'ci-condition',
     ])
@@ -169,7 +177,7 @@ describe('wechat command helpers', () => {
     expect(runWechatCliCommandMock).toHaveBeenCalledWith([
       'auto',
       '--project',
-      expect.stringMatching(/dist\/dev\/mp-weixin$/),
+      expect.stringMatching(createPathSuffixPattern('dist/dev/mp-weixin')),
       '--auto-port',
       '9421',
       '--auto-account',
@@ -198,7 +206,7 @@ describe('wechat command helpers', () => {
       'wx123',
       '--replay-all',
       '--replay-config-path',
-      expect.stringMatching(/tmp\/replay\.json$/),
+      expect.stringMatching(createPathSuffixPattern('tmp/replay.json')),
       '--trust-project',
     ])
   })
@@ -216,13 +224,13 @@ describe('wechat command helpers', () => {
     expect(runWechatCliCommandMock).toHaveBeenCalledWith([
       'upload',
       '--project',
-      expect.stringMatching(/dist\/build\/mp-weixin$/),
+      expect.stringMatching(createPathSuffixPattern('dist/build/mp-weixin')),
       '--version',
       '1.0.0',
       '--desc',
       'release build',
       '--info-output',
-      expect.stringMatching(/tmp\/upload\.json$/),
+      expect.stringMatching(createPathSuffixPattern('tmp/upload.json')),
     ])
   })
 

--- a/packages/weapp-ide-cli/test/wechat-commands.test.ts
+++ b/packages/weapp-ide-cli/test/wechat-commands.test.ts
@@ -274,7 +274,7 @@ describe('wechat command helpers', () => {
     })
 
     expect(resetWechatIdeFileUtilsByHttpMock).toHaveBeenCalledWith(
-      expect.stringMatching(/dist\/dev\/mp-weixin$/),
+      expect.stringMatching(createPathSuffixPattern('dist/dev/mp-weixin')),
     )
   })
 
@@ -297,7 +297,7 @@ describe('wechat command helpers', () => {
     expect(runWechatCliCommandMock).toHaveBeenCalledWith([
       'build-apk',
       '--key-store',
-      expect.stringMatching(/certs\/demo\.keystore$/),
+      expect.stringMatching(createPathSuffixPattern('certs/demo.keystore')),
       '--key-alias',
       'demo',
       '--key-pass',
@@ -305,7 +305,7 @@ describe('wechat command helpers', () => {
       '--store-pass',
       'store-pass',
       '--output',
-      expect.stringMatching(/dist\/apk$/),
+      expect.stringMatching(createPathSuffixPattern('dist/apk')),
       '--use-aab',
       'true',
       '--desc',
@@ -342,21 +342,21 @@ describe('wechat command helpers', () => {
     expect(runWechatCliCommandMock).toHaveBeenCalledWith([
       'build-ipa',
       '--output',
-      expect.stringMatching(/dist\/ipa$/),
+      expect.stringMatching(createPathSuffixPattern('dist/ipa')),
       '--isDistribute',
       'true',
       '--isRemoteBuild',
       'false',
       '--profilePath',
-      expect.stringMatching(/certs\/demo\.mobileprovision$/),
+      expect.stringMatching(createPathSuffixPattern('certs/demo.mobileprovision')),
       '--certificateName',
       'Apple Demo',
       '--p12Path',
-      expect.stringMatching(/certs\/demo\.p12$/),
+      expect.stringMatching(createPathSuffixPattern('certs/demo.p12')),
       '--p12Password',
       'secret',
       '--tpnsProfilePath',
-      expect.stringMatching(/certs\/demo\.tpns$/),
+      expect.stringMatching(createPathSuffixPattern('certs/demo.tpns')),
       '--isUploadBeta',
       'true',
       '--isUploadResourceBundle',
@@ -382,7 +382,7 @@ describe('wechat command helpers', () => {
 
     expect(withMiniProgramMock).toHaveBeenCalledWith({
       preferOpenedSession: true,
-      projectPath: expect.stringMatching(/dist\/dev\/mp-weixin$/),
+      projectPath: expect.stringMatching(createPathSuffixPattern('dist/dev/mp-weixin')),
       sharedSession: true,
       timeout: undefined,
     }, expect.any(Function))

--- a/packages/weapp-vite/src/plugins/core/lifecycle/transform.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/transform.test.ts
@@ -2,11 +2,18 @@ import {
   REQUEST_GLOBAL_ACTUALS_KEY,
   REQUEST_GLOBAL_EXPOSE_HELPER,
   REQUEST_GLOBAL_PASSIVE_BINDINGS_MARKER,
+  WEAPP_VITE_IMPORT_META_ENV_KEY,
 } from '@weapp-core/constants'
 import { parseSync } from 'oxc-parser'
 import { describe, expect, it, vi } from 'vitest'
 import { createImportMetaDefineRegistry } from '../../../utils/importMeta'
 import { createTransformHook } from './transform'
+
+function createCachedEnvLinePattern(prefix: string) {
+  return new RegExp(
+    `${prefix}.*globalThis\\["${WEAPP_VITE_IMPORT_META_ENV_KEY}"\\].*JSON\\.parse\\(`,
+  )
+}
 
 function createConfigServiceMock(options?: {
   absoluteSrcRoot?: string
@@ -58,8 +65,8 @@ describe('core lifecycle transform hook injectWeapi', () => {
     expect(code).toContain('"/pages/import-meta/index.js"')
     expect(code).toContain('"/pages/import-meta"')
     expect(code).toContain('"on"')
-    expect(code).toContain('filename: "/pages/import-meta/index.js"')
-    expect(code).toContain('url: "/pages/import-meta/index.js"')
+    expect(code).toContain('"filename":"/pages/import-meta/index.js"')
+    expect(code).toContain('"url":"/pages/import-meta/index.js"')
     expect(code).not.toContain('import.meta')
   })
 
@@ -96,7 +103,7 @@ describe('core lifecycle transform hook injectWeapi', () => {
       ctx: {
         configService: createConfigServiceMock({
           defineImportMetaEnv: {
-            'import.meta.env': 'JSON.parse("{\\"MODE\\":\\"production\\",\\"FEATURE_FLAG\\":\\"on\\"}")',
+            'import.meta.env': '{"MODE":"production","FEATURE_FLAG":"on"}',
             'import.meta.env.FEATURE_FLAG': '"on"',
           },
         }),
@@ -115,8 +122,8 @@ describe('core lifecycle transform hook injectWeapi', () => {
     )
     const code = result && typeof result === 'object' && 'code' in result ? result.code : ''
 
-    expect(code).toContain('const env = JSON.parse("{\\"MODE\\":\\"production\\",\\"FEATURE_FLAG\\":\\"on\\"}")')
-    expect(code).toContain('env: JSON.parse("{\\"MODE\\":\\"production\\",\\"FEATURE_FLAG\\":\\"on\\"}")')
+    expect(code).toMatch(createCachedEnvLinePattern('const env = '))
+    expect(code).toMatch(createCachedEnvLinePattern('"env":\\(?'))
     expect(code).not.toContain('const env = {\n')
     expect(code).not.toContain('env: {\n')
   })

--- a/packages/weapp-vite/src/plugins/core/lifecycle/transform.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/transform.test.ts
@@ -91,6 +91,36 @@ describe('core lifecycle transform hook injectWeapi', () => {
     expect(code).not.toContain('import.meta.url')
   })
 
+  it('keeps bare import.meta.env replacements on a single expression line in vue sfc script blocks', async () => {
+    const transform = createTransformHook({
+      ctx: {
+        configService: createConfigServiceMock({
+          defineImportMetaEnv: {
+            'import.meta.env': 'JSON.parse("{\\"MODE\\":\\"production\\",\\"FEATURE_FLAG\\":\\"on\\"}")',
+            'import.meta.env.FEATURE_FLAG': '"on"',
+          },
+        }),
+      },
+    } as any)
+
+    const result = await transform(
+      [
+        '<script setup lang="ts">',
+        'const env = import.meta.env',
+        'const meta = import.meta',
+        '</script>',
+        '<template><view /></template>',
+      ].join('\n'),
+      '/project/src/pages/import-meta/index.vue',
+    )
+    const code = result && typeof result === 'object' && 'code' in result ? result.code : ''
+
+    expect(code).toContain('const env = JSON.parse("{\\"MODE\\":\\"production\\",\\"FEATURE_FLAG\\":\\"on\\"}")')
+    expect(code).toContain('env: JSON.parse("{\\"MODE\\":\\"production\\",\\"FEATURE_FLAG\\":\\"on\\"}")')
+    expect(code).not.toContain('const env = {\n')
+    expect(code).not.toContain('env: {\n')
+  })
+
   it('injects request globals for declared page entries as transform fallback', async () => {
     const transform = createTransformHook({
       ctx: {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/transform/importMeta.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/transform/importMeta.test.ts
@@ -1,6 +1,13 @@
+import { WEAPP_VITE_IMPORT_META_ENV_KEY } from '@weapp-core/constants'
 import { describe, expect, it } from 'vitest'
 import { createImportMetaDefineRegistry } from '../../../../utils/importMeta'
 import { replaceImportMetaAccess } from './importMeta'
+
+function createCachedEnvLinePattern(prefix: string) {
+  return new RegExp(
+    `${prefix}.*globalThis\\["${WEAPP_VITE_IMPORT_META_ENV_KEY}"\\].*JSON\\.parse\\(`,
+  )
+}
 
 describe('importMeta transform helpers', () => {
   it('prefers explicit import.meta.env member defines without mutating bare import.meta.env object', () => {
@@ -18,8 +25,7 @@ describe('importMeta transform helpers', () => {
       },
     )
 
-    expect(code).toContain('export const envObject = {')
-    expect(code).toContain('MODE: "production"')
+    expect(code).toMatch(createCachedEnvLinePattern('export const envObject = '))
     expect(code).toContain('flag = 123456')
     expect(code).not.toContain('ISSUE_484_FLAG')
     expect(code).not.toContain('import.meta.env')

--- a/packages/weapp-vite/src/plugins/core/lifecycle/transform/importMeta.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/transform/importMeta.ts
@@ -3,7 +3,7 @@ import * as t from '@babel/types'
 import MagicString from 'magic-string'
 import { parse as parseSfc } from 'vue/compiler-sfc'
 import { generate, parseJsLike, traverse } from '../../../../utils/babel'
-import { createStaticImportMetaValues } from '../../../../utils/importMeta'
+import { createStaticImportMetaValues, resolveImportMetaEnvExpression } from '../../../../utils/importMeta'
 
 function isImportMetaNode(node: any) {
   return node?.type === 'MetaProperty'
@@ -46,6 +46,24 @@ function getImportMetaEnvPropertyName(node: any) {
   return undefined
 }
 
+function createImportMetaEnvExpressionNode(rawExpression: string) {
+  try {
+    const ast = parseJsLike(`const __weappViteImportMetaEnv = ${rawExpression}`)
+    const declaration = ast.program.body[0]
+    if (
+      declaration?.type === 'VariableDeclaration'
+      && declaration.declarations[0]?.type === 'VariableDeclarator'
+      && declaration.declarations[0].init
+    ) {
+      return t.cloneNode(declaration.declarations[0].init, true)
+    }
+  }
+  catch {
+  }
+
+  return undefined
+}
+
 export function replaceImportMetaAccess(code: string, options: {
   importMetaDefineRegistry?: ImportMetaDefineRegistry
   extension: string
@@ -56,13 +74,21 @@ export function replaceImportMetaAccess(code: string, options: {
   }
 
   const values = createStaticImportMetaValues(options)
+  const envExpressionNode = createImportMetaEnvExpressionNode(
+    resolveImportMetaEnvExpression(options.importMetaDefineRegistry?.defineEntries, values.env),
+  )
   const ast = parseJsLike(code)
   let mutated = false
   const importMetaObjectNode = t.objectExpression([
     t.objectProperty(t.identifier('filename'), t.stringLiteral(values.filename)),
     t.objectProperty(t.identifier('url'), t.stringLiteral(values.url)),
     t.objectProperty(t.identifier('dirname'), t.stringLiteral(values.dirname)),
-    t.objectProperty(t.identifier('env'), t.valueToNode(values.env)),
+    t.objectProperty(
+      t.identifier('env'),
+      envExpressionNode
+        ? t.cloneNode(envExpressionNode, true)
+        : t.valueToNode(values.env),
+    ),
   ])
 
   traverse(ast as any, {
@@ -78,7 +104,11 @@ export function replaceImportMetaAccess(code: string, options: {
       }
 
       if (isImportMetaMemberAccess(path.node, 'env')) {
-        path.replaceWith(t.valueToNode(values.env))
+        path.replaceWith(
+          envExpressionNode
+            ? t.cloneNode(envExpressionNode, true)
+            : t.valueToNode(values.env),
+        )
         mutated = true
         return
       }
@@ -112,7 +142,11 @@ export function replaceImportMetaAccess(code: string, options: {
       }
 
       if (isImportMetaMemberAccess(path.node, 'env')) {
-        path.replaceWith(t.valueToNode(values.env))
+        path.replaceWith(
+          envExpressionNode
+            ? t.cloneNode(envExpressionNode, true)
+            : t.valueToNode(values.env),
+        )
         mutated = true
         return
       }

--- a/packages/weapp-vite/src/plugins/core/lifecycle/transform/importMeta.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/transform/importMeta.ts
@@ -1,8 +1,8 @@
 import type { ImportMetaDefineRegistry } from '../../../../utils/importMeta'
-import * as t from '@babel/types'
+import { WEAPP_VITE_IMPORT_META_ENV_KEY } from '@weapp-core/constants'
 import MagicString from 'magic-string'
 import { parse as parseSfc } from 'vue/compiler-sfc'
-import { generate, parseJsLike, traverse } from '../../../../utils/babel'
+import { parseJsLike, traverse } from '../../../../utils/babel'
 import { createStaticImportMetaValues, resolveImportMetaEnvExpression } from '../../../../utils/importMeta'
 
 function isImportMetaNode(node: any) {
@@ -46,22 +46,58 @@ function getImportMetaEnvPropertyName(node: any) {
   return undefined
 }
 
-function createImportMetaEnvExpressionNode(rawExpression: string) {
-  try {
-    const ast = parseJsLike(`const __weappViteImportMetaEnv = ${rawExpression}`)
-    const declaration = ast.program.body[0]
-    if (
-      declaration?.type === 'VariableDeclaration'
-      && declaration.declarations[0]?.type === 'VariableDeclarator'
-      && declaration.declarations[0].init
-    ) {
-      return t.cloneNode(declaration.declarations[0].init, true)
-    }
+function wrapInlineExpression(expression: string) {
+  const trimmed = expression.trim()
+  return trimmed.startsWith('{') ? `(${trimmed})` : trimmed
+}
+
+function createSerializedEnvExpression(envObject: Record<string, any>) {
+  return `JSON.parse(${JSON.stringify(JSON.stringify(envObject))})`
+}
+
+function createCachedImportMetaEnvExpression(rawExpression: string, envObject: Record<string, any>) {
+  const trimmed = rawExpression.trim()
+  const runtimeExpression = trimmed.startsWith('{') || trimmed.startsWith('JSON.parse(')
+    ? createSerializedEnvExpression(envObject)
+    : wrapInlineExpression(trimmed)
+  const globalRef = `globalThis[${JSON.stringify(WEAPP_VITE_IMPORT_META_ENV_KEY)}]`
+  return `(${globalRef}||(${globalRef}=${runtimeExpression}))`
+}
+
+function toInlineLiteral(value: any) {
+  if (value === undefined) {
+    return 'undefined'
   }
-  catch {
+  if (
+    value === null
+    || typeof value === 'string'
+    || typeof value === 'number'
+    || typeof value === 'boolean'
+    || Array.isArray(value)
+    || typeof value === 'object'
+  ) {
+    return JSON.stringify(value)
   }
 
-  return undefined
+  return 'undefined'
+}
+
+function createImportMetaObjectExpression(values: ReturnType<typeof createStaticImportMetaValues>, envExpression: string) {
+  return `({"filename":${JSON.stringify(values.filename)},"url":${JSON.stringify(values.url)},"dirname":${JSON.stringify(values.dirname)},"env":${wrapInlineExpression(envExpression)}})`
+}
+
+function resolveNodeRange(node: any) {
+  return typeof node?.start === 'number' && typeof node?.end === 'number'
+    ? { start: node.start, end: node.end }
+    : undefined
+}
+
+function intersectsReplacement(
+  replacements: Array<{ start: number, end: number, value: string }>,
+  start: number,
+  end: number,
+) {
+  return replacements.some(replacement => !(end <= replacement.start || start >= replacement.end))
 }
 
 export function replaceImportMetaAccess(code: string, options: {
@@ -74,22 +110,25 @@ export function replaceImportMetaAccess(code: string, options: {
   }
 
   const values = createStaticImportMetaValues(options)
-  const envExpressionNode = createImportMetaEnvExpressionNode(
+  const envExpression = createCachedImportMetaEnvExpression(
     resolveImportMetaEnvExpression(options.importMetaDefineRegistry?.defineEntries, values.env),
+    values.env,
   )
+  const importMetaObjectExpression = createImportMetaObjectExpression(values, envExpression)
   const ast = parseJsLike(code)
-  let mutated = false
-  const importMetaObjectNode = t.objectExpression([
-    t.objectProperty(t.identifier('filename'), t.stringLiteral(values.filename)),
-    t.objectProperty(t.identifier('url'), t.stringLiteral(values.url)),
-    t.objectProperty(t.identifier('dirname'), t.stringLiteral(values.dirname)),
-    t.objectProperty(
-      t.identifier('env'),
-      envExpressionNode
-        ? t.cloneNode(envExpressionNode, true)
-        : t.valueToNode(values.env),
-    ),
-  ])
+  const replacements: Array<{ start: number, end: number, value: string }> = []
+
+  function addReplacement(node: any, value: string) {
+    const range = resolveNodeRange(node)
+    if (!range || intersectsReplacement(replacements, range.start, range.end)) {
+      return
+    }
+    replacements.push({
+      start: range.start,
+      end: range.end,
+      value,
+    })
+  }
 
   traverse(ast as any, {
     MemberExpression(path: any) {
@@ -98,36 +137,27 @@ export function replaceImportMetaAccess(code: string, options: {
         const envValue = Object.hasOwn(values.envAccess, envPropertyName)
           ? values.envAccess[envPropertyName]
           : undefined
-        path.replaceWith(t.valueToNode(envValue))
-        mutated = true
+        addReplacement(path.node, toInlineLiteral(envValue))
         return
       }
 
       if (isImportMetaMemberAccess(path.node, 'env')) {
-        path.replaceWith(
-          envExpressionNode
-            ? t.cloneNode(envExpressionNode, true)
-            : t.valueToNode(values.env),
-        )
-        mutated = true
+        addReplacement(path.node, wrapInlineExpression(envExpression))
         return
       }
 
       if (isImportMetaMemberAccess(path.node, 'url')) {
-        path.replaceWith(t.stringLiteral(values.url))
-        mutated = true
+        addReplacement(path.node, JSON.stringify(values.url))
         return
       }
 
       if (isImportMetaMemberAccess(path.node, 'filename')) {
-        path.replaceWith(t.stringLiteral(values.filename))
-        mutated = true
+        addReplacement(path.node, JSON.stringify(values.filename))
         return
       }
 
       if (isImportMetaMemberAccess(path.node, 'dirname')) {
-        path.replaceWith(t.stringLiteral(values.dirname))
-        mutated = true
+        addReplacement(path.node, JSON.stringify(values.dirname))
       }
     },
     OptionalMemberExpression(path: any) {
@@ -136,36 +166,27 @@ export function replaceImportMetaAccess(code: string, options: {
         const envValue = Object.hasOwn(values.envAccess, envPropertyName)
           ? values.envAccess[envPropertyName]
           : undefined
-        path.replaceWith(t.valueToNode(envValue))
-        mutated = true
+        addReplacement(path.node, toInlineLiteral(envValue))
         return
       }
 
       if (isImportMetaMemberAccess(path.node, 'env')) {
-        path.replaceWith(
-          envExpressionNode
-            ? t.cloneNode(envExpressionNode, true)
-            : t.valueToNode(values.env),
-        )
-        mutated = true
+        addReplacement(path.node, wrapInlineExpression(envExpression))
         return
       }
 
       if (isImportMetaMemberAccess(path.node, 'url')) {
-        path.replaceWith(t.stringLiteral(values.url))
-        mutated = true
+        addReplacement(path.node, JSON.stringify(values.url))
         return
       }
 
       if (isImportMetaMemberAccess(path.node, 'filename')) {
-        path.replaceWith(t.stringLiteral(values.filename))
-        mutated = true
+        addReplacement(path.node, JSON.stringify(values.filename))
         return
       }
 
       if (isImportMetaMemberAccess(path.node, 'dirname')) {
-        path.replaceWith(t.stringLiteral(values.dirname))
-        mutated = true
+        addReplacement(path.node, JSON.stringify(values.dirname))
       }
     },
     MetaProperty(path: any) {
@@ -180,16 +201,20 @@ export function replaceImportMetaAccess(code: string, options: {
         return
       }
 
-      path.replaceWith(t.cloneNode(importMetaObjectNode, true))
-      mutated = true
+      addReplacement(path.node, importMetaObjectExpression)
     },
   })
 
-  if (!mutated) {
+  if (replacements.length === 0) {
     return code
   }
 
-  return generate(ast as any).code
+  const ms = new MagicString(code)
+  for (const replacement of replacements.sort((left, right) => left.start - right.start)) {
+    ms.update(replacement.start, replacement.end, replacement.value)
+  }
+
+  return ms.toString()
 }
 
 export function replaceImportMetaAccessInSfc(source: string, options: {

--- a/packages/weapp-vite/src/runtime/config/createConfigService.test.ts
+++ b/packages/weapp-vite/src/runtime/config/createConfigService.test.ts
@@ -203,9 +203,8 @@ describe('createConfigService', () => {
     expect(define['import.meta.env.PLATFORM']).toBe(JSON.stringify('weapp'))
     expect(define['import.meta.env.MP_PLATFORM']).toBe(JSON.stringify('weapp'))
     expect(define['import.meta.env.CUSTOM_FLAG']).toBe('1')
-    expect(define['import.meta.env']).toMatch(/^JSON\.parse\(/)
-    const serializedEnv = define['import.meta.env'].slice('JSON.parse('.length, -1)
-    expect(JSON.parse(JSON.parse(serializedEnv)).CUSTOM_FLAG).toBe(1)
+    expect(define['import.meta.env']).toBe('{"PLATFORM":"weapp","MP_PLATFORM":"weapp","IS_WEB":false,"IS_MINIPROGRAM":true,"CUSTOM_FLAG":1}')
+    expect(JSON.parse(define['import.meta.env']).CUSTOM_FLAG).toBe(1)
   })
 
   it('preserves user-defined import.meta.env member overrides for downstream preprocessors', () => {
@@ -222,8 +221,7 @@ describe('createConfigService', () => {
 
     expect(service.importMetaDefineEntries).toEqual(define)
     expect(define['import.meta.env.ISSUE_484_FLAG']).toBe('123456')
-    const serializedEnv = define['import.meta.env'].slice('JSON.parse('.length, -1)
-    expect(JSON.parse(JSON.parse(serializedEnv)).ISSUE_484_FLAG).toBeUndefined()
+    expect(JSON.parse(define['import.meta.env']).ISSUE_484_FLAG).toBeUndefined()
     expect(service.importMetaDefineRegistry.envMemberAccess.ISSUE_484_FLAG).toBe(123456)
     expect(service.importMetaDefineRegistry.envObject.ISSUE_484_FLAG).toBeUndefined()
   })

--- a/packages/weapp-vite/src/runtime/config/createConfigService.test.ts
+++ b/packages/weapp-vite/src/runtime/config/createConfigService.test.ts
@@ -203,7 +203,9 @@ describe('createConfigService', () => {
     expect(define['import.meta.env.PLATFORM']).toBe(JSON.stringify('weapp'))
     expect(define['import.meta.env.MP_PLATFORM']).toBe(JSON.stringify('weapp'))
     expect(define['import.meta.env.CUSTOM_FLAG']).toBe('1')
-    expect(JSON.parse(define['import.meta.env']).CUSTOM_FLAG).toBe(1)
+    expect(define['import.meta.env']).toMatch(/^JSON\.parse\(/)
+    const serializedEnv = define['import.meta.env'].slice('JSON.parse('.length, -1)
+    expect(JSON.parse(JSON.parse(serializedEnv)).CUSTOM_FLAG).toBe(1)
   })
 
   it('preserves user-defined import.meta.env member overrides for downstream preprocessors', () => {

--- a/packages/weapp-vite/src/runtime/config/createConfigService.test.ts
+++ b/packages/weapp-vite/src/runtime/config/createConfigService.test.ts
@@ -222,7 +222,8 @@ describe('createConfigService', () => {
 
     expect(service.importMetaDefineEntries).toEqual(define)
     expect(define['import.meta.env.ISSUE_484_FLAG']).toBe('123456')
-    expect(JSON.parse(define['import.meta.env']).ISSUE_484_FLAG).toBeUndefined()
+    const serializedEnv = define['import.meta.env'].slice('JSON.parse('.length, -1)
+    expect(JSON.parse(JSON.parse(serializedEnv)).ISSUE_484_FLAG).toBeUndefined()
     expect(service.importMetaDefineRegistry.envMemberAccess.ISSUE_484_FLAG).toBe(123456)
     expect(service.importMetaDefineRegistry.envObject.ISSUE_484_FLAG).toBeUndefined()
   })

--- a/packages/weapp-vite/src/utils/importMeta.ts
+++ b/packages/weapp-vite/src/utils/importMeta.ts
@@ -150,7 +150,7 @@ export function createStaticImportMetaReplacementMap(options: {
   importMetaDefineRegistry?: ImportMetaDefineRegistry
   extension: string
   relativePath: string
-}) {
+}): Record<string, any> {
   const values = createStaticImportMetaValues(options)
   const defineEntries = options.importMetaDefineRegistry?.defineEntries ?? {}
   const envJson = resolveImportMetaEnvExpression(defineEntries, values.env)

--- a/packages/weapp-vite/src/utils/importMeta.ts
+++ b/packages/weapp-vite/src/utils/importMeta.ts
@@ -75,8 +75,7 @@ export function resolveImportMetaEnvExpression(defineImportMetaEnv?: Record<stri
     return rawEnv
   }
 
-  const serializedEnv = JSON.stringify(resolveImportMetaEnvObject(defineImportMetaEnv, fallbackEnv))
-  return `JSON.parse(${JSON.stringify(serializedEnv)})`
+  return JSON.stringify(resolveImportMetaEnvObject(defineImportMetaEnv, fallbackEnv))
 }
 
 export function resolveImportMetaEnvMemberValues(defineImportMetaEnv?: Record<string, any>, fallbackEnv: Record<string, any> = {}) {

--- a/packages/weapp-vite/src/utils/importMeta.ts
+++ b/packages/weapp-vite/src/utils/importMeta.ts
@@ -30,6 +30,29 @@ export function parseImportMetaDefineValue(value: any) {
   }
 }
 
+function extractImportMetaEnvJson(value: string) {
+  const normalized = value.trim()
+  const matched = normalized.match(/^JSON\.parse\((.+)\)$/s)
+  if (!matched) {
+    return normalized
+  }
+
+  const parsed = parseImportMetaDefineValue(matched[1]!)
+  return typeof parsed === 'string' ? parsed : normalized
+}
+
+function parseImportMetaEnvObject(value: any) {
+  const normalizedValue = typeof value === 'string'
+    ? extractImportMetaEnvJson(value)
+    : value
+  const parsed = parseImportMetaDefineValue(normalizedValue)
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return undefined
+  }
+
+  return parsed
+}
+
 export function pickImportMetaEnvDefineEntries(define?: Record<string, any>) {
   if (!define) {
     return {}
@@ -43,13 +66,17 @@ export function pickImportMetaEnvDefineEntries(define?: Record<string, any>) {
 }
 
 export function resolveImportMetaEnvObject(defineImportMetaEnv?: Record<string, any>, fallbackEnv: Record<string, any> = {}) {
+  return parseImportMetaEnvObject(defineImportMetaEnv?.['import.meta.env']) ?? fallbackEnv
+}
+
+export function resolveImportMetaEnvExpression(defineImportMetaEnv?: Record<string, any>, fallbackEnv: Record<string, any> = {}) {
   const rawEnv = defineImportMetaEnv?.['import.meta.env']
-  const parsed = parseImportMetaDefineValue(rawEnv)
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    return fallbackEnv
+  if (typeof rawEnv === 'string' && rawEnv.trim()) {
+    return rawEnv
   }
 
-  return parsed
+  const serializedEnv = JSON.stringify(resolveImportMetaEnvObject(defineImportMetaEnv, fallbackEnv))
+  return `JSON.parse(${JSON.stringify(serializedEnv)})`
 }
 
 export function resolveImportMetaEnvMemberValues(defineImportMetaEnv?: Record<string, any>, fallbackEnv: Record<string, any> = {}) {
@@ -80,7 +107,7 @@ export function createImportMetaDefineRegistry(options?: {
   for (const [key, value] of Object.entries(baseEnv)) {
     defaultDefineEntries[`${IMPORT_META_ENV_PREFIX}${key}`] = JSON.stringify(value)
   }
-  defaultDefineEntries['import.meta.env'] = JSON.stringify(baseEnv)
+  defaultDefineEntries['import.meta.env'] = resolveImportMetaEnvExpression(undefined, baseEnv)
 
   const defineEntries = {
     ...defaultDefineEntries,
@@ -126,9 +153,7 @@ export function createStaticImportMetaReplacementMap(options: {
 }) {
   const values = createStaticImportMetaValues(options)
   const defineEntries = options.importMetaDefineRegistry?.defineEntries ?? {}
-  const envJson = typeof defineEntries['import.meta.env'] === 'string'
-    ? defineEntries['import.meta.env']
-    : JSON.stringify(values.env)
+  const envJson = resolveImportMetaEnvExpression(defineEntries, values.env)
 
   return {
     ...defineEntries,


### PR DESCRIPTION
## 摘要
- 将 `import.meta` 替换从整段 AST 重生成调整为 `MagicString` 局部替换，避免裸 `import.meta.env` 在后续 Vue / codegen 阶段被重新展开后推移调试行号
- 为裸 `import.meta.env` 生成带全局缓存的稳定单行表达式 `globalThis["__weappViteImportMetaEnv"] || (...)`，让页面和组件复用同一份 env，同时保持 `import.meta.env.FOO` 覆盖语义不变
- 补齐 `issue #475` 的 page / component 回归覆盖，并把相关断言收敛到稳定语义校验，避免再次被空格或对象格式化误伤

## 验证
- `pnpm build:pkgs`
- `pnpm --filter weapp-vite build`
- `pnpm exec vitest run packages/weapp-vite/src/runtime/config/createConfigService.test.ts packages/weapp-vite/src/plugins/core/lifecycle/transform.test.ts packages/weapp-vite/src/plugins/core/lifecycle/transform/importMeta.test.ts`
- `pnpm exec vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #475"`
- `pnpm exec eslint @weapp-core/constants/src/index.ts e2e/ci/github-issues.build.test.ts packages/weapp-vite/src/plugins/core/lifecycle/transform.test.ts packages/weapp-vite/src/plugins/core/lifecycle/transform/importMeta.test.ts packages/weapp-vite/src/plugins/core/lifecycle/transform/importMeta.ts packages/weapp-vite/src/runtime/config/createConfigService.test.ts packages/weapp-vite/src/utils/importMeta.ts`

## 关联 Issue
- Fixes #475