### PR TITLE
fix: 修复多层 augmented scoped slot 内容丢失

### DIFF
--- a/.changeset/nested-augmented-scoped-slots.md
+++ b/.changeset/nested-augmented-scoped-slots.md
@@ -1,0 +1,8 @@
+---
+"@wevu/compiler": patch
+"weapp-vite": patch
+"wevu": patch
+"create-weapp-vite": patch
+---
+
+修复 augmented 作用域插槽在多层默认插槽组件嵌套时只生成第一层 scoped slot 资源的问题，并补齐嵌套 scoped slot 组件 JSON 的泛型与依赖声明，避免内层插槽内容在小程序运行时丢失。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -379,6 +379,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-547/index",
+          "pathName": "pages/issue-547/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-528/index",
           "pathName": "pages/issue-528/index",
           "query": "",

--- a/e2e-apps/github-issues/src/components/issue-547/NestedSlotCell/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-547/NestedSlotCell/index.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+defineComponentJson({
+  component: true,
+})
+</script>
+
+<template>
+  <view class="issue547-cell" data-issue547-cell="true">
+    <slot />
+  </view>
+</template>
+
+<style scoped>
+.issue547-cell {
+  padding: 16rpx;
+  background: #ecfeff;
+  border: 2rpx solid #0891b2;
+  border-radius: 8rpx;
+}
+</style>

--- a/e2e-apps/github-issues/src/components/issue-547/NestedSlotGroup/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-547/NestedSlotGroup/index.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+defineComponentJson({
+  component: true,
+})
+</script>
+
+<template>
+  <view class="issue547-group" data-issue547-group="true">
+    <view class="issue547-group__title">
+      issue-547 nested slot group
+    </view>
+    <slot />
+  </view>
+</template>
+
+<style scoped>
+.issue547-group {
+  padding: 20rpx;
+  background: #f8fafc;
+  border: 2rpx solid #475569;
+  border-radius: 8rpx;
+}
+
+.issue547-group__title {
+  margin-bottom: 12rpx;
+  font-size: 26rpx;
+  font-weight: 600;
+  color: #0f172a;
+}
+</style>

--- a/e2e-apps/github-issues/src/components/issue-547/NestedSlotImage/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-547/NestedSlotImage/index.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+defineComponentJson({
+  component: true,
+})
+</script>
+
+<template>
+  <view class="issue547-image" data-issue547-image="true">
+    issue-547 nested slot image
+  </view>
+</template>
+
+<style scoped>
+.issue547-image {
+  min-height: 64rpx;
+  padding: 12rpx;
+  font-size: 24rpx;
+  line-height: 40rpx;
+  color: #052e16;
+  background: #dcfce7;
+  border: 2rpx solid #16a34a;
+  border-radius: 8rpx;
+}
+</style>

--- a/e2e-apps/github-issues/src/pages/issue-547/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-547/index.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import NestedSlotCell from '../../components/issue-547/NestedSlotCell/index.vue'
+import NestedSlotGroup from '../../components/issue-547/NestedSlotGroup/index.vue'
+import NestedSlotImage from '../../components/issue-547/NestedSlotImage/index.vue'
+
+definePageJson({
+  navigationBarTitleText: 'issue-547',
+})
+
+function _runE2E() {
+  return {
+    ok: true,
+    expected: 'issue-547 nested slot image',
+  }
+}
+</script>
+
+<template>
+  <view class="issue547-page">
+    <view class="issue547-title">
+      issue-547 nested augmented slot
+    </view>
+
+    <NestedSlotGroup>
+      <NestedSlotCell>
+        <NestedSlotImage />
+      </NestedSlotCell>
+    </NestedSlotGroup>
+  </view>
+</template>
+
+<style scoped>
+.issue547-page {
+  box-sizing: border-box;
+  min-height: 100vh;
+  padding: 28rpx;
+  background: #fff;
+}
+
+.issue547-title {
+  margin-bottom: 18rpx;
+  font-size: 30rpx;
+  font-weight: 700;
+  color: #111827;
+}
+</style>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -3,7 +3,9 @@ import { defineConfig } from 'weapp-vite'
 
 const issue393ChunkModeEnabled = process.env.WEAPP_GITHUB_ISSUE_393 === 'true'
 const issue510AugmentedEnabled = process.env.WEAPP_GITHUB_ISSUE_510_AUGMENTED === 'true'
