### PR TITLE
fix(weapp-ide-cli): 修复 auto-preview 后台唤起失败

### DIFF
--- a/.changeset/issue-505-auto-preview.md
+++ b/.changeset/issue-505-auto-preview.md
@@ -1,0 +1,7 @@
+---
+"weapp-ide-cli": patch
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复 `weapp auto-preview -p` 在微信开发者工具不在前台时可能无法唤起小程序预览的问题。现在 `auto-preview` 会在执行前先按同一项目定位信息唤起开发者工具，再继续运行官方自动预览命令，提升后台场景下的预览启动稳定性。

--- a/packages/weapp-ide-cli/src/cli/run-wechat-cli.ts
+++ b/packages/weapp-ide-cli/src/cli/run-wechat-cli.ts
@@ -12,6 +12,36 @@ function shouldBootstrapWechatDevtools(command: string | undefined) {
   return command === 'open' || command === 'auto' || command === 'auto-preview'
 }
 
+function appendOptionValue(argv: string[], sourceArgv: readonly string[], optionName: string) {
+  const value = readOptionValue(sourceArgv, optionName)
+  if (value !== undefined) {
+    argv.push(optionName, value)
+  }
+}
+
+function createAutoPreviewWakeArgv(argv: readonly string[], trustProject: boolean | undefined) {
+  if (argv[0] !== 'auto-preview') {
+    return undefined
+  }
+
+  const projectPath = readOptionValue(argv, '--project')
+  const appid = readOptionValue(argv, '--appid')
+  if (!projectPath && !appid) {
+    return undefined
+  }
+
+  const wakeArgv = ['open']
+  appendOptionValue(wakeArgv, argv, '--project')
+  appendOptionValue(wakeArgv, argv, '--appid')
+  appendOptionValue(wakeArgv, argv, '--ext-appid')
+
+  if (trustProject === true) {
+    wakeArgv.push('--trust-project')
+  }
+
+  return wakeArgv
+}
+
 function resolveBooleanCliOption(argv: readonly string[], optionName: string) {
   if (argv.includes(optionName)) {
     return true
@@ -50,12 +80,12 @@ async function handleMissingCliPath(source: 'custom' | 'default' | 'missing') {
 async function maybeBootstrapWechatDevtoolsSettings(argv: readonly string[]) {
   const command = argv[0]
   if (!shouldBootstrapWechatDevtools(command)) {
-    return
+    return undefined
   }
 
   const config = await readCustomConfig()
   if (config.autoBootstrapDevtools === false) {
-    return
+    return undefined
   }
 
   const projectPath = readOptionValue(argv, '--project')
@@ -67,6 +97,10 @@ async function maybeBootstrapWechatDevtoolsSettings(argv: readonly string[]) {
     projectPath,
     trustProject,
   })
+
+  return {
+    trustProject,
+  }
 }
 
 /**
@@ -87,6 +121,11 @@ export async function runWechatCliCommand(argv: string[]) {
     return
   }
 
-  await maybeBootstrapWechatDevtoolsSettings(argv)
+  const bootstrapContext = await maybeBootstrapWechatDevtoolsSettings(argv)
+  const wakeArgv = createAutoPreviewWakeArgv(argv, bootstrapContext?.trustProject)
+  if (wakeArgv) {
+    await runWechatCliWithRetry(cliPath, wakeArgv)
+  }
+
   await runWechatCliWithRetry(cliPath, argv)
 }

--- a/packages/weapp-ide-cli/test/run-wechat-cli.test.ts
+++ b/packages/weapp-ide-cli/test/run-wechat-cli.test.ts
@@ -84,6 +84,60 @@ describe('runWechatCliCommand', () => {
     ])
   })
 
+  it('opens the target project before auto-preview so devtools is foregrounded', async () => {
+    const { runWechatCliCommand } = await import('../src/cli/run-wechat-cli')
+
+    await runWechatCliCommand([
+      'auto-preview',
+      '--project',
+      '/tmp/demo',
+      '--info-output',
+      '/tmp/auto-preview.json',
+    ])
+
+    expect(bootstrapWechatDevtoolsSettingsMock).toHaveBeenCalledWith({
+      projectPath: '/tmp/demo',
+      trustProject: false,
+    })
+    expect(runWechatCliWithRetryMock).toHaveBeenNthCalledWith(1, '/Applications/wechat-cli', [
+      'open',
+      '--project',
+      '/tmp/demo',
+    ])
+    expect(runWechatCliWithRetryMock).toHaveBeenNthCalledWith(2, '/Applications/wechat-cli', [
+      'auto-preview',
+      '--project',
+      '/tmp/demo',
+      '--info-output',
+      '/tmp/auto-preview.json',
+    ])
+  })
+
+  it('passes configured project trust to the auto-preview foreground open command', async () => {
+    readCustomConfigMock.mockResolvedValueOnce({
+      autoTrustProject: true,
+    })
+    const { runWechatCliCommand } = await import('../src/cli/run-wechat-cli')
+
+    await runWechatCliCommand(['auto-preview', '--appid', 'wx123', '--ext-appid', 'wx456'])
+
+    expect(runWechatCliWithRetryMock).toHaveBeenNthCalledWith(1, '/Applications/wechat-cli', [
+      'open',
+      '--appid',
+      'wx123',
+      '--ext-appid',
+      'wx456',
+      '--trust-project',
+    ])
+    expect(runWechatCliWithRetryMock).toHaveBeenNthCalledWith(2, '/Applications/wechat-cli', [
+      'auto-preview',
+      '--appid',
+      'wx123',
+      '--ext-appid',
+      'wx456',
+    ])
+  })
+
   it('prompts for cli path when resolver returns missing', async () => {
     resolveCliPathMock.mockResolvedValueOnce({
       cliPath: '',


### PR DESCRIPTION
## Summary
- 修复 #505
- 在执行 `auto-preview` 前先用同一项目定位信息调用 `open`，确保微信开发者工具被唤起到前台后再执行官方自动预览命令
- 复用 `autoTrustProject` 的配置结果，让预打开项目时保持信任项目语义一致
- 补强 E2E dev 进程清理：Windows 下用进程树终止并启用残留 dev watcher 清理，避免 package-script HMR 用例被子进程残留拖到 job timeout
- 添加 changeset 覆盖 `weapp-ide-cli`、`weapp-vite`、`create-weapp-vite`

## Testing
- `vitest run packages/weapp-ide-cli/test/run-wechat-cli.test.ts packages/weapp-ide-cli/test/wechat-commands.test.ts --config packages/weapp-ide-cli/vitest.config.ts`
- `vitest run e2e/ci/dev-process-env.test.ts --config e2e/vitest.e2e.ci.config.ts`
- `vitest run e2e/utils/ide-devtools-cleanup.test.ts --config e2e/vitest.e2e.utils.config.ts`
- `tsc --noEmit -p packages/weapp-ide-cli/tsconfig.json`
- `eslint packages/weapp-ide-cli/src/cli/run-wechat-cli.ts packages/weapp-ide-cli/test/run-wechat-cli.test.ts e2e/utils/dev-process.ts e2e/utils/dev-process-cleanup.ts e2e/ci/dev-process-env.test.ts e2e/utils/ide-devtools-cleanup.test.ts`
- `tsdown`
- `node scripts/check-changeset-frontmatter.mjs`
- `tsx scripts/check-create-weapp-vite-changeset.ts`
- `tsx scripts/check-publishable-workspace-changeset.ts`

Note: 本地直接运行 `e2e/ci/hmr-package-scripts.test.ts` 在临时 worktree 因未安装 workspace `node_modules` 导致 package script 找不到 `wv`，该用例以 GitHub Actions Miniapp E2E 矩阵为准。