### PR TITLE
fix(wevu): 修复 scoped slot flex 布局

### DIFF
--- a/.changeset/fix-issue-521-scoped-slot-virtual-host.md
+++ b/.changeset/fix-issue-521-scoped-slot-virtual-host.md
@@ -1,0 +1,6 @@
+---
+"wevu": patch
+"create-weapp-vite": patch
+---
+
+修复 scoped slot 兼容组件未启用 `virtualHost` 导致插槽内容在 flex 父级中被额外组件节点包裹、布局无法横向排列的问题。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -281,6 +281,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-521/index",
+          "pathName": "pages/issue-521/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/slot-flex-layout/index",
           "pathName": "pages/slot-flex-layout/index",
           "query": "",

--- a/e2e-apps/github-issues/src/components/issue-521/FlexItem/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-521/FlexItem/index.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+defineProps<{
+  val: number
+  label: string
+}>()
+
+defineComponentJson({
+  component: true,
+})
+</script>
+
+<template>
+  <view class="issue521-flex-item" :data-label="label" :data-val="val">
+    {{ label }}: {{ val }}
+  </view>
+</template>
+
+<style scoped>
+.issue521-flex-item {
+  box-sizing: border-box;
+  width: 120rpx;
+  min-height: 64rpx;
+  padding: 12rpx 0;
+  font-size: 22rpx;
+  line-height: 24rpx;
+  color: #111827;
+  text-align: center;
+  background: #a7f3d0;
+  border: 2rpx solid #047857;
+  border-radius: 8rpx;
+}
+</style>

--- a/e2e-apps/github-issues/src/components/issue-521/ScopedFlexHost/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-521/ScopedFlexHost/index.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+defineComponentJson({
+  component: true,
+})
+</script>
+
+<template>
+  <view class="issue521-scoped-flex-host" data-issue521-host="true">
+    <slot :xyz="0" />
+  </view>
+</template>
+
+<style scoped>
+.issue521-scoped-flex-host {
+  display: flex;
+  flex-flow: row nowrap;
+  gap: 16rpx;
+  align-items: flex-start;
+  padding: 20rpx;
+  overflow: hidden;
+  background: #fff;
+  border: 2rpx solid #64748b;
+  border-radius: 8rpx;
+}
+</style>

--- a/e2e-apps/github-issues/src/pages/issue-521/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-521/index.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import FlexItem from '../../components/issue-521/FlexItem/index.vue'
+import ScopedFlexHost from '../../components/issue-521/ScopedFlexHost/index.vue'
+
+definePageJson({
+  navigationBarTitleText: 'issue-521',
+})
+
+function _runE2E() {
+  return {
+    ok: true,
+    expected: 'scoped slot virtual host keeps flex children as siblings',
+  }
+}
+</script>
+
+<template>
+  <view class="issue521-page">
+    <view class="issue521-title">
+      issue-521 scoped slot flex layout
+    </view>
+
+    <ScopedFlexHost v-slot="io">
+      <FlexItem label="A" :val="io.xyz" />
+      <FlexItem label="B" :val="io.xyz" />
+    </ScopedFlexHost>
+  </view>
+</template>
+
+<style scoped>
+.issue521-page {
+  box-sizing: border-box;
+  min-height: 100vh;
+  padding: 28rpx;
+  background: #f8fafc;
+}
+
+.issue521-title {
+  margin-bottom: 18rpx;
+  font-size: 30rpx;
+  font-weight: 700;
+  color: #0f172a;
+}
+</style>

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -445,6 +445,40 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageJs).toContain('_runE2E')
   })
 
