### PR TITLE
feat(weapp-vite): 支持 app.vue 应用级模板外壳

### DIFF
--- a/.changeset/app-vue-template-shell.md
+++ b/.changeset/app-vue-template-shell.md
@@ -4,4 +4,4 @@
 "weapp-vite": patch
 ---
 
-支持在 `src/app.vue` 中编写应用级 `<template>`，并在微信小程序下将其作为内部 app shell 组件包裹页面输出，避免生成无效的 `app.wxml`。
+支持在 `src/app.vue` 中编写应用级 `<template>`，并在微信小程序下将其作为内部 app shell 组件包裹页面输出，避免生成无效的 `app.wxml`。同时在 app shell 或页面 layout 缺少默认 `<slot />` 时抛出明确错误，避免页面内容被静默丢弃。

--- a/.changeset/app-vue-template-shell.md
+++ b/.changeset/app-vue-template-shell.md
@@ -1,0 +1,7 @@
+---
+"@weapp-core/constants": patch
+"create-weapp-vite": patch
+"weapp-vite": patch
+---
+
+支持在 `src/app.vue` 中编写应用级 `<template>`，并在微信小程序下将其作为内部 app shell 组件包裹页面输出，避免生成无效的 `app.wxml`。

--- a/@weapp-core/constants/src/index.ts
+++ b/@weapp-core/constants/src/index.ts
@@ -28,6 +28,8 @@ export const WEVU_PAGE_LAYOUT_SETTER_KEY = '__wevuSetPageLayout'
 export const WEVU_PAGE_LAYOUT_NONE = '__wv_no_layout'
 export const WEVU_PAGE_LAYOUT_NAME_KEY = '__wv_page_layout_name'
 export const WEVU_PAGE_LAYOUT_PROPS_KEY = '__wv_page_layout_props'
+export const WEVU_APP_SHELL_COMPONENT_BASE = '__weapp_vite_app_shell'
+export const WEVU_APP_SHELL_TAG_NAME = 'weapp-app-shell'
 
 export const WEVU_INLINE_HANDLER = '__weapp_vite_inline'
 export const WEVU_MODEL_HANDLER = '__weapp_vite_model'

--- a/e2e-apps/github-issues/src/app.vue
+++ b/e2e-apps/github-issues/src/app.vue
@@ -31,3 +31,15 @@ ensureGithubIssuesRouter()
 
 onLaunch(() => {})
 </script>
+
+<template>
+  <view class="issue-563-app-shell">
+    <slot />
+  </view>
+</template>
+
+<style>
+.issue-563-app-shell {
+  min-height: 100vh;
+}
+</style>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -12,6 +12,10 @@ const issue510AugmentedEnabled = issue510AugmentedEnvEnabled
 const issue547AugmentedEnabled = issue547AugmentedEnvEnabled || e2eTargetFile.endsWith('github-issues.runtime.issue547.test.ts')
 const githubIssuesWarmupRoutes = ['pages/block-slot/**']
 const githubIssuesRouteGroups: Record<string, string[]> = {
+  'github-issues.runtime.app-shell.test.ts': [
+    'pages/issue-338/**',
+    'pages/issue-448/**',
+  ],
   'github-issues.runtime.import-meta.test.ts': [
     'pages/issue-431/**',
   ],

--- a/e2e-apps/issue-814-tailwind3/src/app.vue
+++ b/e2e-apps/issue-814-tailwind3/src/app.vue
@@ -4,10 +4,6 @@ import { onLaunch } from 'wevu'
 onLaunch(() => {})
 </script>
 
-<template>
-  <view class="app" />
-</template>
-
 <style>
 @tailwind base;
 @tailwind components;

--- a/e2e-apps/issue-814-tailwind4-broken/src/app.vue
+++ b/e2e-apps/issue-814-tailwind4-broken/src/app.vue
@@ -4,8 +4,4 @@ import { onLaunch } from 'wevu'
 onLaunch(() => {})
 </script>
 
-<template>
-  <view class="app" />
-</template>
-
 <style src="./app.css"></style>

--- a/e2e-apps/issue-814-tailwind4/src/app.vue
+++ b/e2e-apps/issue-814-tailwind4/src/app.vue
@@ -4,8 +4,4 @@ import { onLaunch } from 'wevu'
 onLaunch(() => {})
 </script>
 
-<template>
-  <view class="app" />
-</template>
-
 <style src="./app.css"></style>

--- a/e2e-apps/style-import-vue/src/app.vue
+++ b/e2e-apps/style-import-vue/src/app.vue
@@ -3,7 +3,3 @@ import { onLaunch } from 'wevu'
 
 onLaunch(() => {})
 </script>
-
-<template>
-  <view class="app" />
-</template>

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -196,6 +196,34 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageWxml).not.toContain('<a ')
   })
 
+  it('issue #563: applies app.vue template as app shell without app.wxml', async () => {
+    await runBuild()
+
+    const pageWxml = await fs.readFile(path.join(DIST_ROOT, 'pages/issue-338/index.wxml'), 'utf-8')
+    const pageJson = await fs.readJson(path.join(DIST_ROOT, 'pages/issue-338/index.json')) as {
+      usingComponents?: Record<string, string>
+    }
+    const appShellWxml = await fs.readFile(path.join(DIST_ROOT, '__weapp_vite_app_shell.wxml'), 'utf-8')
+    const appShellJson = await fs.readJson(path.join(DIST_ROOT, '__weapp_vite_app_shell.json')) as Record<string, unknown>
+
+    expect(await fs.pathExists(path.join(DIST_ROOT, 'app.wxml'))).toBe(false)
+    expect(appShellWxml).toContain('issue-563-app-shell')
+    expect(appShellJson).toMatchObject({
+      component: true,
+      componentGenerics: {
+        'scoped-slots-default': {
+          default: './__weapp_vite_scoped_slot_generic_component',
+        },
+      },
+    })
+    expect(pageWxml).toContain('<weapp-app-shell><weapp-layout-default>')
+    expect(pageWxml).toContain('</weapp-layout-default></weapp-app-shell>')
+    expect(pageJson.usingComponents).toMatchObject({
+      'weapp-app-shell': '/__weapp_vite_app_shell',
+      'weapp-layout-default': '/layouts/default',
+    })
+  })
+
   it('issue #431: replaces import.meta.env expressions inside native wxml files', async () => {
     await runBuild()
 

--- a/e2e/ci/hmr-app-shell.test.ts
+++ b/e2e/ci/hmr-app-shell.test.ts
@@ -1,0 +1,98 @@
+import { setTimeout as sleep } from 'node:timers/promises'
+import { fs } from '@weapp-core/shared/node'
+import path from 'pathe'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { startDevProcess } from '../utils/dev-process'
+import { cleanupResidualDevProcesses } from '../utils/dev-process-cleanup'
+import { createDevProcessEnv } from '../utils/dev-process-env'
+import { createHmrMarker, replaceFileByRename, waitForFileContains } from '../utils/hmr-helpers'
+
+const CLI_PATH = path.resolve(import.meta.dirname, '../../packages/weapp-vite/bin/weapp-vite.js')
+const APP_ROOT = path.resolve(import.meta.dirname, '../../e2e-apps/github-issues')
+const DIST_ROOT = path.join(APP_ROOT, 'dist')
+const APP_VUE_PATH = path.join(APP_ROOT, 'src/app.vue')
+const APP_SHELL_WXML_DIST = path.join(DIST_ROOT, '__weapp_vite_app_shell.wxml')
+const APP_SHELL_JSON_DIST = path.join(DIST_ROOT, '__weapp_vite_app_shell.json')
+const APP_WXML_DIST = path.join(DIST_ROOT, 'app.wxml')
+const PAGE_WXML_DIST = path.join(DIST_ROOT, 'pages/issue-338/index.wxml')
+const PAGE_JSON_DIST = path.join(DIST_ROOT, 'pages/issue-338/index.json')
+const INITIAL_APP_SHELL_MARKER = 'issue-563-app-shell'
+
+async function waitForFileNotExists(filePath: string, timeoutMs = 90_000) {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (!(await fs.pathExists(filePath))) {
+      return
+    }
+    await sleep(250)
+  }
+  throw new Error(`Timed out waiting for ${filePath} to be absent`)
+}
+
+async function waitForPageUsingAppShell(timeoutMs = 90_000) {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (await fs.pathExists(PAGE_JSON_DIST)) {
+      const pageJson = await fs.readJson(PAGE_JSON_DIST) as {
+        usingComponents?: Record<string, string>
+      }
+      if (pageJson.usingComponents?.['weapp-app-shell'] === '/__weapp_vite_app_shell') {
+        return pageJson
+      }
+    }
+    await sleep(250)
+  }
+  throw new Error(`Timed out waiting for ${PAGE_JSON_DIST} to reference app shell`)
+}
+
+async function restoreAppVueSource(source: string) {
+  await fs.writeFile(APP_VUE_PATH, source, 'utf8')
+}
+
+beforeEach(async () => {
+  await cleanupResidualDevProcesses()
+  await fs.remove(DIST_ROOT)
+})
+
+afterEach(async () => {
+  await cleanupResidualDevProcesses()
+})
+
+describe.sequential('app shell HMR (dev watch)', () => {
+  it('updates app.vue template shell assets and keeps page wrappers in sync', async () => {
+    const originalAppSource = await fs.readFile(APP_VUE_PATH, 'utf8')
+    const updateMarker = createHmrMarker('APP-SHELL', 'weapp')
+    const updatedAppSource = originalAppSource.replace(INITIAL_APP_SHELL_MARKER, updateMarker)
+
+    // @ts-expect-error execa v9 overload resolution
+    const dev = startDevProcess('node', ['--import', 'tsx', CLI_PATH, 'dev', APP_ROOT, '--platform', 'weapp', '--skipNpm'], {
+      cwd: APP_ROOT,
+      env: createDevProcessEnv(),
+      stdio: 'inherit',
+    })
+
+    try {
+      await dev.waitFor(waitForFileContains(APP_SHELL_WXML_DIST, INITIAL_APP_SHELL_MARKER), 'initial app shell emitted')
+      await dev.waitFor(waitForFileContains(APP_SHELL_JSON_DIST, '"component": true'), 'initial app shell json emitted')
+      await dev.waitFor(waitForFileNotExists(APP_WXML_DIST), 'app.wxml is not emitted for app shell')
+      await dev.waitFor(waitForFileContains(PAGE_WXML_DIST, '<weapp-app-shell><weapp-layout-default>'), 'page wrapped with app shell and layout')
+      await dev.waitFor(waitForPageUsingAppShell(), 'page json references app shell component')
+
+      await sleep(1_000)
+      await replaceFileByRename(APP_VUE_PATH, updatedAppSource)
+
+      await dev.waitFor(waitForFileContains(APP_SHELL_WXML_DIST, updateMarker), 'app shell template updates after app.vue edit')
+      await dev.waitFor(waitForFileContains(APP_SHELL_JSON_DIST, '"component": true'), 'app shell json remains a component after update')
+      await dev.waitFor(waitForFileNotExists(APP_WXML_DIST), 'app.wxml remains absent after app.vue edit')
+      await dev.waitFor(waitForFileContains(PAGE_WXML_DIST, '<weapp-app-shell><weapp-layout-default>'), 'page wrapper remains after app.vue edit')
+      await dev.waitFor(waitForPageUsingAppShell(), 'page json keeps app shell component after app.vue edit')
+
+      const pageWxml = await fs.readFile(PAGE_WXML_DIST, 'utf8')
+      expect(pageWxml).toContain('</weapp-layout-default></weapp-app-shell>')
+    }
+    finally {
+      await dev.stop(5_000)
+      await restoreAppVueSource(originalAppSource)
+    }
+  })
+})

