### PR TITLE
feat(weapp-vite): 增强 analyze 组件依赖洞察

### DIFF
--- a/.changeset/analyze-component-usage.md
+++ b/.changeset/analyze-component-usage.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": minor
+"create-weapp-vite": patch
+---
+
+为 `wv analyze` 增加组件依赖洞察能力，JSON 结果会输出组件使用图、页面影响范围和跨包分包优化建议，终端摘要也会展示组件建议数量与重点项。

--- a/docs/subpackages.md
+++ b/docs/subpackages.md
@@ -328,7 +328,7 @@ export default defineConfig({
 
 ## 调试与排查清单
 
-- 执行 `pnpm run analyze`（或 `pnpm run analyze -- --report`）查看每个（子）包的产物结构与共享模块。
+- 执行 `pnpm run analyze`（或 `pnpm run analyze -- --report`）查看每个（子）包的产物结构、共享模块与组件依赖建议；需要完整组件使用图时使用 `pnpm run analyze -- --json --output report/analyze.json`。
 - 若分包样式缺失，确认 `styles` 定义的文件是否存在，以及 `include` / `exclude` 是否匹配实际路径。
 - 关注构建日志中的 `[subpackages]` 警告：它们通常意味着路径超出 `srcRoot`、格式不受支持或重复注册。
 - 检查微信开发者工具的包体积面板，确保主包 < 2MB、单个分包 < 2MB，所有分包合计 < 20MB。

--- a/packages/weapp-vite/src/analyze/components/index.test.ts
+++ b/packages/weapp-vite/src/analyze/components/index.test.ts
@@ -1,0 +1,197 @@
+import type { RolldownOutput } from 'rolldown'
+import { describe, expect, it } from 'vitest'
+import { analyzeComponentUsage, collectAnalyzeComponentJsonConfigs } from './index'
+
+describe('analyze component usage', () => {
+  it('tracks nested component usage from subpackage pages', () => {
+    const result = analyzeComponentUsage({
+      subPackages: [{ root: 'pkgA', independent: false }],
+      jsonConfigs: [
+        {
+          file: 'app.json',
+          config: {
+            pages: ['pages/home/index'],
+            subPackages: [{ root: 'pkgA', pages: ['pages/detail/index'] }],
+          },
+        },
+        {
+          file: 'pkgA/pages/detail/index.json',
+          config: {
+            usingComponents: {
+              card: '/components/detail-card',
+            },
+          },
+        },
+        {
+          file: 'components/detail-card.json',
+          config: {
+            usingComponents: {
+              inner: './inner',
+            },
+          },
+        },
+        {
+          file: 'components/inner.json',
+          config: {},
+        },
+      ],
+    })
+
+    expect(result).toMatchObject([
+      {
+        component: 'components/detail-card',
+        componentPackage: '__main__',
+        totalUsageCount: 1,
+        pageUsageCount: 1,
+        pages: [{ page: 'pkgA/pages/detail/index', packageId: 'pkgA', usageCount: 1 }],
+        suggestions: [{ kind: 'move-to-subpackage', targetPackage: 'pkgA' }],
+      },
+      {
+        component: 'components/inner',
+        componentPackage: '__main__',
+        totalUsageCount: 1,
+        pageUsageCount: 1,
+        pages: [{ page: 'pkgA/pages/detail/index', packageId: 'pkgA', usageCount: 1 }],
+        suggestions: [{ kind: 'move-to-subpackage', targetPackage: 'pkgA' }],
+      },
+    ])
+  })
+
+  it('suggests shared package strategy for main package components used by multiple subpackages', () => {
+    const result = analyzeComponentUsage({
+      subPackages: [
+        { root: 'pkgA', independent: false },
+        { root: 'pkgB', independent: false },
+      ],
+      jsonConfigs: [
+        {
+          file: 'app.json',
+          config: {
+            subPackages: [
+              { root: 'pkgA', pages: ['pages/a'] },
+              { root: 'pkgB', pages: ['pages/b'] },
+            ],
+          },
+        },
+        {
+          file: 'pkgA/pages/a.json',
+          config: { usingComponents: { shared: '/components/shared' } },
+        },
+        {
+          file: 'pkgB/pages/b.json',
+          config: { usingComponents: { shared: '/components/shared' } },
+        },
+        {
+          file: 'components/shared.json',
+          config: {},
+        },
+      ],
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      component: 'components/shared',
+      totalUsageCount: 2,
+      pageUsageCount: 2,
+      suggestions: [{ kind: 'shared-subpackage-or-placeholder' }],
+    })
+  })
+
+  it('does not suggest migration when cross-package references are covered by componentPlaceholder', () => {
+    const result = analyzeComponentUsage({
+      subPackages: [{ root: 'pkgA', independent: false }],
+      jsonConfigs: [
+        {
+          file: 'app.json',
+          config: {
+            subPackages: [{ root: 'pkgA', pages: ['pages/detail/index'] }],
+          },
+        },
+        {
+          file: 'pkgA/pages/detail/index.json',
+          config: {
+            usingComponents: {
+              shared: '/components/shared',
+            },
+            componentPlaceholder: {
+              shared: 'view',
+            },
+          },
+        },
+        {
+          file: 'components/shared.json',
+          config: {},
+        },
+      ],
+    })
+
+    expect(result).toMatchObject([
+      {
+        component: 'components/shared',
+        totalUsageCount: 1,
+        suggestions: [],
+      },
+    ])
+  })
+
+  it('normalizes windows separators before resolving packages and relative components', () => {
+    const result = analyzeComponentUsage({
+      subPackages: [{ root: 'pkgA', independent: false }],
+      jsonConfigs: [
+        {
+          file: 'app.json',
+          config: {
+            subPackages: [{ root: 'pkgA', pages: ['pages/detail/index'] }],
+          },
+        },
+        {
+          file: 'pkgA\\pages\\detail\\index.json',
+          config: {
+            usingComponents: {
+              local: './local-card',
+            },
+          },
+        },
+        {
+          file: 'pkgA\\pages\\detail\\local-card.json',
+          config: {},
+        },
+      ],
+    })
+
+    expect(result).toMatchObject([
+      {
+        component: 'pkgA/pages/detail/local-card',
+        componentPackage: 'pkgA',
+        pages: [{ page: 'pkgA/pages/detail/index', packageId: 'pkgA', usageCount: 1 }],
+        suggestions: [],
+      },
+    ])
+  })
+
+  it('collects json configs from rolldown assets', () => {
+    const configs = collectAnalyzeComponentJsonConfigs({
+      output: [
+        {
+          type: 'asset',
+          fileName: 'pages/index.json',
+          source: '{"usingComponents":{}}',
+        },
+        {
+          type: 'asset',
+          fileName: 'pages/index.wxml',
+          source: '<view />',
+        },
+      ],
+    } as unknown as RolldownOutput)
+
+    expect(configs).toEqual([
+      {
+        file: 'pages/index',
+        config: {
+          usingComponents: {},
+        },
+      },
+    ])
+  })
+})

--- a/packages/weapp-vite/src/analyze/components/index.ts
+++ b/packages/weapp-vite/src/analyze/components/index.ts
@@ -1,0 +1,264 @@
+import type { OutputAsset, RolldownOutput } from 'rolldown'
+import type { SubPackageDescriptor } from '../subpackages/types'
+import type {
+  AnalyzeComponentJsonConfig,
+  AnalyzeComponentPageUsage,
+  AnalyzeComponentSuggestion,
+  AnalyzeComponentUsage,
+} from './types'
+import { posix as path } from 'pathe'
+import { createComponentSuggestion } from './suggestions'
+
+interface ComponentEdge {
+  owner: string
+  component: string
+  placeholderCovered: boolean
+}
+
+interface ComponentUsageAccumulator {
+  component: string
+  componentPackage: string
+  totalUsageCount: number
+  pages: Map<string, AnalyzeComponentPageUsage>
+  crossPackageUsageCount: number
+  placeholderCoveredCrossPackageUsageCount: number
+}
+
+interface AnalyzeComponentUsageOptions {
+  jsonConfigs: AnalyzeComponentJsonConfig[]
+  subPackages: SubPackageDescriptor[]
+}
+
+function normalizeRoute(value: string) {
+  return path.normalize(value.replace(/\\/g, '/').replace(/^\/+/, '').replace(/\.json$/, ''))
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function toStringArray(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim() !== '')
+    : []
+}
+
+function readUsingComponents(config: unknown) {
+  if (!isRecord(config) || !isRecord(config.usingComponents)) {
+    return []
+  }
+
+  return Object.entries(config.usingComponents)
+    .filter((entry): entry is [string, string] => typeof entry[1] === 'string' && entry[1].trim() !== '')
+}
+
+function readComponentPlaceholder(config: unknown) {
+  if (!isRecord(config) || !isRecord(config.componentPlaceholder)) {
+    return new Set<string>()
+  }
+
+  return new Set(Object.keys(config.componentPlaceholder))
+}
+
+function resolveComponentRoute(owner: string, request: string) {
+  const normalizedRequest = request.replace(/\\/g, '/').trim()
+  if (!normalizedRequest || normalizedRequest.startsWith('plugin://')) {
+    return undefined
+  }
+
+  if (normalizedRequest.startsWith('.')) {
+    return normalizeRoute(path.join(path.dirname(owner), normalizedRequest))
+  }
+
+  if (normalizedRequest.startsWith('/')) {
+    return normalizeRoute(normalizedRequest)
+  }
+
+  return normalizeRoute(normalizedRequest)
+}
+
+function resolvePackageId(route: string, subPackages: SubPackageDescriptor[]) {
+  const matched = subPackages
+    .map(item => item.root)
+    .filter(Boolean)
+    .sort((left, right) => right.length - left.length)
+    .find(root => route === root || route.startsWith(`${root}/`))
+
+  return matched ?? '__main__'
+}
+
+function collectAppPages(configs: Map<string, unknown>) {
+  const appJson = configs.get('app')
+  if (!isRecord(appJson)) {
+    return new Set<string>()
+  }
+
+  const pages = new Set<string>()
+  for (const page of toStringArray(appJson.pages)) {
+    pages.add(normalizeRoute(page))
+  }
+
+  const subPackages = Array.isArray(appJson.subPackages)
+    ? appJson.subPackages
+    : Array.isArray(appJson.subpackages)
+      ? appJson.subpackages
+      : []
+
+  for (const item of subPackages) {
+    if (!isRecord(item) || typeof item.root !== 'string') {
+      continue
+    }
+    for (const page of toStringArray(item.pages)) {
+      pages.add(normalizeRoute(path.join(item.root, page)))
+    }
+  }
+
+  return pages
+}
+
+function registerUsage(
+  usageMap: Map<string, ComponentUsageAccumulator>,
+  edge: ComponentEdge,
+  page: string,
+  pagePackage: string,
+  componentPackage: string,
+) {
+  const usage = usageMap.get(edge.component) ?? {
+    component: edge.component,
+    componentPackage,
+    totalUsageCount: 0,
+    pages: new Map<string, AnalyzeComponentPageUsage>(),
+    crossPackageUsageCount: 0,
+    placeholderCoveredCrossPackageUsageCount: 0,
+  }
+
+  usage.totalUsageCount += 1
+  const pageUsage = usage.pages.get(page) ?? {
+    page,
+    packageId: pagePackage,
+    usageCount: 0,
+  }
+  pageUsage.usageCount += 1
+  usage.pages.set(page, pageUsage)
+
+  if (pagePackage !== componentPackage) {
+    usage.crossPackageUsageCount += 1
+    if (edge.placeholderCovered) {
+      usage.placeholderCoveredCrossPackageUsageCount += 1
+    }
+  }
+
+  usageMap.set(edge.component, usage)
+}
+
+export function collectAnalyzeComponentJsonConfigs(output: RolldownOutput | undefined): AnalyzeComponentJsonConfig[] {
+  if (!output) {
+    return []
+  }
+
+  const configs: AnalyzeComponentJsonConfig[] = []
+  for (const item of output.output ?? []) {
+    if (item.type !== 'asset' || !item.fileName.endsWith('.json')) {
+      continue
+    }
+
+    const asset = item as OutputAsset
+    if (typeof asset.source !== 'string') {
+      continue
+    }
+
+    try {
+      configs.push({
+        file: normalizeRoute(asset.fileName),
+        config: JSON.parse(asset.source) as unknown,
+      })
+    }
+    catch {
+      // analyze 只消费合法 JSON 产物，解析失败时保留现有包体分析结果。
+    }
+  }
+
+  return configs
+}
+
+export function analyzeComponentUsage(options: AnalyzeComponentUsageOptions): AnalyzeComponentUsage[] {
+  const configs = new Map<string, unknown>()
+  for (const item of options.jsonConfigs) {
+    configs.set(normalizeRoute(item.file), item.config)
+  }
+
+  const pages = collectAppPages(configs)
+  const graph = new Map<string, ComponentEdge[]>()
+  const packageMap = new Map<string, string>()
+
+  for (const route of configs.keys()) {
+    packageMap.set(route, resolvePackageId(route, options.subPackages))
+  }
+
+  for (const [owner, config] of configs) {
+    const placeholders = readComponentPlaceholder(config)
+    const edges = readUsingComponents(config)
+      .map(([name, request]) => {
+        const component = resolveComponentRoute(owner, request)
+        return component && configs.has(component)
+          ? { owner, component, placeholderCovered: placeholders.has(name) }
+          : undefined
+      })
+      .filter((edge): edge is ComponentEdge => Boolean(edge))
+
+    if (edges.length > 0) {
+      graph.set(owner, edges)
+    }
+  }
+
+  const usageMap = new Map<string, ComponentUsageAccumulator>()
+
+  const visit = (owner: string, page: string, stack: Set<string>) => {
+    for (const edge of graph.get(owner) ?? []) {
+      const componentPackage = packageMap.get(edge.component) ?? '__main__'
+      const pagePackage = packageMap.get(page) ?? '__main__'
+      registerUsage(usageMap, edge, page, pagePackage, componentPackage)
+
+      if (stack.has(edge.component)) {
+        continue
+      }
+
+      const nextStack = new Set(stack)
+      nextStack.add(edge.component)
+      visit(edge.component, page, nextStack)
+    }
+  }
+
+  for (const page of pages) {
+    visit(page, page, new Set([page]))
+  }
+
+  return Array.from(usageMap.values())
+    .map((usage) => {
+      const pages = Array.from(usage.pages.values())
+        .sort((left, right) => left.page.localeCompare(right.page))
+      const suggestions = [createComponentSuggestion(usage)]
+        .filter((item): item is AnalyzeComponentSuggestion => Boolean(item))
+
+      return {
+        component: usage.component,
+        componentPackage: usage.componentPackage,
+        totalUsageCount: usage.totalUsageCount,
+        pageUsageCount: pages.length,
+        pages,
+        suggestions,
+      }
+    })
+    .sort((left, right) => {
+      const usageDelta = right.totalUsageCount - left.totalUsageCount
+      return usageDelta !== 0 ? usageDelta : left.component.localeCompare(right.component)
+    })
+}
+
+export type {
+  AnalyzeComponentJsonConfig,
+  AnalyzeComponentPageUsage,
+  AnalyzeComponentSuggestion,
+  AnalyzeComponentSuggestionKind,
+  AnalyzeComponentUsage,
+} from './types'

--- a/packages/weapp-vite/src/analyze/components/suggestions.ts
+++ b/packages/weapp-vite/src/analyze/components/suggestions.ts
@@ -1,0 +1,66 @@
+import type { AnalyzeComponentPageUsage, AnalyzeComponentSuggestion } from './types'
+
+export interface ComponentSuggestionUsage {
+  component: string
+  componentPackage: string
+  pages: Map<string, AnalyzeComponentPageUsage>
+  crossPackageUsageCount: number
+  placeholderCoveredCrossPackageUsageCount: number
+}
+
+export function createComponentSuggestion(
+  usage: ComponentSuggestionUsage,
+): AnalyzeComponentSuggestion | undefined {
+  if (usage.componentPackage !== '__main__' || usage.crossPackageUsageCount === 0) {
+    return undefined
+  }
+
+  if (usage.crossPackageUsageCount === usage.placeholderCoveredCrossPackageUsageCount) {
+    return undefined
+  }
+
+  const pagePackages = Array.from(new Set(Array.from(usage.pages.values()).map(page => page.packageId)))
+    .sort((left, right) => {
+      if (left === '__main__') {
+        return -1
+      }
+      if (right === '__main__') {
+        return 1
+      }
+      return left.localeCompare(right)
+    })
+  const subPackageIds = pagePackages.filter(packageId => packageId !== '__main__')
+  const usedByMain = pagePackages.includes('__main__')
+
+  if (subPackageIds.length === 1 && !usedByMain) {
+    const targetPackage = subPackageIds[0]
+    return {
+      kind: 'move-to-subpackage',
+      component: usage.component,
+      componentPackage: usage.componentPackage,
+      targetPackage,
+      pagePackages,
+      message: `主包组件 ${usage.component} 仅被分包 ${targetPackage} 使用，建议评估移动到该分包。`,
+    }
+  }
+
+  if (subPackageIds.length > 1) {
+    return {
+      kind: 'shared-subpackage-or-placeholder',
+      component: usage.component,
+      componentPackage: usage.componentPackage,
+      pagePackages,
+      message: `主包组件 ${usage.component} 被多个分包使用，建议评估分包归属、共享策略或 componentPlaceholder。`,
+    }
+  }
+
+  if (usedByMain && subPackageIds.length > 0) {
+    return {
+      kind: 'split-or-async',
+      component: usage.component,
+      componentPackage: usage.componentPackage,
+      pagePackages,
+      message: `主包组件 ${usage.component} 同时被主包和分包使用，建议评估组件拆分、归属或异步化策略。`,
+    }
+  }
+}

--- a/packages/weapp-vite/src/analyze/components/types.ts
+++ b/packages/weapp-vite/src/analyze/components/types.ts
@@ -1,0 +1,33 @@
+export type AnalyzeComponentSuggestionKind
+  = | 'move-to-subpackage'
+    | 'split-or-async'
+    | 'shared-subpackage-or-placeholder'
+
+export interface AnalyzeComponentSuggestion {
+  kind: AnalyzeComponentSuggestionKind
+  message: string
+  component: string
+  componentPackage: string
+  targetPackage?: string
+  pagePackages: string[]
+}
+
+export interface AnalyzeComponentPageUsage {
+  page: string
+  packageId: string
+  usageCount: number
+}
+
+export interface AnalyzeComponentUsage {
+  component: string
+  componentPackage: string
+  totalUsageCount: number
+  pageUsageCount: number
+  pages: AnalyzeComponentPageUsage[]
+  suggestions: AnalyzeComponentSuggestion[]
+}
+
+export interface AnalyzeComponentJsonConfig {
+  file: string
+  config: unknown
+}

--- a/packages/weapp-vite/src/analyze/subpackages/index.ts
+++ b/packages/weapp-vite/src/analyze/subpackages/index.ts
@@ -1,12 +1,21 @@
 import type { RolldownOutput } from 'rolldown'
 import type { CompilerContext } from '../../context'
+import type { AnalyzeComponentJsonConfig } from '../components'
 import type { AnalyzeSubpackagesResult, ModuleAccumulator, PackageAccumulator, PackageClassifierContext } from './types'
 import { build } from 'vite'
 import { createSharedBuildConfig } from '../../runtime/sharedBuildConfig'
+import { analyzeComponentUsage, collectAnalyzeComponentJsonConfigs } from '../components'
 import { createAnalyzeMetadata } from './metadata'
 import { processOutput } from './output'
 import { expandVirtualModulePlacements, summarizeModules, summarizePackages, summarizeSubPackages } from './summary'
 
+export type {
+  AnalyzeComponentJsonConfig,
+  AnalyzeComponentPageUsage,
+  AnalyzeComponentSuggestion,
+  AnalyzeComponentSuggestionKind,
+  AnalyzeComponentUsage,
+} from '../components'
 export type {
   AnalyzeBudgetConfig,
   AnalyzeHistoryMetadata,
@@ -63,22 +72,30 @@ export async function analyzeSubpackages(ctx: CompilerContext): Promise<AnalyzeS
 
   const packages = new Map<string, PackageAccumulator>()
   const modules = new Map<string, ModuleAccumulator>()
+  const componentJsonConfigs: AnalyzeComponentJsonConfig[] = []
 
   for (const output of mainOutputs) {
     processOutput(output as RolldownOutput, 'main', ctx, classifierContext, packages, modules)
+    componentJsonConfigs.push(...collectAnalyzeComponentJsonConfigs(output as RolldownOutput))
   }
 
   for (const root of independentRoots) {
     const output = buildService.getIndependentOutput(root)
     processOutput(output, 'independent', ctx, classifierContext, packages, modules)
+    componentJsonConfigs.push(...collectAnalyzeComponentJsonConfigs(output))
   }
 
   expandVirtualModulePlacements(modules, packages, classifierContext)
+  const subPackages = summarizeSubPackages(subPackageMetas)
 
   return {
     metadata: createAnalyzeMetadata(ctx.configService),
     packages: summarizePackages(packages),
     modules: summarizeModules(modules),
-    subPackages: summarizeSubPackages(subPackageMetas),
+    subPackages,
+    components: analyzeComponentUsage({
+      jsonConfigs: componentJsonConfigs,
+      subPackages,
+    }),
   }
 }

--- a/packages/weapp-vite/src/analyze/subpackages/types.ts
+++ b/packages/weapp-vite/src/analyze/subpackages/types.ts
@@ -1,4 +1,5 @@
 import type { SubPackageMetaValue } from '../../types'
+import type { AnalyzeComponentUsage } from '../components'
 
 export type PackageType = 'main' | 'subPackage' | 'independent' | 'virtual'
 export type ModuleSourceType = 'src' | 'plugin' | 'node_modules' | 'workspace'
@@ -71,6 +72,7 @@ export interface AnalyzeSubpackagesResult {
   packages: PackageReport[]
   modules: ModuleUsage[]
   subPackages: SubPackageDescriptor[]
+  components?: AnalyzeComponentUsage[]
 }
 
 export interface PackageAccumulator {

--- a/packages/weapp-vite/src/cli/commands/analyze.test.ts
+++ b/packages/weapp-vite/src/cli/commands/analyze.test.ts
@@ -296,4 +296,40 @@ describe('analyze cli command', () => {
     expect(startAnalyzeDashboard).not.toHaveBeenCalled()
     writeSpy.mockRestore()
   })
+
+  it('prints component suggestions in default mini analyze summary', async () => {
+    const action = createAnalyzeActionHandler()
+    analyzeSubpackagesMock.mockResolvedValueOnce({
+      packages: [],
+      modules: [],
+      subPackages: [{ root: 'pkgA', independent: false }],
+      components: [
+        {
+          component: 'components/detail-card',
+          componentPackage: '__main__',
+          totalUsageCount: 1,
+          pageUsageCount: 1,
+          pages: [{ page: 'pkgA/pages/detail/index', packageId: 'pkgA', usageCount: 1 }],
+          suggestions: [
+            {
+              kind: 'move-to-subpackage',
+              component: 'components/detail-card',
+              componentPackage: '__main__',
+              targetPackage: 'pkgA',
+              pagePackages: ['pkgA'],
+              message: '主包组件 components/detail-card 仅被分包 pkgA 使用，建议评估移动到该分包。',
+            },
+          ],
+        },
+      ],
+    })
+
+    await action('/project', {
+      platform: 'weapp',
+    })
+
+    expect(loggerMock.info).toHaveBeenCalledWith('组件依赖：1 个组件，1 条分包优化建议')
+    expect(loggerMock.info).toHaveBeenCalledWith(expect.stringContaining('components/detail-card'))
+    expect(startAnalyzeDashboard).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/weapp-vite/src/cli/commands/analyze.ts
+++ b/packages/weapp-vite/src/cli/commands/analyze.ts
@@ -136,6 +136,18 @@ function printAnalysisSummary(result: AnalyzeSubpackagesResult) {
     }
   }
 
+  const componentUsages = result.components ?? []
+  if (componentUsages.length > 0) {
+    const suggestions = componentUsages.flatMap(component => component.suggestions)
+    logger.info(`组件依赖：${componentUsages.length} 个组件，${suggestions.length} 条分包优化建议`)
+    for (const suggestion of suggestions.slice(0, 5)) {
+      logger.info(`- ${suggestion.message}`)
+    }
+    if (suggestions.length > 5) {
+      logger.info(`- …其余 ${suggestions.length - 5} 条组件建议请使用 ${colors.bold(colors.green('weapp-vite analyze --json'))} 查看`)
+    }
+  }
+
   const duplicates = result.modules.filter(module => module.packages.length > 1)
   if (duplicates.length === 0) {
     logger.info('未检测到跨包复用的源码模块。')

--- a/packages/weapp-vite/src/cli/commands/build.test.ts
+++ b/packages/weapp-vite/src/cli/commands/build.test.ts
@@ -107,6 +107,9 @@ describe('build cli command', () => {
         mpDistRoot: '/project/dist',
         packageManager: { agent: 'pnpm' },
         weappViteConfig: {
+          analyze: {
+            history: false,
+          },
           packageSizeWarningBytes: 0,
         },
         weappWebConfig: undefined,
@@ -150,18 +153,22 @@ describe('build cli command', () => {
     }))
     expect(analyzeSubpackages).toHaveBeenCalledTimes(1)
     expect(startAnalyzeDashboard).toHaveBeenCalledTimes(1)
-    const handle = vi.mocked(startAnalyzeDashboard).mock.results[0]?.value
-    const resolvedHandle = await handle
-
-    expect(resolvedHandle?.emitRuntimeEvents).toHaveBeenCalledWith([
+    expect(startAnalyzeDashboard).toHaveBeenCalledWith(
       expect.objectContaining({
-        kind: 'build',
-        level: 'success',
-        title: 'mini build completed',
-        detail: expect.stringContaining('1 个包'),
-        durationMs: expect.any(Number),
+        packages: [{ id: 'main', label: 'main', files: [] }],
       }),
-    ])
+      expect.objectContaining({
+        initialEvents: expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'build',
+            level: 'success',
+            title: 'mini build completed',
+            detail: expect.stringContaining('1 个包'),
+            durationMs: expect.any(Number),
+          }),
+        ]),
+      }),
+    )
     expect(loggerSuccessMock).toHaveBeenCalledWith(expect.stringContaining('小程序构建完成，耗时：'))
   })
 

