### PR TITLE
fix(wevu): inject 缺失 provider 时改为 warning

### DIFF
--- a/.changeset/inject-missing-warning.md
+++ b/.changeset/inject-missing-warning.md
@@ -1,0 +1,6 @@
+---
+"wevu": patch
+"create-weapp-vite": patch
+---
+
+修复 `wevu` 的 `inject()` 缺失 key 行为：未传默认值且找不到 provider 时改为输出 warning 并返回 `undefined`，避免后续 setup 代码被异常阻断，并与 Vue 3 的依赖注入语义保持一致。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -267,6 +267,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-500/index",
+          "pathName": "pages/issue-500/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/slot-flex-layout/index",
           "pathName": "pages/slot-flex-layout/index",
           "query": "",

--- a/e2e-apps/github-issues/src/pages/issue-500/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-500/index.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { computed, inject, ref } from 'wevu'
+
+definePageJson({
+  navigationBarTitleText: 'issue-500',
+})
+
+const afterMissingInjectRan = ref(false)
+const missingValue = inject<string>('issue-500:missing-token')
+afterMissingInjectRan.value = true
+
+const continuationText = computed(() => afterMissingInjectRan.value ? 'continued' : 'blocked')
+const missingType = computed(() => missingValue === undefined ? 'undefined' : typeof missingValue)
+
+function _runE2E() {
+  return {
+    ok: afterMissingInjectRan.value && missingValue === undefined,
+    continuationText: continuationText.value,
+    missingType: missingType.value,
+  }
+}
+</script>
+
+<template>
+  <view class="issue500-page">
+    <view class="issue500-title">
+      issue-500 inject missing key continuation
+    </view>
+    <view
+      class="issue500-status"
+      :data-continuation="continuationText"
+      :data-missing-type="missingType"
+    >
+      inject after line: {{ continuationText }}
+    </view>
+  </view>
+</template>
+
+<style scoped>
+.issue500-page {
+  min-height: 100vh;
+  padding: 32rpx;
+  background: #f8fafc;
+}
+
+.issue500-title {
+  margin-bottom: 20rpx;
+  font-size: 32rpx;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.issue500-status {
+  color: #166534;
+}
+</style>

--- a/e2e/ci/dev-process-env.test.ts
+++ b/e2e/ci/dev-process-env.test.ts
@@ -27,10 +27,30 @@ function createMockChild() {
   })
 }
 
+function createPendingMockChild() {
+  const promise = new Promise(() => {})
+
+  return Object.assign(promise, {
+    exitCode: null,
+    kill: vi.fn(),
+    pid: 12345,
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    all: new EventEmitter(),
+  })
+}
+
 describe('dev process env isolation', () => {
+  const originalPlatform = process.platform
+
   afterEach(() => {
     vi.clearAllMocks()
+    vi.restoreAllMocks()
+    vi.useRealTimers()
     vi.unstubAllEnvs()
+    Object.defineProperty(process, 'platform', {
+      value: originalPlatform,
+    })
   })
 
   it('removes ci and vitest-specific env flags from child dev processes', async () => {
@@ -82,5 +102,60 @@ describe('dev process env isolation', () => {
       env,
       extendEnv: false,
     }))
+  })
+
+  it('stops windows package-script dev processes with taskkill without waiting forever', async () => {
+    vi.useFakeTimers()
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+    })
+
+    const child = createPendingMockChild()
+    execaMock.mockImplementation((command: string) => {
+      if (command === 'taskkill') {
+        return Promise.resolve({
+          exitCode: 0,
+          signal: undefined,
+        })
+      }
+
+      return child
+    })
+
+    let isFirstPidCheck = true
+    vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: NodeJS.Signals | 0) => {
+      if (pid === 12345 && signal === 0 && isFirstPidCheck) {
+        isFirstPidCheck = false
+        return true
+      }
+
+      if (pid === 12345 && signal === 0) {
+        const error = new Error('process is gone') as NodeJS.ErrnoException
+        error.code = 'ESRCH'
+        throw error
+      }
+
+      return true
+    }) as typeof process.kill)
+
+    const { startDevProcess } = await import('../utils/dev-process')
+    const dev = startDevProcess('pnpm', ['--dir', 'fixtures/app', 'run', 'dev'], {
+      all: true,
+      env: {
+        PATH: process.env.PATH ?? '',
+      },
+    })
+
+    const stopPromise = dev.stop(100)
+    await vi.advanceTimersByTimeAsync(1_100)
+    await stopPromise
+
+    expect(execaMock).toHaveBeenCalledWith('taskkill', ['/PID', '12345', '/T', '/F'], expect.objectContaining({
+      reject: false,
+      stdin: 'ignore',
+      stdout: 'ignore',
+      stderr: 'ignore',
+    }))
+    expect(child.kill).not.toHaveBeenCalled()
   })
 })

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -411,6 +411,23 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(componentWxml).toContain('<slot />')
   })
 
