### PR TITLE
fix(wevu-compiler): 简化 slot 兜底内容条件判断

### DIFF
--- a/.changeset/fix-slot-fallback-presence-object.md
+++ b/.changeset/fix-slot-fallback-presence-object.md
@@ -1,0 +1,7 @@
+---
+"@wevu/compiler": patch
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复 Vue SFC 组件 `<slot>` 兜底内容生成过长 `vueSlots` 数组扫描表达式的问题。编译器现在会将插槽元信息转换为对象绑定，并用 `vueSlots.<name>` 生成短条件分支，避免默认内容降级产物异常。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -379,6 +379,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-530/index",
+          "pathName": "pages/issue-530/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "subpackages/item/index",
           "pathName": "subpackages/item/index",
           "query": "",

--- a/e2e-apps/github-issues/src/components/issue-530/SlotFallbackProbe/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-530/SlotFallbackProbe/index.vue
@@ -1,0 +1,13 @@
+<template>
+  <view class="issue530-probe">
+    <slot>
+      <text class="issue530-fallback-default">issue-530 fallback default</text>
+    </slot>
+  </view>
+</template>
+
+<style>
+.issue530-probe {
+  padding: 16rpx;
+}
+</style>

--- a/e2e-apps/github-issues/src/pages/issue-530/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-530/index.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import Issue530SlotFallbackProbe from '../../components/issue-530/SlotFallbackProbe/index.vue'
+
+definePageJson({
+  navigationBarTitleText: 'issue-530',
+})
+</script>
+
+<template>
+  <view class="issue530-page">
+    <Issue530SlotFallbackProbe class="issue530-card-empty" />
+    <Issue530SlotFallbackProbe class="issue530-card-provided">
+      <text class="issue530-provided-default">issue-530 provided default</text>
+    </Issue530SlotFallbackProbe>
+  </view>
+</template>
+
+<style>
+.issue530-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24rpx;
+  padding: 24rpx;
+}
+</style>

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -225,7 +225,7 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageJson.usingComponents).toMatchObject({
       Issue520ResolverSlotCard: '/components/issue-520/ResolverSlotCard/index',
     })
-    expect(pageWxml).toContain(`Issue520ResolverSlotCard vue-slots="{{['header','default']}}"`)
+    expect(pageWxml).toContain(`Issue520ResolverSlotCard vue-slots="{{__wv_bind_0}}"`)
     expect(pageWxml).toContain('issue-520 resolver slot header')
     expect(pageWxml).toContain('issue-520 resolver slot default')
   })
