### PR TITLE
fix(wevu): 修复 v-if 单根插槽投影

### DIFF
--- a/.changeset/issue-555-slot-v-if.md
+++ b/.changeset/issue-555-slot-v-if.md
@@ -1,0 +1,8 @@
+---
+"@wevu/compiler": patch
+"wevu": patch
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复 `slotSingleRootNoWrapper` 遇到带 `v-if` 的单根具名插槽内容时，会把 `slot` 属性错误下推到生成的 `<block>` 上的问题。现在结构指令保留在外层 `<block>`，具名 `slot` 会继续下推到实际的单根元素，避免小程序运行时丢失投影内容。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -267,6 +267,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-555/index",
+          "pathName": "pages/issue-555/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-500/index",
           "pathName": "pages/issue-500/index",
           "query": "",

--- a/e2e-apps/github-issues/src/components/issue-555/SlotCell/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-555/SlotCell/index.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+defineComponentJson({
+  component: true,
+})
+</script>
+
+<template>
+  <view class="issue555-slot-cell">
+    <view class="issue555-slot-cell__text" data-slot-text="host">
+      <slot name="text" />
+    </view>
+  </view>
+</template>
+
+<style scoped>
+.issue555-slot-cell {
+  padding: 24rpx;
+  background: #fff;
+  border-radius: 12rpx;
+}
+
+.issue555-slot-cell__text {
+  min-height: 40rpx;
+  color: #0f172a;
+}
+</style>

--- a/e2e-apps/github-issues/src/pages/issue-555/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-555/index.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import { ref } from 'wevu'
+import SlotCell from '../../components/issue-555/SlotCell/index.vue'
+
+definePageJson({
+  navigationBarTitleText: 'issue-555',
+})
+
+const value = ref('issue-555 conditional slot text')
+
+function toggleValue() {
+  value.value = value.value ? '' : 'issue-555 conditional slot text'
+}
+
+function _runE2E() {
+  return {
+    value: value.value,
+  }
+}
+</script>
+
+<template>
+  <view class="issue555-page">
+    <view class="issue555-title">
+      issue-555 slot v-if projection
+    </view>
+
+    <SlotCell>
+      <template #text>
+        <text
+          v-if="value"
+          class="issue555-text-probe"
+          data-probe="conditional-text"
+        >
+          {{ value }}
+        </text>
+      </template>
+    </SlotCell>
+
+    <view class="issue555-action" @tap="toggleValue">
+      toggle issue-555 value
+    </view>
+  </view>
+</template>
+
+<style scoped>
+.issue555-page {
+  box-sizing: border-box;
+  min-height: 100vh;
+  padding: 32rpx;
+  background: #f1f5f9;
+}
+
+.issue555-title {
+  margin-bottom: 20rpx;
+  font-size: 32rpx;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.issue555-text-probe {
+  color: #0369a1;
+}
+
+.issue555-action {
+  padding: 20rpx;
+  margin-top: 20rpx;
+  color: #0f172a;
+  background: #bae6fd;
+  border-radius: 12rpx;
+}
+</style>

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -509,6 +509,32 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(componentWxml).toContain('<slot />')
   })
 
