### PR TITLE
fix(wevu-compiler): 保持 template slot 输出顺序

### DIFF
--- a/.changeset/quiet-slots-order.md
+++ b/.changeset/quiet-slots-order.md
@@ -1,0 +1,8 @@
+---
+"weapp-vite": patch
+"wevu": patch
+"@wevu/compiler": patch
+"create-weapp-vite": patch
+---
+
+修复组件同时包含隐式默认子节点和 `<template #name>` 具名插槽时，生成的小程序模板会把默认子节点移动到具名插槽之后的问题。现在 plain template slot 会按源码中的子节点顺序输出，同时保留原有的 `vue-slots` 元数据和作用域插槽生成逻辑。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -442,6 +442,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-574/index",
+          "pathName": "pages/issue-574/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/slot-fallback-compiler-off/index",
           "pathName": "pages/slot-fallback-compiler-off/index",
           "query": "",

--- a/e2e-apps/github-issues/src/components/issue-574/VanCell/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-574/VanCell/index.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+defineComponentJson({
+  component: true,
+})
+</script>
+
+<template>
+  <view class="issue574-van-cell">
+    <slot />
+    <slot name="footer1" />
+    <slot name="footer2" />
+  </view>
+</template>
+
+<style scoped>
+.issue574-van-cell {
+  display: block;
+  padding: 16rpx;
+  background: #fff;
+}
+</style>

--- a/e2e-apps/github-issues/src/pages/issue-574/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-574/index.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import VanCell from '../../components/issue-574/VanCell/index.vue'
+
+definePageJson({
+  navigationBarTitleText: 'issue-574',
+})
+
+function _runE2E() {
+  return {
+    ok: true,
+    issue: 574,
+  }
+}
+</script>
+
+<template>
+  <view class="issue574-page">
+    <view class="issue574-title">
+      issue-574 template slot order
+    </view>
+
+    <VanCell>
+      <div class="issue574-default" data-order="default" />
+
+      <template #footer1>
+        <view class="issue574-footer1" data-order="footer1" />
+      </template>
+
+      <template #footer2>
+        <text class="issue574-footer2" data-order="footer2" />
+      </template>
+    </VanCell>
+  </view>
+</template>
+
+<style scoped>
+.issue574-page {
+  min-height: 100vh;
+  padding: 32rpx;
+  background: #f8fafc;
+}
+
+.issue574-title {
+  margin-bottom: 24rpx;
+  font-size: 32rpx;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.issue574-default,
+.issue574-footer1,
+.issue574-footer2 {
+  display: block;
+  min-height: 32rpx;
+}
+</style>

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -700,6 +700,32 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(componentWxml).toContain('<slot name="text" />')
   })
 
