### PR TITLE
fix: 修复 slot 兜底内容展示

### DIFF
--- a/.changeset/fix-slot-fallback-presence.md
+++ b/.changeset/fix-slot-fallback-presence.md
@@ -1,0 +1,7 @@
+---
+"@wevu/compiler": patch
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复 Vue SFC 组件 `<slot>` 兜底内容在小程序端无法按父组件是否传入插槽正确显示的问题。编译器现在会基于合法的 `vue-slots` 数组元信息生成显式条件分支，避免宿主 `<slot>` 原生 fallback 行为不一致。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -372,6 +372,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-528/index",
+          "pathName": "pages/issue-528/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "subpackages/item/index",
           "pathName": "subpackages/item/index",
           "query": "",

--- a/e2e-apps/github-issues/src/components/issue-528/SlotFallbackCard/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-528/SlotFallbackCard/index.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+const fallbackDefault = 'issue-528 fallback default'
+</script>
+
+<template>
+  <view class="issue528-card">
+    <view class="issue528-card__header">
+      <slot name="header">
+        <text class="issue528-fallback-header">issue-528 fallback header</text>
+      </slot>
+    </view>
+    <view class="issue528-card__body">
+      <slot>
+        <text class="issue528-fallback-default">{{ fallbackDefault }}</text>
+      </slot>
+    </view>
+  </view>
+</template>
+
+<style>
+.issue528-card {
+  padding: 16rpx;
+}
+
+.issue528-card__header {
+  font-weight: 600;
+}
+
+.issue528-card__body {
+  margin-top: 8rpx;
+}
+</style>

--- a/e2e-apps/github-issues/src/pages/issue-528/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-528/index.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import Issue528SlotFallbackCard from '../../components/issue-528/SlotFallbackCard/index.vue'
+
+definePageJson({
+  navigationBarTitleText: 'issue-528',
+})
+</script>
+
+<template>
+  <view class="issue528-page">
+    <Issue528SlotFallbackCard class="issue528-card-empty" />
+    <Issue528SlotFallbackCard class="issue528-card-provided">
+      <template #header>
+        <text class="issue528-provided-header">issue-528 provided header</text>
+      </template>
+      <text class="issue528-provided-default">issue-528 provided default</text>
+    </Issue528SlotFallbackCard>
+  </view>
+</template>
+
+<style>
+.issue528-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24rpx;
+  padding: 24rpx;
+}
+</style>

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -230,6 +230,24 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageWxml).toContain('issue-520 resolver slot default')
   })
 