--- a/e2e/ide/github-issues.runtime.app-shell.test.ts
+++ b/e2e/ide/github-issues.runtime.app-shell.test.ts
@@ -1,0 +1,59 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  closeSharedMiniProgram,
+  getSharedMiniProgram,
+  prepareGithubIssuesBuild,
+  readPageWxml,
+  relaunchPage,
+  releaseSharedMiniProgram,
+} from './github-issues.runtime.shared'
+
+describe.sequential('e2e app: github-issues / app shell runtime', () => {
+  beforeAll(async () => {
+    await prepareGithubIssuesBuild()
+  }, 60_000)
+
+  afterAll(async () => {
+    await closeSharedMiniProgram()
+  })
+
+  it('issue #563: renders app.vue shell, page layout, and page content in real DevTools', async (ctx) => {
+    const miniProgram = await getSharedMiniProgram(ctx)
+    try {
+      const page = await relaunchPage(miniProgram, '/pages/issue-338/index', 'issue338-page')
+      if (!page) {
+        throw new Error('Failed to launch issue-338 page')
+      }
+
+      const renderedWxml = await readPageWxml(page)
+      const appShellIndex = renderedWxml.indexOf('issue-563-app-shell')
+      const layoutIndex = renderedWxml.indexOf('issue-380-default-layout')
+      const pageContentIndex = renderedWxml.indexOf('issue338-page')
+
+      expect(appShellIndex).toBeGreaterThanOrEqual(0)
+      expect(layoutIndex).toBeGreaterThan(appShellIndex)
+      expect(pageContentIndex).toBeGreaterThan(layoutIndex)
+    }
+    finally {
+      await releaseSharedMiniProgram(miniProgram)
+    }
+  })
+
+  it('issue #563: keeps app.vue shell when page layout is disabled', async (ctx) => {
+    const miniProgram = await getSharedMiniProgram(ctx)
+    try {
+      const page = await relaunchPage(miniProgram, '/pages/issue-448/index', 'issue448-page')
+      if (!page) {
+        throw new Error('Failed to launch issue-448 page')
+      }
+
+      const renderedWxml = await readPageWxml(page)
+      expect(renderedWxml).toContain('issue-563-app-shell')
+      expect(renderedWxml).toContain('issue448-page')
+      expect(renderedWxml).not.toContain('issue-380-default-layout')
+    }
+    finally {
+      await releaseSharedMiniProgram(miniProgram)
+    }
+  })
+})