+  it('issue #574: preserves template slot output order around implicit default children', async () => {
+    await runBuild()
+
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-574/index.wxml')
+    const pageJsPath = path.join(DIST_ROOT, 'pages/issue-574/index.js')
+    const componentWxmlPath = path.join(DIST_ROOT, 'components/issue-574/VanCell/index.wxml')
+
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+    const pageJs = await fs.readFile(pageJsPath, 'utf-8')
+    const componentWxml = await fs.readFile(componentWxmlPath, 'utf-8')
+    const defaultIndex = pageWxml.indexOf('data-order="default"')
+    const footer1Index = pageWxml.indexOf('data-order="footer1"')
+    const footer2Index = pageWxml.indexOf('data-order="footer2"')
+
+    expect(defaultIndex).toBeGreaterThanOrEqual(0)
+    expect(footer1Index).toBeGreaterThan(defaultIndex)
+    expect(footer2Index).toBeGreaterThan(footer1Index)
+    expect(pageWxml).toContain('VanCell vue-slots="{{__wv_bind_0}}"')
+    expect(pageWxml).toContain('<view slot="footer1" class="issue574-footer1" data-order="footer1" />')
+    expect(pageWxml).toContain('<text slot="footer2" class="issue574-footer2" data-order="footer2" />')
+    expect(pageJs).toContain('_runE2E')
+    expect(componentWxml).toContain('<slot />')
+    expect(componentWxml).toContain('<slot name="footer1" />')
+    expect(componentWxml).toContain('<slot name="footer2" />')
+  })
+
   it('issue #500: compiles missing inject continuation probe', async () => {
     await runBuild()
 

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
@@ -704,6 +704,39 @@ describe('compileVueTemplateToWxml', () => {
     expect(scopedSlotComponents).toBeUndefined()
   })
 
+  it('keeps plain template slot content in source order with implicit default children', () => {
+    const template = `
+<van-cell>
+  <div />
+  <template #footer1>
+    <view />
+  </template>
+  <template #footer2>
+    <text />
+  </template>
+</van-cell>
+    `.trim()
+
+    const { code } = compileVueTemplateToWxml(
+      template,
+      '/project/src/pages/issue-574/index.vue',
+      {
+        scopedSlotsRequireProps: false,
+        slotSingleRootNoWrapper: true,
+        wevuComponentTags: ['van-cell'],
+      },
+    )
+
+    const defaultContentIndex = code.indexOf('<view class="div" />')
+    const footer1Index = code.indexOf('<view slot="footer1" />')
+    const footer2Index = code.indexOf('<text slot="footer2" />')
+
+    expect(code).toContain(`van-cell vue-slots="{{__wv_bind_0}}"`)
+    expect(defaultContentIndex).toBeGreaterThan(-1)
+    expect(footer1Index).toBeGreaterThan(defaultContentIndex)
+    expect(footer2Index).toBeGreaterThan(footer1Index)
+  })
+
   it('keeps explicit default template slots native when default component children are augmented', () => {
     const template = `
 <Provider>

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-component.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-component.ts
@@ -27,6 +27,10 @@ import {
   stringifySlotName,
 } from './tag-slot'
 
+type SlotContentRenderItem
+  = | { type: 'declaration', declaration: ScopedSlotDeclaration }
+    | { type: 'default-child', child: any }
+
 function hasLegacySlotAttribute(children: any[]): boolean {
   return children.some((child) => {
     if (child.type !== NodeTypes.ELEMENT) {
@@ -145,6 +149,32 @@ function shouldExposePlainSlotPresence(node: ElementNode) {
   return node.tag === 'component'
 }
 
+function renderPlainSlotContentInSourceOrder(
+  renderItems: SlotContentRenderItem[],
+  plainSlotDeclarations: ScopedSlotDeclaration[],
+  implicitDefaultDeclaration: ScopedSlotDeclaration | undefined,
+  context: TransformContext,
+  transformNode: TransformNode,
+) {
+  const plainSlots = new Set(plainSlotDeclarations)
+  const shouldRenderImplicitDefault = implicitDefaultDeclaration
+    ? plainSlots.has(implicitDefaultDeclaration)
+    : false
+
+  return renderItems
+    .map((item) => {
+      if (item.type === 'declaration') {
+        return plainSlots.has(item.declaration)
+          ? renderSlotFallback(item.declaration, context, transformNode)
+          : ''
+      }
+      return shouldRenderImplicitDefault
+        ? transformNode(item.child, context)
+        : ''
+    })
+    .join('')
+}
+
 export function shouldTransformAsComponentWithSlots(
   node: ElementNode,
   context: TransformContext,
@@ -174,27 +204,32 @@ export function transformComponentWithSlots(
   const slotDirective = findSlotDirective(node)
 
   const nonTemplateChildren: any[] = []
+  const renderItems: SlotContentRenderItem[] = []
   for (const child of node.children) {
     if (child.type === NodeTypes.ELEMENT && child.tag === 'template') {
       const templateSlot = findSlotDirective(child as ElementNode)
       if (templateSlot) {
         const slotName = resolveSlotNameFromDirective(templateSlot)
-        slotDeclarations.push(
-          buildSlotDeclaration(
-            slotName,
-            templateSlot.exp?.type === NodeTypes.SIMPLE_EXPRESSION ? templateSlot.exp.content : undefined,
-            (child as ElementNode).children,
-            context,
-            { condition: resolveTemplateSlotCondition(child as ElementNode, context) },
-          ),
+        const declaration = buildSlotDeclaration(
+          slotName,
+          templateSlot.exp?.type === NodeTypes.SIMPLE_EXPRESSION ? templateSlot.exp.content : undefined,
+          (child as ElementNode).children,
+          context,
+          { condition: resolveTemplateSlotCondition(child as ElementNode, context) },
         )
+        slotDeclarations.push(declaration)
+        renderItems.push({ type: 'declaration', declaration })
         continue
       }
     }
     nonTemplateChildren.push(child)
+    if (isRenderableSlotChild(child)) {
+      renderItems.push({ type: 'default-child', child })
+    }
   }
 
   const defaultSlotChildren = nonTemplateChildren.filter(isRenderableSlotChild)
+  let implicitDefaultDeclaration: ScopedSlotDeclaration | undefined
 
   if (slotDirective) {
     if (slotDeclarations.length) {
@@ -216,11 +251,13 @@ export function transformComponentWithSlots(
       context.warnings.push('存在显式的 v-slot:default，默认插槽内容将被忽略。')
     }
     else {
-      slotDeclarations.push(buildSlotDeclaration({ type: 'default' }, undefined, defaultSlotChildren, context, { implicitDefault: true }))
+      implicitDefaultDeclaration = buildSlotDeclaration({ type: 'default' }, undefined, defaultSlotChildren, context, { implicitDefault: true })
+      slotDeclarations.push(implicitDefaultDeclaration)
     }
   }
   else if (!slotDeclarations.length && defaultSlotChildren.length && !context.scopedSlotsRequireProps && !hasLegacySlotAttribute(defaultSlotChildren)) {
-    slotDeclarations.push(buildSlotDeclaration({ type: 'default' }, undefined, defaultSlotChildren, context, { implicitDefault: true }))
+    implicitDefaultDeclaration = buildSlotDeclaration({ type: 'default' }, undefined, defaultSlotChildren, context, { implicitDefault: true })
+    slotDeclarations.push(implicitDefaultDeclaration)
   }
 
   if (!slotDeclarations.length) {
@@ -294,9 +331,17 @@ export function transformComponentWithSlots(
 
   const attrString = mergedAttrs.length ? ` ${mergedAttrs.join(' ')}` : ''
   const { tag } = node
-  const plainSlotContent = plainSlotDeclarations
-    .map(decl => renderSlotFallback(decl, context, transformNode))
-    .join('')
+  const plainSlotContent = slotDirective
+    ? plainSlotDeclarations
+        .map(decl => renderSlotFallback(decl, context, transformNode))
+        .join('')
+    : renderPlainSlotContentInSourceOrder(
+        renderItems,
+        plainSlotDeclarations,
+        implicitDefaultDeclaration,
+        context,
+        transformNode,
+      )
   return plainSlotContent
     ? `<${tag}${attrString}>${plainSlotContent}</${tag}>`
     : `<${tag}${attrString} />`
@@ -312,28 +357,33 @@ export function transformComponentWithSlotsFallback(
   const slotDeclarations: ScopedSlotDeclaration[] = []
   const slotDirective = findSlotDirective(node)
   const nonTemplateChildren: any[] = []
+  const renderItems: SlotContentRenderItem[] = []
 
   for (const child of node.children) {
     if (child.type === NodeTypes.ELEMENT && child.tag === 'template') {
       const templateSlot = findSlotDirective(child as ElementNode)
       if (templateSlot) {
         const slotName = resolveSlotNameFromDirective(templateSlot)
-        slotDeclarations.push(
-          buildSlotDeclaration(
-            slotName,
-            templateSlot.exp?.type === NodeTypes.SIMPLE_EXPRESSION ? templateSlot.exp.content : undefined,
-            (child as ElementNode).children,
-            context,
-            { condition: resolveTemplateSlotCondition(child as ElementNode, context) },
-          ),
+        const declaration = buildSlotDeclaration(
+          slotName,
+          templateSlot.exp?.type === NodeTypes.SIMPLE_EXPRESSION ? templateSlot.exp.content : undefined,
+          (child as ElementNode).children,
+          context,
+          { condition: resolveTemplateSlotCondition(child as ElementNode, context) },
         )
+        slotDeclarations.push(declaration)
+        renderItems.push({ type: 'declaration', declaration })
         continue
       }
     }
     nonTemplateChildren.push(child)
+    if (isRenderableSlotChild(child)) {
+      renderItems.push({ type: 'default-child', child })
+    }
   }
 
   const defaultSlotChildren = nonTemplateChildren.filter(isRenderableSlotChild)
+  let implicitDefaultDeclaration: ScopedSlotDeclaration | undefined
 
   if (slotDirective) {
     if (slotDeclarations.length) {
@@ -355,7 +405,8 @@ export function transformComponentWithSlotsFallback(
       context.warnings.push('存在显式的 v-slot:default，默认插槽内容将被忽略。')
     }
     else {
-      slotDeclarations.push(buildSlotDeclaration({ type: 'default' }, undefined, defaultSlotChildren, context))
+      implicitDefaultDeclaration = buildSlotDeclaration({ type: 'default' }, undefined, defaultSlotChildren, context)
+      slotDeclarations.push(implicitDefaultDeclaration)
     }
   }
 
@@ -386,9 +437,17 @@ export function transformComponentWithSlotsFallback(
     context.warnings.push('已禁用作用域插槽参数，插槽绑定将被忽略。')
   }
 
-  const renderedSlots = slotDeclarations
-    .map(decl => renderSlotFallback(decl, context, transformNode))
-    .join('')
+  const renderedSlots = slotDirective
+    ? slotDeclarations
+        .map(decl => renderSlotFallback(decl, context, transformNode))
+        .join('')
+    : renderPlainSlotContentInSourceOrder(
+        renderItems,
+        slotDeclarations,
+        implicitDefaultDeclaration,
+        context,
+        transformNode,
+      )
 
   const { attrs } = collectElementAttributes(node, context, {
     skipSlotDirective: true,


### PR DESCRIPTION
## Summary

修复 #574 中 `<template #xxx>` 与隐式默认子节点混用时的输出顺序问题。编译器现在按源码子节点顺序渲染 plain template slot 内容，同时保留原有 `vue-slots` 元数据与 scoped slot asset 生成逻辑。

## Changes

- 在 `tag-component.ts` 中记录原始 slot/default child 渲染顺序，避免先收集具名 slot 后追加默认 slot 造成顺序漂移。
- 增加 compiler 单测覆盖 issue #574 的最小复现。
- 在 `e2e-apps/github-issues` 添加 issue #574 页面与组件 fixture，并在 CI build 测试中校验生成 WXML 顺序。
- 增加 patch changeset。

## Testing

- `pnpm exec vitest run packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts`
- `pnpm --filter @wevu/compiler typecheck`
- `pnpm --filter @wevu/compiler lint`
- `pnpm exec eslint e2e/ci/github-issues.build.test.ts e2e-apps/github-issues/src/components/issue-574/VanCell/index.vue e2e-apps/github-issues/src/pages/issue-574/index.vue`
- `pnpm --filter weapp-vite... build`
- `pnpm exec vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #574"`

## Related Issues

Closes #574
