### PR TITLE
fix(wevu-compiler): 修复 v-for 组件插槽元数据注入

### DIFF
--- a/.changeset/fresh-rings-juggle.md
+++ b/.changeset/fresh-rings-juggle.md
@@ -1,0 +1,5 @@
+---
+"@wevu/compiler": patch
+---
+
+修复组件节点直接使用 `v-for` 时，隐式默认插槽的 `vue-slots` 元数据没有注入的问题。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -393,6 +393,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-554/index",
+          "pathName": "pages/issue-554/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-528/index",
           "pathName": "pages/issue-528/index",
           "query": "",

--- a/e2e-apps/github-issues/src/components/issue-554/LoopSlotCell/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-554/LoopSlotCell/index.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+defineComponentJson({
+  component: true,
+})
+</script>
+
+<template>
+  <view class="issue554-cell" data-issue554-cell="true">
+    <slot />
+  </view>
+</template>
+
+<style scoped>
+.issue554-cell {
+  padding: 16rpx;
+  background: #f8fafc;
+  border: 2rpx solid #475569;
+  border-radius: 8rpx;
+}
+</style>

--- a/e2e-apps/github-issues/src/pages/issue-554/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-554/index.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import LoopSlotCell from '../../components/issue-554/LoopSlotCell/index.vue'
+
+definePageJson({
+  navigationBarTitleText: 'issue-554',
+})
+
+const items = [
+  {
+    key: 'cover-a',
+    src: '/assets/images/home/goods-1.png',
+  },
+]
+
+function _runE2E() {
+  return {
+    ok: true,
+    expected: items[0]?.src,
+  }
+}
+</script>
+
+<template>
+  <view class="issue554-page">
+    <view class="issue554-title">
+      issue-554 loop slot metadata
+    </view>
+
+    <LoopSlotCell
+      v-for="{ key, src } in items"
+      :key="key"
+    >
+      <image
+        class="issue554-image"
+        :src="src"
+        mode="aspectFit"
+      />
+    </LoopSlotCell>
+  </view>
+</template>
+
+<style scoped>
+.issue554-page {
+  box-sizing: border-box;
+  min-height: 100vh;
+  padding: 28rpx;
+  background: #fff;
+}
+
+.issue554-title {
+  margin-bottom: 18rpx;
+  font-size: 30rpx;
+  font-weight: 700;
+  color: #111827;
+}
+
+.issue554-image {
+  width: 160rpx;
+  height: 120rpx;
+}
+</style>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -30,6 +30,9 @@ const githubIssuesRouteGroups: Record<string, string[]> = {
   'github-issues.runtime.issue547.test.ts': [
     'pages/issue-547/**',
   ],
+  'github-issues.runtime.issue554.test.ts': [
+    'pages/issue-554/**',
+  ],
   'github-issues.runtime.lifecycle.test.ts': [
     'pages/issue-289/**',
     'pages/issue-309/**',

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -312,6 +312,25 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageJs).toContain('route.name')
   })
 