--- a/e2e/scripts/e2e-suite-manifest.ts
+++ b/e2e/scripts/e2e-suite-manifest.ts
@@ -11,6 +11,7 @@ const DEVTOOLS_CONFIG_PATH = path.resolve(ROOT, 'vitest.e2e.devtools.config.ts')
 const HEADLESS_CONFIG_PATH = path.resolve(ROOT, 'vitest.e2e.headless.config.ts')
 const AUTOMATOR_LAUNCH_MODE_ENV = 'WEAPP_VITE_E2E_AUTOMATOR_LAUNCH_MODE'
 const IDE_GITHUB_ISSUES_PATTERNS = [
+  'ide/github-issues.runtime.app-shell.test.ts',
   'ide/github-issues.runtime.issue289.test.ts',
   'ide/github-issues.runtime.issue297-302.test.ts',
   'ide/github-issues.runtime.issue510.test.ts',

--- a/e2e/scripts/hmr-guard-manifest.ts
+++ b/e2e/scripts/hmr-guard-manifest.ts
@@ -10,6 +10,7 @@ function resolveCiTests(testPaths: string[]) {
 
 export const HMR_GUARD_TEST_GROUPS = {
   directEntryUpdates: resolveCiTests([
+    'hmr-app-shell.test.ts',
     'hmr-modify.test.ts',
     'hmr-html-template.test.ts',
     'hmr-layouts.test.ts',

--- a/e2e/scripts/suiteRunner.test.ts
+++ b/e2e/scripts/suiteRunner.test.ts
@@ -235,11 +235,12 @@ describe('suiteRunner', () => {
       'ide/chunk-modes.runtime.hoist.test.ts',
     ])
     expect(ideFullLabels.slice(-3)).toEqual(ideChunkModesLabels)
+    expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.app-shell.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue289.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue510.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.lifecycle.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.slot-fallback.test.ts')
-    expect(ideGithubIssuesTasks.length).toBe(6)
+    expect(ideGithubIssuesTasks.length).toBe(9)
     expect(ideGithubIssuesTasks.every(task => task.env?.WEAPP_VITE_E2E_AUTOMATOR_LAUNCH_MODE === 'direct')).toBe(true)
   })
 

--- a/packages/weapp-vite/src/plugins/core/lifecycle/watch.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/watch.test.ts
@@ -234,6 +234,31 @@ const count = 1
     expect(loggerSuccessMock).toHaveBeenCalledWith('[update] src/pages/hmr/index.ts')
   })
 
+  it('marks page entries dirty when app.vue shell template changes', async () => {
+    const appEntry = '/project/src/app.vue'
+    const pageEntry = '/project/src/pages/hmr/index.vue'
+    const componentEntry = '/project/src/components/card.vue'
+    const state = createState({
+      loadedEntrySet: new Set([appEntry]),
+      resolvedEntryMap: new Map([
+        [appEntry, { id: appEntry }],
+        [pageEntry, { id: pageEntry }],
+        [componentEntry, { id: componentEntry }],
+      ]),
+    })
+    const hook = createWatchChangeHook(state)
+
+    await hook(appEntry, { event: 'update' })
+
+    expect(state.markEntryDirty).toHaveBeenCalledWith(pageEntry, 'dependency')
+    expect(state.markEntryDirty).toHaveBeenCalledWith(componentEntry, 'dependency')
+    expect(state.markEntryDirty).toHaveBeenCalledWith(appEntry, 'direct')
+    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual([
+      'app-shell-dependent:2',
+      'entry-direct:1',
+    ])
+  })
+
   it('does not mark deleted declared page entries as direct dirties after a real delete', async () => {
     vi.spyOn(fs, 'pathExists').mockResolvedValue(false)
     const entryId = '/project/src/pages/logs/hmr-added.vue'

--- a/packages/weapp-vite/src/plugins/core/lifecycle/watch.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/watch.ts
@@ -18,6 +18,7 @@ import { invalidateFileCache } from '../../utils/cache'
 import { ensureSidecarWatcher, invalidateEntryForSidecar } from '../../utils/invalidateEntry'
 import { watchedScriptModuleExts, watchedTemplateExts } from '../../utils/invalidateEntry/shared'
 import { isLayoutSourcePath } from '../../utils/layoutSourcePath'
+import { isAppVueFile } from '../../vue/transform/appShell'
 import { collectAffectedEntries, collectAffectedEntriesFromSharedChunks } from '../helpers'
 
 const configSuffixes = configExtensions.map(ext => `.${ext}`)
@@ -177,6 +178,19 @@ async function processChangedFile(
     const didChangeRoutes = await ctx.autoRoutesService?.handleFileChange(normalizedId, event)
     if (didChangeRoutes) {
       dirtyReasonStats.set('auto-routes-topology', 1)
+    }
+  }
+
+  if (
+    event === 'update'
+    && isAppVueFile(normalizedId)
+    && resolvedEntryMap.size
+  ) {
+    for (const entryId of resolvedEntryMap.keys()) {
+      if (entryId === normalizedId) {
+        continue
+      }
+      markEntryDirtyWithCause(entryId, 'dependency', 'app-shell-dependent')
     }
   }
 

--- a/packages/weapp-vite/src/plugins/vue/transform/appShell.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/appShell.ts
@@ -1,0 +1,69 @@
+import type { VueTransformResult } from 'wevu/compiler'
+import type { ConfigService } from '../../../runtime/config/types'
+import type { LayoutTransformLikeResult, ResolvedPageLayout } from './pageLayout'
+import { WEVU_APP_SHELL_COMPONENT_BASE, WEVU_APP_SHELL_TAG_NAME } from '@weapp-core/constants'
+import path from 'pathe'
+import { normalizeWatchPath, toPosixPath } from '../../../utils/path'
+import { applyPageLayout } from './pageLayout'
+
+const APP_VUE_FILE_RE = /[\\/]app\.vue$/
+
+export interface ResolvedAppShell {
+  file: string
+  importPath: string
+  tagName: string
+}
+
+export function isAppVueFile(filename: string) {
+  return APP_VUE_FILE_RE.test(filename)
+}
+
+export function hasAppShellTemplate(result: Pick<VueTransformResult, 'template'> | undefined) {
+  return Boolean(result?.template?.trim())
+}
+
+export function resolveAppShellBase(configService: Pick<ConfigService, 'absoluteSrcRoot'>) {
+  return path.join(configService.absoluteSrcRoot, WEVU_APP_SHELL_COMPONENT_BASE)
+}
+
+export function resolveAppShellRelativeBase(configService: Pick<ConfigService, 'relativeOutputPath' | 'absoluteSrcRoot'>) {
+  return configService.relativeOutputPath(resolveAppShellBase(configService))
+}
+
+export function resolveAppShellImportPath(configService: Pick<ConfigService, 'relativeOutputPath' | 'absoluteSrcRoot'>) {
+  const relativeBase = resolveAppShellRelativeBase(configService)
+  return relativeBase ? `/${toPosixPath(relativeBase)}` : undefined
+}
+
+export function resolveAppShellLayout(configService: Pick<ConfigService, 'absoluteSrcRoot' | 'relativeOutputPath'>): ResolvedPageLayout | undefined {
+  const importPath = resolveAppShellImportPath(configService)
+  if (!importPath) {
+    return undefined
+  }
+
+  return {
+    file: normalizeWatchPath(resolveAppShellBase(configService)),
+    importPath,
+    kind: 'vue',
+    layoutName: 'app-shell',
+    tagName: WEVU_APP_SHELL_TAG_NAME,
+  }
+}
+
+export function applyAppShell(
+  result: LayoutTransformLikeResult,
+  filename: string,
+  appShell: ResolvedAppShell | undefined,
+) {
+  if (!appShell || !result.template) {
+    return result
+  }
+
+  return applyPageLayout(result as VueTransformResult, filename, {
+    file: appShell.file,
+    importPath: appShell.importPath,
+    kind: 'vue',
+    layoutName: 'app-shell',
+    tagName: appShell.tagName,
+  })
+}

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle.platform.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle.platform.test.ts
@@ -1206,6 +1206,121 @@ export default {
     })
   })
 
+  it('uses app.vue template as an app shell outside page layouts without emitting app.wxml', async () => {
+    const projectDir = await createTempProject()
+    const srcRoot = path.join(projectDir, 'src')
+    await fs.ensureDir(path.join(srcRoot, 'layouts'))
+    await fs.writeFile(path.join(srcRoot, 'layouts', 'default.vue'), '<template><slot /></template>', 'utf8')
+
+    const configService = {
+      isDev: false,
+      platform: 'weapp',
+      outputExtensions: {
+        wxml: 'wxml',
+        wxss: 'wxss',
+        wxs: 'wxs',
+        json: 'json',
+        js: 'js',
+      },
+      weappViteConfig: {
+        json: {},
+      },
+      relativeOutputPath: (p: string) => path.relative(srcRoot, p).replace(/\\/g, '/'),
+      absoluteSrcRoot: srcRoot,
+    } as unknown as CompilerContext['configService']
+
+    const ctx = {
+      configService,
+      scanService: {
+        independentSubPackageMap: new Map(),
+      },
+    } as CompilerContext
+
+    const appFile = path.join(srcRoot, 'app.vue')
+    const pageFile = path.join(srcRoot, 'pages', 'app-shell', 'index.vue')
+    const noLayoutPageFile = path.join(srcRoot, 'pages', 'app-shell-no-layout', 'index.vue')
+
+    const compilationCache = new Map([
+      [
+        appFile,
+        {
+          source: '<template><view class="app-shell"><slot /></view></template><style>.app-shell{min-height:100vh}</style>',
+          result: {
+            template: '<view class="app-shell"><slot /></view>',
+            style: '.app-shell{min-height:100vh}',
+            config: JSON.stringify({ pages: ['pages/app-shell/index'] }),
+            script: 'createApp({})',
+          },
+          isPage: false,
+        },
+      ],
+      [
+        pageFile,
+        {
+          source: '<template><view>page content</view></template>',
+          result: {
+            template: '<view>page content</view>',
+            config: JSON.stringify({ navigationBarTitleText: 'shell' }),
+            script: 'Page({})',
+          },
+          isPage: true,
+        },
+      ],
+      [
+        noLayoutPageFile,
+        {
+          source: '<script setup>definePageMeta({ layout: false })</script><template><view>plain content</view></template>',
+          result: {
+            template: '<view>plain content</view>',
+            config: JSON.stringify({ navigationBarTitleText: 'plain' }),
+            script: 'Page({})',
+          },
+          isPage: true,
+        },
+      ],
+    ])
+
+    const emitFile = vi.fn()
+    const bundle: Record<string, any> = {}
+
+    await emitVueBundleAssets(bundle, {
+      ctx,
+      pluginCtx: { emitFile, addWatchFile: vi.fn() },
+      compilationCache,
+      reExportResolutionCache: new Map(),
+      classStyleRuntimeWarned: { value: false },
+    })
+
+    const assets = new Map<string, string>()
+    for (const call of emitFile.mock.calls) {
+      const asset = call[0]
+      assets.set(asset.fileName, String(asset.source))
+    }
+
+    expect(assets.has('app.wxml')).toBe(false)
+    expect(assets.get('__weapp_vite_app_shell.wxml')).toBe('<view class="app-shell"><slot /></view>')
+    expect(assets.get('__weapp_vite_app_shell.wxss')).toBeUndefined()
+    expect(JSON.parse(assets.get('__weapp_vite_app_shell.json')!)).toEqual({
+      component: true,
+    })
+    expect(assets.get('__weapp_vite_app_shell.js')).toBe('Component({})')
+    expect(assets.get('pages/app-shell/index.wxml')).toBe('<weapp-app-shell><weapp-layout-default><view>page content</view></weapp-layout-default></weapp-app-shell>')
+    expect(assets.get('pages/app-shell-no-layout/index.wxml')).toBe('<weapp-app-shell><view>plain content</view></weapp-app-shell>')
+    expect(JSON.parse(assets.get('pages/app-shell/index.json')!)).toEqual({
+      navigationBarTitleText: 'shell',
+      usingComponents: {
+        'weapp-layout-default': '/layouts/default',
+        'weapp-app-shell': '/__weapp_vite_app_shell',
+      },
+    })
+    expect(JSON.parse(assets.get('pages/app-shell-no-layout/index.json')!)).toEqual({
+      navigationBarTitleText: 'plain',
+      usingComponents: {
+        'weapp-app-shell': '/__weapp_vite_app_shell',
+      },
+    })
+  })
+
   it('emits a js stub for scriptless vue layouts required by page wrappers', async () => {
     const projectDir = await createTempProject()
     const srcRoot = path.join(projectDir, 'src')

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle.platform.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle.platform.test.ts
@@ -1321,6 +1321,107 @@ export default {
     })
   })
 
