### PR TITLE
fix(weapp-vite): 修复 resolver 自动导入组件插槽识别

### DIFF
--- a/.changeset/fix-issue-520-resolver-wevu-slots.md
+++ b/.changeset/fix-issue-520-resolver-wevu-slots.md
@@ -1,0 +1,8 @@
+---
+"@wevu/compiler": patch
+"wevu": patch
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复 `autoImportComponents.resolvers` 命中 wevu/Vue SFC 组件时插槽元信息识别不完整的问题，确保通过 resolver 自动导入的组件在传入子组件插槽时也会生成 `vue-slots` 属性。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -281,6 +281,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-520/index",
+          "pathName": "pages/issue-520/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/slot-flex-layout/index",
           "pathName": "pages/slot-flex-layout/index",
           "query": "",

--- a/e2e-apps/github-issues/src/components/issue-520/ResolverSlotCard/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-520/ResolverSlotCard/index.vue
@@ -1,0 +1,24 @@
+<template>
+  <view class="issue520-card">
+    <view class="issue520-card__header">
+      <slot name="header" />
+    </view>
+    <view class="issue520-card__body">
+      <slot />
+    </view>
+  </view>
+</template>
+
+<style>
+.issue520-card {
+  padding: 16rpx;
+}
+
+.issue520-card__header {
+  font-weight: 600;
+}
+
+.issue520-card__body {
+  margin-top: 8rpx;
+}
+</style>