+  it('issue #521: keeps generated scoped slot components virtual for flex layouts', async () => {
+    await runBuild()
+
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-521/index.wxml')
+    const pageJsonPath = path.join(DIST_ROOT, 'pages/issue-521/index.json')
+    const scopedSlotJsonPath = path.join(DIST_ROOT, 'pages/issue-521/index.__scoped-slot-default-0.json')
+    const scopedSlotWxmlPath = path.join(DIST_ROOT, 'pages/issue-521/index.__scoped-slot-default-0.wxml')
+    const hostWxmlPath = path.join(DIST_ROOT, 'components/issue-521/ScopedFlexHost/index.wxml')
+    const runtime = await findWevuVendorRuntimePath('options: { virtualHost: true }')
+
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+    const pageJson = await fs.readJson(pageJsonPath) as { usingComponents?: Record<string, string> }
+    const scopedSlotJson = await fs.readJson(scopedSlotJsonPath) as { component?: boolean, styleIsolation?: string }
+    const scopedSlotWxml = await fs.readFile(scopedSlotWxmlPath, 'utf-8')
+    const hostWxml = await fs.readFile(hostWxmlPath, 'utf-8')
+
+    expect(pageWxml).toContain('issue-521 scoped slot flex layout')
+    expect(pageWxml).toContain('generic:scoped-slots-default=')
+    expect(pageWxml).toContain('__wv-slot-owner-id="{{__wvOwnerId || \'\'}}"')
+    expect(pageJson.usingComponents).toMatchObject({
+      ScopedFlexHost: '/components/issue-521/ScopedFlexHost/index',
+      FlexItem: '/components/issue-521/FlexItem/index',
+    })
+    expect(Object.values(pageJson.usingComponents ?? {})).toContain('/pages/issue-521/index.__scoped-slot-default-0')
+    expect(scopedSlotJson).toMatchObject({
+      component: true,
+      styleIsolation: 'apply-shared',
+    })
+    expect(scopedSlotWxml).toContain('<FlexItem label="A" val="{{__wvSlotPropsData.xyz}}" /><FlexItem label="B" val="{{__wvSlotPropsData.xyz}}" />')
+    expect(hostWxml).toContain('<scoped-slots-default wx:if="{{__wvSlotOwnerId}}"')
+    expect(runtime.code).toContain('function createScopedSlotOptions')
+    expect(runtime.code).toContain('options: { virtualHost: true }')
+  })
+
   it('experiment: flex parent keeps projected multi-node slot groups visible via view wrappers', async () => {
     await runBuild()
 

--- a/packages-runtime/wevu/src/runtime/define/scopedSlotOptions.ts
+++ b/packages-runtime/wevu/src/runtime/define/scopedSlotOptions.ts
@@ -96,6 +96,9 @@ export function createScopedSlotOptions(
   overrides?: { computed?: ComputedDefinitions, inlineMap?: InlineExpressionMap },
 ) {
   const baseOptions = {
+    options: {
+      virtualHost: true,
+    },
     properties: {
       [WEVU_SLOT_OWNER_ID_KEY]: { type: String, value: '' },
       [WEVU_SLOT_PROPS_KEY]: {

--- a/packages-runtime/wevu/test/runtime-define-helpers.test.ts
+++ b/packages-runtime/wevu/test/runtime-define-helpers.test.ts
@@ -162,6 +162,7 @@ describe('runtime: define helpers', () => {
   it('creates scoped slot options with inline args parsing', () => {
     const options = createScopedSlotOptions({ computed: { foo: () => 1 } })
     expect((options as any).computed).toBeTruthy()
+    expect((options as any).options?.virtualHost).toBe(true)
 
     const handler = vi.fn((msg: string, evt: any) => ({ msg, marker: evt.marker }))
     const ctx = { __wvOwnerProxy: { onTap: handler } }

--- a/packages-runtime/wevu/test/runtime-scoped-slots.test.ts
+++ b/packages-runtime/wevu/test/runtime-scoped-slots.test.ts
@@ -16,6 +16,7 @@ describe('runtime: scoped slots', () => {
     createWevuScopedSlotComponent()
     const opts = registeredComponents.pop()!
     expect(opts).toBeTruthy()
+    expect(opts.options?.virtualHost).toBe(true)
 
     const ownerId = allocateOwnerId()
     const proxy = { handle: vi.fn() }


### PR DESCRIPTION
## 变更说明
- 为 wevu 生成的 scoped slot 兼容组件启用 `options.virtualHost`，避免 flex 父级下多节点插槽内容被额外组件节点影响布局。
- 增加 issue #521 的 github-issues 复现页与 build e2e 断言，覆盖 scoped slot 组件生成和运行时 vendor 产物。
- 增加 wevu 运行时单测与 changeset。

## 验证
- `pnpm --filter wevu typecheck`
- `pnpm --filter wevu test -- runtime-scoped-slots.test.ts runtime-define-helpers.test.ts`
- `pnpm eslint --no-warn-ignored e2e/ci/github-issues.build.test.ts e2e-apps/github-issues/project.private.config.json e2e-apps/github-issues/src/components/issue-521/FlexItem/index.vue e2e-apps/github-issues/src/components/issue-521/ScopedFlexHost/index.vue e2e-apps/github-issues/src/pages/issue-521/index.vue packages-runtime/wevu/src/runtime/define/scopedSlotOptions.ts packages-runtime/wevu/test/runtime-define-helpers.test.ts packages-runtime/wevu/test/runtime-scoped-slots.test.ts`
- `pnpm stylelint "e2e-apps/github-issues/src/components/issue-521/**/*.vue" "e2e-apps/github-issues/src/pages/issue-521/**/*.vue"`
- `pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #521"`
- `pnpm check:create-weapp-vite-changeset`
- `pnpm check:changeset:frontmatter`
- `pnpm check:publishable-workspace-changeset`

Closes #521