@@ -238,14 +238,28 @@ describe.sequential('e2e app: github-issues (build)', () => {
     const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
     const componentWxml = await fs.readFile(componentWxmlPath, 'utf-8')
 
-    expect(pageWxml).toContain('Issue528SlotFallbackCard class="issue528-card-provided" vue-slots="{{[\'header\',\'default\']}}"')
+    expect(pageWxml).toContain('Issue528SlotFallbackCard class="issue528-card-provided" vue-slots="{{__wv_bind_0}}"')
     expect(pageWxml).not.toContain('vue-slot-flags')
-    expect(componentWxml).toContain(`<block wx:if="{{vueSlots&&(vueSlots[0]=='header'||`)
+    expect(componentWxml).toContain(`<block wx:if="{{vueSlots&&vueSlots.header}}">`)
     expect(componentWxml).toContain('<slot name="header" /></block><block wx:else><text class="issue528-fallback-header">issue-528 fallback header</text></block>')
-    expect(componentWxml).toContain(`<block wx:if="{{vueSlots&&(vueSlots[0]=='default'||`)
+    expect(componentWxml).toContain(`<block wx:if="{{vueSlots&&vueSlots.default}}">`)
     expect(componentWxml).toContain('<slot /></block><block wx:else><text class="issue528-fallback-default">{{fallbackDefault}}</text></block>')
+    expect(componentWxml).not.toContain('vueSlots[')
     expect(componentWxml).not.toContain('<slot name="header"><text class="issue528-fallback-header">')
     expect(componentWxml).not.toContain('<slot><text class="issue528-fallback-default">')
+  })
+
+  it('issue #530: compiles default slot fallback guards without slot array scans', async () => {
+    await runBuild()
+
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-530/index.wxml')
+    const componentWxmlPath = path.join(DIST_ROOT, 'components/issue-530/SlotFallbackProbe/index.wxml')
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+    const componentWxml = await fs.readFile(componentWxmlPath, 'utf-8')
+
+    expect(pageWxml).toContain('Issue530SlotFallbackProbe class="issue530-card-provided" vue-slots=')
+    expect(componentWxml).toContain('<block wx:if="{{vueSlots&&vueSlots.default}}"><slot /></block><block wx:else><text class="issue530-fallback-default">issue-530 fallback default</text></block>')
+    expect(componentWxml).not.toContain('vueSlots[')
   })
 
   it('issue #424: avoids duplicated output for imported src/assets images', async () => {

--- a/e2e/ci/wevu-features.build.test.ts
+++ b/e2e/ci/wevu-features.build.test.ts
@@ -282,7 +282,7 @@ describe.sequential('e2e app: wevu-features (build)', () => {
     expect(useProvideInjectScopePageWxml).toContain('<weapp-layout-provide-inject-scope')
     expect(useProvideInjectScopePageWxml).toContain('<ProvideInjectSlotProvider')
     expect(useProvideInjectScopePageWxml).toContain('generic:scoped-slots-default=')
-    expect(useProvideInjectScopePageWxml).toContain(`vue-slots="{{['default']}}"`)
+    expect(useProvideInjectScopePageWxml).toContain(`vue-slots="{{__wv_bind_`)
     expect(useProvideInjectSlotScopedWxml).toContain('<ProvideInjectSlotLeaf')
     expect(useProvideInjectScopeLevel01Wxml).toContain('<ProvideInjectScopeLevel02')
     expect(useProvideInjectScopeLevel09Wxml).toContain('<ProvideInjectScopeLeaf')

--- a/e2e/ide/github-issues.runtime.slot-fallback.test.ts
+++ b/e2e/ide/github-issues.runtime.slot-fallback.test.ts
@@ -109,4 +109,23 @@ describe.sequential('e2e app: github-issues / slot fallback', () => {
       await releaseSharedMiniProgram(miniProgram)
     }
   })
+
+  it('issue #530: renders default slot fallback with short slot presence metadata', async (ctx) => {
+    const miniProgram = await getSharedMiniProgram(ctx)
+    try {
+      const issuePage = await relaunchPage(miniProgram, '/pages/issue-530/index', 'issue530-fallback-default')
+      if (!issuePage) {
+        throw new Error('Failed to launch issue-530 page')
+      }
+
+      const renderedWxml = await readPageWxml(issuePage)
+      expect(renderedWxml).toContain('issue530-fallback-default')
+      expect(renderedWxml).toContain('issue530-provided-default')
+      expect(countToken(renderedWxml, 'issue530-fallback-default')).toBe(1)
+      expect(countToken(renderedWxml, 'issue530-provided-default')).toBe(1)
+    }
+    finally {
+      await releaseSharedMiniProgram(miniProgram)
+    }
+  })
 })

--- a/e2e/scripts/e2e-suite-manifest.ts
+++ b/e2e/scripts/e2e-suite-manifest.ts
@@ -14,6 +14,7 @@ const IDE_GITHUB_ISSUES_PATTERNS = [
   'ide/github-issues.runtime.issue297-302.test.ts',
   'ide/github-issues.runtime.lifecycle.test.ts',
   'ide/github-issues.runtime.props.test.ts',
+  'ide/github-issues.runtime.slot-fallback.test.ts',
 ]
 const IDE_CHUNK_MODES_PATTERNS = [
   'ide/chunk-modes.runtime.duplicate.test.ts',

--- a/e2e/scripts/suiteRunner.test.ts
+++ b/e2e/scripts/suiteRunner.test.ts
@@ -209,7 +209,8 @@ describe('suiteRunner', () => {
     expect(ideFullLabels.slice(-3)).toEqual(ideChunkModesLabels)
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue289.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.lifecycle.test.ts')
-    expect(ideGithubIssuesTasks.length).toBe(4)
+    expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.slot-fallback.test.ts')
+    expect(ideGithubIssuesTasks.length).toBe(5)
   })
 
   it('uses env-based target file selection for suite vitest tasks', async () => {

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
@@ -585,16 +585,17 @@ describe('compileVueTemplateToWxml', () => {
 </Provider>
     `.trim()
 
-    const { code, scopedSlotComponents } = compileVueTemplateToWxml(
+    const { code, scopedSlotComponents, classStyleBindings } = compileVueTemplateToWxml(
       template,
       '/project/src/pages/index/index.vue',
       { scopedSlotsRequireProps: false },
     )
 
     expect(code).toContain('generic:scoped-slots-default="')
-    expect(code).toContain(`vue-slots="{{['default']}}"`)
+    expect(code).toContain(`vue-slots="{{__wv_bind_0}}"`)
     expect(code).toContain('__wv-slot-owner-id="{{__wvOwnerId || \'\'}}"')
     expect(code).not.toContain('<Leaf')
+    expect(classStyleBindings?.some(binding => binding.name === '__wv_bind_0' && binding.exp === `{['default']:true}`)).toBe(true)
     expect(scopedSlotComponents).toHaveLength(1)
     expect(scopedSlotComponents?.[0]?.slotKey).toBe('default')
     expect(scopedSlotComponents?.[0]?.template).toContain('<Leaf />')
@@ -629,15 +630,16 @@ describe('compileVueTemplateToWxml', () => {
 </Provider>
     `.trim()
 
-    const { code, scopedSlotComponents } = compileVueTemplateToWxml(
+    const { code, scopedSlotComponents, classStyleBindings } = compileVueTemplateToWxml(
       template,
       '/project/src/pages/index/index.vue',
       { scopedSlotsRequireProps: false },
     )
 
-    expect(code).toContain(`<Provider vue-slots="{{['default']}}"><view>Default</view></Provider>`)
+    expect(code).toContain(`<Provider vue-slots="{{__wv_bind_0}}"><view>Default</view></Provider>`)
     expect(code).not.toContain('vue-slot-flags')
     expect(code).not.toContain('generic:scoped-slots-default')
+    expect(classStyleBindings?.some(binding => binding.name === '__wv_bind_0' && binding.exp === `{['default']:true}`)).toBe(true)
     expect(scopedSlotComponents).toBeUndefined()
   })
 
@@ -656,7 +658,7 @@ describe('compileVueTemplateToWxml', () => {
       { scopedSlotsRequireProps: false },
     )
 
-    expect(code).toContain(`<Provider vue-slots="{{['default']}}"><view><Leaf /></view></Provider>`)
+    expect(code).toContain(`<Provider vue-slots="{{__wv_bind_0}}"><view><Leaf /></view></Provider>`)
     expect(code).not.toContain('vue-slot-flags')
     expect(code).not.toContain('generic:scoped-slots-default')
     expect(scopedSlotComponents).toBeUndefined()
@@ -754,10 +756,11 @@ describe('compileVueTemplateToWxml', () => {
       { scopedSlotsRequireProps: false },
     )
 
-    expect(code).toContain(`<block wx:if="{{vueSlots&&(vueSlots[0]=='header'||`)
+    expect(code).toContain(`<block wx:if="{{vueSlots&&vueSlots.header}}">`)
     expect(code).toContain(`<slot name="header" /></block><block wx:else><view>Fallback header</view></block>`)
-    expect(code).toContain(`<block wx:if="{{vueSlots&&(vueSlots[0]=='default'||`)
+    expect(code).toContain(`<block wx:if="{{vueSlots&&vueSlots.default}}">`)
     expect(code).toContain(`<slot /></block><block wx:else><text>{{fallbackDefault}}</text></block>`)
+    expect(code).not.toContain('vueSlots[')
     expect(code).not.toContain('<slot name="header"><view>Fallback header</view></slot>')
     expect(code).not.toContain('<slot><text>{{fallbackDefault}}</text></slot>')
   })
@@ -775,12 +778,13 @@ describe('compileVueTemplateToWxml', () => {
       { scopedSlotsRequireProps: false },
     )
 
-    expect(code).toContain(`<block ${DEFAULT_DIRECTIVES.ifAttr}="{{a}}"><block ${DEFAULT_DIRECTIVES.ifAttr}="{{vueSlots&&(vueSlots[0]=='header'||`)
+    expect(code).toContain(`<block ${DEFAULT_DIRECTIVES.ifAttr}="{{a}}"><block ${DEFAULT_DIRECTIVES.ifAttr}="{{vueSlots&&vueSlots.header}}">`)
     expect(code).toContain(`<slot name="header" /></block><block ${DEFAULT_DIRECTIVES.elseAttr}><view>A fallback</view></block></block>`)
-    expect(code).toContain(`<block ${DEFAULT_DIRECTIVES.elifAttr}="{{b}}"><block ${DEFAULT_DIRECTIVES.ifAttr}="{{vueSlots&&(vueSlots[0]=='header'||`)
+    expect(code).toContain(`<block ${DEFAULT_DIRECTIVES.elifAttr}="{{b}}"><block ${DEFAULT_DIRECTIVES.ifAttr}="{{vueSlots&&vueSlots.header}}">`)
     expect(code).toContain(`<slot name="header" /></block><block ${DEFAULT_DIRECTIVES.elseAttr}><view>B fallback</view></block></block>`)
-    expect(code).toContain(`<block ${DEFAULT_DIRECTIVES.elseAttr}><block ${DEFAULT_DIRECTIVES.ifAttr}="{{vueSlots&&(vueSlots[0]=='header'||`)
+    expect(code).toContain(`<block ${DEFAULT_DIRECTIVES.elseAttr}><block ${DEFAULT_DIRECTIVES.ifAttr}="{{vueSlots&&vueSlots.header}}">`)
     expect(code).toContain(`<slot name="header" /></block><block ${DEFAULT_DIRECTIVES.elseAttr}><view>C fallback</view></block></block>`)
+    expect(code).not.toContain('vueSlots[')
   })
 
   it('warns when component v-slot and template v-slot are mixed, preferring component slot', () => {
@@ -812,7 +816,7 @@ describe('compileVueTemplateToWxml', () => {
 <slot :item="card.item"><view>fallback</view></slot>
     `.trim()
 
-    const { code, warnings } = compileVueTemplateToWxml(
+    const { code, warnings, classStyleBindings } = compileVueTemplateToWxml(
       template,
       '/project/src/pages/index/index.vue',
       { scopedSlotsCompiler: 'off' },
@@ -821,7 +825,8 @@ describe('compileVueTemplateToWxml', () => {
     expect(warnings.some(message => message.includes('已禁用作用域插槽参数'))).toBe(true)
     expect(code).toContain('<view slot="header"><view>{{title}}</view></view>')
     expect(code).toContain('<slot><view>fallback</view></slot>')
-    expect(code).toContain(`vue-slots="{{['header']}}"`)
+    expect(code).toContain(`vue-slots="{{__wv_bind_0}}"`)
+    expect(classStyleBindings?.some(binding => binding.name === '__wv_bind_0' && binding.exp === `{['header']:true}`)).toBe(true)
     expect(code).not.toContain('__wv-slot-props=')
   })
 
@@ -834,10 +839,11 @@ describe('compileVueTemplateToWxml', () => {
 </Child>
     `.trim()
 
-    const { code } = compileVueTemplateToWxml(template, '/project/src/pages/index/index.vue')
+    const { code, classStyleBindings } = compileVueTemplateToWxml(template, '/project/src/pages/index/index.vue')
 
     expect(code).toContain('<view slot="icon"><image class="img probe" src="/cover.png" /></view>')
-    expect(code).toContain(`vue-slots="{{['icon']}}"`)
+    expect(code).toContain(`vue-slots="{{__wv_bind_0}}"`)
+    expect(classStyleBindings?.some(binding => binding.name === '__wv_bind_0' && binding.exp === `{['icon']:true}`)).toBe(true)
   })
 
   it('emits slot presence metadata for implicit default slots', () => {
@@ -847,9 +853,10 @@ describe('compileVueTemplateToWxml', () => {
 </Child>
     `.trim()
 
-    const { code } = compileVueTemplateToWxml(template, '/project/src/pages/index/index.vue')
+    const { code, classStyleBindings } = compileVueTemplateToWxml(template, '/project/src/pages/index/index.vue')
 
-    expect(code).toContain(`vue-slots="{{['default']}}"`)
+    expect(code).toContain(`vue-slots="{{__wv_bind_0}}"`)
+    expect(classStyleBindings?.some(binding => binding.name === '__wv_bind_0' && binding.exp === `{['default']:true}`)).toBe(true)
   })
 
   it('guards plain slot metadata and fallback content with template v-if', () => {
@@ -861,10 +868,11 @@ describe('compileVueTemplateToWxml', () => {
 </Child>
     `.trim()
 
-    const { code } = compileVueTemplateToWxml(template, '/project/src/pages/index/index.vue')
+    const { code, classStyleBindings } = compileVueTemplateToWxml(template, '/project/src/pages/index/index.vue')
 
-    expect(code).toContain(`vue-slots="{{[((showHeader) ? 'header' : '')]}}"`)
+    expect(code).toContain(`vue-slots="{{__wv_bind_0}}"`)
     expect(code).not.toContain('vue-slot-flags')
+    expect(classStyleBindings?.some(binding => binding.name === '__wv_bind_0' && binding.exp === `{['header']:(showHeader)}`)).toBe(true)
     expect(code).toContain(`<block ${DEFAULT_DIRECTIVES.ifAttr}="{{showHeader}}"><view slot="header">`)
   })
 
@@ -880,10 +888,11 @@ describe('compileVueTemplateToWxml', () => {
 </Child>
     `.trim()
 
-    const { code } = compileVueTemplateToWxml(template, '/project/src/pages/index/index.vue')
+    const { code, classStyleBindings } = compileVueTemplateToWxml(template, '/project/src/pages/index/index.vue')
 
-    expect(code).toContain(`vue-slots="{{[((showPrimary) ? 'header' : ''),((showSecondary) ? 'header' : '')]}}"`)
+    expect(code).toContain(`vue-slots="{{__wv_bind_0}}"`)
     expect(code).not.toContain('vue-slot-flags')
+    expect(classStyleBindings?.some(binding => binding.name === '__wv_bind_0' && binding.exp === `{['header']:(showPrimary)||(showSecondary)}`)).toBe(true)
   })
 
   it('projects plain named slot single child without synthetic view wrapper when enabled', () => {

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-component.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-component.ts
@@ -11,6 +11,7 @@ import {
 import { transformAttribute } from '../attributes'
 import { transformDirective } from '../directives'
 import { normalizeWxmlExpressionWithContext } from '../expression'
+import { registerRuntimeBindingExpression } from '../expression/runtimeBinding'
 import { resolveTemplateTagName } from '../htmlTagMapping'
 import { renderMustache } from '../mustache'
 import { collectElementAttributes, isBuiltinTag } from './attrs'
@@ -83,16 +84,38 @@ function pushSlotNamesAttr(
     return
   }
   const seen = new Set<string>()
-  const entries: string[] = []
+  const entries = new Map<string, { conditions: string[], unconditional: boolean }>()
   for (const item of slotNames) {
     const dedupeKey = `${item.name}:${item.condition ?? ''}`
     if (seen.has(dedupeKey)) {
       continue
     }
     seen.add(dedupeKey)
-    entries.push(item.condition ? `((${item.condition}) ? ${item.name} : '')` : item.name)
+    const entry = entries.get(item.name) ?? { conditions: [], unconditional: false }
+    if (item.condition) {
+      if (!entry.unconditional) {
+        entry.conditions.push(item.condition)
+      }
+    }
+    else {
+      entry.conditions.length = 0
+      entry.unconditional = true
+    }
+    entries.set(item.name, entry)
   }
-  attrs.push(`${WEVU_SLOT_NAMES_ATTR}="${renderMustache(`[${entries.join(',')}]`, context)}"`)
+  const properties: string[] = []
+  for (const [name, entry] of entries) {
+    const value = entry.conditions.length
+      ? entry.conditions.map(condition => `(${condition})`).join('||')
+      : 'true'
+    properties.push(`[${name}]:${value}`)
+  }
+  const slotNamesRef = registerRuntimeBindingExpression(`{${properties.join(',')}}`, context, {
+    hint: 'vue-slots 元数据',
+  })
+  if (slotNamesRef) {
+    attrs.push(`${WEVU_SLOT_NAMES_ATTR}="${renderMustache(slotNamesRef, context)}"`)
+  }
 }
 
 function shouldExposePlainSlotPresence(node: ElementNode) {

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts
@@ -23,8 +23,6 @@ import { collectSlotBindingExpression, parseSlotPropsExpression } from './slotPr
 
 export type SlotNameInfo = { type: 'default' } | { type: 'static', value: string } | { type: 'dynamic', exp: string }
 
-const SLOT_PRESENCE_SCAN_LIMIT = 32
-
 export interface ScopedSlotDeclaration {
   name: SlotNameInfo
   props: Record<string, string>
@@ -112,17 +110,17 @@ function resolveSlotStaticName(info: SlotNameInfo): string | undefined {
   return undefined
 }
 
+const SLOT_PRESENCE_IDENTIFIER_RE = /^[A-Z_$][\w$]*$/i
+
 function createSlotPresenceExpression(info: SlotNameInfo) {
   const slotName = resolveSlotStaticName(info)
   if (!slotName) {
     return undefined
   }
-  const slotLiteral = `'${slotName.replace(/\\/g, '\\\\').replace(/'/g, '\\\'')}'`
-  const checks = Array.from(
-    { length: SLOT_PRESENCE_SCAN_LIMIT },
-    (_, index) => `${WEVU_SLOT_NAMES_PROP}[${index}]==${slotLiteral}`,
-  )
-  return `${WEVU_SLOT_NAMES_PROP}&&(${checks.join('||')})`
+  const access = SLOT_PRESENCE_IDENTIFIER_RE.test(slotName)
+    ? `${WEVU_SLOT_NAMES_PROP}.${slotName}`
+    : `${WEVU_SLOT_NAMES_PROP}['${slotName.replace(/\\/g, '\\\\').replace(/'/g, '\\\'')}']`
+  return `${WEVU_SLOT_NAMES_PROP}&&${access}`
 }
 
 export function buildSlotDeclaration(

--- a/packages/weapp-vite/src/plugins/vue/transform/compileVueFile.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/compileVueFile.test.ts
@@ -71,7 +71,8 @@ import MyCard from './my-card.vue'
       },
     )
 
-    expect(result.template).toContain(`my-card vue-slots="{{['header']}}"`)
+    expect(result.template).toContain(`my-card vue-slots="{{__wv_bind_0}}"`)
+    expect(result.script).toContain('__wv_bind_0')
   })
 
   it('injects slot metadata for kebab-case direct .vue imports without resolver', async () => {
@@ -91,7 +92,8 @@ import MyCard from './my-card.vue'
       '/project/src/pages/index/index.vue',
     )
 
-    expect(result.template).toContain(`my-card vue-slots="{{['header']}}"`)
+    expect(result.template).toContain(`my-card vue-slots="{{__wv_bind_0}}"`)
+    expect(result.script).toContain('__wv_bind_0')
   })
 
   it('does not inject slot metadata for kebab-case native auto-import components', async () => {
@@ -152,7 +154,8 @@ import MyCard from './my-card.vue'
       },
     )
 
-    expect(result.template).toContain(`resolver-card vue-slots="{{['header']}}"`)
+    expect(result.template).toContain(`resolver-card vue-slots="{{__wv_bind_0}}"`)
+    expect(result.script).toContain('__wv_bind_0')
   })
 
   it('injects inline expression map for template handlers', async () => {

--- a/packages/weapp-vite/test/vue/compiler.test.ts
+++ b/packages/weapp-vite/test/vue/compiler.test.ts
@@ -302,8 +302,9 @@ describe('Vue Template Compiler', () => {
         '<slot><view>Fallback content</view></slot>',
         'test.vue',
       )
-      expect(result.code).toContain(`<block wx:if="{{vueSlots&&(vueSlots[0]=='default'||`)
+      expect(result.code).toContain(`<block wx:if="{{vueSlots&&vueSlots.default}}">`)
       expect(result.code).toContain('<block wx:else><view>Fallback content</view></block>')
+      expect(result.code).not.toContain('vueSlots[')
     })
 
     it('should compile scoped slot provider bindings', () => {
@@ -337,7 +338,8 @@ describe('Vue Template Compiler', () => {
       const slotComp = result.scopedSlotComponents?.[0]
       expect(slotComp).toBeDefined()
       expect(result.code).toContain(`generic:scoped-slots-default="${slotComp?.componentName}"`)
-      expect(result.code).toContain('vue-slots="{{[\'default\']}}"')
+      expect(result.code).toContain('vue-slots="{{__wv_bind_0}}"')
+      expect(result.classStyleBindings?.some(binding => binding.name === '__wv_bind_0' && binding.exp === `{['default']:true}`)).toBe(true)
       expect(result.code).toContain('__wv-slot-owner-id="{{__wvOwnerId || \'\'}}"')
       expect(slotComp?.template).toContain('{{__wvSlotPropsData.item}}')
       expect(slotComp?.template).toContain('{{__wvOwner.foo}}')
@@ -400,7 +402,8 @@ describe('Vue Template Compiler', () => {
       const slotComp = result.scopedSlotComponents?.[0]
       expect(slotComp?.slotKey).toBe('header')
       expect(result.code).toContain(`generic:scoped-slots-header="${slotComp?.componentName}"`)
-      expect(result.code).toContain('vue-slots="{{[\'header\']}}"')
+      expect(result.code).toContain('vue-slots="{{__wv_bind_0}}"')
+      expect(result.classStyleBindings?.some(binding => binding.name === '__wv_bind_0' && binding.exp === `{['header']:true}`)).toBe(true)
       expect(slotComp?.template).toContain('{{__wvSlotPropsData.title}}')
     })
 
@@ -413,7 +416,8 @@ describe('Vue Template Compiler', () => {
       const slotComp = result.scopedSlotComponents?.[0]
       expect(slotComp?.slotKey.startsWith('dyn-')).toBe(true)
       expect(result.code).toContain(`generic:scoped-slots-${slotComp?.slotKey}`)
-      expect(result.code).toContain('vue-slots="{{[slotName]}}"')
+      expect(result.code).toContain('vue-slots="{{__wv_bind_0}}"')
+      expect(result.classStyleBindings?.some(binding => binding.name === '__wv_bind_0' && binding.exp === `{[slotName]:true}`)).toBe(true)
       expect(result.warnings.some(warning => warning.includes('动态插槽名'))).toBe(true)
     })
 


### PR DESCRIPTION
## 总结
- 将普通插槽存在性元信息从数组形式改为运行时对象绑定，避免 `<slot>` 兜底内容生成 32 个 `vueSlots[index]` 扫描条件。
- 将 slot fallback 判断改为 `vueSlots.<name>` / bracket access 的短表达式，并保留条件插槽的布尔合并语义。
- 增加 issue #530 的 github-issues fixture、构建断言和 DevTools IDE runtime case，同时更新 #528 相关断言到新的元信息形态。

## 验证
- `pnpm --filter @wevu/compiler typecheck`
- `pnpm --filter @wevu/compiler lint`
- `pnpm eslint packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-component.ts packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts packages/weapp-vite/test/vue/compiler.test.ts packages/weapp-vite/src/plugins/vue/transform/compileVueFile.test.ts e2e/ci/github-issues.build.test.ts e2e/ci/wevu-features.build.test.ts e2e-apps/github-issues/src/components/issue-530/SlotFallbackProbe/index.vue e2e-apps/github-issues/src/pages/issue-530/index.vue e2e/ide/github-issues.runtime.slot-fallback.test.ts e2e/scripts/e2e-suite-manifest.ts e2e/scripts/suiteRunner.test.ts`
- `pnpm stylelint e2e-apps/github-issues/src/components/issue-530/SlotFallbackProbe/index.vue e2e-apps/github-issues/src/pages/issue-530/index.vue`
- `pnpm vitest run packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts packages/weapp-vite/test/vue/compiler.test.ts packages/weapp-vite/src/plugins/vue/transform/compileVueFile.test.ts packages/weapp-vite/test/vue/class-style-runtime.test.ts packages/weapp-vite/test/vue/sfc-integration.test.ts`
- `pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #5(28|30)"`
- `pnpm vitest run -c e2e/vitest.e2e.devtools.config.ts e2e/ide/github-issues.runtime.slot-fallback.test.ts -t "issue #530"`
- `node --import tsx -e "import { getSuiteTasks } from './e2e/scripts/e2e-suite-manifest.ts'; const tasks = await getSuiteTasks('ide-full:github-issues'); console.log(tasks.map(task => task.label).join('\n'));"`

## 备注
- `tag-component.ts` 和 `tag-slot.ts` 在本次修改前已超过 300 行；本次改动只集中在 slot 元信息与 fallback guard 生成逻辑，暂不拆分以避免引入无关重构。

Closes #530