--- a/e2e-apps/github-issues/src/pages/issue-520/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-520/index.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+definePageJson({
+  navigationBarTitleText: 'issue-520',
+})
+</script>
+
+<template>
+  <view class="issue520-page">
+    <Issue520ResolverSlotCard>
+      <template #header>
+        <text>issue-520 resolver slot header</text>
+      </template>
+      <text>issue-520 resolver slot default</text>
+    </Issue520ResolverSlotCard>
+  </view>
+</template>
+
+<style>
+.issue520-page {
+  padding: 24rpx;
+}
+</style>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -24,6 +24,15 @@ export default defineConfig({
     wevu: {
       autoSetDataPick: true,
     },
+    autoImportComponents: {
+      resolvers: [
+        {
+          components: {
+            Issue520ResolverSlotCard: '/components/issue-520/ResolverSlotCard/index',
+          },
+        },
+      ],
+    },
     vue: {
       template: {
         slotSingleRootNoWrapper: true,

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -214,6 +214,22 @@ describe.sequential('e2e app: github-issues (build)', () => {
     })
   })
 
+  it('issue #520: injects slot metadata for resolver-imported wevu components', async () => {
+    await runBuild()
+
+    const pageJsonPath = path.join(DIST_ROOT, 'pages/issue-520/index.json')
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-520/index.wxml')
+    const pageJson = await fs.readJson(pageJsonPath)
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+
+    expect(pageJson.usingComponents).toMatchObject({
+      Issue520ResolverSlotCard: '/components/issue-520/ResolverSlotCard/index',
+    })
+    expect(pageWxml).toContain(`Issue520ResolverSlotCard vue-slots="{{['header','default']}}"`)
+    expect(pageWxml).toContain('issue-520 resolver slot header')
+    expect(pageWxml).toContain('issue-520 resolver slot default')
+  })
+
   it('issue #424: avoids duplicated output for imported src/assets images', async () => {
     await runBuild()
 

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/componentSources.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/componentSources.ts
@@ -33,7 +33,9 @@ function normalizeResolvedUsingComponent(result: ResolvedUsingComponentPath | un
 }
 
 function isWevuSfcComponent(result: ReturnType<typeof normalizeResolvedUsingComponent>) {
-  return result?.sourceType === 'wevu-sfc' || Boolean(result?.resolvedId?.endsWith('.vue'))
+  return result?.sourceType === 'wevu-sfc'
+    || Boolean(result?.resolvedId?.endsWith('.vue'))
+    || Boolean(result?.from?.endsWith('.vue'))
 }
 
 function isVueSfcSource(source: string) {

--- a/packages/weapp-vite/src/auto-import-components/resolvers/types.ts
+++ b/packages/weapp-vite/src/auto-import-components/resolvers/types.ts
@@ -1,4 +1,9 @@
-export interface ResolvedValue { name: string, from: string }
+export interface ResolvedValue {
+  name: string
+  from: string
+  resolvedId?: string
+  sourceType?: 'wevu-sfc' | 'native'
+}
 
 export type ResolverSupportFilesStrategy = 'used' | 'full'
 

--- a/packages/weapp-vite/src/plugins/vue/transform/compileOptions.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/compileOptions.test.ts
@@ -214,6 +214,44 @@ describe('resolveVueTemplatePlatformOptions', () => {
     expect(loggerWarnMock).toHaveBeenCalled()
   })
 
+  it('marks resolver auto-imports that point at local vue sfc files', async () => {
+    const autoImportResolve = vi.fn(() => ({
+      kind: 'resolver',
+      value: {
+        name: 'Issue520ResolverSlotCard',
+        from: '/components/issue-520/ResolverSlotCard/index.vue',
+      },
+    }))
+    const options = createCompileVueFileOptions(
+      {
+        autoImportService: {
+          resolve: autoImportResolve,
+        },
+      } as any,
+      {} as any,
+      '/project/src/pages/issue-520/index.vue',
+      true,
+      false,
+      {
+        platform: 'weapp',
+        outputExtensions: {},
+        absoluteSrcRoot: '/project/src',
+        weappViteConfig: {},
+        relativeOutputPath: () => undefined,
+      } as any,
+      {
+        reExportResolutionCache: new Map(),
+        classStyleRuntimeWarned: { value: false },
+      },
+    )
+
+    expect(await options.autoImportTags.resolveUsingComponent('Issue520ResolverSlotCard')).toEqual({
+      name: 'Issue520ResolverSlotCard',
+      from: '/components/issue-520/ResolverSlotCard/index.vue',
+      sourceType: 'wevu-sfc',
+    })
+  })
+
   it('defaults plain slots to augmented scoped slot compilation', () => {
     const options = createCompileVueFileOptions(
       {} as any,

--- a/packages/weapp-vite/src/plugins/vue/transform/compileOptions.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/compileOptions.ts
@@ -2,8 +2,10 @@ import type { CompileVueFileOptions } from 'wevu/compiler'
 import type { CompilerContext } from '../../../context'
 import type { MpPlatform } from '../../../types'
 import { removeExtensionDeep } from '@weapp-core/shared'
+import path from 'pathe'
 import { getMiniProgramTemplatePlatform } from 'wevu/compiler'
 import logger from '../../../logger'
+import { createCachedEntryResolveOptions, resolveEntryPath } from '../../../utils/entryResolve'
 import { createSfcResolveSrcOptions } from '../../utils/vueSfc'
 import { resolveClassStyleWxsLocationForBase } from './classStyle'
 import { createUsingComponentPathResolver } from './usingComponentResolver'
@@ -16,6 +18,8 @@ interface CompileOptionsContext {
   classStyleRuntimeWarned: { value: boolean }
   compileOptionsCache?: Map<string, CompileVueFileResolvedOptions>
 }
+
+type AutoImportComponentSourceType = 'wevu-sfc' | 'native'
 
 export function getCompileVueFileOptionsCacheKey(vuePath: string, isPage: boolean, isApp: boolean) {
   return `${vuePath}::${isPage ? 'page' : 'component'}::${isApp ? 'app' : 'entry'}`
@@ -93,6 +97,51 @@ function buildCompileVueFileOptions(
   const jsonConfig = configService.weappViteConfig?.json
   const wevuDefaults = resolveWevuDefaultsWithPreset(configService.weappViteConfig)
   const jsonKind = isApp ? 'app' : isPage ? 'page' : 'component'
+
+  async function resolveAutoImportComponentSourceType(match: NonNullable<ReturnType<NonNullable<CompilerContext['autoImportService']>['resolve']>>) {
+    if (match.kind === 'local') {
+      const resolvedId = match.entry.templatePath
+      const sourceType: AutoImportComponentSourceType = resolvedId?.endsWith('.vue') ? 'wevu-sfc' : 'native'
+      return {
+        resolvedId,
+        sourceType,
+      }
+    }
+
+    const explicitSourceType = (match.value as { sourceType?: AutoImportComponentSourceType }).sourceType
+    const explicitResolvedId = (match.value as { resolvedId?: string }).resolvedId
+    if (explicitSourceType || explicitResolvedId?.endsWith('.vue') || match.value.from.endsWith('.vue')) {
+      return {
+        resolvedId: explicitResolvedId,
+        sourceType: explicitSourceType ?? (explicitResolvedId?.endsWith('.vue') || match.value.from.endsWith('.vue') ? 'wevu-sfc' : 'native'),
+      }
+    }
+
+    let localSourceBase: string | undefined
+    if (match.value.from.startsWith('/')) {
+      localSourceBase = path.join(configService.absoluteSrcRoot, match.value.from.slice(1))
+    }
+    else if (match.value.from.startsWith('.')) {
+      localSourceBase = path.resolve(path.dirname(importerBaseName), match.value.from)
+    }
+
+    if (!localSourceBase) {
+      return {
+        resolvedId: explicitResolvedId,
+        sourceType: 'native' as const,
+      }
+    }
+
+    const resolvedId = await resolveEntryPath(
+      localSourceBase,
+      createCachedEntryResolveOptions(configService, { kind: 'default' }),
+    )
+    return {
+      resolvedId,
+      sourceType: resolvedId?.endsWith('.vue') ? 'wevu-sfc' as const : 'native' as const,
+    }
+  }
+
   return {
     isPage,
     isApp,
@@ -127,18 +176,10 @@ function buildCompileVueFileOptions(
         if (!match?.value) {
           return undefined
         }
-        if (match.kind === 'local') {
-          const resolvedId = match.entry.templatePath
-          const sourceType: 'wevu-sfc' | 'native' = resolvedId?.endsWith('.vue') ? 'wevu-sfc' : 'native'
-          return {
-            ...match.value,
-            resolvedId,
-            sourceType,
-          }
-        }
+        const sourceInfo = await resolveAutoImportComponentSourceType(match)
         return {
           ...match.value,
-          sourceType: 'native' as const,
+          ...sourceInfo,
         }
       },
     },

--- a/packages/weapp-vite/src/plugins/vue/transform/compileVueFile.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/compileVueFile.test.ts
@@ -125,6 +125,36 @@ import MyCard from './my-card.vue'
     expect(result.template).not.toContain('vue-slots=')
   })
 
+  it('injects slot metadata for resolver-imported vue sfc components', async () => {
+    const result = await compileVueFile(
+      `
+<template>
+  <resolver-card>
+    <template #header>
+      <view>Header</view>
+    </template>
+  </resolver-card>
+</template>
+<script setup lang="ts">
+</script>
+      `.trim(),
+      '/project/src/pages/index/index.vue',
+      {
+        autoImportTags: {
+          enabled: true,
+          resolveUsingComponent: async (tag) => {
+            if (tag === 'resolver-card') {
+              return { name: tag, from: '/components/resolver-card/index.vue' }
+            }
+            return undefined
+          },
+        },
+      },
+    )
+
+    expect(result.template).toContain(`resolver-card vue-slots="{{['header']}}"`)
+  })
+
   it('injects inline expression map for template handlers', async () => {
     const result = await compileVueFile(
       `

--- a/packages/weapp-vite/src/runtime/autoImport/service/resolver.test.ts
+++ b/packages/weapp-vite/src/runtime/autoImport/service/resolver.test.ts
@@ -62,6 +62,7 @@ describe('autoImport resolver helpers', () => {
           return {
             name: 't-button',
             from: 'tdesign-miniprogram/button/button',
+            sourceType: 'native',
           }
         }
         return undefined
@@ -80,6 +81,7 @@ describe('autoImport resolver helpers', () => {
     expect(resolved).toEqual({
       name: 'TButton',
       from: 'tdesign-miniprogram/button/button',
+      sourceType: 'native',
     })
     expect((resolver as any).resolve).toHaveBeenCalledWith('TButton', '/project/src/pages/index/index')
     expect((resolver as any).resolve).toHaveBeenCalledWith('t-button', '/project/src/pages/index/index')

--- a/packages/weapp-vite/src/runtime/autoImport/service/resolver.ts
+++ b/packages/weapp-vite/src/runtime/autoImport/service/resolver.ts
@@ -111,7 +111,7 @@ export function createResolverHelpers(state: ResolverState): ResolverHelpers {
       if (typeof resolverAny.resolve === 'function') {
         const resolved = resolverAny.resolve(candidate, baseName)
         if (resolved) {
-          return candidate === componentName ? resolved : { name: componentName, from: resolved.from }
+          return candidate === componentName ? resolved : { ...resolved, name: componentName }
         }
       }
 
@@ -124,7 +124,7 @@ export function createResolverHelpers(state: ResolverState): ResolverHelpers {
       if (typeof resolver === 'function') {
         const resolved = resolver(candidate, baseName)
         if (resolved) {
-          return candidate === componentName ? resolved : { name: componentName, from: resolved.from }
+          return candidate === componentName ? resolved : { ...resolved, name: componentName }
         }
       }
     }

--- a/packages/weapp-vite/test-d/config-define-config/index.d.ts
+++ b/packages/weapp-vite/test-d/config-define-config/index.d.ts
@@ -1,5 +1,13 @@
 export interface AutoImportComponentsConfig {
   vueComponents?: boolean | string
+  resolvers?: Array<{
+    resolve?: (componentName: string, baseName: string) => {
+      name: string
+      from: string
+      resolvedId?: string
+      sourceType?: 'wevu-sfc' | 'native'
+    } | void
+  }>
 }
 
 export interface WeappViteConfig {

--- a/packages/weapp-vite/test-d/config-define-config/index.test-d.ts
+++ b/packages/weapp-vite/test-d/config-define-config/index.test-d.ts
@@ -31,6 +31,17 @@ const objectConfig = defineConfig({
     },
     autoImportComponents: {
       vueComponents: true,
+      resolvers: [
+        {
+          resolve(componentName) {
+            return {
+              name: componentName,
+              from: '/components/issue-520/ResolverSlotCard/index',
+              sourceType: 'wevu-sfc',
+            }
+          },
+        },
+      ],
     },
   },
 })
@@ -81,6 +92,19 @@ const syncNoEnvVueComponents = syncNoEnvResolved.weapp?.autoImportComponents
   ? syncNoEnvResolved.weapp.autoImportComponents.vueComponents
   : undefined
 expectAssignable<boolean | string | undefined>(syncNoEnvVueComponents)
+
+const objectConfigResolvers = objectConfig.weapp?.autoImportComponents
+  && typeof objectConfig.weapp.autoImportComponents === 'object'
+  ? objectConfig.weapp.autoImportComponents.resolvers
+  : undefined
+expectAssignable<Array<{
+  resolve?: (componentName: string, baseName: string) => {
+    name: string
+    from: string
+    resolvedId?: string
+    sourceType?: 'wevu-sfc' | 'native'
+  } | void
+}> | undefined>(objectConfigResolvers)
 
 const asyncNoEnvConfig = defineConfig(async () => ({
   weapp: {


### PR DESCRIPTION
## 变更说明

- 修复 resolver 自动导入 wevu/Vue SFC 组件时未传递组件来源信息，导致模板缺少 `vue-slots` 的问题。
- 保留 resolver 返回的 `sourceType` / `resolvedId` 元信息，并对本地小程序组件路径反查源文件类型。
- 在 github-issues e2e app 中新增 #520 回归用例。

Closes #520

## 验证

- `pnpm exec vitest run packages/weapp-vite/src/runtime/autoImport/service/resolver.test.ts packages/weapp-vite/src/plugins/vue/transform/compileVueFile.test.ts packages/weapp-vite/src/plugins/vue/transform/compileOptions.test.ts packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/script.test.ts`
- `pnpm --filter @wevu/compiler typecheck`
- `pnpm --filter weapp-vite typecheck`
- `pnpm --filter weapp-vite test:types`
- `pnpm exec eslint <changed files>`
- `pnpm exec stylelint e2e-apps/github-issues/src/components/issue-520/ResolverSlotCard/index.vue e2e-apps/github-issues/src/pages/issue-520/index.vue`
- `pnpm --filter weapp-vite... build`
- `pnpm exec vitest run -c e2e/vitest.e2e.ci.build-only.config.ts e2e/ci/github-issues.build.test.ts -t "issue #520"`
- `pnpm check:create-weapp-vite-changeset`
- `pnpm run check:publishable-workspace-changeset`
- `pnpm run check:changeset:frontmatter`