### PR TITLE
test(weapp-vite): 补齐 issue 446 自动导入 ref 回归

### DIFF
--- a/e2e-apps/github-issues/src/pages/issue-446/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-446/index.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, useTemplateRef } from 'wevu'
-import ShortBindProbe from '../../components/issue-446/ShortBindProbe/index.vue'
 
 definePageJson({
   navigationBarTitleText: 'issue-446',

--- a/packages/weapp-vite/test/issue-446-watch-auto-import-template-ref.test.ts
+++ b/packages/weapp-vite/test/issue-446-watch-auto-import-template-ref.test.ts
@@ -1,0 +1,168 @@
+import type { CompilerContext } from '@/context'
+import type { WatcherInstance } from '@/runtime/watcherPlugin'
+import { fs } from '@weapp-core/shared/fs'
+import path from 'pathe'
+import { describe, expect, it, vi } from 'vitest'
+import { createTempFixtureProject, createTestCompilerContext } from './utils'
+
+vi.mock('@weapp-vite/web', () => ({
+  weappWebPlugin: () => [],
+}), { virtual: true })
+
+interface WatcherEvent {
+  code?: string
+  error?: unknown
+}
+
+type WatcherEmitter = WatcherInstance & {
+  on: (event: 'event', listener: (event: WatcherEvent) => void) => void
+  off?: (event: 'event', listener: (event: WatcherEvent) => void) => void
+  removeListener?: (event: 'event', listener: (event: WatcherEvent) => void) => void
+}
+
+function isWatcherEmitter(value: unknown): value is WatcherEmitter {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+  const candidate = value as { on?: unknown, close?: unknown }
+  return typeof candidate.on === 'function' && typeof candidate.close === 'function'
+}
+
+async function waitForBuild(watcher: WatcherEmitter, timeoutMs = 45_000) {
+  return new Promise<void>((resolve, reject) => {
+    const seenEvents: string[] = []
+
+    const unsubscribe = (fn: (event: WatcherEvent) => void) => {
+      if (typeof watcher.off === 'function') {
+        watcher.off('event', fn)
+      }
+      else if (typeof watcher.removeListener === 'function') {
+        watcher.removeListener('event', fn)
+      }
+    }
+
+    let timer: ReturnType<typeof setTimeout>
+    const handler = (event: WatcherEvent) => {
+      seenEvents.push(event.code ?? 'unknown')
+      if (event.code === 'END' || event.code === 'BUNDLE_END') {
+        clearTimeout(timer)
+        unsubscribe(handler)
+        resolve()
+      }
+      else if (event.code === 'ERROR') {
+        clearTimeout(timer)
+        unsubscribe(handler)
+        reject(event.error ?? new Error('watch build failed'))
+      }
+    }
+
+    timer = setTimeout(() => {
+      unsubscribe(handler)
+      reject(new Error(`watch build timed out, events seen: ${seenEvents.join(', ')}`))
+    }, timeoutMs)
+
+    watcher.on('event', handler)
+  })
+}
+
+async function waitForFileContains(filePath: string, marker: string, timeoutMs = 45_000) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await fs.pathExists(filePath)) {
+      const content = await fs.readFile(filePath, 'utf8')
+      if (content.includes(marker)) {
+        return
+      }
+    }
+    await new Promise(resolve => setTimeout(resolve, 200))
+  }
+
+  throw new Error(`watch build timed out, output missing marker: ${marker}`)
+}
+
+async function readWevuComputedRuntime(outDir: string) {
+  const vendorRoot = path.resolve(outDir, 'weapp-vendors')
+  const files = await fs.readdir(vendorRoot)
+  for (const file of files) {
+    if (!file.endsWith('.js')) {
+      continue
+    }
+    const filePath = path.join(vendorRoot, file)
+    const code = await fs.readFile(filePath, 'utf8')
+    if (code.includes('Object.defineProperty(exports, "computed"')) {
+      return code
+    }
+  }
+
+  throw new Error('watch build output missing wevu computed export')
+}
+
+describe.sequential('issue #446 watch auto-import component template ref', () => {
+  it('keeps computed exported after editing a page with auto-imported component refs', async () => {
+    const fixtureSource = path.resolve(__dirname, '../../../e2e-apps/github-issues')
+    const tempProject = await createTempFixtureProject(fixtureSource, 'issue-446-watch')
+    const cwd = tempProject.tempDir
+
+    const ctxResult: { ctx: CompilerContext, dispose: () => Promise<void> } = await createTestCompilerContext({
+      cwd,
+      isDev: true,
+      inlineConfig: {
+        build: {
+          watch: {
+            chokidar: {
+              usePolling: true,
+              interval: 100,
+            },
+          },
+        },
+      },
+    })
+
+    let watcher: WatcherEmitter | undefined
+
+    try {
+      const buildResult = await ctxResult.ctx.buildService.build({ skipNpm: true })
+      if (!isWatcherEmitter(buildResult)) {
+        throw new Error('Expected watch mode build to return a watcher')
+      }
+      watcher = buildResult
+
+      const outDir = ctxResult.ctx.configService.outDir
+      const pageOutputPath = path.resolve(outDir, 'pages/issue-446/index.js')
+      const pageJsonPath = path.resolve(outDir, 'pages/issue-446/index.json')
+      const pageSourcePath = path.resolve(cwd, 'src/pages/issue-446/index.vue')
+
+      await waitForFileContains(pageOutputPath, 'issue-446-short-bind')
+      await waitForFileContains(pageJsonPath, '"ShortBindProbe": "/components/issue-446/ShortBindProbe/index"')
+
+      const initialPageOutput = await fs.readFile(pageOutputPath, 'utf8')
+      const initialRuntimeOutput = await readWevuComputedRuntime(outDir)
+
+      expect(initialPageOutput).toContain('computed(() => nativeAnchorRef.value != null)')
+      expect(initialPageOutput).toContain('computed(() => typeof shortBindProbeRef.value?.snapshot === "function")')
+      expect(initialRuntimeOutput).toContain('Object.defineProperty(exports, "computed"')
+
+      const originalSource = await fs.readFile(pageSourcePath, 'utf8')
+      const updatedSource = originalSource.replaceAll('issue-446-short-bind', 'issue-446-short-bind-updated')
+      expect(updatedSource).not.toBe(originalSource)
+
+      const buildPromise = waitForBuild(watcher)
+      await fs.writeFile(pageSourcePath, updatedSource, 'utf8')
+      await buildPromise
+      await waitForFileContains(pageOutputPath, 'issue-446-short-bind-updated')
+
+      const updatedPageOutput = await fs.readFile(pageOutputPath, 'utf8')
+      const updatedRuntimeOutput = await readWevuComputedRuntime(outDir)
+
+      expect(updatedPageOutput).toContain('issue-446-short-bind-updated')
+      expect(updatedPageOutput).toContain('computed(() => nativeAnchorRef.value != null)')
+      expect(updatedPageOutput).toContain('computed(() => typeof shortBindProbeRef.value?.snapshot === "function")')
+      expect(updatedRuntimeOutput).toContain('Object.defineProperty(exports, "computed"')
+    }
+    finally {
+      await watcher?.close()
+      await ctxResult.dispose()
+      await tempProject.cleanup()
+    }
+  }, 180_000)
+})


### PR DESCRIPTION
## Summary
- 将 issue #446 复现页改为自动导入组件路径，贴近截图中的组件 ref 使用方式
- 新增 watch 回归，覆盖自动导入组件 ref、shortBind、computed 在增量构建后的共享 chunk 导出

## Testing
- pnpm vitest run test/issue-446-watch-auto-import-template-ref.test.ts
- pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #446"
- pnpm --filter e2e-app-github-issues exec wv prepare
- pnpm --filter e2e-app-github-issues exec vue-tsc --noEmit -p tsconfig.json
- pnpm eslint e2e-apps/github-issues/src/pages/issue-446/index.vue packages/weapp-vite/test/issue-446-watch-auto-import-template-ref.test.ts
- pnpm --filter weapp-vite typecheck

Fixes #446