+  it('issue #528: compiles slot fallback content to conditional wxml branches', async () => {
+    await runBuild()
+
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-528/index.wxml')
+    const componentWxmlPath = path.join(DIST_ROOT, 'components/issue-528/SlotFallbackCard/index.wxml')
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+    const componentWxml = await fs.readFile(componentWxmlPath, 'utf-8')
+
+    expect(pageWxml).toContain('Issue528SlotFallbackCard class="issue528-card-provided" vue-slots="{{[\'header\',\'default\']}}"')
+    expect(pageWxml).not.toContain('vue-slot-flags')
+    expect(componentWxml).toContain(`<block wx:if="{{vueSlots&&(vueSlots[0]=='header'||`)
+    expect(componentWxml).toContain('<slot name="header" /></block><block wx:else><text class="issue528-fallback-header">issue-528 fallback header</text></block>')
+    expect(componentWxml).toContain(`<block wx:if="{{vueSlots&&(vueSlots[0]=='default'||`)
+    expect(componentWxml).toContain('<slot /></block><block wx:else><text class="issue528-fallback-default">{{fallbackDefault}}</text></block>')
+    expect(componentWxml).not.toContain('<slot name="header"><text class="issue528-fallback-header">')
+    expect(componentWxml).not.toContain('<slot><text class="issue528-fallback-default">')
+  })
+
   it('issue #424: avoids duplicated output for imported src/assets images', async () => {
     await runBuild()
 

--- a/e2e/ide/github-issues.runtime.slot-fallback.test.ts
+++ b/e2e/ide/github-issues.runtime.slot-fallback.test.ts
@@ -1,0 +1,41 @@
+import { afterAll, describe, expect, it } from 'vitest'
+import {
+  closeSharedMiniProgram,
+  getSharedMiniProgram,
+  readPageWxml,
+  relaunchPage,
+  releaseSharedMiniProgram,
+} from './github-issues.runtime.shared'
+
+function countToken(wxml: string, token: string) {
+  return wxml.split(token).length - 1
+}
+
+describe.sequential('e2e app: github-issues / slot fallback', () => {
+  afterAll(async () => {
+    await closeSharedMiniProgram()
+  })
+
+  it('issue #528: renders slot fallback only when parent slot content is absent', async (ctx) => {
+    const miniProgram = await getSharedMiniProgram(ctx)
+    try {
+      const issuePage = await relaunchPage(miniProgram, '/pages/issue-528/index', 'issue528-fallback-default')
+      if (!issuePage) {
+        throw new Error('Failed to launch issue-528 page')
+      }
+
+      const renderedWxml = await readPageWxml(issuePage)
+      expect(renderedWxml).toContain('issue528-fallback-header')
+      expect(renderedWxml).toContain('issue528-fallback-default')
+      expect(renderedWxml).toContain('issue528-provided-header')
+      expect(renderedWxml).toContain('issue528-provided-default')
+      expect(countToken(renderedWxml, 'issue528-fallback-header')).toBe(1)
+      expect(countToken(renderedWxml, 'issue528-fallback-default')).toBe(1)
+      expect(countToken(renderedWxml, 'issue528-provided-header')).toBe(1)
+      expect(countToken(renderedWxml, 'issue528-provided-default')).toBe(1)
+    }
+    finally {
+      await releaseSharedMiniProgram(miniProgram)
+    }
+  })
+})

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
@@ -636,6 +636,7 @@ describe('compileVueTemplateToWxml', () => {
     )
 
     expect(code).toContain(`<Provider vue-slots="{{['default']}}"><view>Default</view></Provider>`)
+    expect(code).not.toContain('vue-slot-flags')
     expect(code).not.toContain('generic:scoped-slots-default')
     expect(scopedSlotComponents).toBeUndefined()
   })
@@ -656,6 +657,7 @@ describe('compileVueTemplateToWxml', () => {
     )
 
     expect(code).toContain(`<Provider vue-slots="{{['default']}}"><view><Leaf /></view></Provider>`)
+    expect(code).not.toContain('vue-slot-flags')
     expect(code).not.toContain('generic:scoped-slots-default')
     expect(scopedSlotComponents).toBeUndefined()
   })
@@ -740,6 +742,47 @@ describe('compileVueTemplateToWxml', () => {
     expect(componentGenerics?.['scoped-slots-action']).toBeUndefined()
   })
 