+const issue547AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_547_AUGMENTED === 'true'
 const e2eTargetFile = process.env.WEAPP_VITE_E2E_TARGET_FILE?.replaceAll('\\', '/') ?? ''
+const issue547AugmentedEnabled = issue547AugmentedEnvEnabled || e2eTargetFile.endsWith('github-issues.runtime.issue547.test.ts')
 const githubIssuesWarmupRoutes = ['pages/block-slot/**']
 const githubIssuesRouteGroups: Record<string, string[]> = {
   'github-issues.runtime.import-meta.test.ts': [
@@ -20,6 +22,9 @@ const githubIssuesRouteGroups: Record<string, string[]> = {
   'github-issues.runtime.issue466.test.ts': [
     'pages/issue-466/**',
     'subpackages/issue-466/**',
+  ],
+  'github-issues.runtime.issue547.test.ts': [
+    'pages/issue-547/**',
   ],
   'github-issues.runtime.lifecycle.test.ts': [
     'pages/issue-289/**',
@@ -71,6 +76,13 @@ function resolveGithubIssuesAutoRoutes() {
     return {
       include: [
         'pages/issue-510/**',
+      ],
+    }
+  }
+  if (issue547AugmentedEnvEnabled) {
+    return {
+      include: [
+        'pages/issue-547/**',
       ],
     }
   }
@@ -195,7 +207,7 @@ export default defineConfig({
     vue: {
       template: {
         slotSingleRootNoWrapper: true,
-        ...(issue510AugmentedEnabled
+        ...(issue510AugmentedEnabled || issue547AugmentedEnabled
           ? {
               scopedSlotsCompiler: 'augmented',
             } as const

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -151,6 +151,30 @@ async function runIssue510AugmentedBuild() {
   distVariant = null
 }
 
+async function runIssue547AugmentedBuild() {
+  await fs.remove(DIST_ROOT)
+
+  await execa('node', [
+    CLI_PATH,
+    'build',
+    APP_ROOT,
+    '--platform',
+    'weapp',
+    '--skipNpm',
+    '--config',
+    path.join(APP_ROOT, 'weapp-vite.config.ts'),
+  ], {
+    stdio: 'inherit',
+    env: {
+      ...sanitizeBuildCommandEnv(),
+      WEAPP_GITHUB_ISSUE_547_AUGMENTED: 'true',
+    },
+  })
+
+  standardBuildPromise = null
+  distVariant = null
+}
+
 describe.sequential('e2e app: github-issues (build)', () => {
   it('discussion #338: emits mapped wxml tags from vue html-style templates', async () => {
     await runBuild()
@@ -567,6 +591,37 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(Object.values(pageJson.usingComponents ?? {})).toContain('/pages/issue-510/index.__scoped-slot-default-0')
     expect(scopedSlotWxml).toContain('<view class="issue510-wrapper"><AugmentedSlotLeaf /></view>')
     expect(hostWxml).toContain('<scoped-slots-default wx:if="{{__wvSlotOwnerId}}"')
+  })
+
+  it('issue #547: augmented nested default slots emit every scoped slot asset', async () => {
+    await runIssue547AugmentedBuild()
+
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-547/index.wxml')
+    const pageJsonPath = path.join(DIST_ROOT, 'pages/issue-547/index.json')
+    const parentScopedSlotWxmlPath = path.join(DIST_ROOT, 'pages/issue-547/index.__scoped-slot-default-0.wxml')
+    const parentScopedSlotJsonPath = path.join(DIST_ROOT, 'pages/issue-547/index.__scoped-slot-default-0.json')
+    const childScopedSlotWxmlPath = path.join(DIST_ROOT, 'pages/issue-547/index.__scoped-slot-default-1.wxml')
+
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+    const pageJson = await fs.readJson(pageJsonPath) as { usingComponents?: Record<string, string> }
+    const parentScopedSlotWxml = await fs.readFile(parentScopedSlotWxmlPath, 'utf-8')
+    const parentScopedSlotJson = await fs.readJson(parentScopedSlotJsonPath) as { componentGenerics?: Record<string, true>, usingComponents?: Record<string, string> }
+    const childScopedSlotWxml = await fs.readFile(childScopedSlotWxmlPath, 'utf-8')
+
+    expect(pageWxml).toContain('issue-547 nested augmented slot')
+    expect(pageWxml).toContain('generic:scoped-slots-default=')
+    expect(pageWxml).not.toContain('<NestedSlotCell')
+    expect(pageJson.usingComponents).toMatchObject({
+      NestedSlotGroup: '/components/issue-547/NestedSlotGroup/index',
+      NestedSlotCell: '/components/issue-547/NestedSlotCell/index',
+      NestedSlotImage: '/components/issue-547/NestedSlotImage/index',
+    })
+    expect(Object.values(pageJson.usingComponents ?? {})).toContain('/pages/issue-547/index.__scoped-slot-default-0')
+    expect(parentScopedSlotWxml).toContain('<NestedSlotCell generic:scoped-slots-default=')
+    expect(parentScopedSlotWxml).not.toContain('<NestedSlotImage')
+    expect(parentScopedSlotJson.componentGenerics).toBeUndefined()
+    expect(Object.values(parentScopedSlotJson.usingComponents ?? {})).toContain('/pages/issue-547/index.__scoped-slot-default-1')
+    expect(childScopedSlotWxml).toContain('<NestedSlotImage />')
   })
 
   it('experiment: flex parent keeps projected multi-node slot groups visible via view wrappers', async () => {

--- a/e2e/ide/github-issues.runtime.issue547.test.ts
+++ b/e2e/ide/github-issues.runtime.issue547.test.ts
@@ -1,0 +1,41 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  closeSharedMiniProgram,
+  getSharedMiniProgram,
+  prepareGithubIssuesBuild,
+  readPageWxml,
+  relaunchPage,
+  releaseSharedMiniProgram,
+} from './github-issues.runtime.shared'
+
+describe.sequential('e2e app: github-issues / issue #547', () => {
+  beforeAll(async () => {
+    await prepareGithubIssuesBuild()
+  }, 60_000)
+
+  afterAll(async () => {
+    await closeSharedMiniProgram()
+  })
+
+  it('renders nested augmented default slot content in DevTools', async (ctx) => {
+    const miniProgram = await getSharedMiniProgram(ctx)
+    try {
+      const issuePage = await relaunchPage(miniProgram, '/pages/issue-547/index', 'issue-547 nested augmented slot')
+      if (!issuePage) {
+        throw new Error('Failed to launch issue-547 page')
+      }
+
+      const renderedWxml = await readPageWxml(issuePage)
+      expect(renderedWxml).toContain('issue-547 nested slot image')
+
+      const imageProbe = await issuePage.$('[data-issue547-image="true"]')
+      if (!imageProbe) {
+        throw new Error('Failed to query issue-547 nested slot image')
+      }
+      expect((await imageProbe.text()).trim()).toBe('issue-547 nested slot image')
+    }
+    finally {
+      await releaseSharedMiniProgram(miniProgram)
+    }
+  })
+})

--- a/e2e/scripts/e2e-suite-manifest.ts
+++ b/e2e/scripts/e2e-suite-manifest.ts
@@ -13,6 +13,7 @@ const AUTOMATOR_LAUNCH_MODE_ENV = 'WEAPP_VITE_E2E_AUTOMATOR_LAUNCH_MODE'
 const IDE_GITHUB_ISSUES_PATTERNS = [
   'ide/github-issues.runtime.issue289.test.ts',
   'ide/github-issues.runtime.issue297-302.test.ts',
+  'ide/github-issues.runtime.issue547.test.ts',
   'ide/github-issues.runtime.lifecycle.test.ts',
   'ide/github-issues.runtime.props.test.ts',
   'ide/github-issues.runtime.slot-fallback.test.ts',

--- a/packages-runtime/weapi/reports/api-compat/README.md
+++ b/packages-runtime/weapi/reports/api-compat/README.md
@@ -1,7 +1,7 @@
 # weapi 三端 API 兼容报告（总览）
 
 - 类型来源：
-  - 微信：`miniprogram-api-typings@5.1.3`
+  - 微信：`miniprogram-api-typings@5.2.0`
   - 支付宝：`@mini-types/alipay@3.0.14`
   - 抖音：`@douyin-microapp/typings@1.3.1`
 

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
@@ -703,6 +703,31 @@ describe('compileVueTemplateToWxml', () => {
     expect(scopedSlotComponents?.[0]?.template).toContain('<view><Leaf /></view>')
   })
 
+  it('emits nested augmented scoped slot components for multi-level default component children', () => {
+    const template = `
+<MyCellGroup>
+  <MyCell>
+    <MyImage />
+  </MyCell>
+</MyCellGroup>
+    `.trim()
+
+    const { code, scopedSlotComponents } = compileVueTemplateToWxml(
+      template,
+      '/project/src/pages/issue-547/index.vue',
+      { scopedSlotsCompiler: 'augmented' },
+    )
+
+    expect(code).toContain('generic:scoped-slots-default="')
+    expect(code).not.toContain('<MyCell ')
+    expect(scopedSlotComponents).toHaveLength(2)
+    expect(scopedSlotComponents?.[0]?.template).toContain('<MyCell generic:scoped-slots-default="')
+    expect(scopedSlotComponents?.[0]?.template).not.toContain('<MyImage')
+    expect(scopedSlotComponents?.[0]?.componentGenerics).toBeUndefined()
+    expect(scopedSlotComponents?.[1]?.template).toContain('<MyImage />')
+    expect(scopedSlotComponents?.[1]?.componentGenerics).toBeUndefined()
+  })
+
   it('keeps wrapped plain default children native when explicit require props wins over augmented mode', () => {
     const template = `
 <Provider>

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-component.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-component.ts
@@ -23,7 +23,6 @@ import {
   renderSlotFallback,
   resolveSlotKey,
   resolveSlotNameFromDirective,
-
   stringifySlotName,
 } from './tag-slot'
 

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts
@@ -1,5 +1,5 @@
 import type { DirectiveNode, ElementNode } from '@vue/compiler-core'
-import type { TransformContext, TransformNode } from '../types'
+import type { ScopedSlotComponentAsset, TransformContext, TransformNode } from '../types'
 import { NodeTypes } from '@vue/compiler-core'
 import {
   WEVU_SLOT_NAMES_PROP,
@@ -148,9 +148,16 @@ export function createScopedSlotComponent(
   const index = context.scopedSlotComponents.length
   const id = `${slotKey}-${index}`
   const componentName = `scoped-slot-${ownerHash}-${slotKey}-${index}`
+  const asset: ScopedSlotComponentAsset = {
+    id,
+    componentName,
+    slotKey,
+    template: '',
+  }
+  context.scopedSlotComponents.push(asset)
   const scopedContext: TransformContext = {
     ...context,
-    scopedSlotComponents: [],
+    scopedSlotComponents: context.scopedSlotComponents,
     componentGenerics: {},
     scopeStack: [],
     slotPropStack: [],
@@ -175,15 +182,11 @@ export function createScopedSlotComponent(
     const helperTag = buildClassStyleWxsTag(ext, scopedContext.classStyleWxsSrc)
     template = `${helperTag}\n${template}`
   }
-  context.scopedSlotComponents.push({
-    id,
-    componentName,
-    slotKey,
-    template,
-    classStyleBindings: scopedContext.classStyleBindings.length ? scopedContext.classStyleBindings : undefined,
-    classStyleWxs: scopedContext.classStyleWxs || undefined,
-    inlineExpressions: scopedContext.inlineExpressions.length ? scopedContext.inlineExpressions : undefined,
-  })
+  asset.template = template
+  asset.componentGenerics = Object.keys(scopedContext.componentGenerics).length ? scopedContext.componentGenerics : undefined
+  asset.classStyleBindings = scopedContext.classStyleBindings.length ? scopedContext.classStyleBindings : undefined
+  asset.classStyleWxs = scopedContext.classStyleWxs || undefined
+  asset.inlineExpressions = scopedContext.inlineExpressions.length ? scopedContext.inlineExpressions : undefined
   return { componentName, slotKey }
 }
 

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/types.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/types.ts
@@ -9,6 +9,7 @@ export interface ScopedSlotComponentAsset {
   componentName: string
   slotKey: string
   template: string
+  componentGenerics?: Record<string, true>
   classStyleBindings?: ClassStyleBinding[]
   classStyleWxs?: boolean
   inlineExpressions?: InlineExpressionAsset[]

--- a/packages/weapp-vite/src/cli/openIde/reuse.ts
+++ b/packages/weapp-vite/src/cli/openIde/reuse.ts
@@ -1,17 +1,25 @@
 import { connectOpenedAutomator, launchAutomator, promptRetryKeypress } from 'weapp-ide-cli'
 import logger, { colors } from '../../logger'
 
+interface DisconnectableMiniProgram {
+  disconnect: () => void
+}
+
 function formatReuseOpenedWechatIdePrompt() {
   const highlightedRetryKey = colors.bold(colors.green('r'))
   return `目标项目已在微信开发者工具中打开，已跳过重复打开。按 ${highlightedRetryKey} 关闭当前窗口后重新打开。`
+}
+
+function disconnectMiniProgram(miniProgram: DisconnectableMiniProgram) {
+  miniProgram.disconnect()
 }
 
 async function openWechatIdeByAutomator(projectPath: string) {
   const miniProgram = await launchAutomator({
     projectPath,
     trustProject: true,
-  })
-  miniProgram.disconnect()
+  }) as DisconnectableMiniProgram
+  disconnectMiniProgram(miniProgram)
 }
 
 async function connectOpenedProject(projectPath: string) {
@@ -19,7 +27,7 @@ async function connectOpenedProject(projectPath: string) {
     return await connectOpenedAutomator({
       projectPath,
       timeout: 3_000,
-    })
+    }) as DisconnectableMiniProgram
   }
   catch {
     return null
@@ -38,7 +46,7 @@ export async function tryReuseOpenedWechatIde(
     return null
   }
 
-  miniProgram.disconnect()
+  disconnectMiniProgram(miniProgram)
   logger.info(formatReuseOpenedWechatIdePrompt())
 
   const action = await promptRetryKeypress({ logger })
@@ -74,7 +82,7 @@ export async function reopenOpenedWechatIde(
     return false
   }
 
-  miniProgram.disconnect()
+  disconnectMiniProgram(miniProgram)
   logger.info('目标项目已在微信开发者工具中打开，当前命令将主动重开以刷新最新构建产物。')
   const closed = await closeIde()
   if (!closed) {

--- a/packages/weapp-vite/src/plugins/vue/transform/scopedSlot.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/scopedSlot.test.ts
@@ -229,6 +229,52 @@ describe('scoped slot helpers', () => {
     })
   })
 
+  it('emits component generics for scoped slot assets that contain nested scoped slots', () => {
+    const emitFile = vi.fn()
+    const result: any = {
+      config: '{}',
+      scopedSlotComponents: [
+        {
+          id: 'default-0',
+          componentName: 'ScopedParent',
+          template: '<Child generic:scoped-slots-default="ScopedChild" />',
+          componentGenerics: {
+            'scoped-slots-default': true,
+          },
+        },
+        {
+          id: 'default-1',
+          componentName: 'ScopedChild',
+          template: '<Leaf />',
+        },
+      ],
+    }
+
+    emitScopedSlotAssets(
+      { emitFile },
+      {},
+      'pages/index/index',
+      result,
+      undefined,
+      undefined,
+      { wxml: 'wxml', json: 'json' } as any,
+    )
+
+    const emittedParentJson = emitFile.mock.calls
+      .map(call => call[0])
+      .find(asset => asset.fileName === 'pages/index/index.__scoped-slot-default-0.json')
+
+    expect(emittedParentJson).toBeTruthy()
+    expect(JSON.parse(emittedParentJson.source)).toMatchObject({
+      usingComponents: {
+        ScopedChild: '/pages/index/index.__scoped-slot-default-1',
+      },
+      componentGenerics: {
+        'scoped-slots-default': true,
+      },
+    })
+  })
+
   it('skips emitting scoped slot asset files when bundle already has targets', () => {
     const emitFile = vi.fn()
     const result: any = {

--- a/packages/weapp-vite/src/plugins/vue/transform/scopedSlot/assets.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/scopedSlot/assets.ts
@@ -97,6 +97,27 @@ function resolveScopedSlotAutoImports(
   return usingComponents
 }
 
+function resolveNestedScopedSlotUsingComponents(
+  scopedSlots: NonNullable<VueTransformResult['scopedSlotComponents']>,
+  currentComponentName: string,
+  relativeBase: string,
+  template: string,
+) {
+  const usingComponents: Record<string, string> = {}
+
+  for (const scopedSlot of scopedSlots) {
+    if (scopedSlot.componentName === currentComponentName) {
+      continue
+    }
+    if (!template.includes(scopedSlot.componentName)) {
+      continue
+    }
+    usingComponents[scopedSlot.componentName] = `/${toPosixPath(`${relativeBase}.__scoped-slot-${scopedSlot.id}`)}`
+  }
+
+  return usingComponents
+}
+
 export function emitScopedSlotAssets(
   ctx: { emitFile: (asset: { type: 'asset', fileName: string, source: string }) => void },
   bundle: Record<string, any>,
@@ -135,6 +156,10 @@ export function emitScopedSlotAssets(
       componentBase,
       scopedSlot.template,
     )
+    Object.assign(
+      scopedUsingComponents,
+      resolveNestedScopedSlotUsingComponents(scopedSlots, scopedSlot.componentName, relativeBase, scopedSlot.template),
+    )
 
     if (!bundle[wxmlFile]) {
       ctx.emitFile({ type: 'asset', fileName: wxmlFile, source: scopedSlot.template })
@@ -145,6 +170,9 @@ export function emitScopedSlotAssets(
         kind: 'component',
       })
       let json = mergeJson({}, { usingComponents: scopedUsingComponents }, 'auto-using-components')
+      if (scopedSlot.componentGenerics && Object.keys(scopedSlot.componentGenerics).length > 0) {
+        json = mergeJson(json, { componentGenerics: scopedSlot.componentGenerics }, 'component-generics')
+      }
       if (jsonOptions?.defaults && Object.keys(jsonOptions.defaults).length > 0) {
         json = mergeJson(json, jsonOptions.defaults, 'defaults')
       }


### PR DESCRIPTION
## 变更说明
- 修复 augmented scoped slot 在多层默认插槽组件嵌套时只返回第一层 scoped slot 资源的问题。
- 为嵌套生成的 scoped slot 组件补齐 usingComponents 依赖，确保内层生成组件可被小程序 JSON 引用。
- 新增 issue #547 的编译器单测、scoped slot 资产单测、github-issues build e2e 与 DevTools runtime e2e 覆盖。

## 验证
- pnpm exec vitest run src/plugins/vue/compiler/template.test.ts
- pnpm exec vitest run src/plugins/vue/transform/scopedSlot.test.ts
- pnpm --filter @wevu/compiler typecheck
- pnpm --filter @wevu/compiler build
- pnpm --filter weapp-vite typecheck
- pnpm --filter weapp-vite build
- pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #547"
- pnpm vitest run -c ./e2e/vitest.e2e.devtools.config.ts e2e/ide/github-issues.runtime.issue547.test.ts

Fixes #547