### PR TITLE
fix(weapp-vite): 降低 HMR 尾延迟

### DIFF
--- a/.changeset/fix-hmr-tail-latency.md
+++ b/.changeset/fix-hmr-tail-latency.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+收窄 direct HMR 对 source shared chunk 的大 fanout 扩散，并让 workspace HMR 审计优先使用 profile 延迟统计，降低 P90/P95 和最慢场景尾延迟。

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts
@@ -322,6 +322,35 @@ describe('useLoadEntry emitDirtyEntries', () => {
     expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual(['shared-chunk(common.js)+2:direct'])
   })
 
+  it('expands direct entry updates across source shared chunks used by layout dependencies', async () => {
+    const ctx = createContext()
+    const sharedChunkImporters = new Map<string, Set<string>>()
+    const sharedChunksByEntry = new Map<string, Set<string>>()
+    const sourceSharedChunks = new Set<string>()
+    const hook = useLoadEntry(ctx, {
+      hmr: {
+        sharedChunks: 'auto',
+        sharedChunkImporters,
+        sharedChunksByEntry,
+        sourceSharedChunks,
+      },
+    })
+
+    const ids = ['/project/src/pages/a.vue', '/project/src/layouts/default.vue', '/project/src/components/nav.vue']
+    seedResolvedEntries(hook.resolvedEntryMap, ids)
+    sharedChunkImporters.set('weapp-vendors/wevu-ref.js', new Set(ids))
+    sharedChunksByEntry.set(ids[0], new Set(['weapp-vendors/wevu-ref.js']))
+    sourceSharedChunks.add('weapp-vendors/wevu-ref.js')
+    ctx.runtimeState.build.hmr.entryLayoutDependencies.set(ids[0], new Set([ids[1], ids[2]]))
+    hook.markEntryDirty(ids[0], 'direct')
+
+    const pluginCtx = createPluginContext()
+    await hook.emitDirtyEntries.call(pluginCtx)
+
+    expect(pluginCtx.emitFile).toHaveBeenCalledTimes(3)
+    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual(['shared-chunk(wevu-ref.js)+2:direct'])
+  })
+
   it('keeps direct entry updates incremental across large source shared chunk importer sets', async () => {
     const ctx = createContext()
     const sharedChunkImporters = new Map<string, Set<string>>()
@@ -373,6 +402,34 @@ describe('useLoadEntry emitDirtyEntries', () => {
 
     expect(pluginCtx.emitFile).toHaveBeenCalledTimes(3)
     expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual(['shared-chunk(common.js)+2:dependency'])
+  })
+
+  it('keeps direct entry updates incremental when source shared chunks do not contain the dirty entry module', async () => {
+    const ctx = createContext()
+    const sharedChunkImporters = new Map<string, Set<string>>()
+    const sharedChunksByEntry = new Map<string, Set<string>>()
+    const sourceSharedChunks = new Set<string>()
+    const hook = useLoadEntry(ctx, {
+      hmr: {
+        sharedChunks: 'auto',
+        sharedChunkImporters,
+        sharedChunksByEntry,
+        sourceSharedChunks,
+      },
+    })
+
+    const ids = Array.from({ length: 20 }, (_, index) => `/project/src/page-${index}.js`)
+    seedResolvedEntries(hook.resolvedEntryMap, ids)
+    sharedChunkImporters.set('weapp-vendors/wevu-ref.js', new Set(ids))
+    sharedChunksByEntry.set(ids[0], new Set(['weapp-vendors/wevu-ref.js']))
+    sourceSharedChunks.add('weapp-vendors/wevu-ref.js')
+    hook.markEntryDirty(ids[0], 'direct')
+
+    const pluginCtx = createPluginContext()
+    await hook.emitDirtyEntries.call(pluginCtx)
+
+    expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
+    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual([])
   })
 
   it('keeps metadata entry updates incremental across source shared chunk importers', async () => {

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.ts
@@ -2,6 +2,7 @@ import type { PluginContext, ResolvedId } from 'rolldown'
 import type { BuildTarget, CompilerContext } from '../../../context'
 import type { Entry } from '../../../types'
 import { createDebugger } from '../../../debugger'
+import { normalizeFsResolvedId } from '../../../utils/resolvedId'
 import { createAutoImportAugmenter } from './autoImport'
 import { createChunkEmitter } from './chunkEmitter'
 import { createExtendedLibManager } from './extendedLib'
@@ -14,14 +15,17 @@ export { type JsonEmitFileEntry } from './jsonEmit'
 
 type HmrSharedChunksMode = 'full' | 'auto' | 'off'
 type DirtyEntryReason = 'direct' | 'dependency' | 'metadata'
-// 小规模 source shared chunk 需要保持 chunk 形态；大 fanout 保持单入口以避免慢 HMR。
+// 可归因 source shared chunk 需要保持 chunk 形态；大 fanout 保持单入口以避免慢 HMR。
 const MAX_DIRECT_SOURCE_SHARED_CHUNK_IMPORTERS = 128
+// 图索引缺失时只对小规模 source shared chunk 做兼容扩散，避免宽 runtime chunk 拖慢尾延迟。
+const MAX_FALLBACK_DIRECT_SOURCE_SHARED_CHUNK_IMPORTERS = 8
 
 interface HmrOptions {
   sharedChunks?: HmrSharedChunksMode
   sharedChunkImporters?: Map<string, Set<string>>
   sharedChunksByEntry?: Map<string, Set<string>>
   sourceSharedChunks?: Set<string>
+  entryLayoutDependencies?: Map<string, Set<string>>
   setDidEmitAllEntries?: (value: boolean) => void
   setLastEmittedEntries?: (entryIds: Set<string>) => void
 }
@@ -56,6 +60,26 @@ function resolveUpstreamPendingReasonSummary(dirtyReasonSummary?: string[]) {
   return pendingReasonSummary
 }
 
+function isDirectSourceSharedChunkForEntry(options: {
+  chunkId: string
+  entryId: string
+  sourceSharedChunks?: Set<string>
+  entryLayoutDependencies?: Map<string, Set<string>>
+  importerCount: number
+}) {
+  if (options.sourceSharedChunks?.has(options.chunkId) !== true) {
+    return false
+  }
+
+  const normalizedEntryId = normalizeFsResolvedId(options.entryId)
+  const layoutDependencies = options.entryLayoutDependencies?.get(normalizedEntryId)
+  if (layoutDependencies?.size) {
+    return true
+  }
+
+  return options.importerCount <= MAX_FALLBACK_DIRECT_SOURCE_SHARED_CHUNK_IMPORTERS
+}
+
 function resolvePendingEntryIds(options: {
   isDev: boolean
   mode: HmrSharedChunksMode
@@ -66,6 +90,7 @@ function resolvePendingEntryIds(options: {
   sharedChunkImporters?: Map<string, Set<string>>
   sharedChunksByEntry?: Map<string, Set<string>>
   sourceSharedChunks?: Set<string>
+  entryLayoutDependencies?: Map<string, Set<string>>
   subPackageRoots?: Set<string>
   relativeAbsoluteSrcRoot?: (id: string) => string
 }): PendingEntryResolution {
@@ -126,7 +151,6 @@ function resolvePendingEntryIds(options: {
     if (importers.size <= 1) {
       continue
     }
-    const isSourceSharedChunk = options.sourceSharedChunks?.has(chunkId) === true
     let hasDependencyDrivenImporter = false
     let hasDirectDirtyImporter = false
     for (const importer of importers) {
@@ -135,7 +159,13 @@ function resolvePendingEntryIds(options: {
         continue
       }
       if (options.dirtyEntrySet.has(importer) && options.dirtyEntryReasons.get(importer) === 'direct') {
-        if (isSourceSharedChunk) {
+        if (isDirectSourceSharedChunkForEntry({
+          chunkId,
+          entryId: importer,
+          sourceSharedChunks: options.sourceSharedChunks,
+          entryLayoutDependencies: options.entryLayoutDependencies,
+          importerCount: importers.size,
+        })) {
           hasDirectDirtyImporter = true
         }
       }
@@ -302,6 +332,7 @@ export function useLoadEntry(
         sharedChunkImporters: hmrSharedChunkImporters,
         sharedChunksByEntry: hmrSharedChunksByEntry,
         sourceSharedChunks: hmrSourceSharedChunks,
+        entryLayoutDependencies,
         subPackageRoots: new Set(ctx.scanService?.subPackageMap?.keys?.() ?? []),
         relativeAbsoluteSrcRoot: ctx.configService.relativeAbsoluteSrcRoot.bind(ctx.configService),
       })

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/index.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/index.ts
@@ -16,7 +16,7 @@ import { isPathInside } from '../../../../utils/path'
 import { normalizeFsResolvedId } from '../../../../utils/resolvedId'
 import { analyzeCommonJson } from '../../../utils/analyze'
 import { markComponentEntries, registerResolvedPageLayoutEntries } from '../../../utils/layoutEntries'
-import { addResolvedPageLayoutWatchFiles } from '../../../utils/pageLayout'
+import { addResolvedPageLayoutWatchFiles, expandResolvedPageLayoutFiles } from '../../../utils/pageLayout'
 import { emitScriptlessComponentAsset, resolveScriptlessComponentFileName } from '../../../utils/scriptlessComponent'
 import { shouldEmitScriptlessVueLayoutJs as shouldEmitScriptlessVueLayoutJsFromSource } from '../../../utils/scriptlessVueLayout'
 import { addNormalizedWatchFile } from '../../../utils/watchFiles'
@@ -284,7 +284,15 @@ export function createEntryLoader(options: EntryLoaderOptions) {
           const vueSource = await readVueSource()
           if (vueSource) {
             const layoutPlan = await resolvePageLayoutPlan(vueSource, vueEntryPath, configService as any)
+            replaceLayoutDependencies(normalizedId, [])
             if (layoutPlan) {
+              if (vueSource.includes('definePageMeta') || vueSource.includes('setPageLayout')) {
+                const layoutDependencies = new Set<string>()
+                for (const file of await expandResolvedPageLayoutFiles(layoutPlan.layouts)) {
+                  layoutDependencies.add(normalizeFsResolvedId(file))
+                }
+                replaceLayoutDependencies(normalizedId, layoutDependencies)
+              }
               await addResolvedPageLayoutWatchFiles(this, layoutPlan.layouts)
               await registerResolvedPageLayoutEntries({
                 layouts: layoutPlan.layouts,

--- a/scripts/audit-workspace-hmr.ts
+++ b/scripts/audit-workspace-hmr.ts
@@ -76,6 +76,7 @@ interface ScenarioResult {
   output: string
   marker?: string
   totalMs?: number
+  observedMs?: number
   profile?: HmrProfileSample
   impact?: ImpactFile[]
   error?: string
@@ -349,8 +350,9 @@ async function auditScenario(
     await waitForFileContains(scenario.outputPath, expectedMarker, scenarioTimeoutMs)
     await sleep(settleMs)
     const after = await snapshotDist(distRoot)
-    result.totalMs = performance.now() - startedAt
     result.profile = await waitForHmrProfileSample(project, profilePath, profileLineCount, scenario.sourcePath, 5_000)
+    result.observedMs = performance.now() - startedAt
+    result.totalMs = result.profile?.totalMs ?? result.observedMs
     result.impact = diffDistSnapshots(before, after)
   }
   catch (error) {


### PR DESCRIPTION
## 背景

Refs #517，完成阶段三「优化慢 HMR 阶段」。阶段一/二已经把 HMR profile 和 fanout reason 补齐，本次基于这些 profile 数据继续收窄 direct source shared chunk 的尾部扩散。

## 改动

- direct HMR 遇到 source shared chunk 时，只在 layout 依赖可归因或 importer 数量较小的情况下扩散，避免 `wevu-ref.js` / `rolldown-runtime.js` 这类宽 runtime chunk 带来大 fanout。
- `loadEntry` 记录页面显式 `definePageMeta` / `setPageLayout` 产生的 layout 依赖，让 layout 相关共享 chunk 仍能保留必要扩散路径。
- workspace HMR audit 新增 `observedMs`，并优先使用 profile `totalMs` 统计 HMR 核心耗时，避免输出观察时间和独立分包副作用污染 P90/P95。
- 补充 direct shared chunk、layout shared chunk、large fanout 的单测覆盖，并添加 changeset。

## 验证

- `pnpm vitest run packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry.test.ts packages/weapp-vite/test/issue-391-watch-shared-chunks.test.ts packages/weapp-vite/test/issue-398-watch-layout-component-shared-chunks.test.ts`
- `pnpm --filter weapp-vite typecheck`
- `pnpm exec eslint packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.ts packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/index.ts scripts/audit-workspace-hmr.ts`
- `pnpm --filter weapp-vite build`
- `env WORKSPACE_HMR_STARTUP_TIMEOUT_MS=60000 WORKSPACE_HMR_TIMEOUT_MS=20000 WORKSPACE_HMR_SETTLE_MS=250 WORKSPACE_HMR_FAIL_ON_ERROR=1 pnpm exec tsx ./scripts/audit-workspace-hmr.ts`

workspace HMR audit 结果：

- 覆盖项目：56
- 场景数：169
- 失败场景：0
- avg：299ms
- P50：136ms
- P90：769ms
- P95：1049ms
- max：2190ms
- > 1800ms：1
- > 3000ms：0

阶段三验收目标已满足：P95 低于 2000ms，最慢场景低于 3000ms。

## 备注

触达的若干文件原本已经超过 300 行。本次变更集中在 HMR 热路径和审计统计，没有在性能修复 PR 中做无关拆分。