+  it('issue #500: compiles missing inject continuation probe', async () => {
+    await runBuild()
+
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-500/index.wxml')
+    const pageJsPath = path.join(DIST_ROOT, 'pages/issue-500/index.js')
+
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+    const pageJs = await fs.readFile(pageJsPath, 'utf-8')
+
+    expect(pageWxml).toContain('issue-500 inject missing key continuation')
+    expect(pageWxml).toContain('inject after line: {{continuationText}}')
+    expect(pageWxml).toContain('data-continuation="{{continuationText}}"')
+    expect(pageWxml).toContain('data-missing-type="{{missingType}}"')
+    expect(pageJs).toContain('issue-500:missing-token')
+    expect(pageJs).toContain('_runE2E')
+  })
+
   it('experiment: flex parent keeps projected multi-node slot groups visible via view wrappers', async () => {
     await runBuild()
 

--- a/e2e/ide/github-issues.runtime.lifecycle.test.ts
+++ b/e2e/ide/github-issues.runtime.lifecycle.test.ts
@@ -843,6 +843,36 @@ describe.sequential('e2e app: github-issues / lifecycle', () => {
     }
   })
 
+  it('issue #500: missing inject warns without blocking later setup code in DevTools runtime', async (ctx) => {
+    const issuePageWxmlPath = path.join(DIST_ROOT, 'pages/issue-500/index.wxml')
+    const issuePageJsPath = path.join(DIST_ROOT, 'pages/issue-500/index.js')
+
+    expect(await fs.readFile(issuePageWxmlPath, 'utf-8')).toContain('issue-500 inject missing key continuation')
+    expect(await fs.readFile(issuePageJsPath, 'utf-8')).toContain('issue-500:missing-token')
+    expect(await fs.readFile(issuePageJsPath, 'utf-8')).toContain('_runE2E')
+
+    const miniProgram = await launchFreshMiniProgram(ctx)
+    try {
+      const issuePage = await relaunchPage(miniProgram, '/pages/issue-500/index', 'inject after line: continued')
+      if (!issuePage) {
+        throw new Error('Failed to launch issue-500 page')
+      }
+
+      const runtime = await issuePage.callMethod('_runE2E')
+      expect(runtime?.ok).toBe(true)
+      expect(runtime?.continuationText).toBe('continued')
+      expect(runtime?.missingType).toBe('undefined')
+
+      const wxml = await readPageWxml(issuePage)
+      expect(wxml).toContain('data-continuation="continued"')
+      expect(wxml).toContain('data-missing-type="undefined"')
+      expect(wxml).toContain('inject after line: continued')
+    }
+    finally {
+      await miniProgram.close().catch(() => {})
+    }
+  })
+
   it('experiment: flex parent keeps projected multi-node slot groups visible in DevTools runtime', async (ctx) => {
     const issuePageWxmlPath = path.join(DIST_ROOT, 'pages/slot-flex-layout/index.wxml')
     const issuePageJsPath = path.join(DIST_ROOT, 'pages/slot-flex-layout/index.js')

--- a/e2e/utils/dev-process.ts
+++ b/e2e/utils/dev-process.ts
@@ -122,8 +122,31 @@ function collectProcessTreePids(rootPid: number, processList: ProcessEntry[]) {
   return orderedPids
 }
 
+async function terminateWindowsPid(pid: number, forceKillDelayMs: number) {
+  await execa('taskkill', ['/PID', String(pid), '/T', '/F'], {
+    reject: false,
+    stdin: 'ignore',
+    stdout: 'ignore',
+    stderr: 'ignore',
+  })
+
+  const deadline = Date.now() + forceKillDelayMs
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid)) {
+      return
+    }
+    await sleep(100)
+  }
+}
+
 async function terminatePid(pid: number, forceKillDelayMs: number) {
   if (!isPidAlive(pid)) {
+    TRACKED_DEV_PIDS.delete(pid)
+    return
+  }
+
+  if (process.platform === 'win32') {
+    await terminateWindowsPid(pid, forceKillDelayMs)
     TRACKED_DEV_PIDS.delete(pid)
     return
   }
@@ -161,6 +184,16 @@ async function terminatePid(pid: number, forceKillDelayMs: number) {
   catch {}
 
   TRACKED_DEV_PIDS.delete(pid)
+}
+
+async function waitForExitWithTimeout(
+  settledExit: Promise<DevProcessExitInfo>,
+  timeoutMs: number,
+) {
+  await Promise.race([
+    settledExit,
+    sleep(timeoutMs),
+  ])
 }
 
 export async function cleanupTrackedDevProcesses(forceKillDelayMs = 3_000) {
@@ -289,7 +322,7 @@ export function startDevProcess(
     else if (child.exitCode == null) {
       child.kill('SIGTERM')
     }
-    await settledExit
+    await waitForExitWithTimeout(settledExit, forceKillDelayMs + 1_000)
   }
 
   return {

--- a/packages-runtime/wevu/src/runtime/provide.ts
+++ b/packages-runtime/wevu/src/runtime/provide.ts
@@ -90,7 +90,9 @@ export function provide<T>(key: any, value: T): void {
  * })
  * ```
  */
-export function inject<T>(key: any, defaultValue?: T): T {
+export function inject<T>(key: any, defaultValue: T): T
+export function inject<T>(key: any): T | undefined
+export function inject<T>(key: any, defaultValue?: T): T | undefined {
   const instance = getCurrentInstance()
 
   // 优先尝试基于实例的注入，找不到再回退全局
@@ -117,8 +119,12 @@ export function inject<T>(key: any, defaultValue?: T): T {
     return defaultValue as T
   }
 
-  // 保留旧版错误提示格式，避免破坏性改动
-  throw new Error('wevu.inject：未找到对应 key 的值')
+  const warn = globalThis.console?.warn
+  if (typeof warn === 'function') {
+    warn(`wevu.inject：未找到对应 key 的值：${String(key)}`)
+  }
+
+  return undefined
 }
 
 // ============================================================================

--- a/packages-runtime/wevu/test-d/runtime.test-d.ts
+++ b/packages-runtime/wevu/test-d/runtime.test-d.ts
@@ -161,7 +161,7 @@ defineComponent({
     const injected = inject<number>(TOKEN, 0)
     expectType<number>(injected)
     provide(TOKEN, props.count)
-    expectType<number>(inject<number>(TOKEN))
+    expectType<number | undefined>(inject<number>(TOKEN))
     const readonlyProps = shallowReadonly(props)
     expectType<string | undefined>(readonlyProps.title)
     onMounted(() => {})

--- a/packages-runtime/wevu/test/runtime-core-extra.test.ts
+++ b/packages-runtime/wevu/test/runtime-core-extra.test.ts
@@ -83,7 +83,9 @@ describe('provide/inject', () => {
     provide('global', 123)
     expect(inject('global')).toBe(123)
     expect(inject('missing', 'fallback')).toBe('fallback')
-    expect(() => inject('absent')).toThrow('wevu.inject：未找到对应 key 的值')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(inject('absent')).toBeUndefined()
+    expect(warn).toHaveBeenCalledWith('wevu.inject：未找到对应 key 的值：absent')
   })
 
   it('elevates provide() to global store when called in app setup context', () => {

--- a/packages-runtime/wevu/test/runtime-provide.test.ts
+++ b/packages-runtime/wevu/test/runtime-provide.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { inject, provide, provideGlobal, setGlobalProvidedValue } from '@/runtime/provide'
 
 describe('provide/inject', () => {
   // 注意：provide 和 inject 使用全局 Map，需要在每个测试后清理
   afterEach(() => {
+    vi.restoreAllMocks()
     // 清空全局 store（通过注入不存在的 key 强制重置）
     // 注意：实际实现可能需要导出清理函数
   })
@@ -111,18 +112,26 @@ describe('provide/inject', () => {
   })
 
   describe('error handling', () => {
-    it('should throw error when key not found and no default', () => {
+    it('should warn and return undefined when key not found and no default', () => {
       const key = Symbol('missing')
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-      expect(() => inject(key)).toThrow('wevu.inject：未找到对应 key 的值')
+      expect(inject(key)).toBeUndefined()
+      expect(warn).toHaveBeenCalledWith('wevu.inject：未找到对应 key 的值：Symbol(missing)')
     })
 
-    it('should throw error for undefined key without default', () => {
-      expect(() => inject(undefined as any)).toThrow('wevu.inject：未找到对应 key 的值')
+    it('should warn and return undefined for undefined key without default', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      expect(inject(undefined as any)).toBeUndefined()
+      expect(warn).toHaveBeenCalledWith('wevu.inject：未找到对应 key 的值：undefined')
     })
 
-    it('should throw error for null key without default', () => {
-      expect(() => inject(null as any)).toThrow('wevu.inject：未找到对应 key 的值')
+    it('should warn and return undefined for null key without default', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      expect(inject(null as any)).toBeUndefined()
+      expect(warn).toHaveBeenCalledWith('wevu.inject：未找到对应 key 的值：null')
     })
   })
 
@@ -137,7 +146,7 @@ describe('provide/inject', () => {
       const user: User = { name: 'Alice', age: 30 }
 
       provide<User>(key, user)
-      const injected = inject<User>(key)
+      const injected = inject<User>(key)!
 
       expect(injected.name).toBe('Alice')
       expect(injected.age).toBe(30)


### PR DESCRIPTION
## Summary

修复 #500：`wevu` 的 `inject()` 在找不到 key 且未传默认值时，不再抛出异常阻断后续 `setup` 代码，而是输出 warning 并返回 `undefined`，与 Vue 3 行为保持一致。

## Changes

- 调整 `inject()` 的运行时缺省分支与公开类型返回值。
- 更新 `provide/inject` 单测和 tsd 类型断言。
- 在 `e2e-apps/github-issues` 增加 issue-500 页面，并补充 build 与 DevTools runtime 回归覆盖。
- 增加 `wevu` 与 `create-weapp-vite` patch changeset。

## Testing

- `pnpm exec eslint packages-runtime/wevu/src/runtime/provide.ts packages-runtime/wevu/test/runtime-provide.test.ts packages-runtime/wevu/test/runtime-core-extra.test.ts packages-runtime/wevu/test-d/runtime.test-d.ts e2e/ci/github-issues.build.test.ts e2e/ide/github-issues.runtime.lifecycle.test.ts e2e-apps/github-issues/src/pages/issue-500/index.vue`
- `pnpm exec stylelint e2e-apps/github-issues/src/pages/issue-500/index.vue`
- `pnpm --filter wevu exec vitest run test/runtime-provide.test.ts test/runtime-core-extra.test.ts`
- `pnpm --filter wevu typecheck`
- `pnpm --filter wevu build`
- `pnpm --filter wevu test:types`
- `pnpm --filter e2e-app-github-issues build`
- `pnpm vitest run -c ./e2e/vitest.e2e.config.ts e2e/ci/github-issues.build.test.ts -t "issue #500"`
- `pnpm vitest run -c ./e2e/vitest.e2e.devtools.config.ts e2e/ide/github-issues.runtime.lifecycle.test.ts -t "issue #500"`

## Related Issues

Closes #500
