### PR TITLE
fix(wevu-compiler): 移除未使用的 script setup 标识

### DIFF
--- a/.changeset/remove-script-setup-marker.md
+++ b/.changeset/remove-script-setup-marker.md
@@ -1,0 +1,5 @@
+---
+"@wevu/compiler": patch
+---
+
+移除 Vue SFC `<script setup>` 编译产物中运行时未使用的 `__isScriptSetup` 标识，减少每个 SFC 额外生成的无效代码体积。

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/scriptVueSfcTransform.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/scriptVueSfcTransform.ts
@@ -8,6 +8,7 @@ import { WE_VU_RUNTIME_APIS } from '../../../constants'
  * 1. 移除从 'vue' 导入 defineComponent
  * 2. 移除 __name 属性
  * 3. 移除空参数的 __expose() 调用（保留 defineExpose 生成的 __expose({...})）
+ * 4. 移除运行时未使用的 __isScriptSetup 标识
  */
 export function vueSfcTransformPlugin() {
   return {
@@ -49,6 +50,18 @@ export function vueSfcTransformPlugin() {
       },
 
       CallExpression(path: NodePath<t.CallExpression>) {
+        if (
+          t.isMemberExpression(path.node.callee)
+          && t.isIdentifier(path.node.callee.object, { name: 'Object' })
+          && t.isIdentifier(path.node.callee.property, { name: 'defineProperty' })
+          && t.isIdentifier(path.node.arguments[0], { name: '__returned__' })
+          && t.isStringLiteral(path.node.arguments[1], { value: '__isScriptSetup' })
+          && path.parentPath?.isExpressionStatement()
+        ) {
+          path.parentPath.remove()
+          return
+        }
+
         // 移除 __expose() 调用（仅空参数；有参数时为 defineExpose 的产物，需要保留）
         if (
           t.isIdentifier(path.node.callee, { name: '__expose' })

--- a/packages-runtime/wevu-compiler/test/index.test.ts
+++ b/packages-runtime/wevu-compiler/test/index.test.ts
@@ -67,6 +67,22 @@ const title = 'hello'
     expect(crlfResult.config).toEqual(lfResult.config)
   })
 
+  it('removes unused script setup runtime marker from compiled output', async () => {
+    const source = `
+<script setup lang="ts">
+const title = 'hello'
+</script>
+<template>
+  <view>{{ title }}</view>
+</template>
+    `.trim()
+
+    const result = await compileVueFile(source, '/project/src/pages/index/index.vue')
+
+    expect(result.script).toContain('title')
+    expect(result.script).not.toContain('__isScriptSetup')
+  })
+
   it('supports SFCs with both script setup and normal script', async () => {
     const source = `
 <script setup lang="ts">


### PR DESCRIPTION
## Summary
- 移除 Vue SFC `<script setup>` 编译产物中运行时未使用的 `__isScriptSetup` 标识
- 补充编译回归测试，确认最终脚本不再输出该标识
- 添加 `@wevu/compiler` patch changeset

## Testing
- `pnpm --filter @wevu/compiler typecheck`
- `pnpm --filter @wevu/compiler lint`
- `pnpm vitest run packages-runtime/wevu-compiler/test/index.test.ts packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/script.test.ts`
- `pnpm --filter @wevu/compiler test`
- `pnpm --filter @wevu/compiler build`

## Related
- https://github.com/weapp-vite/weapp-vite/discussions/338#discussioncomment-16645860