+  it('throws when app.vue template has no default slot', async () => {
+    const projectDir = await createTempProject()
+    const srcRoot = path.join(projectDir, 'src')
+
+    const configService = {
+      isDev: false,
+      platform: 'weapp',
+      outputExtensions: {
+        wxml: 'wxml',
+        wxss: 'wxss',
+        wxs: 'wxs',
+        json: 'json',
+        js: 'js',
+      },
+      weappViteConfig: {
+        json: {},
+      },
+      relativeOutputPath: (p: string) => path.relative(srcRoot, p).replace(/\\/g, '/'),
+      absoluteSrcRoot: srcRoot,
+    } as unknown as CompilerContext['configService']
+
+    const appFile = path.join(srcRoot, 'app.vue')
+    await expect(emitVueBundleAssets({}, {
+      ctx: {
+        configService,
+        scanService: {
+          independentSubPackageMap: new Map(),
+        },
+      } as CompilerContext,
+      pluginCtx: { emitFile: vi.fn(), addWatchFile: vi.fn() },
+      compilationCache: new Map([
+        [
+          appFile,
+          {
+            source: '<template><view class="app-shell" /></template>',
+            result: {
+              template: '<view class="app-shell" />',
+              config: JSON.stringify({ pages: [] }),
+              script: 'createApp({})',
+            },
+            isPage: false,
+          },
+        ],
+      ]),
+      reExportResolutionCache: new Map(),
+      classStyleRuntimeWarned: { value: false },
+    })).rejects.toThrow(`${appFile} 中 app.vue <template> 必须包含默认 <slot />`)
+  })
+
+  it('throws when a page layout template has no default slot', async () => {
+    const projectDir = await createTempProject()
+    const srcRoot = path.join(projectDir, 'src')
+    const layoutFile = path.join(srcRoot, 'layouts', 'default.vue')
+    await fs.ensureDir(path.dirname(layoutFile))
+    await fs.writeFile(layoutFile, '<template><view class="layout-only" /></template>', 'utf8')
+
+    const configService = {
+      isDev: false,
+      platform: 'weapp',
+      outputExtensions: {
+        wxml: 'wxml',
+        wxss: 'wxss',
+        wxs: 'wxs',
+        json: 'json',
+        js: 'js',
+      },
+      weappViteConfig: {
+        json: {},
+      },
+      relativeOutputPath: (p: string) => path.relative(srcRoot, p).replace(/\\/g, '/'),
+      absoluteSrcRoot: srcRoot,
+    } as unknown as CompilerContext['configService']
+
+    const pageFile = path.join(srcRoot, 'pages', 'layout-no-slot', 'index.vue')
+    await expect(emitVueBundleAssets({}, {
+      ctx: {
+        configService,
+        scanService: {
+          independentSubPackageMap: new Map(),
+        },
+      } as CompilerContext,
+      pluginCtx: { emitFile: vi.fn(), addWatchFile: vi.fn() },
+      compilationCache: new Map([
+        [
+          pageFile,
+          {
+            source: '<template><view>page content</view></template>',
+            result: {
+              template: '<view>page content</view>',
+              config: JSON.stringify({ navigationBarTitleText: 'layout' }),
+              script: 'Page({})',
+            },
+            isPage: true,
+          },
+        ],
+      ]),
+      reExportResolutionCache: new Map(),
+      classStyleRuntimeWarned: { value: false },
+    })).rejects.toThrow(`${layoutFile} 对应的 layout template 必须包含默认 <slot />`)
+  })
+
   it('emits a js stub for scriptless vue layouts required by page wrappers', async () => {
     const projectDir = await createTempProject()
     const srcRoot = path.join(projectDir, 'src')

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/emitCompiledEntry.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/emitCompiledEntry.test.ts
@@ -186,6 +186,49 @@ describe('emitCompiledEntry helpers', () => {
     })
   })
 