--- a/packages/weapp-vite/src/cli/commands/serve.test.ts
+++ b/packages/weapp-vite/src/cli/commands/serve.test.ts
@@ -153,7 +153,11 @@ describe('serve cli command', () => {
           outDir: '/project/dist',
           mpDistRoot: '/project/dist',
           packageManager: { agent: 'pnpm' },
-          weappViteConfig: {},
+          weappViteConfig: {
+            analyze: {
+              history: false,
+            },
+          },
         },
         webService: undefined,
         watcherService: {
@@ -227,7 +231,7 @@ describe('serve cli command', () => {
       packages: [{ id: 'refresh', label: 'refresh', files: [] }],
       modules: [{ id: 'm1', source: 'src/a.ts', sourceType: 'src', packages: [] }],
       subPackages: [],
-    })
+    }, null)
     expect(startDevHotkeysMock).toHaveBeenCalledWith({
       cwd: '/project',
       mcpConfig: undefined,
@@ -236,7 +240,11 @@ describe('serve cli command', () => {
       projectPath: '/project/dist',
       rebuild: expect.any(Function),
       silentStartupHint: true,
-      weappViteConfig: {},
+      weappViteConfig: {
+        analyze: {
+          history: false,
+        },
+      },
     })
     expect(devHotkeysRestoreMock).toHaveBeenCalledTimes(1)
     expect(loggerSuccessMock).toHaveBeenCalledWith(expect.stringContaining('小程序初次构建完成，耗时：'))
@@ -324,7 +332,11 @@ describe('serve cli command', () => {
         outDir: '/project/dist',
         mpDistRoot: '/project/dist/miniprogram',
         packageManager: { agent: 'pnpm' },
-        weappViteConfig: {},
+        weappViteConfig: {
+          analyze: {
+            history: false,
+          },
+        },
       },
       webService: undefined,
       watcherService: {

--- a/packages/weapp-vite/test/analyze-command-web.test.ts
+++ b/packages/weapp-vite/test/analyze-command-web.test.ts
@@ -53,6 +53,11 @@ function createContext(overrides: Record<string, unknown> = {}) {
       packageManager: {
         agent: 'pnpm',
       },
+      weappViteConfig: {
+        analyze: {
+          history: false,
+        },
+      },
       configFilePath: '/virtual/project/vite.config.ts',
       weappWebConfig: {
         enabled: true,
@@ -189,6 +194,7 @@ describe('analyze command web branch', () => {
     expect(startAnalyzeDashboard).toHaveBeenCalledWith(miniResult, {
       cwd: '/virtual/project',
       packageManagerAgent: 'pnpm',
+      previousResult: null,
     })
     expect(logger.success).toHaveBeenCalledWith('分包分析完成')
   })
@@ -284,6 +290,7 @@ describe('analyze command web branch', () => {
     expect(startAnalyzeDashboard).toHaveBeenCalledWith(miniResult, {
       cwd: '/virtual/project',
       packageManagerAgent: 'pnpm',
+      previousResult: null,
     })
     expect(logger.info).toHaveBeenCalledWith('分包配置：')
     expect(logger.info).toHaveBeenCalledWith('- pkg-a，别名：pkgAlias，独立构建')

--- a/website/guide/cli.md
+++ b/website/guide/cli.md
@@ -101,7 +101,7 @@ wv build [root]
 
 ### 3) `analyze`
 
-分析小程序分包产物映射，或输出 Web 静态分析结果。
+分析小程序分包产物映射、组件依赖链路，或输出 Web 静态分析结果。
 
 ```bash
 wv analyze [root]
@@ -115,6 +115,8 @@ wv analyze [root]
 | `--output <file>`           | 将分析结果写入文件                |
 | `-p, --platform <platform>` | 目标平台（`weapp` \| `h5`）       |
 | `--project-config <path>`   | 小程序 `project.config.json` 路径 |
+
+小程序模式下，JSON 结果会包含 `components` 字段，用于展示组件被哪些页面递归引用、组件所属主包/分包、总使用次数，以及主包组件跨分包使用时的优化建议。默认终端摘要会展示组件建议数量和前几条高优先级建议，完整列表可通过 `--json` 或 `--output` 查看。
 
 ### 4) `open`
 


### PR DESCRIPTION
## 摘要

Closes #534

为 `wv analyze` 增加组件依赖洞察能力，基于构建产物 JSON 扫描 `usingComponents` 与 `componentPlaceholder`，输出页面影响范围、组件所属包和分包优化建议。

## 变更

- 新增 `analyze/components` 纯分析模块，递归统计页面到组件、组件到组件的依赖链路。
- 扩展 `AnalyzeSubpackagesResult.components`，`--json` 输出完整组件使用图。
- 默认 CLI 摘要展示组件建议数量和前几条重点建议。
- 补充组件分析单测、CLI 摘要单测、CLI/分包文档和 changeset。

## 验证

- `pnpm --filter weapp-vite lint:src`
- `pnpm --filter weapp-vite typecheck`
- `pnpm --filter weapp-vite test:types`
- `pnpm --filter weapp-vite build`
- `pnpm build:pkgs`
- `../../node_modules/.bin/vitest run src/analyze/components/index.test.ts src/cli/commands/analyze.test.ts src/analyze/subpackages/output.test.ts`（在 `packages/weapp-vite` 下执行）
- `pnpm --filter subpackage-shared-chunks build`
- `pnpm --filter subpackage-shared-chunks exec wv analyze --json --output .tmp/analyze-534.json`：已确认 JSON 包含 `components` 字段和建议项；写出结果后存在 `sass-embedded` 子进程残留，已手动清理。