+  it('issue #554: injects slot metadata for v-for component default slots', async () => {
+    await runBuild()
+
+    const pageJsonPath = path.join(DIST_ROOT, 'pages/issue-554/index.json')
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-554/index.wxml')
+    const pageJson = await fs.readJson(pageJsonPath) as { usingComponents?: Record<string, string> }
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+
+    expect(pageJson.usingComponents).toMatchObject({
+      LoopSlotCell: '/components/issue-554/LoopSlotCell/index',
+    })
+    expect(pageWxml).toContain('LoopSlotCell')
+    expect(pageWxml).toContain('wx:for="{{items}}"')
+    expect(pageWxml).toContain('wx:for-item="__wv_item_')
+    expect(pageWxml).toContain('wx:key="key"')
+    expect(pageWxml).toContain(`vue-slots="{{__wv_bind_0[__wv_index_1]}}"`)
+    expect(pageWxml).toContain('<image class="issue554-image" src="{{__wv_item_0.src}}" mode="aspectFit" />')
+  })
+
   it('issue #424: avoids duplicated output for imported src/assets images', async () => {
     await runBuild()
 

--- a/e2e/ide/github-issues.runtime.issue554.test.ts
+++ b/e2e/ide/github-issues.runtime.issue554.test.ts
@@ -1,0 +1,41 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  closeSharedMiniProgram,
+  getSharedMiniProgram,
+  prepareGithubIssuesBuild,
+  readPageWxml,
+  relaunchPage,
+  releaseSharedMiniProgram,
+} from './github-issues.runtime.shared'
+
+describe.sequential('e2e app: github-issues / issue #554', () => {
+  beforeAll(async () => {
+    await prepareGithubIssuesBuild()
+  }, 60_000)
+
+  afterAll(async () => {
+    await closeSharedMiniProgram()
+  })
+
+  it('renders default slot content from components with v-for in DevTools', async (ctx) => {
+    const miniProgram = await getSharedMiniProgram(ctx)
+    try {
+      const issuePage = await relaunchPage(miniProgram, '/pages/issue-554/index', 'issue-554 loop slot metadata')
+      if (!issuePage) {
+        throw new Error('Failed to launch issue-554 page')
+      }
+
+      const renderedWxml = await readPageWxml(issuePage)
+      expect(renderedWxml).toContain('class="issue554-image"')
+      expect(renderedWxml).toContain('src="/assets/images/home/goods-1.png"')
+
+      const imageProbe = await issuePage.$('.issue554-image')
+      if (!imageProbe) {
+        throw new Error('Failed to query issue-554 slot image')
+      }
+    }
+    finally {
+      await releaseSharedMiniProgram(miniProgram)
+    }
+  })
+})

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
@@ -967,6 +967,24 @@ describe('compileVueTemplateToWxml', () => {
     expect(classStyleBindings?.some(binding => binding.name === '__wv_bind_0' && binding.exp === `{['default']:true}`)).toBe(true)
   })
 
+  it('emits slot presence metadata for implicit default slots inside v-for components', () => {
+    const template = `
+<MyCell v-for="{ key, src } in items" :key="key">
+  <image :src="src" />
+</MyCell>
+    `.trim()
+
+    const { code, classStyleBindings } = compileVueTemplateToWxml(template, '/project/src/pages/index/index.vue')
+
+    expect(code).toContain('<MyCell ')
+    expect(code).toContain(`${DEFAULT_DIRECTIVES.forAttr}="{{items}}"`)
+    expect(code).toContain(`${DEFAULT_DIRECTIVES.forItemAttr}="__wv_item_0"`)
+    expect(code).toContain(`${DEFAULT_DIRECTIVES.keyAttr}="key"`)
+    expect(code).toContain(`vue-slots="{{__wv_bind_0[__wv_index_1]}}"`)
+    expect(code).toContain('<image src="{{__wv_item_0.src}}" />')
+    expect(classStyleBindings?.some(binding => binding.name === '__wv_bind_0' && binding.exp === `{['default']:true}`)).toBe(true)
+  })
+
   it('guards plain slot metadata and fallback content with template v-if', () => {
     const template = `
 <Child>

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-component.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-component.ts
@@ -135,6 +135,20 @@ function isWevuComponentTag(node: ElementNode, context: TransformContext) {
   return context.wevuComponentTags ? context.wevuComponentTags.has(node.tag) : /^[A-Z]/.test(node.tag)
 }
 
+export function shouldTransformAsComponentWithSlots(
+  node: ElementNode,
+  context: TransformContext,
+  resolvedTag = resolveTemplateTagName(node.tag, context),
+) {
+  const slotDirective = findSlotDirective(node)
+  const templateSlotChildren = node.children.filter(
+    child => child.type === NodeTypes.ELEMENT && child.tag === 'template' && findSlotDirective(child as ElementNode),
+  )
+  const shouldUseAugmentedDefaultSlot = node.children.length > 0 && !context.scopedSlotsRequireProps && !isBuiltinTag(resolvedTag)
+  const shouldUseSlotPresenceMetadata = node.children.length > 0 && isWevuComponentTag(node, context)
+  return slotDirective || templateSlotChildren.length > 0 || shouldUseAugmentedDefaultSlot || shouldUseSlotPresenceMetadata
+}
+
 export function transformComponentWithSlots(
   node: ElementNode,
   context: TransformContext,
@@ -214,7 +228,8 @@ export function transformComponentWithSlots(
     if (children && defaultSlotChildren.length && !hasLegacySlotAttribute(defaultSlotChildren) && isWevuComponentTag(node, context)) {
       pushSlotNamesAttr(attrs, [{ name: '\'default\'' }], context)
     }
-    const attrString = attrs.length ? ` ${attrs.join(' ')}` : ''
+    const mergedAttrs = [...extraAttrs, ...attrs]
+    const attrString = mergedAttrs.length ? ` ${mergedAttrs.join(' ')}` : ''
     const { tag } = node
     return children
       ? `<${tag}${attrString}>${children}</${tag}>`
@@ -344,7 +359,8 @@ export function transformComponentWithSlotsFallback(
     if (children && defaultSlotChildren.length && !hasLegacySlotAttribute(defaultSlotChildren) && isWevuComponentTag(node, context)) {
       pushSlotNamesAttr(attrs, [{ name: '\'default\'' }], context)
     }
-    const attrString = attrs.length ? ` ${attrs.join(' ')}` : ''
+    const mergedAttrs = [...extraAttrs, ...attrs]
+    const attrString = mergedAttrs.length ? ` ${mergedAttrs.join(' ')}` : ''
     const { tag } = node
     return children
       ? `<${tag}${attrString}>${children}</${tag}>`

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-normal.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-normal.ts
@@ -1,24 +1,14 @@
 import type { ElementNode } from '@vue/compiler-core'
 import type { TransformContext, TransformNode } from '../types'
-import { NodeTypes } from '@vue/compiler-core'
 import { resolveTemplateTagName } from '../htmlTagMapping'
 import { renderMustache } from '../mustache'
-import { collectElementAttributes, isBuiltinTag } from './attrs'
-import { findSlotDirective } from './helpers'
-import { transformComponentWithSlots } from './tag-component'
+import { collectElementAttributes } from './attrs'
+import { shouldTransformAsComponentWithSlots, transformComponentWithSlots } from './tag-component'
 
 export function transformNormalElement(node: ElementNode, context: TransformContext, transformNode: TransformNode): string {
   const tag = resolveTemplateTagName(node.tag, context)
 
-  const slotDirective = findSlotDirective(node)
-  const templateSlotChildren = node.children.filter(
-    child => child.type === NodeTypes.ELEMENT && child.tag === 'template' && findSlotDirective(child as ElementNode),
-  )
-  const shouldUseAugmentedDefaultSlot = node.children.length > 0 && !context.scopedSlotsRequireProps && !isBuiltinTag(tag)
-  const shouldUseSlotPresenceMetadata = node.children.length > 0 && (
-    context.wevuComponentTags ? context.wevuComponentTags.has(node.tag) : /^[A-Z]/.test(node.tag)
-  )
-  if (slotDirective || templateSlotChildren.length > 0 || shouldUseAugmentedDefaultSlot || shouldUseSlotPresenceMetadata) {
+  if (shouldTransformAsComponentWithSlots(node, context, tag)) {
     return transformComponentWithSlots(node, context, transformNode)
   }
 

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-structural.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-structural.ts
@@ -7,7 +7,7 @@ import { resolveTemplateTagName } from '../htmlTagMapping'
 import { renderMustache } from '../mustache'
 import { collectElementAttributes } from './attrs'
 import { findSlotDirective, FOR_ITEM_ALIAS_PLACEHOLDER, parseForExpression, withForScope, withScope } from './helpers'
-import { transformComponentWithSlots } from './tag-component'
+import { shouldTransformAsComponentWithSlots, transformComponentWithSlots } from './tag-component'
 import { transformNormalElement } from './tag-normal'
 import { transformSlotElement } from './tag-slot'
 
@@ -117,18 +117,15 @@ export function transformForElement(node: ElementNode, context: TransformContext
       ? context.platform.forAttrs(listExp, renderTemplateMustache, forInfo.item, forInfo.index)
       : []
 
-    const slotDirective = findSlotDirective(elementWithoutFor)
-    const templateSlotChildren = elementWithoutFor.children.filter(
-      child => child.type === NodeTypes.ELEMENT && child.tag === 'template' && findSlotDirective(child as ElementNode),
-    )
-    if (slotDirective || templateSlotChildren.length > 0) {
+    const resolvedTag = resolveTemplateTagName(elementWithoutFor.tag, context)
+    if (shouldTransformAsComponentWithSlots(elementWithoutFor, context, resolvedTag)) {
       return transformComponentWithSlots(elementWithoutFor, context, transformNode, { extraAttrs, forInfo })
     }
 
     const { attrs, vTextExp } = collectElementAttributes(elementWithoutFor, context, {
       forInfo,
       extraAttrs,
-      resolvedTag: resolveTemplateTagName(elementWithoutFor.tag, context),
+      resolvedTag,
     })
 
     let children = ''
@@ -141,7 +138,7 @@ export function transformForElement(node: ElementNode, context: TransformContext
       children = renderMustache(vTextExp, context)
     }
 
-    const tag = resolveTemplateTagName(elementWithoutFor.tag, context)
+    const tag = resolvedTag
     const attrString = attrs.length ? ` ${attrs.join(' ')}` : ''
 
     return children


### PR DESCRIPTION
## 背景

修复 #554。组件节点直接使用 v-for 且通过隐式默认插槽传入内容时，编译产物没有注入 vue-slots 元数据，导致子组件内 slot 判断失效。

## 改动

- 复用组件 slot-aware 编译判定，让 v-for 分支也能处理隐式默认插槽元数据。
- 修复隐式 slot metadata 分支没有合并 v-for 结构属性的问题，保留 wx:for / wx:for-item / wx:key。
- 为 github-issues 增加 issue-554 最小复现页和 build / DevTools runtime 覆盖。
- 添加 @wevu/compiler patch changeset。

## 验证

- pnpm --filter @wevu/compiler exec vitest run src/plugins/vue/compiler/template.test.ts
- pnpm --filter @wevu/compiler typecheck
- pnpm --filter @wevu/compiler build
- pnpm --filter weapp-vite build
- WEAPP_VITE_E2E_TARGET_FILE=ci/github-issues.build.test.ts pnpm exec vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #554"
- pnpm exec eslint packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-component.ts packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-normal.ts packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-structural.ts e2e/ci/github-issues.build.test.ts e2e/ide/github-issues.runtime.issue554.test.ts e2e-apps/github-issues/weapp-vite.config.ts e2e-apps/github-issues/src/components/issue-554/LoopSlotCell/index.vue e2e-apps/github-issues/src/pages/issue-554/index.vue
- pnpm exec stylelint e2e-apps/github-issues/src/components/issue-554/LoopSlotCell/index.vue e2e-apps/github-issues/src/pages/issue-554/index.vue
- git diff --check