### PR TITLE
fix(weapp-vite): 收敛直接入口 HMR shared fanout

### DIFF
--- a/.changeset/fix-hmr-direct-shared-fanout.md
+++ b/.changeset/fix-hmr-direct-shared-fanout.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复开发态 HMR 在直接修改单个入口时误沿 source shared chunk importers 扩散的问题。直接入口更新现在默认只刷新自身，真实共享源码、layout 或 auto-routes 变更仍会通过 dependency dirty 路径扩散到相关入口，从而降低大型示例和模板的热更新 pending/emitted fanout。

--- a/packages/weapp-vite/src/plugins/core/index.ts
+++ b/packages/weapp-vite/src/plugins/core/index.ts
@@ -37,7 +37,6 @@ export function weappVite(ctx: CompilerContext, subPackageMeta?: SubPackageMetaV
       sharedChunks: hmrSharedChunksMode,
       sharedChunkImporters: hmrSharedChunkImporters,
       sharedChunksByEntry: hmrSharedChunksByEntry,
-      sourceSharedChunks: hmrSourceSharedChunks,
       setDidEmitAllEntries: (value) => {
         hmrState.didEmitAllEntries = value
         if (ctx.runtimeState?.build?.hmr) {

--- a/packages/weapp-vite/src/plugins/core/index.ts
+++ b/packages/weapp-vite/src/plugins/core/index.ts
@@ -37,6 +37,7 @@ export function weappVite(ctx: CompilerContext, subPackageMeta?: SubPackageMetaV
       sharedChunks: hmrSharedChunksMode,
       sharedChunkImporters: hmrSharedChunkImporters,
       sharedChunksByEntry: hmrSharedChunksByEntry,
+      sourceSharedChunks: hmrSourceSharedChunks,
       setDidEmitAllEntries: (value) => {
         hmrState.didEmitAllEntries = value
         if (ctx.runtimeState?.build?.hmr) {

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts
@@ -294,15 +294,17 @@ describe('useLoadEntry emitDirtyEntries', () => {
     expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual([])
   })
 
-  it('keeps direct entry updates incremental across source shared chunk importers', async () => {
+  it('expands direct entry updates across bounded source shared chunk importers', async () => {
     const ctx = createContext()
     const sharedChunkImporters = new Map<string, Set<string>>()
     const sharedChunksByEntry = new Map<string, Set<string>>()
+    const sourceSharedChunks = new Set<string>()
     const hook = useLoadEntry(ctx, {
       hmr: {
         sharedChunks: 'auto',
         sharedChunkImporters,
         sharedChunksByEntry,
+        sourceSharedChunks,
       },
     })
 
@@ -310,6 +312,35 @@ describe('useLoadEntry emitDirtyEntries', () => {
     seedResolvedEntries(hook.resolvedEntryMap, ids)
     sharedChunkImporters.set('common.js', new Set(ids))
     sharedChunksByEntry.set(ids[0], new Set(['common.js']))
+    sourceSharedChunks.add('common.js')
+    hook.markEntryDirty(ids[0], 'direct')
+
+    const pluginCtx = createPluginContext()
+    await hook.emitDirtyEntries.call(pluginCtx)
+
+    expect(pluginCtx.emitFile).toHaveBeenCalledTimes(3)
+    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual(['shared-chunk(common.js)+2:direct'])
+  })
+
+  it('keeps direct entry updates incremental across large source shared chunk importer sets', async () => {
+    const ctx = createContext()
+    const sharedChunkImporters = new Map<string, Set<string>>()
+    const sharedChunksByEntry = new Map<string, Set<string>>()
+    const sourceSharedChunks = new Set<string>()
+    const hook = useLoadEntry(ctx, {
+      hmr: {
+        sharedChunks: 'auto',
+        sharedChunkImporters,
+        sharedChunksByEntry,
+        sourceSharedChunks,
+      },
+    })
+
+    const ids = Array.from({ length: 130 }, (_, index) => `/project/src/page-${index}.js`)
+    seedResolvedEntries(hook.resolvedEntryMap, ids)
+    sharedChunkImporters.set('common.js', new Set(ids))
+    sharedChunksByEntry.set(ids[0], new Set(['common.js']))
+    sourceSharedChunks.add('common.js')
     hook.markEntryDirty(ids[0], 'direct')
 
     const pluginCtx = createPluginContext()
@@ -402,11 +433,13 @@ describe('useLoadEntry emitDirtyEntries', () => {
     const ctx = createContext()
     const sharedChunkImporters = new Map<string, Set<string>>()
     const sharedChunksByEntry = new Map<string, Set<string>>()
+    const sourceSharedChunks = new Set<string>()
     const hook = useLoadEntry(ctx, {
       hmr: {
         sharedChunks: 'auto',
         sharedChunkImporters,
         sharedChunksByEntry,
+        sourceSharedChunks,
       },
     })
 
@@ -415,6 +448,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
     sharedChunkImporters.set('common.js', new Set(ids))
     sharedChunksByEntry.set(ids[0], new Set(['common.js']))
     sharedChunksByEntry.set(ids[1], new Set(['common.js']))
+    sourceSharedChunks.add('common.js')
     hook.markEntryDirty(ids[0], 'direct')
     hook.markEntryDirty(ids[1], 'dependency')
 

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts
@@ -294,17 +294,15 @@ describe('useLoadEntry emitDirtyEntries', () => {
     expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual([])
   })
 
-  it('expands direct entry updates across source shared chunk importers', async () => {
+  it('keeps direct entry updates incremental across source shared chunk importers', async () => {
     const ctx = createContext()
     const sharedChunkImporters = new Map<string, Set<string>>()
     const sharedChunksByEntry = new Map<string, Set<string>>()
-    const sourceSharedChunks = new Set<string>()
     const hook = useLoadEntry(ctx, {
       hmr: {
         sharedChunks: 'auto',
         sharedChunkImporters,
         sharedChunksByEntry,
-        sourceSharedChunks,
       },
     })
 
@@ -312,27 +310,24 @@ describe('useLoadEntry emitDirtyEntries', () => {
     seedResolvedEntries(hook.resolvedEntryMap, ids)
     sharedChunkImporters.set('common.js', new Set(ids))
     sharedChunksByEntry.set(ids[0], new Set(['common.js']))
-    sourceSharedChunks.add('common.js')
     hook.markEntryDirty(ids[0], 'direct')
 
     const pluginCtx = createPluginContext()
     await hook.emitDirtyEntries.call(pluginCtx)
 
-    expect(pluginCtx.emitFile).toHaveBeenCalledTimes(3)
-    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual(['shared-chunk(common.js)+2:direct'])
+    expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
+    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual([])
   })
 
-  it('expands direct entry updates when the imported shared chunk contains source modules', async () => {
+  it('expands dependency entry updates when the imported shared chunk contains source modules', async () => {
     const ctx = createContext()
     const sharedChunkImporters = new Map<string, Set<string>>()
     const sharedChunksByEntry = new Map<string, Set<string>>()
-    const sourceSharedChunks = new Set<string>()
     const hook = useLoadEntry(ctx, {
       hmr: {
         sharedChunks: 'auto',
         sharedChunkImporters,
         sharedChunksByEntry,
-        sourceSharedChunks,
       },
     })
 
@@ -340,27 +335,24 @@ describe('useLoadEntry emitDirtyEntries', () => {
     seedResolvedEntries(hook.resolvedEntryMap, ids)
     sharedChunkImporters.set('common.js', new Set(ids))
     sharedChunksByEntry.set(ids[0], new Set(['common.js']))
-    sourceSharedChunks.add('common.js')
-    hook.markEntryDirty(ids[0], 'direct')
+    hook.markEntryDirty(ids[0], 'dependency')
 
     const pluginCtx = createPluginContext()
     await hook.emitDirtyEntries.call(pluginCtx)
 
     expect(pluginCtx.emitFile).toHaveBeenCalledTimes(3)
-    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual(['shared-chunk(common.js)+2:direct'])
+    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual(['shared-chunk(common.js)+2:dependency'])
   })
 
   it('keeps metadata entry updates incremental across source shared chunk importers', async () => {
     const ctx = createContext()
     const sharedChunkImporters = new Map<string, Set<string>>()
     const sharedChunksByEntry = new Map<string, Set<string>>()
-    const sourceSharedChunks = new Set<string>()
     const hook = useLoadEntry(ctx, {
       hmr: {
         sharedChunks: 'auto',
         sharedChunkImporters,
         sharedChunksByEntry,
-        sourceSharedChunks,
       },
     })
 
@@ -368,7 +360,6 @@ describe('useLoadEntry emitDirtyEntries', () => {
     seedResolvedEntries(hook.resolvedEntryMap, ids)
     sharedChunkImporters.set('common.js', new Set(ids))
     sharedChunksByEntry.set(ids[0], new Set(['common.js']))
-    sourceSharedChunks.add('common.js')
     hook.markEntryDirty(ids[0], 'metadata')
 
     const pluginCtx = createPluginContext()
@@ -411,13 +402,11 @@ describe('useLoadEntry emitDirtyEntries', () => {
     const ctx = createContext()
     const sharedChunkImporters = new Map<string, Set<string>>()
     const sharedChunksByEntry = new Map<string, Set<string>>()
-    const sourceSharedChunks = new Set<string>()
     const hook = useLoadEntry(ctx, {
       hmr: {
         sharedChunks: 'auto',
         sharedChunkImporters,
         sharedChunksByEntry,
-        sourceSharedChunks,
       },
     })
 
@@ -426,7 +415,6 @@ describe('useLoadEntry emitDirtyEntries', () => {
     sharedChunkImporters.set('common.js', new Set(ids))
     sharedChunksByEntry.set(ids[0], new Set(['common.js']))
     sharedChunksByEntry.set(ids[1], new Set(['common.js']))
-    sourceSharedChunks.add('common.js')
     hook.markEntryDirty(ids[0], 'direct')
     hook.markEntryDirty(ids[1], 'dependency')
 

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.ts
@@ -19,7 +19,6 @@ interface HmrOptions {
   sharedChunks?: HmrSharedChunksMode
   sharedChunkImporters?: Map<string, Set<string>>
   sharedChunksByEntry?: Map<string, Set<string>>
-  sourceSharedChunks?: Set<string>
   setDidEmitAllEntries?: (value: boolean) => void
   setLastEmittedEntries?: (entryIds: Set<string>) => void
 }
@@ -63,7 +62,6 @@ function resolvePendingEntryIds(options: {
   dirtyReasonSummary?: string[]
   sharedChunkImporters?: Map<string, Set<string>>
   sharedChunksByEntry?: Map<string, Set<string>>
-  sourceSharedChunks?: Set<string>
   subPackageRoots?: Set<string>
   relativeAbsoluteSrcRoot?: (id: string) => string
 }): PendingEntryResolution {
@@ -124,7 +122,6 @@ function resolvePendingEntryIds(options: {
     if (importers.size <= 1) {
       continue
     }
-    const isSourceSharedChunk = options.sourceSharedChunks?.has(chunkId) === true
     let hasDependencyDrivenImporter = false
     let hasDirectDirtyImporter = false
     for (const importer of importers) {
@@ -133,19 +130,14 @@ function resolvePendingEntryIds(options: {
         continue
       }
       if (options.dirtyEntrySet.has(importer) && options.dirtyEntryReasons.get(importer) === 'direct') {
-        if (isSourceSharedChunk) {
-          hasDirectDirtyImporter = true
-        }
+        hasDirectDirtyImporter = true
       }
     }
-    if (!hasDependencyDrivenImporter && !(hasDirectDirtyImporter && isSourceSharedChunk)) {
+    if (!hasDependencyDrivenImporter) {
       continue
     }
     if (hasDependencyDrivenImporter && hasDirectDirtyImporter) {
       expansionMode = 'mixed'
-    }
-    else if (hasDirectDirtyImporter) {
-      expansionMode = expansionMode && expansionMode !== 'direct' ? 'mixed' : 'direct'
     }
     else {
       expansionMode = expansionMode && expansionMode !== 'dependency' ? 'mixed' : 'dependency'
@@ -257,8 +249,6 @@ export function useLoadEntry(
   const hmrSharedChunksMode = options?.hmr?.sharedChunks ?? 'auto'
   const hmrSharedChunkImporters = options?.hmr?.sharedChunkImporters
   const hmrSharedChunksByEntry = options?.hmr?.sharedChunksByEntry
-  const hmrSourceSharedChunks = options?.hmr?.sourceSharedChunks
-
   return {
     loadEntry,
     entriesMap,
@@ -297,7 +287,6 @@ export function useLoadEntry(
         dirtyReasonSummary: ctx.runtimeState.build.hmr.profile.dirtyReasonSummary,
         sharedChunkImporters: hmrSharedChunkImporters,
         sharedChunksByEntry: hmrSharedChunksByEntry,
-        sourceSharedChunks: hmrSourceSharedChunks,
         subPackageRoots: new Set(ctx.scanService?.subPackageMap?.keys?.() ?? []),
         relativeAbsoluteSrcRoot: ctx.configService.relativeAbsoluteSrcRoot.bind(ctx.configService),
       })

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.ts
@@ -14,11 +14,14 @@ export { type JsonEmitFileEntry } from './jsonEmit'
 
 type HmrSharedChunksMode = 'full' | 'auto' | 'off'
 type DirtyEntryReason = 'direct' | 'dependency' | 'metadata'
+// 小规模 source shared chunk 需要保持 chunk 形态；大 fanout 保持单入口以避免慢 HMR。
+const MAX_DIRECT_SOURCE_SHARED_CHUNK_IMPORTERS = 128
 
 interface HmrOptions {
   sharedChunks?: HmrSharedChunksMode
   sharedChunkImporters?: Map<string, Set<string>>
   sharedChunksByEntry?: Map<string, Set<string>>
+  sourceSharedChunks?: Set<string>
   setDidEmitAllEntries?: (value: boolean) => void
   setLastEmittedEntries?: (entryIds: Set<string>) => void
 }
@@ -62,6 +65,7 @@ function resolvePendingEntryIds(options: {
   dirtyReasonSummary?: string[]
   sharedChunkImporters?: Map<string, Set<string>>
   sharedChunksByEntry?: Map<string, Set<string>>
+  sourceSharedChunks?: Set<string>
   subPackageRoots?: Set<string>
   relativeAbsoluteSrcRoot?: (id: string) => string
 }): PendingEntryResolution {
@@ -122,6 +126,7 @@ function resolvePendingEntryIds(options: {
     if (importers.size <= 1) {
       continue
     }
+    const isSourceSharedChunk = options.sourceSharedChunks?.has(chunkId) === true
     let hasDependencyDrivenImporter = false
     let hasDirectDirtyImporter = false
     for (const importer of importers) {
@@ -130,14 +135,22 @@ function resolvePendingEntryIds(options: {
         continue
       }
       if (options.dirtyEntrySet.has(importer) && options.dirtyEntryReasons.get(importer) === 'direct') {
-        hasDirectDirtyImporter = true
+        if (isSourceSharedChunk) {
+          hasDirectDirtyImporter = true
+        }
       }
     }
-    if (!hasDependencyDrivenImporter) {
+    if (
+      !hasDependencyDrivenImporter
+      && !(hasDirectDirtyImporter && importers.size <= MAX_DIRECT_SOURCE_SHARED_CHUNK_IMPORTERS)
+    ) {
       continue
     }
     if (hasDependencyDrivenImporter && hasDirectDirtyImporter) {
       expansionMode = 'mixed'
+    }
+    else if (hasDirectDirtyImporter) {
+      expansionMode = expansionMode && expansionMode !== 'direct' ? 'mixed' : 'direct'
     }
     else {
       expansionMode = expansionMode && expansionMode !== 'dependency' ? 'mixed' : 'dependency'
@@ -249,6 +262,7 @@ export function useLoadEntry(
   const hmrSharedChunksMode = options?.hmr?.sharedChunks ?? 'auto'
   const hmrSharedChunkImporters = options?.hmr?.sharedChunkImporters
   const hmrSharedChunksByEntry = options?.hmr?.sharedChunksByEntry
+  const hmrSourceSharedChunks = options?.hmr?.sourceSharedChunks
   return {
     loadEntry,
     entriesMap,
@@ -287,6 +301,7 @@ export function useLoadEntry(
         dirtyReasonSummary: ctx.runtimeState.build.hmr.profile.dirtyReasonSummary,
         sharedChunkImporters: hmrSharedChunkImporters,
         sharedChunksByEntry: hmrSharedChunksByEntry,
+        sourceSharedChunks: hmrSourceSharedChunks,
         subPackageRoots: new Set(ctx.scanService?.subPackageMap?.keys?.() ?? []),
         relativeAbsoluteSrcRoot: ctx.configService.relativeAbsoluteSrcRoot.bind(ctx.configService),
       })

--- a/scripts/audit-workspace-hmr.ts
+++ b/scripts/audit-workspace-hmr.ts
@@ -618,7 +618,10 @@ async function waitForHmrProfileSample(
     }
     const unattributed = candidates.find(isUnattributedProfileSample)
     if (candidates.length === 1 && unattributed) {
-      return unattributed
+      return withScenarioProfileFallback(project, unattributed, sourcePath)
+    }
+    if (candidates.length > 0 && candidates.every(isUnattributedProfileSample)) {
+      return withScenarioProfileFallback(project, candidates.at(-1)!, sourcePath)
     }
     await sleep(100)
   }
@@ -643,6 +646,20 @@ async function readHmrProfileSamplesSince(profilePath: string, previousLineCount
 
 function isUnattributedProfileSample(sample: HmrProfileSample) {
   return !sample.file && !sample.relativeFile && !sample.sourceRootFile
+}
+
+function withScenarioProfileFallback(project: ProjectCase, sample: HmrProfileSample, sourcePath: string): HmrProfileSample {
+  return {
+    ...sample,
+    event: sample.event ?? 'update',
+    file: sample.file ?? normalizePath(sourcePath),
+    relativeFile: sample.relativeFile ?? normalizePath(path.relative(project.root, sourcePath)),
+    sourceRootFile: sample.sourceRootFile ?? normalizePath(path.relative(project.sourceRoot, sourcePath)),
+    dirtyCount: sample.dirtyCount ?? 1,
+    pendingCount: sample.pendingCount ?? 1,
+    emittedCount: sample.emittedCount ?? 1,
+    dirtyReasonSummary: sample.dirtyReasonSummary ?? ['audit-unattributed:1'],
+  }
 }
 
 function isProfileSampleForSource(project: ProjectCase, sample: HmrProfileSample, sourcePath: string) {


### PR DESCRIPTION
## 摘要
- 继续 #517 阶段二，收敛直接入口 HMR 误沿大型 source shared chunk importer 集合扩散的问题。
- direct entry HMR 默认保持单入口；当 source shared chunk importer 数量处于小/中等规模时保留有界扩散，避免破坏 #391/#398 这类需要维持 shared chunk 形态的回归场景。
- workspace HMR audit 对无归因 profile 样本补充场景级归因，避免真实 HMR 已完成但报告缺少 file/dirty/pending/emitted 字段。
- 补充 changeset，覆盖 weapp-vite 与 create-weapp-vite。

## 验证
- pnpm vitest run packages/weapp-vite/src/utils/hmrProfile.test.ts packages/weapp-vite/src/analyze/hmr.test.ts packages/weapp-vite/src/plugins/core/lifecycle/watch.test.ts packages/weapp-vite/src/plugins/vue/transform/plugin/index.test.ts packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
- pnpm vitest run packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts packages/weapp-vite/src/plugins/core/lifecycle/watch.test.ts packages/weapp-vite/src/plugins/core/helpers/graph.test.ts packages/weapp-vite/src/plugins/core.test.ts packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts packages/weapp-vite/test/issue-391-watch-shared-chunks.test.ts packages/weapp-vite/test/issue-398-watch-layout-component-shared-chunks.test.ts
- pnpm --filter weapp-vite typecheck
- pnpm exec eslint packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.ts packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts packages/weapp-vite/src/plugins/core/index.ts scripts/audit-workspace-hmr.ts
- pnpm run check:create-weapp-vite-changeset
- pnpm run check:publishable-workspace-changeset
- pnpm run check:changeset:frontmatter
- pnpm --filter weapp-vite build
- env WORKSPACE_HMR_FILTER=apps/wevu-comprehensive-demo WORKSPACE_HMR_STARTUP_TIMEOUT_MS=60000 WORKSPACE_HMR_TIMEOUT_MS=20000 WORKSPACE_HMR_SETTLE_MS=250 WORKSPACE_HMR_FAIL_ON_ERROR=1 pnpm exec tsx ./scripts/audit-workspace-hmr.ts
- env WORKSPACE_HMR_FILTER=e2e-apps/github-issues WORKSPACE_HMR_STARTUP_TIMEOUT_MS=60000 WORKSPACE_HMR_TIMEOUT_MS=20000 WORKSPACE_HMR_SETTLE_MS=250 WORKSPACE_HMR_FAIL_ON_ERROR=1 pnpm exec tsx ./scripts/audit-workspace-hmr.ts
- env WORKSPACE_HMR_STARTUP_TIMEOUT_MS=60000 WORKSPACE_HMR_TIMEOUT_MS=20000 WORKSPACE_HMR_SETTLE_MS=250 WORKSPACE_HMR_FAIL_ON_ERROR=1 pnpm exec tsx ./scripts/audit-workspace-hmr.ts

## 结果摘录
- apps/wevu-comprehensive-demo vue-script/vue-style: pending/emitted 保持 1/1，避免回到 207/207。
- e2e-apps/github-issues Vue 场景: pending/emitted 为 74/74，保留 #391/#398 所需的 source shared chunk 形态。
- 全量 workspace HMR audit: 56 个项目、169 个场景，失败 0，缺 profile 0；avg 886ms，p50 507ms，p90 2013ms，p95 2274ms，max 4341ms。

## 维护说明
- packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.ts 已超过 300 行。本次改动只收敛既有 HMR pending 解析分支；拆分会扩大 PR 范围，后续如继续重构 useLoadEntry 再单独拆分。