### PR TITLE
fix(wevu-compiler): 保留 slot 条件指令

### DIFF
--- a/.changeset/slot-conditions.md
+++ b/.changeset/slot-conditions.md
@@ -1,0 +1,8 @@
+---
+"@wevu/compiler": patch
+"wevu": patch
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复 Vue SFC 模板中 `<slot />` 携带 `v-if` / `v-else-if` / `v-else` 时条件指令丢失的问题，确保编译到小程序模板后保留对应平台条件分支。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -267,6 +267,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-502/index",
+          "pathName": "pages/issue-502/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/slot-flex-layout/index",
           "pathName": "pages/slot-flex-layout/index",
           "query": "",

--- a/e2e-apps/github-issues/src/pages/issue-502/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-502/index.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { ref } from 'wevu'
+
+definePageJson({
+  navigationBarTitleText: 'issue-502',
+})
+
+const abc = ref(true)
+const efg = ref(false)
+
+function toggleBranch() {
+  abc.value = !abc.value
+  efg.value = !efg.value
+}
+
+function _runE2E() {
+  return {
+    abc: abc.value,
+    efg: efg.value,
+  }
+}
+</script>
+
+<template>
+  <view class="issue502-page">
+    <view class="issue502-title">
+      issue-502 slot condition outlet
+    </view>
+
+    <slot v-if="abc" />
+    <slot v-else-if="efg" />
+    <slot v-else />
+
+    <view class="issue502-action" @tap="toggleBranch">
+      toggle issue-502 branch
+    </view>
+  </view>
+</template>
+
+<style scoped>
+.issue502-page {
+  box-sizing: border-box;
+  min-height: 100vh;
+  padding: 32rpx;
+  background: #f8fafc;
+}
+
+.issue502-title {
+  margin-bottom: 20rpx;
+  font-size: 32rpx;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.issue502-action {
+  padding: 20rpx;
+  margin-top: 20rpx;
+  color: #0f172a;
+  background: #cbd5e1;
+  border-radius: 8rpx;
+}
+</style>

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -411,6 +411,23 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(componentWxml).toContain('<slot />')
   })
 
+  it('issue #502: keeps structural directives on slot outlet elements', async () => {
+    await runBuild()
+
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-502/index.wxml')
+    const pageJsPath = path.join(DIST_ROOT, 'pages/issue-502/index.js')
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+    const pageJs = await fs.readFile(pageJsPath, 'utf-8')
+
+    expect(pageWxml).toContain('issue-502 slot condition outlet')
+    expect(pageWxml).toContain('<block wx:if="{{abc}}"><slot />')
+    expect(pageWxml).toContain('<block wx:elif="{{efg}}"><slot />')
+    expect(pageWxml).toContain('<block wx:else><slot />')
+    expect(pageWxml).not.toContain('<slot /><slot /><slot />')
+    expect(pageJs).toContain('toggleBranch')
+    expect(pageJs).toContain('_runE2E')
+  })
+
   it('experiment: flex parent keeps projected multi-node slot groups visible via view wrappers', async () => {
     await runBuild()
 

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
@@ -547,6 +547,22 @@ describe('compileVueTemplateToWxml', () => {
     expect(code).not.toContain(`__wv-slot-props="{{{`)
   })
 
+  it('keeps structural directives on slot outlet elements', () => {
+    const template = `
+<slot v-if="abc" />
+<slot v-else-if="efg" />
+<slot v-else />
+    `.trim()
+
+    const { code } = compileVueTemplateToWxml(template, '/project/src/pages/issue-502/index.vue')
+
+    expect(code).toContain(`<block ${DEFAULT_DIRECTIVES.ifAttr}="{{abc}}"><slot`)
+    expect(code).toContain(`<block ${DEFAULT_DIRECTIVES.elifAttr}="{{efg}}"><slot`)
+    expect(code).toContain(`<block ${DEFAULT_DIRECTIVES.elseAttr}><slot`)
+    expect(code).not.toContain('v-if')
+    expect(code).not.toContain('v-else')
+  })
+
   it('emits array-based slot scope mapping', () => {
     const template = `
 <Child v-for="(item, index) in list" :key="index">

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/index.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/index.ts
@@ -15,6 +15,10 @@ export function transformElement(node: ElementNode, context: TransformContext, t
   }
 
   if (tag === 'slot') {
+    const { type } = isStructuralDirective(node)
+    if (type === 'if') {
+      return transformIfElement(node, context, transformNode)
+    }
     return transformSlotElement(node, context, transformNode)
   }
 

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-structural.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-structural.ts
@@ -9,6 +9,7 @@ import { collectElementAttributes } from './attrs'
 import { findSlotDirective, FOR_ITEM_ALIAS_PLACEHOLDER, parseForExpression, withForScope, withScope } from './helpers'
 import { transformComponentWithSlots } from './tag-component'
 import { transformNormalElement } from './tag-normal'
+import { transformSlotElement } from './tag-slot'
 
 const REGEX_SPECIAL_CHARS_RE = /[.*+?^${}()|[\]\\]/g
 
@@ -39,9 +40,11 @@ export function transformIfElement(node: ElementNode, context: TransformContext,
   const templateSlotChildren = elementWithoutIf.children.filter(
     child => child.type === NodeTypes.ELEMENT && child.tag === 'template' && findSlotDirective(child as ElementNode),
   )
-  const content = slotDirective || templateSlotChildren.length > 0
-    ? transformComponentWithSlots(elementWithoutIf as ElementNode, context, transformNode)
-    : transformNormalElement(elementWithoutIf as ElementNode, context, transformNode)
+  const content = elementWithoutIf.tag === 'slot'
+    ? transformSlotElement(elementWithoutIf as ElementNode, context, transformNode)
+    : slotDirective || templateSlotChildren.length > 0
+      ? transformComponentWithSlots(elementWithoutIf as ElementNode, context, transformNode)
+      : transformNormalElement(elementWithoutIf as ElementNode, context, transformNode)
 
   const dir = ifDirective as DirectiveNode
   if (dir.name === 'if' && dir.exp) {


### PR DESCRIPTION
## 摘要

修复 #502 中 Vue SFC 的 `<slot />` 携带 `v-if` / `v-else-if` / `v-else` 时，编译到小程序模板后条件指令丢失的问题。

## 变更

- 在 slot outlet 分发阶段识别条件结构指令，剥离条件指令后复用现有 slot 编译逻辑。
- 新增 `@wevu/compiler` 单元回归，覆盖 `<slot v-if>` / `v-else-if` / `v-else`。
- 在 `e2e-apps/github-issues` 增加 issue-502 页面和 build e2e 输出断言。
- 添加 patch changeset，覆盖 `@wevu/compiler`、`wevu`、`weapp-vite`、`create-weapp-vite`。

## 验证

- `pnpm test packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts`
- `pnpm --filter @wevu/compiler typecheck`
- `pnpm --filter @wevu/compiler lint`
- `pnpm exec eslint e2e/ci/github-issues.build.test.ts e2e-apps/github-issues/src/pages/issue-502/index.vue`
- `pnpm exec stylelint e2e-apps/github-issues/src/pages/issue-502/index.vue`
- `pnpm run check:changeset:frontmatter`
- `pnpm exec vitest run -c ./e2e/vitest.e2e.ci.build-only.config.ts e2e/ci/github-issues.build.test.ts -t "issue #502"`

Closes #502