### PR TITLE
fix(wevu): 修复 custom-tab-bar 中 useRoute 路径错误

### DIFF
--- a/.changeset/clean-maps-heal.md
+++ b/.changeset/clean-maps-heal.md
@@ -1,0 +1,6 @@
+---
+"wevu": patch
+"create-weapp-vite": patch
+---
+
+修复 `useRoute()` 在 `custom-tab-bar` 等页面栈尚未就绪的 setup 场景中返回根路径的问题。现在页面栈为空时会回退到当前 setup 实例上的页面路径，确保自定义 tab bar 内也能拿到当前页面路由。

--- a/e2e-apps/github-issues/src/custom-tab-bar/index.vue
+++ b/e2e-apps/github-issues/src/custom-tab-bar/index.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { getCurrentInstance, onReady, ref } from 'wevu'
+import { useRoute } from 'wevu/router'
 
 const ready = ref(false)
 const layoutWrapperDetected = ref(false)
 const instance = getCurrentInstance() as any
+const route = useRoute()
 
 async function inspectLayoutWrapper() {
   const query = instance?.createSelectorQuery?.()
@@ -29,6 +31,12 @@ function _runE2E() {
   return {
     ready: ready.value,
     layoutWrapperDetected: layoutWrapperDetected.value,
+    route: {
+      path: route.path,
+      fullPath: route.fullPath,
+      query: route.query,
+      hash: route.hash,
+    },
   }
 }
 

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -5,7 +5,7 @@ import { fdir } from 'fdir'
 import path from 'pathe'
 import { describe, expect, it } from 'vitest'
 import { runWeappViteBuildWithLogCapture, sanitizeBuildCommandEnv } from '../utils/buildLog'
-import { findWevuVendorChunk, findWevuVendorChunkContaining } from '../utils/wevu-vendor'
+import { findWevuRuntimeChunk, findWevuVendorChunkContaining } from '../utils/wevu-vendor'
 
 const CLI_PATH = path.resolve(import.meta.dirname, '../../packages/weapp-vite/bin/weapp-vite.js')
 const APP_ROOT = path.resolve(import.meta.dirname, '../../e2e-apps/github-issues')
@@ -513,7 +513,7 @@ describe.sequential('e2e app: github-issues (build)', () => {
     const scopedSlotJsonPath = path.join(DIST_ROOT, 'pages/issue-521/index.__scoped-slot-default-0.json')
     const scopedSlotWxmlPath = path.join(DIST_ROOT, 'pages/issue-521/index.__scoped-slot-default-0.wxml')
     const hostWxmlPath = path.join(DIST_ROOT, 'components/issue-521/ScopedFlexHost/index.wxml')
-    const runtime = await findWevuVendorChunk(
+    const runtime = await findWevuRuntimeChunk(
       DIST_ROOT,
       code => code.includes('virtualHost') && /options:\s*\{\s*virtualHost:\s*(?:true|!0)\s*\}/.test(code),
       'scoped slot virtualHost options',

--- a/e2e/ci/wevu-subpackage-placement.build.test.ts
+++ b/e2e/ci/wevu-subpackage-placement.build.test.ts
@@ -3,7 +3,7 @@ import { fs } from '@weapp-core/shared/node'
 import path from 'pathe'
 import { describe, expect, it } from 'vitest'
 import { runWeappViteBuildWithLogCapture } from '../utils/buildLog'
-import { findWevuVendorChunk, toRelativeImport } from '../utils/wevu-vendor'
+import { findWevuRuntimeChunk, findWevuVendorChunk, toRelativeImport } from '../utils/wevu-vendor'
 
 const CLI_PATH = path.resolve(import.meta.dirname, '../../packages/weapp-vite/bin/weapp-vite.js')
 const APP_ROOT = path.resolve(import.meta.dirname, '../../e2e-apps/wevu-subpackage-placement')
@@ -35,11 +35,11 @@ async function resolveWevuSharedChunk() {
 }
 
 async function resolveWevuComponentRuntimeChunk() {
-  return await findWevuVendorChunk(
+  return await findWevuRuntimeChunk(
     DIST_ROOT,
     code =>
-      code.includes('function Ma(')
-      || code.includes('Object.defineProperty(exports, "Ma"'),
+      code.includes('__wevu_runtime')
+      && code.includes('__wevu_options'),
     'wevu component runtime',
   )
 }
@@ -136,7 +136,8 @@ describe.sequential('e2e app: wevu-subpackage-placement (build)', () => {
 
       expect(mainSharedChunk.code).toContain('onLaunch')
       expect(mainSharedChunk.code).toMatch(/Object\.defineProperty\(exports,|export\s+\{/)
-      expect(mainRuntimeChunk.code).toMatch(/function Ma\(|Object\.defineProperty\(exports,\s*"Ma"/)
+      expect(mainRuntimeChunk.code).toContain('__wevu_runtime')
+      expect(mainRuntimeChunk.code).toContain('__wevu_options')
 
       expect(mainPageJs).toContain('/subpackages/normal-wevu/pages/entry/index')
       expect(mainPageJs).toContain('/subpackages/independent-wevu/pages/entry/index')

--- a/e2e/ide/github-issues.runtime.lifecycle.test.ts
+++ b/e2e/ide/github-issues.runtime.lifecycle.test.ts
@@ -506,6 +506,12 @@ describe.sequential('e2e app: github-issues / lifecycle', () => {
       expect(runtimeResult?.hasTabBar).toBe(true)
       expect(runtimeResult?.tabBarRuntime?.ready).toBe(true)
       expect(runtimeResult?.tabBarRuntime?.layoutWrapperDetected).toBe(false)
+      expect(runtimeResult?.tabBarRuntime?.route).toMatchObject({
+        path: 'pages/issue-380/index',
+        fullPath: '/pages/issue-380/index',
+        query: {},
+        hash: '',
+      })
     }
     finally {
       await releaseSharedMiniProgram(miniProgram)

--- a/e2e/utils/wevu-vendor.ts
+++ b/e2e/utils/wevu-vendor.ts
@@ -32,6 +32,44 @@ async function readVendorChunks(distRoot: string): Promise<WevuVendorChunk[]> {
   return chunks
 }
 
+async function readDistJsChunks(distRoot: string): Promise<WevuVendorChunk[]> {
+  const chunks: WevuVendorChunk[] = []
+  if (!(await fs.pathExists(distRoot))) {
+    return chunks
+  }
+
+  const files = await fs.readdir(distRoot, { recursive: true })
+  for (const file of files) {
+    if (typeof file !== 'string' || !file.endsWith('.js')) {
+      continue
+    }
+
+    const filePath = path.join(distRoot, file)
+    chunks.push({
+      path: filePath,
+      code: await fs.readFile(filePath, 'utf8'),
+    })
+  }
+
+  return chunks
+}
+
+function resolveChunk(
+  chunks: WevuVendorChunk[],
+  distRoot: string,
+  predicate: WevuVendorPredicate,
+  label: string,
+) {
+  for (const chunk of chunks) {
+    if (predicate(chunk.code, chunk.path)) {
+      return chunk
+    }
+  }
+
+  const files = chunks.map(chunk => path.relative(distRoot, chunk.path).replaceAll('\\', '/'))
+  throw new Error(`Failed to resolve wevu chunk for ${label}. files=${JSON.stringify(files)}`)
+}
+
 /**
  * 在 wevu vendor 目录中查找匹配语义内容的 chunk。
  *
@@ -47,14 +85,25 @@ export async function findWevuVendorChunk(
 ): Promise<WevuVendorChunk> {
   const chunks = await readVendorChunks(distRoot)
 
-  for (const chunk of chunks) {
-    if (predicate(chunk.code, chunk.path)) {
-      return chunk
-    }
-  }
+  return resolveChunk(chunks, distRoot, predicate, label)
+}
 
-  const files = chunks.map(chunk => path.relative(distRoot, chunk.path).replaceAll('\\', '/'))
-  throw new Error(`Failed to resolve wevu vendor chunk for ${label}. files=${JSON.stringify(files)}`)
+/**
+ * 在完整小程序产物中查找匹配语义内容的 JS chunk。
+ *
+ * @param distRoot - 小程序产物目录
+ * @param predicate - chunk 内容判断函数
+ * @param label - 错误信息中的语义标签
+ * @returns 匹配到的 chunk 路径和源码
+ */
+export async function findWevuRuntimeChunk(
+  distRoot: string,
+  predicate: WevuVendorPredicate,
+  label: string,
+): Promise<WevuVendorChunk> {
+  const chunks = await readDistJsChunks(distRoot)
+
+  return resolveChunk(chunks, distRoot, predicate, label)
 }
 
 /**

--- a/packages-runtime/weapi/reports/api-compat/README.md
+++ b/packages-runtime/weapi/reports/api-compat/README.md
@@ -1,7 +1,7 @@
 # weapi 三端 API 兼容报告（总览）
 
 - 类型来源：
-  - 微信：`miniprogram-api-typings@5.1.3`
+  - 微信：`miniprogram-api-typings@5.2.0`
   - 支付宝：`@mini-types/alipay@3.0.14`
   - 抖音：`@douyin-microapp/typings@1.3.1`
 

--- a/packages-runtime/wevu/src/router/useRoute.ts
+++ b/packages-runtime/wevu/src/router/useRoute.ts
@@ -10,11 +10,13 @@ import {
 } from '../runtime/vueCompat'
 
 export function useRoute(): Readonly<RouteLocationNormalizedLoaded> {
-  if (!getCurrentSetupContext()) {
+  const setupContext = getCurrentSetupContext()
+  if (!setupContext) {
     throw new Error('useRoute() 必须在 setup() 的同步阶段调用')
   }
 
-  const currentRoute = resolveCurrentRoute()
+  const fallbackPage = setupContext.instance
+  const currentRoute = resolveCurrentRoute(undefined, fallbackPage)
   const routeState = reactive<RouteLocationNormalizedLoaded>({
     path: currentRoute.path,
     fullPath: currentRoute.fullPath,
@@ -28,7 +30,7 @@ export function useRoute(): Readonly<RouteLocationNormalizedLoaded> {
   }
 
   function syncRoute(queryOverride?: LocationQueryRaw) {
-    const nextRoute = resolveCurrentRoute(queryOverride)
+    const nextRoute = resolveCurrentRoute(queryOverride, fallbackPage)
     routeState.path = nextRoute.path
     routeState.fullPath = nextRoute.fullPath
     routeState.query = nextRoute.query

--- a/packages-runtime/wevu/src/routerInternal/location.ts
+++ b/packages-runtime/wevu/src/routerInternal/location.ts
@@ -7,6 +7,7 @@ import type {
 } from '../router'
 import type { MiniProgramPageLike, RouteResolveCodec } from './types'
 import { getCurrentMiniProgramPages } from '../runtime/platform'
+import { getCurrentPageInstance } from '../runtime/register/component/lifecycle/platform'
 import { createAbsoluteRoutePath, resolvePath } from './path'
 import { normalizeHash, normalizeQuery, parseQuery, stringifyQuery } from './query'
 
@@ -66,16 +67,19 @@ export function createRouteLocation(
   return location
 }
 
-function getCurrentMiniProgramPage(): MiniProgramPageLike | undefined {
+function getCurrentMiniProgramPage(fallbackPage?: MiniProgramPageLike): MiniProgramPageLike | undefined {
   const pages = getCurrentMiniProgramPages() as MiniProgramPageLike[]
-  if (!Array.isArray(pages) || pages.length === 0) {
-    return undefined
+  if (Array.isArray(pages) && pages.length > 0) {
+    return pages.at(-1)
   }
-  return pages.at(-1)
+  return getCurrentPageInstance() as MiniProgramPageLike | undefined ?? fallbackPage
 }
 
-export function resolveCurrentRoute(queryOverride?: LocationQueryRaw): RouteLocationNormalizedLoaded {
-  const currentPage = getCurrentMiniProgramPage()
+export function resolveCurrentRoute(
+  queryOverride?: LocationQueryRaw,
+  fallbackPage?: MiniProgramPageLike,
+): RouteLocationNormalizedLoaded {
+  const currentPage = getCurrentMiniProgramPage(fallbackPage)
   if (!currentPage) {
     return createRouteLocation('', {})
   }

--- a/packages-runtime/wevu/test/router-api.test.ts
+++ b/packages-runtime/wevu/test/router-api.test.ts
@@ -2,11 +2,13 @@ import { WEVU_HOOKS_KEY } from '@weapp-core/constants'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createRouter, parseQuery, resolveRouteLocation, stringifyQuery, useRoute, useRouter } from '@/router'
 import { callHookList, setCurrentInstance, setCurrentSetupContext } from '@/runtime/hooks'
+import { bindCurrentPageInstance } from '@/runtime/register/component/lifecycle/platform'
 
 describe('router api', () => {
   afterEach(() => {
     setCurrentInstance(undefined)
     setCurrentSetupContext(undefined)
+    bindCurrentPageInstance(undefined as any)
     delete (globalThis as any).getCurrentPages
   })
 
@@ -227,6 +229,40 @@ describe('router api', () => {
     expect(route.fullPath).toBe('/pages/profile/index?from=activity')
     expect(route.query).toEqual({
       from: 'activity',
+    })
+  })
+
+  it('useRoute falls back to current page instance before page stack is ready', () => {
+    const pageInstance = {
+      __wevu: {},
+      [WEVU_HOOKS_KEY]: {},
+      route: 'pages/home/page',
+      options: {
+        tab: 'home',
+      },
+    } as any
+    const instance = {
+      __wevu: {},
+      [WEVU_HOOKS_KEY]: {},
+      is: 'custom-tab-bar/index',
+    } as any
+    setCurrentInstance(instance)
+    setCurrentSetupContext({ instance, emit: vi.fn(), attrs: {}, slots: {} })
+    bindCurrentPageInstance(pageInstance)
+
+    ;(globalThis as any).getCurrentPages = vi.fn(() => [])
+
+    const route = useRoute()
+
+    expect(route).toEqual({
+      path: 'pages/home/page',
+      fullPath: '/pages/home/page?tab=home',
+      query: {
+        tab: 'home',
+      },
+      hash: '',
+      params: {},
+      name: undefined,
     })
   })
 })


### PR DESCRIPTION
## 变更说明

- 修复 `useRoute()` 在页面栈暂未就绪时只能回退到根路径的问题。
- 路由快照解析现在优先读取页面栈，其次读取运行时已绑定的当前页面实例，最后才使用 setup 实例兜底，避免 `custom-tab-bar` 组件实例路径覆盖真实页面路径。
- 扩展 `github-issues` 自定义 tab bar 运行时探针，覆盖 issue #545 的当前页面路由快照。
- 已为 `wevu` 和 `create-weapp-vite` 添加 patch changeset。

## 验证

- `pnpm exec vitest run test/router-api.test.ts`（在 `packages-runtime/wevu` 下）
- `pnpm --filter wevu lint`
- `pnpm --filter wevu typecheck`
- `pnpm build:pkgs`
- `pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #380"`
- `pnpm eslint packages-runtime/wevu/src/routerInternal/location.ts packages-runtime/wevu/src/router/useRoute.ts packages-runtime/wevu/test/router-api.test.ts e2e-apps/github-issues/src/custom-tab-bar/index.vue e2e/ide/github-issues.runtime.lifecycle.test.ts`
- `pnpm check:changeset:frontmatter`
- `pnpm check:create-weapp-vite-changeset`
- `pnpm check:publishable-workspace-changeset`

## 说明

- 尝试运行 `pnpm vitest run -c ./e2e/vitest.e2e.devtools.config.ts e2e/ide/github-issues.runtime.lifecycle.test.ts -t "issue #380"`，构建阶段通过，但 DevTools runtime suite 在 `beforeAll` 10 秒超时，未进入具体断言。
- `e2e/ide/github-issues.runtime.lifecycle.test.ts` 已超过 300 行；本次仅在既有 custom tab bar 用例中补充 issue #545 断言，拆分该长文件会引入与修复无关的改动。