+  it('issue #555: keeps slot attribute on v-if single root content instead of generated block', async () => {
+    await runBuild()
+
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-555/index.wxml')
+    const pageJsPath = path.join(DIST_ROOT, 'pages/issue-555/index.js')
+    const componentWxmlPath = path.join(DIST_ROOT, 'components/issue-555/SlotCell/index.wxml')
+
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+    const pageJs = await fs.readFile(pageJsPath, 'utf-8')
+    const componentWxml = await fs.readFile(componentWxmlPath, 'utf-8')
+    const conditionalTextSlotStart = pageWxml.indexOf('<block wx:if="{{value}}"><text')
+    const conditionalTextSlotEnd = pageWxml.indexOf('{{value}}</text></block>', conditionalTextSlotStart)
+    const conditionalTextSlot = pageWxml.slice(conditionalTextSlotStart, conditionalTextSlotEnd)
+
+    expect(conditionalTextSlotStart).toBeGreaterThanOrEqual(0)
+    expect(conditionalTextSlotEnd).toBeGreaterThan(conditionalTextSlotStart)
+    expect(conditionalTextSlot).toContain('slot="text"')
+    expect(pageWxml).toContain('data-probe="conditional-text"')
+    expect(pageWxml).toContain('{{value}}</text></block>')
+    expect(pageWxml).not.toContain('<block slot="text"')
+    expect(pageWxml).not.toContain('<view slot="text">')
+    expect(pageJs).toContain('toggleValue')
+    expect(pageJs).toContain('_runE2E')
+    expect(componentWxml).toContain('<slot name="text" />')
+  })
+
   it('issue #500: compiles missing inject continuation probe', async () => {
     await runBuild()
 

--- a/mpcore/packages/simulator/test/testingBridge.test.ts
+++ b/mpcore/packages/simulator/test/testingBridge.test.ts
@@ -158,17 +158,13 @@ describe('headless testing bridge', () => {
     expect(await button?.text()).toBe('Hello')
 
     await page.callMethod('showAsyncText')
-    expect(await page.waitForText('async ready', {
-      timeout: 200,
-    })).toBe('async ready')
+    expect(await page.waitForText('async ready')).toBe('async ready')
 
     const asyncNode = await page.waitForSelector('#async-text')
     expect(await asyncNode?.text()).toBe('async ready')
 
     await page.callMethod('clearAsyncText')
-    await page.waitForTextGone('async ready', {
-      timeout: 200,
-    })
+    await page.waitForTextGone('async ready')
     expect(await page.waitForSelector('#missing-node', {
       state: 'detached',
       timeout: 30,
@@ -200,9 +196,7 @@ describe('headless testing bridge', () => {
 
     await page.callMethod('bumpAsyncCount')
 
-    expect(await page.waitForData('__e2eAsyncCount', 2, {
-      timeout: 200,
-    })).toBe(2)
+    expect(await page.waitForData('__e2eAsyncCount', 2)).toBe(2)
     expect(await page.waitForData('__e2eAsyncCount', (value: unknown) => Number(value) >= 2, {
       timeout: 30,
     })).toBe(2)
@@ -244,9 +238,7 @@ describe('headless testing bridge', () => {
     const homePage = await miniProgram.reLaunch('/pages/home/index')
     await homePage.callMethod('goDetailLater')
 
-    const detailPage = await miniProgram.waitForCurrentPage('/pages/detail/index', {
-      timeout: 200,
-    })
+    const detailPage = await miniProgram.waitForCurrentPage('/pages/detail/index')
 
     expect(detailPage).not.toBeNull()
     expect(await detailPage?.data('logs')).toEqual([

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
@@ -1022,6 +1022,26 @@ describe('compileVueTemplateToWxml', () => {
     expect(code).not.toContain('<view slot="icon">')
   })
 
+  it('projects plain named slot v-if single child without putting slot on block when enabled', () => {
+    const template = `
+<Child>
+  <template #text>
+    <text v-if="value" v-text="value" />
+  </template>
+</Child>
+    `.trim()
+
+    const { code } = compileVueTemplateToWxml(
+      template,
+      '/project/src/pages/index/index.vue',
+      { slotSingleRootNoWrapper: true },
+    )
+
+    expect(code).toContain(`<block ${DEFAULT_DIRECTIVES.ifAttr}="{{value}}"><text slot="text">{{value}}</text></block>`)
+    expect(code).not.toContain('<block slot="text"')
+    expect(code).not.toContain('<view slot="text">')
+  })
+
   it('keeps plain named slot multiple children wrapped when enabled', () => {
     const template = `
 <Child>

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts
@@ -1,4 +1,4 @@
-import type { DirectiveNode, ElementNode } from '@vue/compiler-core'
+import type { AttributeNode, DirectiveNode, ElementNode } from '@vue/compiler-core'
 import type { ScopedSlotComponentAsset, TransformContext, TransformNode } from '../types'
 import { NodeTypes } from '@vue/compiler-core'
 import {
@@ -17,6 +17,7 @@ import {
   getBindDirectiveExpression,
   hashString,
   isScopedSlotsDisabled,
+  isStructuralDirective,
   withSlotProps,
 } from './helpers'
 import { collectSlotBindingExpression, parseSlotPropsExpression } from './slotProps'
@@ -211,47 +212,103 @@ function injectAttributeIntoOpeningTag(source: string, attr: string): string | n
   return `${source.slice(0, tagNameEnd)} ${attr}${source.slice(tagNameEnd)}`
 }
 
+function createSlotAttributeNode(sourceNode: ElementNode, attr: string): AttributeNode | null {
+  const match = /^slot="([\s\S]*)"$/.exec(attr)
+  if (!match) {
+    return null
+  }
+  return {
+    type: NodeTypes.ATTRIBUTE,
+    name: 'slot',
+    nameLoc: sourceNode.loc,
+    value: {
+      type: NodeTypes.TEXT,
+      content: match[1]!,
+      loc: sourceNode.loc,
+    },
+    loc: sourceNode.loc,
+  }
+}
+
+function injectSlotAttributeIntoElementNode(
+  child: any,
+  slotAttr: string,
+  transformNode: TransformNode,
+  context: TransformContext,
+): string | null {
+  if (child.type !== NodeTypes.ELEMENT || child.tag === 'template') {
+    return null
+  }
+  const sourceNode = child as ElementNode
+  const slotAttribute = createSlotAttributeNode(sourceNode, slotAttr)
+  if (!slotAttribute) {
+    return null
+  }
+  const projectedNode: ElementNode = {
+    ...sourceNode,
+    props: [slotAttribute, ...sourceNode.props],
+  }
+  return transformNode(projectedNode, context)
+}
+
+function isRenderableFallbackChild(child: any): boolean {
+  if (child.type === NodeTypes.COMMENT) {
+    return false
+  }
+  if (child.type === NodeTypes.TEXT) {
+    return child.content.trim().length > 0
+  }
+  return true
+}
+
 export function renderSlotFallback(
   decl: ScopedSlotDeclaration,
   context: TransformContext,
   transformNode: TransformNode,
 ): string {
-  const rawRenderedChildren = decl.children
-    .map(child => ({
-      code: transformNode(child, context),
-    }))
-  const rawContent = rawRenderedChildren.map(item => item.code).join('')
-  if (!rawContent) {
-    return ''
-  }
-
   const slotAttr = renderSlotNameAttribute(decl.name, context, 'slot')
   const wrapCondition = (content: string) => {
     return decl.condition ? context.platform.wrapIf(decl.condition, content, exp => renderMustache(exp, context)) : content
   }
 
   if (!slotAttr) {
+    const rawContent = decl.children
+      .map(child => transformNode(child, context))
+      .join('')
+    if (!rawContent) {
+      return ''
+    }
     return wrapCondition(rawContent)
   }
 
-  if (!context.slotSingleRootNoWrapper) {
-    return wrapCondition(`<view ${slotAttr}>${rawContent}</view>`)
-  }
-
-  const renderedChildren = rawRenderedChildren
-    .filter(item => item.code.trim().length > 0)
-  if (!renderedChildren.length) {
+  const renderableChildren = decl.children.filter(isRenderableFallbackChild)
+  if (!renderableChildren.length) {
     return ''
   }
 
-  const content = renderedChildren.map(item => item.code).join('')
+  if (!context.slotSingleRootNoWrapper) {
+    const rawContent = decl.children
+      .map(child => transformNode(child, context))
+      .join('')
+    if (!rawContent) {
+      return ''
+    }
+    return wrapCondition(`<view ${slotAttr}>${rawContent}</view>`)
+  }
 
-  if (renderedChildren.length === 1) {
-    const projected = injectAttributeIntoOpeningTag(renderedChildren[0]!.code, slotAttr)
+  if (renderableChildren.length === 1) {
+    const child = renderableChildren[0]!
+    const projected = child.type === NodeTypes.ELEMENT && isStructuralDirective(child as ElementNode).type
+      ? injectSlotAttributeIntoElementNode(child, slotAttr, transformNode, context)
+      : injectAttributeIntoOpeningTag(transformNode(child, context), slotAttr)
     if (projected) {
       return wrapCondition(projected)
     }
   }
+
+  const content = renderableChildren
+    .map(child => transformNode(child, context))
+    .join('')
 
   // 真机 / DevTools 运行时里，多节点 fallback 通过 `<block slot="...">` 投影并不稳定，
   // 某些布局场景（尤其父级是 flex）会直接丢失整组内容，因此这里只对“单根节点”做无包裹下推；

--- a/packages/weapp-vite/test/vue/compiler.test.ts
+++ b/packages/weapp-vite/test/vue/compiler.test.ts
@@ -381,6 +381,18 @@ describe('Vue Template Compiler', () => {
       expect(result.code).not.toContain('<view slot="icon">')
     })
 
+    it('should lower plain template v-slot single v-if child without block slot when enabled', () => {
+      const result = compileVueTemplateToWxml(
+        '<my-comp><template #text><text v-if="value" v-text="value" /></template></my-comp>',
+        'test.vue',
+        { slotSingleRootNoWrapper: true },
+      )
+      expect(result.scopedSlotComponents).toBeUndefined()
+      expect(result.code).toContain('<block wx:if="{{value}}"><text slot="text">{{value}}</text></block>')
+      expect(result.code).not.toContain('<block slot="text"')
+      expect(result.code).not.toContain('<view slot="text">')
+    })
+
     it('should keep plain template v-slot multi child content wrapped when enabled', () => {
       const result = compileVueTemplateToWxml(
         '<my-comp><template #header><view>A</view><view>B</view></template></my-comp>',


### PR DESCRIPTION
## 背景

Closes #555。

当 `slotSingleRootNoWrapper` 遇到具名插槽内的单根 `v-if` 元素时，编译器会先生成结构 `<block>`，再把 `slot` 下推到这个 `<block>` 上，导致小程序运行时插槽投影不符合预期。

## 修改

- 对单根结构指令插槽内容先在 AST 层注入 `slot` 属性，再交回结构指令转换，输出形态保持为外层 `<block wx:if>` 包裹实际带 `slot` 的元素。
- 保留普通单根节点的既有字符串注入路径，避免改变已有输出格式。
- 新增 `issue #555` 的单元测试和 `e2e-apps/github-issues` 构建回归用例。
- 添加 changeset。

## 验证

- `pnpm --filter @wevu/compiler typecheck`
- `pnpm --filter @wevu/compiler lint`
- `pnpm --filter weapp-vite lint:src`（仅有既有 warning，无 error）
- `pnpm vitest run -c packages-runtime/wevu-compiler/vitest.config.ts packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts`
- `pnpm vitest run -c packages/weapp-vite/vitest.config.ts packages/weapp-vite/test/vue/compiler.test.ts`
- `pnpm build:pkgs`
- `pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #555"`（存在既有 issue-429 组件重名 warning）