+  it('keeps app.vue without template compatible with the normal app entry flow', async () => {
+    const result = {
+      config: JSON.stringify({ pages: ['pages/index/index'] }),
+      script: 'createApp({})',
+    } as any
+
+    await emitResolvedCompiledVueEntryAssets({
+      bundle: {},
+      state: {
+        ctx: {
+          configService: { platform: DEFAULT_MP_PLATFORM },
+        },
+        pluginCtx: {},
+      } as any,
+      filename: '/project/src/app.vue',
+      cached: {
+        isPage: false,
+        source: '<script setup>defineAppJson({ pages: [\'pages/index/index\'] })</script>',
+      } as any,
+      result,
+      relativeBase: 'app',
+      compileOptionsState: {
+        reExportResolutionCache: new Map(),
+        classStyleRuntimeWarned: { value: false },
+      },
+      outputExtensions: { wxml: 'wxml' } as any,
+      templateExtension: 'wxml',
+      jsonExtension: 'json',
+      scriptExtension: 'js',
+      scriptModuleExtension: 'wxs',
+      platformAssetOptions: DEFAULT_PLATFORM_ASSET_OPTIONS,
+    })
+
+    expect(emitAppShellAssetsIfNeededMock).not.toHaveBeenCalled()
+    expect(handleCompiledEntryPageLayoutsMock).not.toHaveBeenCalled()
+    expect(emitCompiledEntryBundleAssetsMock).toHaveBeenCalledWith(expect.objectContaining({
+      filename: '/project/src/app.vue',
+      relativeBase: 'app',
+      result,
+      isPage: false,
+    }))
+  })
+
   it('emits scriptless component fallbacks for component entries without script', async () => {
     emitCompiledEntryBundleAssetsMock.mockReturnValue({
       shouldEmitComponentJson: true,

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/emitCompiledEntry.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/emitCompiledEntry.test.ts
@@ -25,9 +25,11 @@ const resolveVueBundleAssetContextMock = vi.hoisted(() => vi.fn(() => ({
   platformAssetOptions: DEFAULT_PLATFORM_ASSET_OPTIONS,
 })))
 const emitBundlePageLayoutsIfNeededMock = vi.hoisted(() => vi.fn(async () => {}))
+const emitAppShellAssetsIfNeededMock = vi.hoisted(() => vi.fn())
 const emitScriptlessComponentJsFallbackIfMissingMock = vi.hoisted(() => vi.fn())
 
 vi.mock('./layoutAssets', () => ({
+  emitAppShellAssetsIfNeeded: emitAppShellAssetsIfNeededMock,
   emitBundlePageLayoutsIfNeeded: emitBundlePageLayoutsIfNeededMock,
   emitScriptlessComponentJsFallbackIfMissing: emitScriptlessComponentJsFallbackIfMissingMock,
 }))
@@ -64,6 +66,7 @@ describe('emitCompiledEntry helpers', () => {
     })
     emitBundlePageLayoutsIfNeededMock.mockReset()
     emitBundlePageLayoutsIfNeededMock.mockResolvedValue(undefined)
+    emitAppShellAssetsIfNeededMock.mockReset()
     emitScriptlessComponentJsFallbackIfMissingMock.mockReset()
   })
 
@@ -102,6 +105,7 @@ describe('emitCompiledEntry helpers', () => {
     })
 
     expect(handleCompiledEntryPageLayoutsMock).toHaveBeenCalledTimes(1)
+    expect(result.template).toBe('<view />')
     expect(emitBundlePageLayoutsIfNeededMock).toHaveBeenCalledWith({
       layouts: [{ kind: 'native', file: '/project/src/layouts/default' }],
       pluginCtx: {},
@@ -127,6 +131,59 @@ describe('emitCompiledEntry helpers', () => {
       platformAssetOptions: DEFAULT_PLATFORM_ASSET_OPTIONS,
     })
     expect(emitScriptlessComponentJsFallbackIfMissingMock).not.toHaveBeenCalled()
+  })
+
+  it('wraps compiled page templates with the app shell after page layouts', async () => {
+    handleCompiledEntryPageLayoutsMock.mockImplementation(async ({ result, emitLayouts }: any) => {
+      result.template = '<weapp-layout-default><view /></weapp-layout-default>'
+      result.config = JSON.stringify({
+        usingComponents: {
+          'weapp-layout-default': '/layouts/default',
+        },
+      })
+      await emitLayouts([{ kind: 'native', file: '/project/src/layouts/default' }])
+    })
+
+    const result = { template: '<view />', script: 'Page({})' } as any
+    await emitResolvedCompiledVueEntryAssets({
+      bundle: {},
+      state: {
+        ctx: {
+          configService: { platform: DEFAULT_MP_PLATFORM },
+        },
+        pluginCtx: {},
+        appShell: {
+          file: '/project/src/__weapp_vite_app_shell',
+          importPath: '/__weapp_vite_app_shell',
+          tagName: 'weapp-app-shell',
+        },
+      } as any,
+      filename: '/project/src/pages/index/index.vue',
+      cached: {
+        isPage: true,
+        source: '<template><view /></template>',
+      } as any,
+      result,
+      relativeBase: 'pages/index/index',
+      compileOptionsState: {
+        reExportResolutionCache: new Map(),
+        classStyleRuntimeWarned: { value: false },
+      },
+      outputExtensions: { wxml: 'wxml' } as any,
+      templateExtension: 'wxml',
+      jsonExtension: 'json',
+      scriptExtension: 'js',
+      scriptModuleExtension: 'wxs',
+      platformAssetOptions: DEFAULT_PLATFORM_ASSET_OPTIONS,
+    })
+
+    expect(result.template).toBe('<weapp-app-shell><weapp-layout-default><view /></weapp-layout-default></weapp-app-shell>')
+    expect(JSON.parse(result.config)).toEqual({
+      usingComponents: {
+        'weapp-layout-default': '/layouts/default',
+        'weapp-app-shell': '/__weapp_vite_app_shell',
+      },
+    })
   })
 
   it('emits scriptless component fallbacks for component entries without script', async () => {

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/emitCompiledEntry.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/emitCompiledEntry.ts
@@ -1,5 +1,6 @@
 import type { CompilationCacheEntry, VueBundleCompileOptionsState, VueBundleState } from './shared'
 import { applyAppShell, hasAppShellTemplate, isAppVueFile, resolveAppShellRelativeBase } from '../appShell'
+import { assertTemplateHasDefaultSlot, isLayoutFile } from '../pageLayout'
 import {
   emitAppShellAssetsIfNeeded,
   emitBundlePageLayoutsIfNeeded,
@@ -40,6 +41,7 @@ export async function emitResolvedCompiledVueEntryAssets(options: {
       bundle,
       pluginCtx,
       ctx,
+      filename,
       relativeBase: resolveAppShellRelativeBase(configService),
       result,
       configService,
@@ -71,6 +73,14 @@ export async function emitResolvedCompiledVueEntryAssets(options: {
       },
     })
     applyAppShell(result, filename, state.appShell)
+  }
+
+  if (isLayoutFile(filename, configService)) {
+    assertTemplateHasDefaultSlot({
+      filename,
+      kind: 'page-layout',
+      template: result.template,
+    })
   }
 
   const { shouldEmitComponentJson } = emitCompiledEntryBundleAssets({

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/emitCompiledEntry.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/emitCompiledEntry.ts
@@ -1,5 +1,7 @@
 import type { CompilationCacheEntry, VueBundleCompileOptionsState, VueBundleState } from './shared'
+import { applyAppShell, hasAppShellTemplate, isAppVueFile, resolveAppShellRelativeBase } from '../appShell'
 import {
+  emitAppShellAssetsIfNeeded,
   emitBundlePageLayoutsIfNeeded,
   emitScriptlessComponentJsFallbackIfMissing,
 } from './layoutAssets'
@@ -33,6 +35,23 @@ export async function emitResolvedCompiledVueEntryAssets(options: {
     return
   }
 
+  if (isAppVueFile(filename) && hasAppShellTemplate(result)) {
+    emitAppShellAssetsIfNeeded({
+      bundle,
+      pluginCtx,
+      ctx,
+      relativeBase: resolveAppShellRelativeBase(configService),
+      result,
+      configService,
+      templateExtension: options.templateExtension,
+      jsonExtension: options.jsonExtension,
+      scriptExtension: options.scriptExtension,
+      scriptModuleExtension: options.scriptModuleExtension,
+      outputExtensions: options.outputExtensions,
+      platformAssetOptions: options.platformAssetOptions,
+    })
+  }
+
   if (cached.isPage && cached.source) {
     await handleCompiledEntryPageLayouts({
       source: cached.source,
@@ -51,6 +70,7 @@ export async function emitResolvedCompiledVueEntryAssets(options: {
         })
       },
     })
+    applyAppShell(result, filename, state.appShell)
   }
 
   const { shouldEmitComponentJson } = emitCompiledEntryBundleAssets({

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/emitFallbackPage.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/emitFallbackPage.ts
@@ -2,6 +2,7 @@ import type { VueBundleCompileOptionsState, VueBundleState } from './shared'
 import logger from '../../../../logger'
 import { getPathExistsTtlMs } from '../../../../utils/cachePolicy'
 import { pathExists as pathExistsCached } from '../../../utils/cache'
+import { applyAppShell } from '../appShell'
 import { collectFallbackPageEntryIds } from '../fallbackEntries'
 import { emitBundlePageLayoutsIfNeeded } from './layoutAssets'
 import { addBundleWatchFile, emitFallbackPageBundleAssets, handleFallbackPageLayouts, loadFallbackPageEntryCompilation, resolveFallbackPageEmitState, resolveVueBundleAssetContext } from './shared'
@@ -26,6 +27,7 @@ export async function emitResolvedFallbackPageEntryAssets(options: {
     dependencies?: Record<string, string>
     alipayNpmMode?: string
   }
+  appShell?: VueBundleState['appShell']
 }) {
   const { source, result } = await loadFallbackPageEntryCompilation({
     entryFilePath: options.entryFilePath,
@@ -51,6 +53,8 @@ export async function emitResolvedFallbackPageEntryAssets(options: {
       })
     },
   })
+
+  applyAppShell(result, options.entryFilePath, options.appShell)
 
   emitFallbackPageBundleAssets({
     bundle: options.bundle,
@@ -123,6 +127,7 @@ export async function emitFallbackPageAssets(
         scriptModuleExtension,
         outputExtensions,
         platformAssetOptions,
+        appShell: state.appShell,
       })
     }
     catch (error) {

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/index.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/index.ts
@@ -1,5 +1,6 @@
 import type { CompilationCacheEntry, VueBundleState } from './shared'
 import { normalizeFsResolvedId } from '../../../../utils/resolvedId'
+import { hasAppShellTemplate, isAppVueFile, resolveAppShellLayout } from '../appShell'
 import { emitCompiledVueEntryAssets } from './emitCompiledEntry'
 import { emitFallbackPageAssets } from './emitFallbackPage'
 
@@ -13,6 +14,12 @@ export function resolveVueBundleEmitState(state: VueBundleState) {
   if (!configService || !scanService) {
     return undefined
   }
+  const appShellEntry = Array.from(compilationCache.entries()).find(([filename, cached]) => {
+    return isAppVueFile(filename) && hasAppShellTemplate(cached.result)
+  })
+  state.appShell = appShellEntry
+    ? resolveAppShellLayout(configService)
+    : undefined
   const shouldFilterHmrEntries = Boolean(
     configService.isDev
     && ctx.runtimeState?.build?.hmr?.profile?.event === 'update'

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/layoutAssets.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/layoutAssets.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createBundleLayoutEmitters, emitBundlePageLayoutsIfNeeded, emitNativeLayoutAssetsIfNeeded, emitNativeLayoutScriptChunkIfNeeded, emitResolvedBundleLayouts, emitResolvedNativeLayoutStaticAssets, emitVueLayoutScriptFallbackIfNeeded, resolveNativeLayoutAssetState, resolveNativeLayoutScriptChunkState, resolveVueLayoutAssetOptions, resolveVueLayoutScriptFallbackState } from './layoutAssets'
 
-const readFileMock = vi.hoisted(() => vi.fn(async () => '<view />'))
+const readFileMock = vi.hoisted(() => vi.fn(async () => '<view><slot /></view>'))
 const collectNativeLayoutAssetsMock = vi.hoisted(() => vi.fn(async () => ({
   template: '/project/layouts/default/index.wxml',
 })))
@@ -10,6 +10,7 @@ const emitSfcStyleIfMissingMock = vi.hoisted(() => vi.fn())
 const emitSfcJsonAssetMock = vi.hoisted(() => vi.fn())
 const compileVueLikeFileMock = vi.hoisted(() => vi.fn(async () => ({
   script: '',
+  template: '<view><slot /></view>',
 })))
 const ensureScriptlessComponentAssetMock = vi.hoisted(() => vi.fn())
 const emitNativeLayoutScriptChunkIfNeededSharedMock = vi.hoisted(() => vi.fn())
@@ -25,9 +26,13 @@ vi.mock('@weapp-core/shared/fs', async (importOriginal) => {
   }
 })
 
-vi.mock('../pageLayout', () => ({
-  collectNativeLayoutAssets: collectNativeLayoutAssetsMock,
-}))
+vi.mock('../pageLayout', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../pageLayout')>()
+  return {
+    ...actual,
+    collectNativeLayoutAssets: collectNativeLayoutAssetsMock,
+  }
+})
 
 vi.mock('../emitAssets', () => ({
   emitSfcJsonAsset: emitSfcJsonAssetMock,
@@ -62,7 +67,7 @@ vi.mock('../../../utils/nativeLayout', async (importOriginal) => {
 describe('resolveVueLayoutAssetOptions', () => {
   beforeEach(() => {
     readFileMock.mockReset()
-    readFileMock.mockResolvedValue('<view />')
+    readFileMock.mockResolvedValue('<view><slot /></view>')
     collectNativeLayoutAssetsMock.mockReset()
     collectNativeLayoutAssetsMock.mockResolvedValue({
       template: '/project/layouts/default/index.wxml',
@@ -73,6 +78,7 @@ describe('resolveVueLayoutAssetOptions', () => {
     compileVueLikeFileMock.mockReset()
     compileVueLikeFileMock.mockResolvedValue({
       script: '',
+      template: '<view><slot /></view>',
     })
     ensureScriptlessComponentAssetMock.mockReset()
     emitNativeLayoutScriptChunkIfNeededSharedMock.mockReset()
@@ -274,7 +280,7 @@ describe('resolveVueLayoutAssetOptions', () => {
   it('emits resolved native layout static assets by asset kind', async () => {
     readFileMock.mockImplementation(async (file: string) => {
       if (file.endsWith('.wxml')) {
-        return '<view />'
+        return '<view><slot /></view>'
       }
       return '.layout{}'
     })
@@ -300,7 +306,7 @@ describe('resolveVueLayoutAssetOptions', () => {
       expect.anything(),
       {},
       'dist/layouts/default/index',
-      '<view />',
+      '<view><slot /></view>',
       'wxml',
     )
     expect(emitSfcStyleIfMissingMock).toHaveBeenCalledWith(
@@ -365,6 +371,7 @@ describe('resolveVueLayoutAssetOptions', () => {
   it('returns early for vue layout fallback when compiled script already exists', async () => {
     compileVueLikeFileMock.mockResolvedValue({
       script: 'Component({})',
+      template: '<view><slot /></view>',
     })
 
     await emitVueLayoutScriptFallbackIfNeeded({
@@ -388,6 +395,30 @@ describe('resolveVueLayoutAssetOptions', () => {
     expect(ensureScriptlessComponentAssetMock).not.toHaveBeenCalled()
   })
 
+  it('throws for vue layout fallback without default slot', async () => {
+    compileVueLikeFileMock.mockResolvedValue({
+      script: '',
+      template: '<view />',
+    })
+
+    await expect(emitVueLayoutScriptFallbackIfNeeded({
+      pluginCtx: { emitFile: vi.fn() },
+      bundle: {},
+      layoutFilePath: '/project/layouts/vue-default/index.vue',
+      ctx: {} as any,
+      configService: {
+        relativeOutputPath: (value: string) => `dist/${value}`,
+      } as any,
+      compileOptionsState: {
+        reExportResolutionCache: new Map(),
+        classStyleRuntimeWarned: { value: false },
+      },
+      outputExtensions: {
+        js: 'mjs',
+      } as any,
+    })).rejects.toThrow('/project/layouts/vue-default/index.vue 对应的 layout template 必须包含默认 <slot />')
+  })
+
   it('emits native layout assets including json when present', async () => {
     collectNativeLayoutAssetsMock.mockResolvedValue({
       json: '/project/layouts/default/index.json',
@@ -397,7 +428,7 @@ describe('resolveVueLayoutAssetOptions', () => {
       if (file.endsWith('.json')) {
         return '{"component":true}'
       }
-      return '<view />'
+      return '<view><slot /></view>'
     })
 
     await emitNativeLayoutAssetsIfNeeded({
@@ -545,7 +576,7 @@ describe('resolveVueLayoutAssetOptions', () => {
       expect.anything(),
       {},
       'dist/layouts/native-default/index',
-      '<view />',
+      '<view><slot /></view>',
       'wxml',
     )
     expect(readFileMock).toHaveBeenCalledWith('/project/layouts/vue-default/index.vue', 'utf-8')

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/layoutAssets.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/layoutAssets.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../utils/nativeLayout'
 import { ensureScriptlessComponentAsset, resolveScriptlessComponentFileName } from '../../../utils/scriptlessComponent'
 import { emitSfcJsonAsset, emitSfcStyleIfMissing, emitSfcTemplateIfMissing } from '../emitAssets'
-import { collectNativeLayoutAssets } from '../pageLayout'
+import { assertTemplateHasDefaultSlot, collectNativeLayoutAssets } from '../pageLayout'
 import { compileVueLikeFile, getEntryBaseName } from './shared'
 import { emitBundleVueEntryAssets, emitSharedVueEntryJsonAsset } from './shared/assets'
 
@@ -123,6 +123,11 @@ export async function emitResolvedNativeLayoutStaticAssets(options: {
   })
   for (const asset of staticAssetEntries) {
     if (asset.kind === 'template') {
+      assertTemplateHasDefaultSlot({
+        filename: options.assets.template!,
+        kind: 'page-layout',
+        template: asset.source,
+      })
       emitSfcTemplateIfMissing(
         options.pluginCtx,
         options.bundle,
@@ -256,6 +261,12 @@ export async function emitVueLayoutScriptFallbackIfNeeded(options: {
     compileOptionsState,
   })
 
+  assertTemplateHasDefaultSlot({
+    filename: layoutFilePath,
+    kind: 'page-layout',
+    template: result.template,
+  })
+
   if (result.script?.trim()) {
     return
   }
@@ -353,6 +364,7 @@ export function emitAppShellAssetsIfNeeded(options: {
   bundle: Record<string, any>
   pluginCtx: any
   ctx: CompilerContext
+  filename: string
   relativeBase: string | undefined
   result: Pick<VueTransformResult, 'template' | 'config' | 'classStyleWxs' | 'scopedSlotComponents'>
   configService: NonNullable<CompilerContext['configService']>
@@ -373,6 +385,12 @@ export function emitAppShellAssetsIfNeeded(options: {
   if (!relativeBase || !result.template?.trim()) {
     return
   }
+
+  assertTemplateHasDefaultSlot({
+    filename: options.filename,
+    kind: 'app-shell',
+    template: result.template,
+  })
 
   emitBundleVueEntryAssets({
     bundle: options.bundle,

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/layoutAssets.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/layoutAssets.ts
@@ -1,3 +1,4 @@
+import type { VueTransformResult } from 'wevu/compiler'
 import type { CompilerContext } from '../../../../context'
 import type { OutputExtensions } from '../../../../platforms/types'
 import type { VueBundleCompileOptionsState } from './shared'
@@ -11,6 +12,7 @@ import { ensureScriptlessComponentAsset, resolveScriptlessComponentFileName } fr
 import { emitSfcJsonAsset, emitSfcStyleIfMissing, emitSfcTemplateIfMissing } from '../emitAssets'
 import { collectNativeLayoutAssets } from '../pageLayout'
 import { compileVueLikeFile, getEntryBaseName } from './shared'
+import { emitBundleVueEntryAssets, emitSharedVueEntryJsonAsset } from './shared/assets'
 
 export interface ResolvedBundleLayout {
   kind: 'native' | 'vue'
@@ -316,5 +318,94 @@ export async function emitBundlePageLayoutsIfNeeded(options: {
     layouts: options.layouts,
     emitNativeLayout: layoutEmitters.emitNativeLayout,
     emitVueLayout: layoutEmitters.emitVueLayout,
+  })
+}
+
+function resolveAppShellComponentConfig(config: string | undefined) {
+  if (!config) {
+    return undefined
+  }
+
+  try {
+    const parsed = JSON.parse(config)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return undefined
+    }
+
+    const shellConfig: Record<string, any> = {}
+    for (const key of ['usingComponents', 'componentGenerics']) {
+      const value = parsed[key]
+      if (value && typeof value === 'object' && !Array.isArray(value)) {
+        shellConfig[key] = value
+      }
+    }
+
+    return Object.keys(shellConfig).length
+      ? JSON.stringify(shellConfig, null, 2)
+      : undefined
+  }
+  catch {
+    return undefined
+  }
+}
+
+export function emitAppShellAssetsIfNeeded(options: {
+  bundle: Record<string, any>
+  pluginCtx: any
+  ctx: CompilerContext
+  relativeBase: string | undefined
+  result: Pick<VueTransformResult, 'template' | 'config' | 'classStyleWxs' | 'scopedSlotComponents'>
+  configService: NonNullable<CompilerContext['configService']>
+  templateExtension: string
+  jsonExtension: string
+  scriptExtension: string
+  scriptModuleExtension?: string
+  outputExtensions: NonNullable<CompilerContext['configService']>['outputExtensions']
+  platformAssetOptions: {
+    platform: string
+    templateExtension: string
+    scriptModuleExtension?: string
+    dependencies?: Record<string, string>
+    alipayNpmMode?: string
+  }
+}) {
+  const { relativeBase, result } = options
+  if (!relativeBase || !result.template?.trim()) {
+    return
+  }
+
+  emitBundleVueEntryAssets({
+    bundle: options.bundle,
+    pluginCtx: options.pluginCtx,
+    ctx: options.ctx,
+    filename: relativeBase,
+    relativeBase,
+    result: result as VueTransformResult,
+    configService: options.configService,
+    templateExtension: options.templateExtension,
+    scriptModuleExtension: options.scriptModuleExtension,
+    outputExtensions: options.outputExtensions,
+    platformAssetOptions: options.platformAssetOptions,
+  })
+
+  emitSharedVueEntryJsonAsset({
+    bundle: options.bundle,
+    pluginCtx: options.pluginCtx,
+    relativeBase,
+    config: resolveAppShellComponentConfig(result.config),
+    outputExtensions: options.outputExtensions,
+    platformAssetOptions: options.platformAssetOptions,
+    jsonOptions: {
+      defaultConfig: { component: true },
+      kind: 'component',
+      extension: options.jsonExtension,
+    },
+  })
+
+  emitScriptlessComponentJsFallbackIfMissing({
+    pluginCtx: options.pluginCtx,
+    bundle: options.bundle,
+    relativeBase,
+    scriptExtension: options.scriptExtension,
   })
 }

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/shared.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/shared.test.ts
@@ -428,6 +428,7 @@ describe('emitSharedVueEntryAssets', () => {
       },
     })
 
+    expect(emitPlatformTemplateAssetMock).not.toHaveBeenCalled()
     expect(emitSfcJsonAssetMock).toHaveBeenCalledWith(
       expect.anything(),
       {},

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/assets.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/assets.ts
@@ -174,8 +174,9 @@ export function emitSharedVueEntryAssets(options: {
     scopedSlotDefaults,
     scopedSlotMergeStrategy,
   } = options
+  const isAppVue = APP_VUE_LIKE_FILE_RE.test(filename)
 
-  if (result.template) {
+  if (result.template && !isAppVue) {
     emitPlatformTemplateAsset(bundle, {
       ctx,
       pluginCtx,

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/types.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/types.ts
@@ -1,5 +1,6 @@
 import type { VueTransformResult } from 'wevu/compiler'
 import type { CompilerContext } from '../../../../../context'
+import type { ResolvedAppShell } from '../../appShell'
 import type { CompileVueFileResolvedOptions } from '../../compileOptions'
 import type { ResolvedPageLayoutPlan } from '../../pageLayout'
 
@@ -33,6 +34,7 @@ export interface VueBundleState {
   ctx: CompilerContext
   pluginCtx: any
   compilationCache: Map<string, CompilationCacheEntry>
+  appShell?: ResolvedAppShell
   reExportResolutionCache: Map<string, Map<string, string | undefined>>
   classStyleRuntimeWarned: { value: boolean }
   compileOptionsCache?: Map<string, CompileVueFileResolvedOptions>

--- a/packages/weapp-vite/src/plugins/vue/transform/compileVueFile.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/compileVueFile.test.ts
@@ -358,6 +358,49 @@ defineAppJson({
     })
   })
 
+  it('compiles app.vue template while keeping app config and runtime code', async () => {
+    const result = await compileVueFile(
+      `
+<script setup lang="ts">
+defineAppJson({
+  pages: ['pages/index/index'],
+  window: {
+    navigationBarTitleText: 'weapp-vite',
+  },
+})
+</script>
+<template>
+  <view class="app-shell">
+    <slot />
+  </view>
+</template>
+<style>
+.app-shell {
+  min-height: 100vh;
+}
+</style>
+      `.trim(),
+      '/project/src/app.vue',
+      {
+        isApp: true,
+        json: { kind: 'app' },
+      },
+    )
+
+    expect(result.config).toBeTruthy()
+    expect(JSON.parse(result.config!)).toEqual({
+      pages: ['pages/index/index'],
+      window: {
+        navigationBarTitleText: 'weapp-vite',
+      },
+    })
+    expect(result.template).toContain('class="app-shell"')
+    expect(result.template).toContain('<slot />')
+    expect(result.style).toContain('.app-shell')
+    expect(result.script).toContain('createApp')
+    expect(result.script).not.toContain('createWevuComponent')
+  })
+
   it('injects defineAppSetup runtime import for app.vue bare macro usage', async () => {
     const result = await compileVueFile(
       `

--- a/packages/weapp-vite/src/plugins/vue/transform/pageLayout/index.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/pageLayout/index.ts
@@ -20,6 +20,11 @@ export {
   resolvePageLayoutPlan,
 } from './resolve'
 
+export {
+  assertTemplateHasDefaultSlot,
+  hasDefaultSlotTemplate,
+} from './slot'
+
 export type {
   LayoutPropValue,
   LayoutTransformLikeResult,

--- a/packages/weapp-vite/src/plugins/vue/transform/pageLayout/shared.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/pageLayout/shared.test.ts
@@ -6,6 +6,7 @@ import {
   getPlatformLayoutConditionalDirective,
   getPlatformLayoutElseDirective,
 } from './shared'
+import { assertTemplateHasDefaultSlot, hasDefaultSlotTemplate } from './slot'
 
 const DEFAULT_WXML_DIRECTIVE_PREFIX = getWxmlDirectivePrefix()
 
@@ -24,5 +25,25 @@ describe('page layout shared helpers', () => {
     expect(getPlatformLayoutConditionalDirective(0, 'weapp')).toBe(`${DEFAULT_WXML_DIRECTIVE_PREFIX}:if`)
     expect(getPlatformLayoutConditionalDirective(1, 'alipay')).toBe('a:elif')
     expect(getPlatformLayoutElseDirective('alipay')).toBe('a:else')
+  })
+
+  it('detects default slots in layout templates', () => {
+    expect(hasDefaultSlotTemplate('<view><slot /></view>')).toBe(true)
+    expect(hasDefaultSlotTemplate('<view><slot name="header" /></view>')).toBe(false)
+    expect(hasDefaultSlotTemplate('<view />')).toBe(false)
+  })
+
+  it('throws user-facing errors for layout templates without default slot', () => {
+    expect(() => assertTemplateHasDefaultSlot({
+      filename: '/project/src/app.vue',
+      kind: 'app-shell',
+      template: '<view />',
+    })).toThrow('/project/src/app.vue 中 app.vue <template> 必须包含默认 <slot />')
+
+    expect(() => assertTemplateHasDefaultSlot({
+      filename: '/project/src/layouts/default.vue',
+      kind: 'page-layout',
+      template: '<view />',
+    })).toThrow('/project/src/layouts/default.vue 对应的 layout template 必须包含默认 <slot />')
   })
 })

--- a/packages/weapp-vite/src/plugins/vue/transform/pageLayout/slot.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/pageLayout/slot.ts
@@ -1,0 +1,35 @@
+const SLOT_OPEN_TAG_RE = /<slot\b([^>]*)>/gi
+const DEFAULT_SLOT_NAME_RE = /(?:^|\s)name\s*=/
+
+export type LayoutSlotTemplateKind = 'app-shell' | 'page-layout'
+
+export function hasDefaultSlotTemplate(template: string | undefined) {
+  if (!template) {
+    return false
+  }
+
+  for (const match of template.matchAll(SLOT_OPEN_TAG_RE)) {
+    const attrs = match[1] ?? ''
+    if (!DEFAULT_SLOT_NAME_RE.test(attrs)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+export function assertTemplateHasDefaultSlot(options: {
+  filename: string
+  kind: LayoutSlotTemplateKind
+  template: string | undefined
+}) {
+  if (hasDefaultSlotTemplate(options.template)) {
+    return
+  }
+
+  if (options.kind === 'app-shell') {
+    throw new Error(`${options.filename} 中 app.vue <template> 必须包含默认 <slot />，否则页面内容无法渲染到应用外壳内。`)
+  }
+
+  throw new Error(`${options.filename} 对应的 layout template 必须包含默认 <slot />，否则页面内容无法渲染到布局内。`)
+}

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/index.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/index.ts
@@ -3,6 +3,7 @@ import type { SFCStyleBlock } from 'vue/compiler-sfc'
 import type { VueTransformResult } from 'wevu/compiler'
 import type { CompilerContext } from '../../../../context'
 import type { createPageEntryMatcher } from '../../../wevu'
+import type { ResolvedAppShell } from '../appShell'
 import type { CompileVueFileResolvedOptions } from '../compileOptions'
 import { fs } from '@weapp-core/shared/fs'
 import { createHmrProfileEventId, recordHmrProfileDuration } from '../../../../utils/hmrProfile'
@@ -20,6 +21,7 @@ import { transformVueLikeFile } from './transformFile'
 
 export function createVueTransformPlugin(ctx: CompilerContext): Plugin {
   const compilationCache = new Map<string, { result: VueTransformResult, source?: string, isPage: boolean }>()
+  let appShell: ResolvedAppShell | undefined
   let pageMatcher: ReturnType<typeof createPageEntryMatcher> | null = null
   let scanDirtySynced = false
   const reExportResolutionCache = new Map<string, Map<string, string | undefined>>()
@@ -85,6 +87,7 @@ export function createVueTransformPlugin(ctx: CompilerContext): Plugin {
           code,
           id,
           compilationCache,
+          setAppShell: shell => (appShell = shell),
           pageMatcher,
           setPageMatcher: matcher => (pageMatcher = matcher),
           scanDirtySynced,
@@ -109,6 +112,7 @@ export function createVueTransformPlugin(ctx: CompilerContext): Plugin {
         ctx,
         pluginCtx: this,
         compilationCache,
+        appShell,
         reExportResolutionCache,
         compileOptionsCache,
         classStyleRuntimeWarned,

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/shared/compile.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/shared/compile.ts
@@ -2,11 +2,13 @@ import type { SFCStyleBlock } from 'vue/compiler-sfc'
 import type { CompileVueFileOptions, VueTransformResult } from 'wevu/compiler'
 import type { CompilerContext } from '../../../../../context'
 import type { EncodedSourceMapLike } from '../../../../../utils/sourcemap'
+import type { ResolvedAppShell } from '../../appShell'
 import MagicString from 'magic-string'
 import { resolveAstEngine } from '../../../../../ast'
 import logger from '../../../../../logger'
 import { composeSourceMaps, normalizeEncodedSourceMapLike } from '../../../../../utils/sourcemap'
 import { collectOnPageScrollPerformanceWarnings } from '../../../../performance/onPageScrollDiagnostics'
+import { hasAppShellTemplate, resolveAppShellLayout } from '../../appShell'
 import { injectWevuPageFeaturesInJsWithViteResolver } from '../../injectPageFeatures'
 import { collectSetDataPickKeysFromTemplate, injectSetDataPickInJs, isAutoSetDataPickEnabled, mayNeedInjectSetDataPickInJs } from '../../injectSetDataPick'
 import { registerVueTemplateToken, resolveVueOutputBase } from '../../shared'
@@ -158,6 +160,7 @@ export async function finalizeTransformCompiledResult(options: {
   source: string
   result: VueTransformResult
   compilationCache: Map<string, { result: VueTransformResult, source?: string, isPage: boolean }>
+  setAppShell?: (shell: ResolvedAppShell | undefined) => void
   configService: NonNullable<CompilerContext['configService']>
   isPage: boolean
   isApp: boolean
@@ -180,6 +183,7 @@ export async function finalizeTransformCompiledResult(options: {
     source,
     result,
     compilationCache,
+    setAppShell,
     configService,
     isPage,
     isApp,
@@ -200,7 +204,17 @@ export async function finalizeTransformCompiledResult(options: {
     })
   }
 
-  registerVueTemplateToken(ctx, filename, result.template)
+  if (isApp) {
+    setAppShell?.(
+      hasAppShellTemplate(result)
+        ? resolveAppShellLayout(configService)
+        : undefined,
+    )
+  }
+
+  if (!isApp) {
+    registerVueTemplateToken(ctx, filename, result.template)
+  }
 
   if (Array.isArray(result.meta?.sfcSrcDeps) && typeof pluginCtx.addWatchFile === 'function') {
     for (const dep of result.meta.sfcSrcDeps) {

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile.ts
@@ -1,6 +1,7 @@
 import type { SFCStyleBlock } from 'vue/compiler-sfc'
 import type { VueTransformResult } from 'wevu/compiler'
 import type { CompilerContext } from '../../../../context'
+import type { ResolvedAppShell } from '../appShell'
 import type { CompileVueFileResolvedOptions } from '../compileOptions'
 import { compileJsxFile, compileVueFile } from 'wevu/compiler'
 import { readFile as readFileCached } from '../../../utils/cache'
@@ -17,6 +18,7 @@ export async function transformVueLikeFile(options: {
   code: string
   id: string
   compilationCache: Map<string, { result: VueTransformResult, source?: string, isPage: boolean }>
+  setAppShell: (shell: ResolvedAppShell | undefined) => void
   pageMatcher: ReturnType<typeof createPageEntryMatcher> | null
   setPageMatcher: (matcher: ReturnType<typeof createPageEntryMatcher>) => void
   scanDirtySynced: boolean
@@ -36,6 +38,7 @@ export async function transformVueLikeFile(options: {
     code,
     id,
     compilationCache,
+    setAppShell,
     pageMatcher,
     setPageMatcher,
     scanDirtySynced,
@@ -135,6 +138,7 @@ export async function transformVueLikeFile(options: {
         source: transformedSource,
         result,
         compilationCache,
+        setAppShell,
         configService,
         isPage,
         isApp,

--- a/packages/weapp-vite/test/vue/json-macros.test.ts
+++ b/packages/weapp-vite/test/vue/json-macros.test.ts
@@ -227,7 +227,6 @@ const foo = 1
 
       await plugin.transform!(
         `
-<template><view>app</view></template>
 <script setup lang="ts">
 defineAppJson({
   style: 'v3'

--- a/packages/weapp-vite/test/vue/transform-plugin.test.ts
+++ b/packages/weapp-vite/test/vue/transform-plugin.test.ts
@@ -977,7 +977,7 @@ onPageScroll(() => {
 
     compileVueFileMock.mockImplementation(async (_source, filename) => {
       if (filename.endsWith('app.vue')) {
-        return { script: 'export default {}', meta: {}, template: '<view />' }
+        return { script: 'export default {}', meta: {} }
       }
       return { script: 'export default {}', meta: {}, template: '<view />', style: '.x{}', config: '{"a":1}' }
     })
@@ -999,7 +999,7 @@ onPageScroll(() => {
     const plugin = createVueTransformPlugin(ctx as any)
 
     const appVue = path.join(tmpDir!, 'app.vue')
-    await fs.writeFile(appVue, '<template><view/></template>', 'utf8')
+    await fs.writeFile(appVue, '<script setup>const app = true</script>', 'utf8')
     await plugin.transform!.call({}, await fs.readFile(appVue, 'utf8'), appVue)
     await plugin.transform!.call({}, await fs.readFile(vuePath!, 'utf8'), vuePath!)
 


### PR DESCRIPTION
## 变更内容

- 支持在 src/app.vue 中编写应用级 template，并在微信小程序下编译为内部 app shell 组件。
- 页面输出时将 app shell 包在页面 layout 外层，layout: false 只禁用页面 layout，不禁用 app shell。
- 避免生成微信不支持的 app.wxml，并补充内部 shell 组件 JSON/JS fallback 与 HMR dirty 标记。
- 为 issue #563 增加编译、bundle、watch 与 github-issues e2e 覆盖。

Closes #563

## 验证

- pnpm --filter weapp-vite exec vitest run src/plugins/vue/transform/compileVueFile.test.ts src/plugins/vue/transform/bundle/shared.test.ts src/plugins/vue/transform/bundle/emitCompiledEntry.test.ts src/plugins/vue/transform/bundle.platform.test.ts src/plugins/core/lifecycle/watch.test.ts
- pnpm --filter weapp-vite typecheck
- pnpm --filter @weapp-core/constants typecheck
- pnpm --filter @weapp-core/constants test
- pnpm --filter weapp-vite lint:src（通过，保留既有 36 个 warning）
- pnpm --filter @weapp-core/constants build
- pnpm --filter weapp-vite build
- pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #563"
- pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts