### PR TITLE
fix(wevu): 支持作用域插槽 fallback 内容

### DIFF
--- a/.changeset/scoped-slot-fallback.md
+++ b/.changeset/scoped-slot-fallback.md
@@ -1,0 +1,8 @@
+---
+"@wevu/compiler": patch
+"wevu": patch
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复作用域插槽出口带默认兜底内容时会被编译器忽略的问题；现在 `<slot :foo="bar">fallback</slot>` 会根据父级插槽存在元数据正确切换作用域插槽投影与 fallback 渲染。

--- a/e2e-apps/github-issues/src/components/issue-530/SlotFallbackProbe/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-530/SlotFallbackProbe/index.vue
@@ -1,7 +1,12 @@
+<script setup lang="ts">
+const scopedLabel = 'issue-530 scoped slot prop'
+</script>
+
 <template>
   <view class="issue530-probe">
-    <slot>
+    <slot :label="scopedLabel">
       <text class="issue530-fallback-default">issue-530 fallback default</text>
+      <text class="issue530-scoped-fallback-default">issue-530 scoped fallback default</text>
     </slot>
   </view>
 </template>

--- a/e2e-apps/github-issues/src/pages/issue-530/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-530/index.vue
@@ -9,8 +9,8 @@ definePageJson({
 <template>
   <view class="issue530-page">
     <Issue530SlotFallbackProbe class="issue530-card-empty" />
-    <Issue530SlotFallbackProbe class="issue530-card-provided">
-      <text class="issue530-provided-default">issue-530 provided default</text>
+    <Issue530SlotFallbackProbe v-slot="{ label }" class="issue530-card-provided">
+      <text class="issue530-provided-default">issue-530 provided default: {{ label }}</text>
     </Issue530SlotFallbackProbe>
   </view>
 </template>

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -237,8 +237,16 @@ describe.sequential('e2e app: github-issues (build)', () => {
     const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
     const componentWxml = await fs.readFile(componentWxmlPath, 'utf-8')
 
-    expect(pageWxml).toContain('Issue530SlotFallbackProbe class="issue530-card-provided" vue-slots=')
-    expect(componentWxml).toContain('<block wx:if="{{vueSlots&&vueSlots.default}}"><slot /></block><block wx:else><text class="issue530-fallback-default">issue-530 fallback default</text></block>')
+    const providedProbe = pageWxml
+      .match(/<Issue530SlotFallbackProbe[^>]*\/>/g)
+      ?.find(tag => tag.includes('class="issue530-card-provided"'))
+    expect(providedProbe).toBeDefined()
+    expect(providedProbe!).toContain('vue-slots=')
+    expect(providedProbe!).toContain('generic:scoped-slots-default=')
+    expect(componentWxml).toContain('<block wx:if="{{vueSlots&&vueSlots.default}}">')
+    expect(componentWxml).toContain('<slot />')
+    expect(componentWxml).toContain('<scoped-slots-default')
+    expect(componentWxml).toContain('<block wx:else><text class="issue530-fallback-default">issue-530 fallback default</text><text class="issue530-scoped-fallback-default">issue-530 scoped fallback default</text></block>')
     expect(componentWxml).not.toContain('vueSlots[')
   })
 

--- a/e2e/ide/github-issues.runtime.slot-fallback.test.ts
+++ b/e2e/ide/github-issues.runtime.slot-fallback.test.ts
@@ -125,9 +125,16 @@ describe.sequential('e2e app: github-issues / slot fallback', () => {
 
       const renderedWxml = await readPageWxml(issuePage)
       expect(renderedWxml).toContain('issue530-fallback-default')
+      expect(renderedWxml).toContain('issue530-scoped-fallback-default')
       expect(renderedWxml).toContain('issue530-provided-default')
       expect(countToken(renderedWxml, 'issue530-fallback-default')).toBe(1)
-      expect(countToken(renderedWxml, 'issue530-provided-default')).toBe(1)
+      expect(countToken(renderedWxml, 'issue530-scoped-fallback-default')).toBe(1)
+
+      const provided = await issuePage.$('.issue530-provided-default')
+      if (!provided) {
+        throw new Error('Failed to query issue-530 scoped slot provided probe')
+      }
+      expect((await provided.text()).trim()).toBe('issue-530 provided default: issue-530 scoped slot prop')
     }
     finally {
       await releaseSharedMiniProgram(miniProgram)

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "types": [
+      "node",
+      "vitest/globals"
+    ]
+  },
+  "include": [
+    "**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/node_modules",
+    ".tmp",
+    "**/.tmp",
+    "coverage",
+    "**/coverage"
+  ]
+}

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
@@ -782,6 +782,27 @@ describe('compileVueTemplateToWxml', () => {
     expect(code).not.toContain('<slot><text>{{fallbackDefault}}</text></slot>')
   })
 
+  it('compiles scoped slot fallback content to presence-guarded branches', () => {
+    const template = `
+<slot :item="card.item" :index="card.index">
+  <view class="fallback">{{ fallbackDefault }}</view>
+</slot>
+    `.trim()
+
+    const { code, warnings, componentGenerics } = compileVueTemplateToWxml(
+      template,
+      '/project/src/components/provider/index.vue',
+    )
+
+    expect(code).toContain(`<block wx:if="{{vueSlots&&vueSlots.default}}">`)
+    expect(code).toContain(`<slot />`)
+    expect(code).toContain(`<scoped-slots-default wx:if="{{__wvSlotOwnerId}}" __wv-owner-id="{{__wvSlotOwnerId}}" __wv-slot-props="{{['item',card.item,'index',card.index]}}" __wv-slot-scope="{{__wvSlotScope}}" />`)
+    expect(code).toContain(`</block><block wx:else><view class="fallback">{{fallbackDefault}}</view></block>`)
+    expect(code).not.toContain('不支持作用域插槽的兜底内容')
+    expect(warnings.some(message => message.includes('不支持作用域插槽的兜底内容'))).toBe(false)
+    expect(componentGenerics?.['scoped-slots-default']).toBe(true)
+  })
+
   it('keeps slot fallback branches nested inside v-if chains', () => {
     const template = `
 <slot v-if="a" name="header"><view>A fallback</view></slot>

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts
@@ -271,10 +271,6 @@ export function transformSlotElement(node: ElementNode, context: TransformContex
       .join('')
   }
 
-  if (slotPropsExp && fallbackContent) {
-    context.warnings.push('不支持作用域插槽的兜底内容，已忽略。')
-    fallbackContent = ''
-  }
   const slotAttrs: string[] = []
   const nameAttr = renderSlotNameAttribute(slotNameInfo, context, 'name')
   if (nameAttr) {
@@ -283,13 +279,13 @@ export function transformSlotElement(node: ElementNode, context: TransformContex
 
   const slotAttrString = slotAttrs.length ? ` ${slotAttrs.join(' ')}` : ''
   let slotTag = `<slot${slotAttrString} />`
+  const slotPresentExp = fallbackContent ? createSlotPresenceExpression(slotNameInfo) : undefined
 
   if (fallbackContent) {
-    const slotPresentExp = createSlotPresenceExpression(slotNameInfo)
     if (!slotPropsExp && slotPresentExp) {
       slotTag = `${context.platform.wrapIf(slotPresentExp, slotTag, exp => renderMustache(exp, context))}${context.platform.wrapElse(fallbackContent)}`
     }
-    else {
+    else if (!slotPropsExp) {
       slotTag = `<slot${slotAttrString}>${fallbackContent}</slot>`
     }
   }
@@ -313,8 +309,13 @@ export function transformSlotElement(node: ElementNode, context: TransformContex
   }
   const scopedAttrString = scopedAttrs.length ? ` ${scopedAttrs.join(' ')}` : ''
   const scopedTag = `<${genericKey}${scopedAttrString} />`
+  const projectedContent = `${slotTag}${scopedTag}`
 
-  return `${slotTag}${scopedTag}`
+  if (fallbackContent && slotPresentExp) {
+    return `${context.platform.wrapIf(slotPresentExp, projectedContent, exp => renderMustache(exp, context))}${context.platform.wrapElse(fallbackContent)}`
+  }
+
+  return projectedContent
 }
 
 export function transformSlotElementPlain(node: ElementNode, context: TransformContext, transformNode: TransformNode): string {

--- a/packages/weapp-vite/test/vue/compiler.test.ts
+++ b/packages/weapp-vite/test/vue/compiler.test.ts
@@ -317,6 +317,20 @@ describe('Vue Template Compiler', () => {
       expect(result.code).toContain('__wv-slot-props')
       expect(result.componentGenerics?.['scoped-slots-default']).toBe(true)
     })
+
+    it('should compile scoped slot fallback content', () => {
+      const result = compileVueTemplateToWxml(
+        '<slot :data="slotProps"><view>Scoped fallback</view></slot>',
+        'test.vue',
+      )
+
+      expect(result.code).toContain(`<block wx:if="{{vueSlots&&vueSlots.default}}">`)
+      expect(result.code).toContain('<slot />')
+      expect(result.code).toContain('scoped-slots-default')
+      expect(result.code).toContain('__wv-slot-props="{{[\'data\',slotProps]}}"')
+      expect(result.code).toContain('<block wx:else><view>Scoped fallback</view></block>')
+      expect(result.warnings.some(warning => warning.includes('不支持作用域插槽的兜底内容'))).toBe(false)
+    })
   })
 
   describe('Template Slots', () => {

--- a/packages/weapp-vite/test/workspace-hmr-selection.test.ts
+++ b/packages/weapp-vite/test/workspace-hmr-selection.test.ts
@@ -1,5 +1,53 @@
+import type { ProjectResult } from '../../../scripts/workspace-hmr/baseline'
 import { describe, expect, it } from 'vitest'
 import { shouldFallbackToSmokeForChangedFiles } from '../../../scripts/audit-workspace-hmr'
+import {
+  createWorkspaceHmrBaseline,
+  evaluateWorkspaceHmrThresholds,
+} from '../../../scripts/workspace-hmr/baseline'
+
+const templateResult: ProjectResult = {
+  id: 'templates/weapp-vite-template',
+  kind: 'templates',
+  platform: 'weapp',
+  source: 'templates/weapp-vite-template',
+  startupMs: 1_000,
+  scenarios: [
+    {
+      id: 'native-template',
+      label: 'native template',
+      source: 'templates/weapp-vite-template/src/pages/index/index.wxml',
+      output: 'templates/weapp-vite-template/dist/pages/index/index.wxml',
+      totalMs: 400,
+      profile: {
+        dirtyCount: 1,
+        pendingCount: 1,
+        emittedCount: 1,
+      },
+    },
+  ],
+}
+
+const githubIssuesResult: ProjectResult = {
+  id: 'e2e-apps/github-issues',
+  kind: 'e2e-apps',
+  platform: 'weapp',
+  source: 'e2e-apps/github-issues',
+  scenarios: [
+    {
+      id: 'vue-template',
+      label: 'Vue SFC template',
+      source: 'e2e-apps/github-issues/src/pages/issue-398/index.vue',
+      output: 'e2e-apps/github-issues/dist/pages/issue-398/index.wxml',
+      totalMs: 4_000,
+      profile: {
+        dirtyCount: 1,
+        pendingCount: 81,
+        emittedCount: 81,
+      },
+    },
+  ],
+}
 
 describe('workspace HMR changed-file selection', () => {
   it('skips smoke fallback for test-only changes without runnable project impact', () => {
@@ -16,5 +64,28 @@ describe('workspace HMR changed-file selection', () => {
 
   it('keeps smoke fallback when changed files cannot be resolved', () => {
     expect(shouldFallbackToSmokeForChangedFiles([])).toBe(true)
+  })
+
+  it('uses explicit github-issues baseline counts for changed-project audits', () => {
+    const baseline = createWorkspaceHmrBaseline([templateResult], {
+      generatedAt: '2026-04-29T00:00:00.000Z',
+      mode: 'templates-baseline',
+      thresholds: {
+        maxPendingCount: 16,
+        maxEmittedCount: 16,
+        maxPendingDelta: 8,
+        maxEmittedDelta: 8,
+      },
+    })
+    baseline.projects[githubIssuesResult.id] = {
+      scenarios: {
+        'vue-template': {
+          pendingCount: 81,
+          emittedCount: 81,
+        },
+      },
+    }
+
+    expect(evaluateWorkspaceHmrThresholds([githubIssuesResult], { baseline }).issues).toHaveLength(0)
   })
 })

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "types": [
+      "node",
+      "vitest/globals"
+    ]
+  },
+  "include": [
+    "**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/node_modules",
+    ".tmp",
+    "**/.tmp",
+    "coverage",
+    "**/coverage"
+  ]
+}

--- a/scripts/workspace-hmr/templates-baseline.json
+++ b/scripts/workspace-hmr/templates-baseline.json
@@ -19,6 +19,32 @@
     "maxEmittedDelta": 2
   },
   "projects": {
+    "e2e-apps/github-issues": {
+      "startupMs": 3014,
+      "scenarios": {
+        "vue-template": {
+          "totalMs": 1793,
+          "dirtyCount": 1,
+          "pendingCount": 81,
+          "emittedCount": 81,
+          "impactFiles": 3
+        },
+        "vue-script": {
+          "totalMs": 1704,
+          "dirtyCount": 1,
+          "pendingCount": 81,
+          "emittedCount": 81,
+          "impactFiles": 1
+        },
+        "vue-style": {
+          "totalMs": 1757,
+          "dirtyCount": 1,
+          "pendingCount": 81,
+          "emittedCount": 81,
+          "impactFiles": 1
+        }
+      }
+    },
     "templates/weapp-vite-lib-template": {
       "startupMs": 1256,
       "scenarios": {


### PR DESCRIPTION
## 变更内容

- 修复 `<slot :foo="bar">fallback</slot>` 编译时 fallback 被忽略的问题
- scoped slot outlet 现在根据 `vueSlots` presence 元数据切换投影内容和 fallback 内容
- 补充 `@wevu/compiler` 与 `weapp-vite` 编译入口测试
- 在 `e2e-apps/github-issues` 的 issue-530 场景覆盖作用域插槽 fallback 与已提供 slot 的运行时表现
- 更新 `github-issues` build E2E 断言，覆盖作用域 fallback 的编译输出且不依赖属性顺序
- 为 `e2e/` 与 `scripts/` 补齐 tsconfig，避免 Vite/OXC 加载对应 TS 入口时缺少 tsconfig
- 补充 `e2e-apps/github-issues` 的 HMR changed-project baseline，避免 issue 聚合 app 缺少基准时被全局 fan-out 阈值误拦截
- 添加 patch changeset，覆盖 `@wevu/compiler`、`wevu`、`weapp-vite`、`create-weapp-vite`

## 验证

- `pnpm exec vitest run --config packages-runtime/wevu-compiler/vitest.config.ts packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts`
- `pnpm exec vitest run --config packages/weapp-vite/vitest.config.ts packages/weapp-vite/test/vue/compiler.test.ts`
- `pnpm --filter @wevu/compiler typecheck`
- `pnpm --filter @wevu/compiler lint`
- `pnpm --filter @wevu/compiler build`
- `pnpm --filter weapp-vite typecheck`
- `pnpm --filter weapp-vite lint:src`
- `pnpm exec eslint packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts packages/weapp-vite/test/vue/compiler.test.ts`
- `pnpm --filter weapp-vite... build`
- `pnpm exec eslint e2e/tsconfig.json e2e/ide/github-issues.runtime.slot-fallback.test.ts e2e-apps/github-issues/src/components/issue-530/SlotFallbackProbe/index.vue e2e-apps/github-issues/src/pages/issue-530/index.vue`
- `pnpm exec vitest run --config packages/weapp-vite/vitest.config.ts packages/weapp-vite/test/workspace-hmr-selection.test.ts`
- `pnpm exec eslint packages/weapp-vite/test/workspace-hmr-selection.test.ts scripts/workspace-hmr/templates-baseline.json scripts/tsconfig.json`
- `pnpm vitest run -c e2e/vitest.e2e.config.ts e2e/ci/github-issues.build.test.ts`
- `pnpm exec eslint e2e/ci/github-issues.build.test.ts`
- `git diff --check`
- `pnpm audit:hmr:changed`
- `WEAPP_VITE_E2E_TARGET_FILE=ide/github-issues.runtime.slot-fallback.test.ts WEAPP_VITE_E2E_AUTOMATOR_LAUNCH_MODE=direct pnpm vitest run -c e2e/vitest.e2e.devtools.config.ts`
