### PR TITLE
fix(wevu): 修复组件式页面触底回调分发

### DIFF
--- a/.changeset/quiet-rivers-reach.md
+++ b/.changeset/quiet-rivers-reach.md
@@ -1,0 +1,6 @@
+---
+"wevu": patch
+"create-weapp-vite": patch
+---
+
+修复 wevu 组件式页面中 `onReachBottom` 未同步暴露到页面 `methods` 的问题，确保微信运行时按页面方法分发触底事件时也能触发通过组合式 API 注册的回调。

--- a/e2e/ide/github-issues.runtime.lifecycle.test.ts
+++ b/e2e/ide/github-issues.runtime.lifecycle.test.ts
@@ -259,12 +259,12 @@ async function waitForIssue446Runtime(page: any, timeoutMs = 20_000) {
   return null
 }
 
-async function waitForIssue479Runtime(page: any, timeoutMs = 20_000) {
+async function waitForIssue479PullRuntime(page: any, timeoutMs = 20_000) {
   const startedAt = Date.now()
   while (Date.now() - startedAt <= timeoutMs) {
     try {
       const runtime = await callPageMethodWithTimeout(page, '_runE2E')
-      if (runtime?.hasPull && runtime?.hasBottom) {
+      if (runtime?.hasPull) {
         return runtime
       }
     }
@@ -281,12 +281,12 @@ async function waitForIssue479Runtime(page: any, timeoutMs = 20_000) {
   return null
 }
 
-async function waitForIssue479PullRuntime(page: any, timeoutMs = 20_000) {
+async function waitForIssue479BottomRuntime(page: any, timeoutMs = 20_000) {
   const startedAt = Date.now()
   while (Date.now() - startedAt <= timeoutMs) {
     try {
       const runtime = await callPageMethodWithTimeout(page, '_runE2E')
-      if (runtime?.hasPull) {
+      if (runtime?.hasBottom) {
         return runtime
       }
     }
@@ -707,12 +707,7 @@ describe.sequential('e2e app: github-issues / lifecycle', () => {
     }
   })
 
-  // DevTools automator 限制：
-  // 1. miniProgram.pageScrollTo() 能把页面 scrollTop 推到真实底部；
-  // 2. 但程序化滚动不会派发 onReachBottom；
-  // 3. page 根节点的 touchstart/touchmove/touchend 也不会驱动页面滚动。
-  // 在没有“真实用户上拉”触发链路前，这条 case 只能保留 skip。
-  it.skip('issue #479: triggers indirect reach-bottom hook in DevTools runtime', async (ctx) => {
+  it('issue #479: triggers indirect reach-bottom hook through Component page method bridge', async (ctx) => {
     const issuePageWxmlPath = path.join(DIST_ROOT, 'pages/issue-479/index.wxml')
     const issuePageJsPath = path.join(DIST_ROOT, 'pages/issue-479/index.js')
     const issuePageJsonPath = path.join(DIST_ROOT, 'pages/issue-479/index.json')
@@ -730,10 +725,10 @@ describe.sequential('e2e app: github-issues / lifecycle', () => {
       const initialRuntime = await waitForIssue479Ready(issuePage)
       expect(Array.isArray(initialRuntime?.logs)).toBe(true)
 
-      await miniProgram.pageScrollTo(2400)
+      await issuePage.callMethod('onReachBottom')
       await issuePage.waitFor(300)
 
-      const runtimeResult = await waitForIssue479Runtime(issuePage)
+      const runtimeResult = await waitForIssue479BottomRuntime(issuePage)
       expect(runtimeResult?.hasBottom).toBe(true)
       expect(runtimeResult?.logs).toContain('bottom')
     }

--- a/packages-runtime/wevu/src/runtime/register/component/registerDefinition.ts
+++ b/packages-runtime/wevu/src/runtime/register/component/registerDefinition.ts
@@ -66,7 +66,7 @@ export function registerComponentDefinition<D extends object, C extends Computed
     getRuntimeOwnerLabel,
   } = options
 
-  const pageShareMethodBridges: Record<string, (...args: any[]) => any> = {}
+  const pageMethodBridges: Record<string, (...args: any[]) => any> = {}
   const attachRuntimeLayoutHosts = (instance: InternalRuntimeState) => {
     if (!Array.isArray(layoutHosts) || !layoutHosts.length) {
       return
@@ -95,8 +95,8 @@ export function registerComponentDefinition<D extends object, C extends Computed
     }
   }
   if (isPage) {
-    const shareHookNames = ['onShareAppMessage', 'onShareTimeline', 'onAddToFavorites']
-    for (const hookName of shareHookNames) {
+    const methodBridgeHookNames = ['onReachBottom', 'onShareAppMessage', 'onShareTimeline', 'onAddToFavorites']
+    for (const hookName of methodBridgeHookNames) {
       const pageHook = (pageLifecycleHooks as any)[hookName]
       if (typeof pageHook !== 'function') {
         continue
@@ -104,7 +104,7 @@ export function registerComponentDefinition<D extends object, C extends Computed
       if (typeof (finalMethods as any)[hookName] === 'function') {
         continue
       }
-      pageShareMethodBridges[hookName] = function pageShareMethodBridge(this: InternalRuntimeState, ...args: any[]) {
+      pageMethodBridges[hookName] = function pageMethodBridge(this: InternalRuntimeState, ...args: any[]) {
         return pageHook.apply(this, args)
       }
     }
@@ -290,7 +290,7 @@ export function registerComponentDefinition<D extends object, C extends Computed
       },
     },
     methods: {
-      ...pageShareMethodBridges,
+      ...pageMethodBridges,
       ...finalMethods,
     },
     options: finalOptions,

--- a/packages-runtime/wevu/test/runtime-features.test.ts
+++ b/packages-runtime/wevu/test/runtime-features.test.ts
@@ -127,6 +127,29 @@ describe('runtime: features & hooks', () => {
     expect(componentOptions.methods.onShareTimeline.call(pageInst)).toMatchObject({ title: 'share-timeline' })
   })
 
+  it('exposes reach-bottom handler in methods for Component-built pages', () => {
+    const logs: string[] = []
+    defineComponent({
+      features: {
+        enableOnReachBottom: true,
+      },
+      setup() {
+        onReachBottom(() => {
+          logs.push('bottom')
+        })
+      },
+    })
+
+    expect(registeredComponents).toHaveLength(1)
+    const componentOptions = registeredComponents[0]
+    expect(typeof componentOptions.methods?.onReachBottom).toBe('function')
+
+    const pageInst: any = {}
+    componentOptions.lifetimes.attached.call(pageInst)
+    componentOptions.methods.onReachBottom.call(pageInst)
+    expect(logs).toEqual(['bottom'])
+  })
+
   it('binds share handlers onto page instance directly', () => {
     defineComponent({
       features: {


### PR DESCRIPTION
## 变更内容

Fixes #479

- 将 wevu 组件式页面的页面方法桥接从分享回调扩展到 `onReachBottom`。
- 新增单测，验证 `Component` 注册页会在 `methods` 暴露并触发 `onReachBottom`。
- 恢复 issue #479 的 DevTools runtime 触底 e2e，用 `callMethod('onReachBottom')` 覆盖页面方法分发链路。
- 添加 `wevu` 与 `create-weapp-vite` patch changeset。

## 验证

- `pnpm --filter wevu test -- runtime-features.test.ts -t "reach-bottom handler in methods"`
- `pnpm --filter wevu typecheck`
- `pnpm --filter wevu build`
- `pnpm --filter wevu lint`（通过，保留既有 warning）
- `pnpm exec eslint e2e/ide/github-issues.runtime.lifecycle.test.ts`
- `pnpm run check:changeset:frontmatter`
- `pnpm run check:create-weapp-vite-changeset`
- `pnpm exec vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #479"`
- `pnpm exec vitest run -c ./e2e/vitest.e2e.devtools.config.ts e2e/ide/github-issues.runtime.lifecycle.test.ts -t "issue #479"`