+  it('compiles slot fallback content to presence-guarded branches', () => {
+    const template = `
+<slot name="header"><view>Fallback header</view></slot>
+<slot><text>{{ fallbackDefault }}</text></slot>
+    `.trim()
+
+    const { code } = compileVueTemplateToWxml(
+      template,
+      '/project/src/components/provider/index.vue',
+      { scopedSlotsRequireProps: false },
+    )
+
+    expect(code).toContain(`<block wx:if="{{vueSlots&&(vueSlots[0]=='header'||`)
+    expect(code).toContain(`<slot name="header" /></block><block wx:else><view>Fallback header</view></block>`)
+    expect(code).toContain(`<block wx:if="{{vueSlots&&(vueSlots[0]=='default'||`)
+    expect(code).toContain(`<slot /></block><block wx:else><text>{{fallbackDefault}}</text></block>`)
+    expect(code).not.toContain('<slot name="header"><view>Fallback header</view></slot>')
+    expect(code).not.toContain('<slot><text>{{fallbackDefault}}</text></slot>')
+  })
+
+  it('keeps slot fallback branches nested inside v-if chains', () => {
+    const template = `
+<slot v-if="a" name="header"><view>A fallback</view></slot>
+<slot v-else-if="b" name="header"><view>B fallback</view></slot>
+<slot v-else name="header"><view>C fallback</view></slot>
+    `.trim()
+
+    const { code } = compileVueTemplateToWxml(
+      template,
+      '/project/src/components/provider/index.vue',
+      { scopedSlotsRequireProps: false },
+    )
+
+    expect(code).toContain(`<block ${DEFAULT_DIRECTIVES.ifAttr}="{{a}}"><block ${DEFAULT_DIRECTIVES.ifAttr}="{{vueSlots&&(vueSlots[0]=='header'||`)
+    expect(code).toContain(`<slot name="header" /></block><block ${DEFAULT_DIRECTIVES.elseAttr}><view>A fallback</view></block></block>`)
+    expect(code).toContain(`<block ${DEFAULT_DIRECTIVES.elifAttr}="{{b}}"><block ${DEFAULT_DIRECTIVES.ifAttr}="{{vueSlots&&(vueSlots[0]=='header'||`)
+    expect(code).toContain(`<slot name="header" /></block><block ${DEFAULT_DIRECTIVES.elseAttr}><view>B fallback</view></block></block>`)
+    expect(code).toContain(`<block ${DEFAULT_DIRECTIVES.elseAttr}><block ${DEFAULT_DIRECTIVES.ifAttr}="{{vueSlots&&(vueSlots[0]=='header'||`)
+    expect(code).toContain(`<slot name="header" /></block><block ${DEFAULT_DIRECTIVES.elseAttr}><view>C fallback</view></block></block>`)
+  })
+
   it('warns when component v-slot and template v-slot are mixed, preferring component slot', () => {
     const template = `
 <Child v-slot="{ item }">
@@ -821,7 +864,26 @@ describe('compileVueTemplateToWxml', () => {
     const { code } = compileVueTemplateToWxml(template, '/project/src/pages/index/index.vue')
 
     expect(code).toContain(`vue-slots="{{[((showHeader) ? 'header' : '')]}}"`)
+    expect(code).not.toContain('vue-slot-flags')
     expect(code).toContain(`<block ${DEFAULT_DIRECTIVES.ifAttr}="{{showHeader}}"><view slot="header">`)
+  })
+
+  it('keeps repeated conditional slot templates in slot metadata order', () => {
+    const template = `
+<Child>
+  <template #header v-if="showPrimary">
+    <view>Primary</view>
+  </template>
+  <template #header v-if="showSecondary">
+    <view>Secondary</view>
+  </template>
+</Child>
+    `.trim()
+
+    const { code } = compileVueTemplateToWxml(template, '/project/src/pages/index/index.vue')
+
+    expect(code).toContain(`vue-slots="{{[((showPrimary) ? 'header' : ''),((showSecondary) ? 'header' : '')]}}"`)
+    expect(code).not.toContain('vue-slot-flags')
   })
 
   it('projects plain named slot single child without synthetic view wrapper when enabled', () => {

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts
@@ -2,6 +2,7 @@ import type { DirectiveNode, ElementNode } from '@vue/compiler-core'
 import type { TransformContext, TransformNode } from '../types'
 import { NodeTypes } from '@vue/compiler-core'
 import {
+  WEVU_SLOT_NAMES_PROP,
   WEVU_SLOT_OWNER_ATTR,
   WEVU_SLOT_OWNER_ID_PROP,
   WEVU_SLOT_PROPS_ATTR,
@@ -21,6 +22,8 @@ import {
 import { collectSlotBindingExpression, parseSlotPropsExpression } from './slotProps'
 
 export type SlotNameInfo = { type: 'default' } | { type: 'static', value: string } | { type: 'dynamic', exp: string }
+
+const SLOT_PRESENCE_SCAN_LIMIT = 32
 
 export interface ScopedSlotDeclaration {
   name: SlotNameInfo
@@ -97,6 +100,29 @@ export function stringifySlotName(info: SlotNameInfo, context: TransformContext)
   }
   const normalized = normalizeWxmlExpressionWithContext(info.exp, context)
   return normalized
+}
+
+function resolveSlotStaticName(info: SlotNameInfo): string | undefined {
+  if (info.type === 'default') {
+    return 'default'
+  }
+  if (info.type === 'static') {
+    return info.value || 'default'
+  }
+  return undefined
+}
+
+function createSlotPresenceExpression(info: SlotNameInfo) {
+  const slotName = resolveSlotStaticName(info)
+  if (!slotName) {
+    return undefined
+  }
+  const slotLiteral = `'${slotName.replace(/\\/g, '\\\\').replace(/'/g, '\\\'')}'`
+  const checks = Array.from(
+    { length: SLOT_PRESENCE_SCAN_LIMIT },
+    (_, index) => `${WEVU_SLOT_NAMES_PROP}[${index}]==${slotLiteral}`,
+  )
+  return `${WEVU_SLOT_NAMES_PROP}&&(${checks.join('||')})`
 }
 
 export function buildSlotDeclaration(
@@ -258,9 +284,17 @@ export function transformSlotElement(node: ElementNode, context: TransformContex
   }
 
   const slotAttrString = slotAttrs.length ? ` ${slotAttrs.join(' ')}` : ''
-  const slotTag = fallbackContent
-    ? `<slot${slotAttrString}>${fallbackContent}</slot>`
-    : `<slot${slotAttrString} />`
+  let slotTag = `<slot${slotAttrString} />`
+
+  if (fallbackContent) {
+    const slotPresentExp = createSlotPresenceExpression(slotNameInfo)
+    if (!slotPropsExp && slotPresentExp) {
+      slotTag = `${context.platform.wrapIf(slotPresentExp, slotTag, exp => renderMustache(exp, context))}${context.platform.wrapElse(fallbackContent)}`
+    }
+    else {
+      slotTag = `<slot${slotAttrString}>${fallbackContent}</slot>`
+    }
+  }
 
   if (!slotPropsExp && (context.scopedSlotsRequireProps || slotNameInfo.type !== 'default')) {
     return slotTag

--- a/packages/weapp-vite/test/vue/compiler.test.ts
+++ b/packages/weapp-vite/test/vue/compiler.test.ts
@@ -302,8 +302,8 @@ describe('Vue Template Compiler', () => {
         '<slot><view>Fallback content</view></slot>',
         'test.vue',
       )
-      expect(result.code).toContain('<slot>')
-      expect(result.code).toContain('Fallback content')
+      expect(result.code).toContain(`<block wx:if="{{vueSlots&&(vueSlots[0]=='default'||`)
+      expect(result.code).toContain('<block wx:else><view>Fallback content</view></block>')
     })
 
     it('should compile scoped slot provider bindings', () => {


### PR DESCRIPTION
Closes #528

## 变更
- 复用已有 `vue-slots` 插槽数组元信息，子组件 fallback 分支通过稳定下标扫描判断父组件是否传入对应插槽。
- 将子组件 `<slot>` 兜底内容编译为显式条件分支，避免小程序宿主原生 fallback 行为不一致。
- 增加 issue #528 的 github-issues 复现页、build e2e、IDE e2e 和编译器单测覆盖。

## 验证
- `pnpm --filter @wevu/compiler typecheck`
- `pnpm --filter weapp-vite typecheck`
- `pnpm --filter wevu typecheck`
- `pnpm vitest run @weapp-core/constants/test/index.test.ts packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts packages/weapp-vite/test/vue/compiler.test.ts packages/weapp-vite/src/plugins/vue/transform/compileVueFile.test.ts`
- `pnpm --filter @wevu/compiler lint`
- `pnpm exec eslint e2e/ci/github-issues.build.test.ts e2e/ide/github-issues.runtime.slot-fallback.test.ts e2e-apps/github-issues/src/pages/issue-528/index.vue packages/weapp-vite/test/vue/compiler.test.ts`
- `pnpm exec stylelint e2e-apps/github-issues/src/pages/issue-528/index.vue`
- `pnpm --filter @wevu/compiler build`
- `pnpm --filter weapp-vite build`
- `pnpm vitest run -c ./e2e/vitest.e2e.ci.build-only.config.ts e2e/ci/github-issues.build.test.ts -t "issue #528|issue #494"`
- `pnpm vitest run -c ./e2e/vitest.e2e.devtools.config.ts e2e/ide/github-issues.runtime.slot-fallback.test.ts`