### PR TITLE
fix: 支持 template v-slot 单根节点去除包裹层

### DIFF
--- a/.changeset/funny-houses-compete.md
+++ b/.changeset/funny-houses-compete.md
@@ -1,0 +1,7 @@
+---
+"@wevu/compiler": patch
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+为 `weapp.vue.template` 新增 `slotSingleRootNoWrapper` 配置，在 `<template v-slot>` 只有单个可挂载根节点时可直接把 `slot` 挂到该节点上，避免额外的 `<view>` 包裹；同时补齐编译器、类型与 github-issues 回归覆盖。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -260,6 +260,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-494/index",
+          "pathName": "pages/issue-494/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-459/index",
           "pathName": "pages/issue-459/index",
           "query": "",

--- a/e2e-apps/github-issues/src/components/issue-494/IconHost/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-494/IconHost/index.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <view class="issue494-host">
+    <slot name="icon" />
+    <slot name="content" />
+  </view>
+</template>
+
+<style scoped>
+.issue494-host {
+  display: flex;
+  flex-direction: column;
+  gap: 16rpx;
+}
+</style>

--- a/e2e-apps/github-issues/src/pages/issue-494/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-494/index.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+definePageMeta({
+  navigationBarTitleText: 'issue-494',
+})
+
+const iconSrc = 'https://static.example.com/issue-494/icon.png'
+</script>
+
+<template>
+  <Issue494IconHost>
+    <template #icon>
+      <img class="issue494-icon" :src="iconSrc" mode="aspectFit">
+    </template>
+
+    <template #content>
+      <view class="issue494-title">
+        issue-494 template slot single root no wrapper
+      </view>
+      <view class="issue494-desc">
+        multi root fallback keeps wrapper
+      </view>
+    </template>
+  </Issue494IconHost>
+</template>
+
+<style scoped>
+.issue494-icon {
+  width: 80rpx;
+  height: 80rpx;
+}
+
+.issue494-title {
+  font-size: 32rpx;
+  font-weight: 600;
+}
+
+.issue494-desc {
+  color: #475569;
+  font-size: 24rpx;
+}
+</style>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -24,6 +24,11 @@ export default defineConfig({
     wevu: {
       autoSetDataPick: true,
     },
+    vue: {
+      template: {
+        slotSingleRootNoWrapper: true,
+      },
+    },
     npm: {
       mainPackage: {
         dependencies: [

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -336,6 +336,25 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(helperJs).not.toContain('ISSUE_484_FLAG')
   })
 
+  it('issue #494: removes the extra named slot wrapper for single-root template slot content when enabled', async () => {
+    await runBuild()
+
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-494/index.wxml')
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+
+    expect(pageWxml).toContain('issue-494 template slot single root no wrapper')
+    expect(pageWxml).toContain('<Issue494IconHost>')
+    expect(pageWxml).toContain('<image')
+    expect(pageWxml).toContain('class="img issue494-icon"')
+    expect(pageWxml).toContain('slot="icon"')
+    expect(pageWxml).not.toContain('<view slot="icon">')
+    expect(pageWxml).toContain('<view slot="content">')
+    expect(pageWxml).toContain('class="issue494-title"')
+    expect(pageWxml).toContain('issue-494 template slot single root no wrapper')
+    expect(pageWxml).toContain('class="issue494-desc"')
+    expect(pageWxml).toContain('multi root fallback keeps wrapper')
+  })
+
   it('issue #459: keeps directly imported web-apis polyfills interoperable in github-issues app', async () => {
     await runBuild()
 

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
@@ -604,6 +604,78 @@ describe('compileVueTemplateToWxml', () => {
     expect(code).not.toContain('__wv-slot-props=')
   })
 
+  it('keeps the named slot wrapper by default for template v-slot fallback content', () => {
+    const template = `
+<Child>
+  <template #icon>
+    <img class="issue494-icon" src="/assets/issue-494.png" />
+  </template>
+</Child>
+    `.trim()
+
+    const { code } = compileVueTemplateToWxml(template, '/project/src/pages/index/index.vue')
+
+    expect(code).toContain('<view slot="icon"><image class="img issue494-icon" src="/assets/issue-494.png" /></view>')
+  })
+
+  it('unwraps the named slot wrapper when the fallback content has a single root element and the option is enabled', () => {
+    const template = `
+<Child>
+  <template #icon>
+    <img class="issue494-icon" src="/assets/issue-494.png" />
+  </template>
+</Child>
+    `.trim()
+
+    const { code } = compileVueTemplateToWxml(
+      template,
+      '/project/src/pages/index/index.vue',
+      { slotSingleRootNoWrapper: true },
+    )
+
+    expect(code).toContain('<image class="img issue494-icon" src="/assets/issue-494.png" slot="icon" />')
+    expect(code).not.toContain('<view slot="icon">')
+  })
+
+  it('preserves the named slot wrapper for multi-root fallback content when the option is enabled', () => {
+    const template = `
+<Child>
+  <template #content>
+    <view>one</view>
+    <view>two</view>
+  </template>
+</Child>
+    `.trim()
+
+    const { code } = compileVueTemplateToWxml(
+      template,
+      '/project/src/pages/index/index.vue',
+      { slotSingleRootNoWrapper: true },
+    )
+
+    expect(code).toContain('<view slot="content"><view>one</view><view>two</view></view>')
+  })
+
+  it('preserves the named slot wrapper for structural template children when the option is enabled', () => {
+    const template = `
+<Child>
+  <template #callout>
+    <template v-if="ok">
+      <view>callout</view>
+    </template>
+  </template>
+</Child>
+    `.trim()
+
+    const { code } = compileVueTemplateToWxml(
+      template,
+      '/project/src/pages/index/index.vue',
+      { slotSingleRootNoWrapper: true },
+    )
+
+    expect(code).toContain('<view slot="callout"><block wx:if="{{ok}}"><view>callout</view></block></view>')
+  })
+
   it.each([
     ['weapp', 'bindtap'],
     ['alipay', 'onTap'],

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.ts
@@ -82,6 +82,7 @@ export function compileVueTemplateToWxml(
       scopedSlotsCompiler: options?.scopedSlotsCompiler ?? 'auto',
       scopedSlotsRequireProps,
       slotMultipleInstance: options?.slotMultipleInstance ?? true,
+      slotSingleRootNoWrapper: options?.slotSingleRootNoWrapper ?? false,
       scopedSlotComponents: [],
       componentGenerics: {},
       scopeStack: [],

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts
@@ -28,6 +28,93 @@ export interface ScopedSlotDeclaration {
   children: any[]
 }
 
+function isRenderableSlotChild(node: any): boolean {
+  if (node.type === NodeTypes.COMMENT) {
+    return false
+  }
+  if (node.type === NodeTypes.TEXT) {
+    return node.content.trim().length > 0
+  }
+  return true
+}
+
+function canAttachSlotToChild(node: ElementNode): boolean {
+  return !['template', 'slot', 'transition', 'keep-alive'].includes(node.tag)
+}
+
+function findSingleRenderableSlotRoot(children: any[]): ElementNode | undefined {
+  const renderableChildren = children.filter(isRenderableSlotChild)
+  if (renderableChildren.length !== 1) {
+    return undefined
+  }
+  const [child] = renderableChildren
+  if (child.type !== NodeTypes.ELEMENT) {
+    return undefined
+  }
+  return canAttachSlotToChild(child as ElementNode)
+    ? child as ElementNode
+    : undefined
+}
+
+function hasExplicitSlotAttribute(node: ElementNode): boolean {
+  return node.props.some((prop) => {
+    if (prop.type === NodeTypes.ATTRIBUTE) {
+      return prop.name === 'slot'
+    }
+    if (prop.type === NodeTypes.DIRECTIVE) {
+      return prop.name === 'slot'
+        || (prop.name === 'bind'
+          && prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION
+          && prop.arg.content === 'slot')
+    }
+    return false
+  })
+}
+
+function createSlotAttribute(info: Extract<SlotNameInfo, { type: 'static' | 'dynamic' }>, node: ElementNode): any {
+  if (info.type === 'dynamic') {
+    return {
+      type: NodeTypes.DIRECTIVE,
+      name: 'bind',
+      rawName: ':slot',
+      exp: {
+        type: NodeTypes.SIMPLE_EXPRESSION,
+        content: info.exp,
+        isStatic: false,
+        constType: 0,
+        loc: node.loc,
+      },
+      arg: {
+        type: NodeTypes.SIMPLE_EXPRESSION,
+        content: 'slot',
+        isStatic: true,
+        constType: 3,
+        loc: node.loc,
+      },
+      modifiers: [],
+      loc: node.loc,
+    }
+  }
+
+  return {
+    type: NodeTypes.ATTRIBUTE,
+    name: 'slot',
+    value: {
+      type: NodeTypes.TEXT,
+      content: info.value,
+      loc: node.loc,
+    },
+    loc: node.loc,
+  }
+}
+
+function cloneNodeWithSlotAttribute(node: ElementNode, info: Extract<SlotNameInfo, { type: 'static' | 'dynamic' }>): ElementNode {
+  return {
+    ...node,
+    props: [...node.props, createSlotAttribute(info, node)],
+  }
+}
+
 export function renderSlotNameAttribute(
   info: SlotNameInfo,
   context: TransformContext,
@@ -162,13 +249,20 @@ export function renderSlotFallback(
   context: TransformContext,
   transformNode: TransformNode,
 ): string {
+  const slotAttr = renderSlotNameAttribute(decl.name, context, 'slot')
+  if (!slotAttr) {
+    const content = decl.children.map(child => transformNode(child, context)).join('')
+    return content
+  }
+  if (context.slotSingleRootNoWrapper) {
+    const singleRootChild = findSingleRenderableSlotRoot(decl.children)
+    if (singleRootChild && decl.name.type !== 'default' && !hasExplicitSlotAttribute(singleRootChild)) {
+      return transformNode(cloneNodeWithSlotAttribute(singleRootChild, decl.name), context)
+    }
+  }
   const content = decl.children.map(child => transformNode(child, context)).join('')
   if (!content) {
     return ''
-  }
-  const slotAttr = renderSlotNameAttribute(decl.name, context, 'slot')
-  if (!slotAttr) {
-    return content
   }
   return `<view ${slotAttr}>${content}</view>`
 }

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/types.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/types.ts
@@ -70,6 +70,7 @@ export interface TransformContext {
   scopedSlotsCompiler: ScopedSlotsCompilerMode
   scopedSlotsRequireProps: boolean
   slotMultipleInstance: boolean
+  slotSingleRootNoWrapper: boolean
   scopedSlotComponents: ScopedSlotComponentAsset[]
   componentGenerics: Record<string, true>
   scopeStack: Array<Set<string>>
@@ -119,6 +120,7 @@ export interface TemplateCompileOptions {
   scopedSlotsCompiler?: ScopedSlotsCompilerMode
   scopedSlotsRequireProps?: boolean
   slotMultipleInstance?: boolean
+  slotSingleRootNoWrapper?: boolean
   classStyleRuntime?: ClassStyleRuntime | 'auto'
   objectLiteralBindMode?: ObjectLiteralBindMode
   mustacheInterpolation?: MustacheInterpolationMode

--- a/packages/weapp-vite/src/plugins/vue/transform/compileOptions.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/compileOptions.test.ts
@@ -133,6 +133,7 @@ describe('resolveVueTemplatePlatformOptions', () => {
               },
               htmlTagToWxmlTagClass: false,
               scopedSlotsCompiler: 'augmented',
+              slotSingleRootNoWrapper: true,
               classStyleRuntime: 'auto',
             },
           },
@@ -154,6 +155,7 @@ describe('resolveVueTemplatePlatformOptions', () => {
     expect(options.template.wxsExtension).toBe('sjs')
     expect(options.template.classStyleWxsSrc).toBe('/virtual/__class_style__.wxs')
     expect(options.template.scopedSlotsRequireProps).toBe(false)
+    expect(options.template.slotSingleRootNoWrapper).toBe(true)
     expect(options.json).toEqual({
       kind: 'page',
       defaults: {

--- a/packages/weapp-vite/src/plugins/vue/transform/compileOptions.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/compileOptions.ts
@@ -56,6 +56,7 @@ export function createCompileVueFileOptions(
   const scopedSlotsRequirePropsConfig = configService.weappViteConfig?.vue?.template?.scopedSlotsRequireProps
   const scopedSlotsRequireProps = scopedSlotsRequirePropsConfig ?? (scopedSlotsCompiler !== 'augmented')
   const slotMultipleInstance = configService.weappViteConfig?.vue?.template?.slotMultipleInstance ?? true
+  const slotSingleRootNoWrapper = configService.weappViteConfig?.vue?.template?.slotSingleRootNoWrapper ?? false
   const htmlTagToWxml = configService.weappViteConfig?.vue?.template?.htmlTagToWxml
   const htmlTagToWxmlTagClass = configService.weappViteConfig?.vue?.template?.htmlTagToWxmlTagClass ?? true
   const classStyleRuntimeConfig = configService.weappViteConfig?.vue?.template?.classStyleRuntime ?? 'js'
@@ -103,6 +104,7 @@ export function createCompileVueFileOptions(
       scopedSlotsCompiler,
       scopedSlotsRequireProps,
       slotMultipleInstance,
+      slotSingleRootNoWrapper,
       classStyleRuntime: templatePlatformOptions.classStyleRuntime,
       objectLiteralBindMode,
       mustacheInterpolation,

--- a/packages/weapp-vite/src/types/config/features.ts
+++ b/packages/weapp-vite/src/types/config/features.ts
@@ -265,6 +265,7 @@ export interface WeappVueTemplateConfig {
   scopedSlotsCompiler?: 'auto' | 'augmented' | 'off'
   scopedSlotsRequireProps?: boolean
   slotMultipleInstance?: boolean
+  slotSingleRootNoWrapper?: boolean
   classStyleRuntime?: 'auto' | 'wxs' | 'js'
   objectLiteralBindMode?: 'runtime' | 'inline'
   mustacheInterpolation?: 'compact' | 'spaced'

--- a/packages/weapp-vite/test-d/config-define-config/index.d.ts
+++ b/packages/weapp-vite/test-d/config-define-config/index.d.ts
@@ -38,6 +38,7 @@ export interface WeappViteConfig {
     template?: {
       htmlTagToWxml?: boolean | Record<string, string>
       htmlTagToWxmlTagClass?: boolean
+      slotSingleRootNoWrapper?: boolean
     }
   }
 }

--- a/packages/weapp-vite/test-d/config-define-config/index.test-d.ts
+++ b/packages/weapp-vite/test-d/config-define-config/index.test-d.ts
@@ -26,6 +26,7 @@ const objectConfig = defineConfig({
           div: 'view',
         },
         htmlTagToWxmlTagClass: false,
+        slotSingleRootNoWrapper: true,
       },
     },
     autoImportComponents: {
@@ -52,6 +53,7 @@ expectAssignable<boolean | {
 } | undefined>(objectConfig.weapp?.injectWebRuntimeGlobals)
 expectAssignable<boolean | Record<string, string> | undefined>(objectConfig.weapp?.vue?.template?.htmlTagToWxml)
 expectAssignable<boolean | undefined>(objectConfig.weapp?.vue?.template?.htmlTagToWxmlTagClass)
+expectAssignable<boolean | undefined>(objectConfig.weapp?.vue?.template?.slotSingleRootNoWrapper)
 
 const promiseConfig = defineConfig(Promise.resolve({
   weapp: {

--- a/website/config/vue.md
+++ b/website/config/vue.md
@@ -36,6 +36,7 @@ keywords:
     scopedSlotsCompiler?: 'auto' | 'augmented' | 'off'
     scopedSlotsRequireProps?: boolean
     slotMultipleInstance?: boolean
+    slotSingleRootNoWrapper?: boolean
     classStyleRuntime?: 'auto' | 'wxs' | 'js'
     objectLiteralBindMode?: 'runtime' | 'inline'
     mustacheInterpolation?: 'compact' | 'spaced'
@@ -57,6 +58,7 @@ export default defineConfig({
         scopedSlotsCompiler: 'auto',
         scopedSlotsRequireProps: true,
         slotMultipleInstance: true,
+        slotSingleRootNoWrapper: false,
         classStyleRuntime: 'js',
         objectLiteralBindMode: 'runtime',
         mustacheInterpolation: 'compact',
@@ -83,6 +85,7 @@ export default defineConfig({
   - `off`：关闭 scoped slot（仅保留原生 slot，不支持 slot props）。
 - `scopedSlotsRequireProps`：仅在 slot 传递作用域参数时才生成 scoped slot 组件。默认值随 `scopedSlotsCompiler` 自动推导。
 - `slotMultipleInstance`：`v-for` 下 scoped slot 多实例模式（默认 `true`）。
+- `slotSingleRootNoWrapper`：当 `<template v-slot>` 的兜底内容只有一个可挂载根节点时，直接把 `slot` 挂到该节点上，而不是额外包一层 `<view>`。默认 `false`，多根节点、`template v-if` 等结构化子节点仍会保留包裹层。
 - `classStyleRuntime`：class/style 绑定运行时。
   - `js`：强制 JS（默认）。
   - `auto`：平台支持 WXS 时优先 WXS，否则回退 JS。


### PR DESCRIPTION
## 背景
- 修复 #494 提到的 template v-slot 单根节点会额外包裹 view 的问题
- 保留多根节点与结构化子节点场景的兼容行为

## 变更
- 新增 weapp.vue.template.slotSingleRootNoWrapper 配置，默认关闭
- 在 @wevu/compiler 中为 template v-slot 单个可挂载根节点直接挂载 slot 属性
- 补充 weapp-vite 配置透传、tsd 覆盖、文档说明与 github-issues 最小复现

## 验证
- pnpm --filter @wevu/compiler test -- packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts -t "slot wrapper"
- pnpm --filter @wevu/compiler typecheck
- pnpm vitest run packages/weapp-vite/src/plugins/vue/transform/compileOptions.test.ts -t "creates compile options with resolved platform helpers"
- pnpm --filter weapp-vite test:types
- pnpm --filter @wevu/compiler build
- pnpm --filter wevu build
- pnpm --filter weapp-vite build
- pnpm vitest run -c e2e/vitest.e2e.config.ts e2e/ci/github-issues.build.test.ts -t "issue #494"
