### PR TITLE
fix(wevu): 修复 setup 对象内数组更新被调度吞掉

### DIFF
--- a/.changeset/fix-issue-581-reactive-array-flush.md
+++ b/.changeset/fix-issue-581-reactive-array-flush.md
@@ -1,0 +1,6 @@
+---
+"wevu": patch
+"create-weapp-vite": patch
+---
+
+修复同一轮更新中 setup 返回对象内的 loading ref 先触发刷新时，后续 reactive 数组 push 可能被调度去重吞掉，导致列表首屏未渲染新增项的问题。

--- a/.changeset/fix-issue-581-reactive-array-flush.md
+++ b/.changeset/fix-issue-581-reactive-array-flush.md
@@ -1,6 +1,9 @@
 ---
+"weapp-vite": patch
 "wevu": patch
 "create-weapp-vite": patch
 ---
 
 修复同一轮更新中 setup 返回对象内的 loading ref 先触发刷新时，后续 reactive 数组 push 可能被调度去重吞掉，导致列表首屏未渲染新增项的问题。
+
+同时修复 `wevu` 产物 hash 中包含短横线时，`weapp-vite` 未能继续把运行时 shared chunk 稳定重命名到 `weapp-vendors/wevu-src.js` 的问题，避免开发者工具热重载时旧模块引用悬空。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -449,6 +449,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-581/index",
+          "pathName": "pages/issue-581/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/slot-fallback-compiler-off/index",
           "pathName": "pages/slot-fallback-compiler-off/index",
           "query": "",

--- a/e2e-apps/github-issues/src/pages/issue-581/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-581/index.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { reactive, ref, watch } from 'wevu'
+
+definePageJson({
+  navigationBarTitleText: 'issue-581',
+})
+
+interface Issue581Row {
+  name: string
+}
+
+function fetchIssue581Rows(): Issue581Row[] {
+  return [{ name: '123' }, { name: '456' }]
+}
+
+function useIssue581List() {
+  const queryData = ref<Issue581Row[]>()
+  const state = reactive([{ name: 'init' }])
+  const loading = ref(true)
+
+  watch(queryData, (newData) => {
+    state.push(...newData || [])
+  })
+
+  Promise.resolve().then(() => {
+    loading.value = false
+    queryData.value = fetchIssue581Rows()
+  })
+
+  return {
+    state,
+    loading,
+  }
+}
+
+const back = useIssue581List()
+
+function _runE2E() {
+  return {
+    ok: true,
+    issue: 581,
+    loading: back.loading.value,
+    rows: back.state.map(row => row.name),
+  }
+}
+</script>
+
+<template>
+  <view class="issue581-page">
+    <view class="issue581-title">
+      issue-581 reactive array flush
+    </view>
+    <view class="issue581-loading" :data-loading="back.loading ? 'true' : 'false'">
+      {{ back.loading ? 'loading' : 'loaded' }}
+    </view>
+    <view
+      v-for="(value, idx) in back.state"
+      :key="idx"
+      class="issue581-row"
+      :data-issue581-name="value.name"
+      :data-issue581-index="idx"
+    >
+      {{ value.name }}
+    </view>
+  </view>
+</template>
+
+<style scoped>
+.issue581-page {
+  min-height: 100vh;
+  padding: 32rpx;
+  background: #f8fafc;
+}
+
+.issue581-title {
+  margin-bottom: 24rpx;
+  font-size: 32rpx;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.issue581-loading {
+  margin-bottom: 16rpx;
+  color: #475569;
+}
+
+.issue581-row {
+  display: block;
+  min-height: 32rpx;
+  color: #111827;
+}
+</style>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -47,6 +47,9 @@ const githubIssuesRouteGroups: Record<string, string[]> = {
     'pages/issue-564/**',
     'components/issue-564/**',
   ],
+  'github-issues.runtime.issue581.test.ts': [
+    'pages/issue-581/**',
+  ],
   'github-issues.runtime.lifecycle.test.ts': [
     'pages/issue-289/**',
     'pages/issue-309/**',

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -726,6 +726,23 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(componentWxml).toContain('<slot name="footer2" />')
   })
 
+  it('issue #581: compiles setup object reactive array and loading refs', async () => {
+    await runBuild()
+
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-581/index.wxml')
+    const pageJsPath = path.join(DIST_ROOT, 'pages/issue-581/index.js')
+
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+    const pageJs = await fs.readFile(pageJsPath, 'utf-8')
+
+    expect(pageWxml).toContain('issue-581 reactive array flush')
+    expect(pageWxml).toContain('wx:for="{{back.state}}"')
+    expect(pageWxml).toContain('data-issue581-name="{{value.name}}"')
+    expect(pageWxml).toContain('data-loading="{{back.loading ? \'true\' : \'false\'}}"')
+    expect(pageJs).toContain('fetchIssue581Rows')
+    expect(pageJs).toContain('_runE2E')
+  })
+
   it('issue #500: compiles missing inject continuation probe', async () => {
     await runBuild()
 

--- a/e2e/ide/github-issues.runtime.issue581.test.ts
+++ b/e2e/ide/github-issues.runtime.issue581.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  closeSharedMiniProgram,
+  delay,
+  getSharedMiniProgram,
+  PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT,
+  prepareGithubIssuesBuild,
+  readPageWxml,
+  relaunchPage,
+  releaseSharedMiniProgram,
+} from './github-issues.runtime.shared'
+
+const ISSUE_581_RENDER_TIMEOUT = 8_000
+const ISSUE_581_EXPECTED_ROWS = ['init', '123', '456']
+
+async function waitForIssue581Rows(page: any) {
+  const start = Date.now()
+  let latestRuntime: any
+  let latestWxml = ''
+
+  while (Date.now() - start <= ISSUE_581_RENDER_TIMEOUT) {
+    latestRuntime = await page.callMethod('_runE2E')
+    latestWxml = await readPageWxml(page)
+    if (
+      latestRuntime?.loading === false
+      && Array.isArray(latestRuntime.rows)
+      && ISSUE_581_EXPECTED_ROWS.every((row, index) => latestRuntime.rows[index] === row)
+      && ISSUE_581_EXPECTED_ROWS.every(row => latestWxml.includes(`data-issue581-name="${row}"`))
+    ) {
+      return { runtime: latestRuntime, wxml: latestWxml }
+    }
+
+    if (typeof page?.waitFor === 'function') {
+      await page.waitFor(220)
+    }
+    else {
+      await delay(220)
+    }
+  }
+
+  return { runtime: latestRuntime, wxml: latestWxml }
+}
+
+describe.sequential('e2e app: github-issues / issue #581', () => {
+  beforeAll(async () => {
+    await prepareGithubIssuesBuild()
+  }, PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT)
+
+  afterAll(async () => {
+    await closeSharedMiniProgram()
+  })
+
+  it('renders reactive array pushes after a sibling setup ref flushes first in DevTools', async (ctx) => {
+    const miniProgram = await getSharedMiniProgram(ctx)
+    try {
+      const issuePage = await relaunchPage(miniProgram, '/pages/issue-581/index', 'issue-581 reactive array flush')
+      if (!issuePage) {
+        throw new Error('Failed to launch issue-581 page')
+      }
+
+      const { runtime, wxml } = await waitForIssue581Rows(issuePage)
+
+      expect(runtime).toMatchObject({
+        ok: true,
+        issue: 581,
+        loading: false,
+        rows: ISSUE_581_EXPECTED_ROWS,
+      })
+      expect(wxml).toContain('data-loading="false"')
+      for (const row of ISSUE_581_EXPECTED_ROWS) {
+        expect(wxml).toContain(`data-issue581-name="${row}"`)
+      }
+    }
+    finally {
+      await releaseSharedMiniProgram(miniProgram)
+    }
+  })
+})

--- a/packages-runtime/wevu/src/scheduler.ts
+++ b/packages-runtime/wevu/src/scheduler.ts
@@ -3,22 +3,41 @@ const resolvedPromise: Promise<void> = Promise.resolve()
 type Job = () => void
 
 const jobQueue = new Set<Job>()
+const deferredJobQueue = new Set<Job>()
 let isFlushing = false
 let isFlushPending = false
+let flushedJobs: Set<Job> | undefined
 
 function flushJobs() {
   isFlushPending = false
   isFlushing = true
+  flushedJobs = new Set()
   try {
-    jobQueue.forEach(job => job())
+    jobQueue.forEach((job) => {
+      flushedJobs?.add(job)
+      job()
+    })
   }
   finally {
     jobQueue.clear()
+    flushedJobs = undefined
     isFlushing = false
+    if (deferredJobQueue.size) {
+      deferredJobQueue.forEach(job => jobQueue.add(job))
+      deferredJobQueue.clear()
+      if (!isFlushPending) {
+        isFlushPending = true
+        resolvedPromise.then(flushJobs)
+      }
+    }
   }
 }
 
 export function queueJob(job: Job) {
+  if (isFlushing && flushedJobs?.has(job)) {
+    deferredJobQueue.add(job)
+    return
+  }
   jobQueue.add(job)
   if (!isFlushing && !isFlushPending) {
     isFlushPending = true

--- a/packages-runtime/wevu/test/runtime-register-extra.test.ts
+++ b/packages-runtime/wevu/test/runtime-register-extra.test.ts
@@ -6,7 +6,7 @@ import {
   WEVU_WATCH_STOPS_KEY,
 } from '@weapp-core/constants'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { getCurrentScope, nextTick, onScopeDispose, ref, setPageLayout, watch, watchEffect } from '@/index'
+import { getCurrentScope, nextTick, onScopeDispose, reactive, ref, setPageLayout, watch, watchEffect } from '@/index'
 import { createApp } from '@/runtime/app'
 import { callHookReturn, setCurrentInstance } from '@/runtime/hooks'
 import {
@@ -344,6 +344,50 @@ describe('mountRuntimeInstance and teardown', () => {
 
     expect(getterCalls).toBe(0)
     expect(target.setData).toHaveBeenCalledWith(expect.objectContaining({ active: false }))
+
+    teardownRuntimeInstance(target)
+  })
+
+  it('keeps setup reactive array updates when another setup ref inside the same object flushes first', async () => {
+    const app = createApp({})
+    const target: any = {
+      route: 'pages/issue-581/index',
+      setData: vi.fn(),
+    }
+    const queryData = ref<{ name: string }[] | undefined>()
+    const isLoading = ref(true)
+
+    mountRuntimeInstance(target, app as any, undefined, () => {
+      const state = reactive([{ name: 'init' }])
+
+      watch(queryData, (newData) => {
+        state.push(...newData || [])
+      })
+
+      const back = {
+        state,
+        loading: isLoading,
+      }
+
+      return {
+        back,
+      }
+    })
+
+    target.setData.mockClear()
+    isLoading.value = false
+    queryData.value = [{ name: '123' }, { name: '456' }]
+    await nextTick()
+
+    expect(target.setData).toHaveBeenCalledWith(expect.objectContaining({
+      'back.loading': false,
+    }))
+
+    await nextTick()
+
+    expect(target.setData).toHaveBeenCalledWith(expect.objectContaining({
+      'back.state': [{ name: 'init' }, { name: '123' }, { name: '456' }],
+    }))
 
     teardownRuntimeInstance(target)
   })

--- a/packages/weapp-vite/src/runtime/sharedBuildConfig.test.ts
+++ b/packages/weapp-vite/src/runtime/sharedBuildConfig.test.ts
@@ -183,6 +183,9 @@ describe('sharedBuildConfig', () => {
       facadeModuleId: '/project/packages-runtime/wevu/dist/src-BD3I133J.mjs',
     })).toBe('weapp-vendors/wevu-src.js')
     expect(resolveStableHashedDistChunkFileName({
+      facadeModuleId: '/project/packages-runtime/wevu/dist/src-BdXSqz-9.mjs',
+    })).toBe('weapp-vendors/wevu-src.js')
+    expect(resolveStableHashedDistChunkFileName({
       facadeModuleId: '/project/packages-runtime/wevu/dist/store-BD3I133J.mjs',
       moduleIds: [
         '/project/packages-runtime/wevu/dist/store-BD3I133J.mjs',

--- a/packages/weapp-vite/src/runtime/sharedBuildConfig.ts
+++ b/packages/weapp-vite/src/runtime/sharedBuildConfig.ts
@@ -17,7 +17,7 @@ import { DEFAULT_SHARED_CHUNK_STRATEGY } from './chunkStrategy'
 const REG_NODE_MODULES_DIR = /[\\/]node_modules[\\/]/gi
 const REG_COMMONJS_HELPERS = /commonjsHelpers\.js$/
 const REG_REQUEST_GLOBAL_RUNTIME_VENDOR_ID = /(?:^|[/\\])(?:@wevu[/\\]web-apis|web-apis[/\\]dist[/\\]index\.(?:m?js|cjs)|weapp-vite[/\\](?:dist[/\\]web-apis\.mjs|src[/\\](?:webApis\.ts|runtime[/\\]webApis[/\\]index\.ts)))(?:$|[?#])/
-const REG_HASHED_DIST_CHUNK_ID = /(?:^|[/\\])dist[/\\]([^/\\]+)-(\w{6,})\.(?:m?js|cjs)(?:$|[?#])/
+const REG_HASHED_DIST_CHUNK_ID = /(?:^|[/\\])dist[/\\]([^/\\-]+)-([\w-]{6,})\.(?:m?js|cjs)(?:$|[?#])/
 const STABLE_HASHED_DIST_CHUNK_PRIORITY = ['src']
 
 function resolveSharedPathRoot(


### PR DESCRIPTION
## 变更内容

- 修复 wevu 调度器在同一轮 flush 中重复入队同一个 job 时被 Set 去重吞掉的问题。
- 增加 issue #581 的 setup 返回对象复现页和运行时单测，覆盖 loading ref 先刷新、reactive 数组随后 push 的场景。
- 增加 github-issues 的 CI build 断言和 DevTools runtime 用例。
- 补充 changeset：wevu patch，并联动 create-weapp-vite patch。

## 验证

- `pnpm exec eslint packages-runtime/wevu/src/scheduler.ts packages-runtime/wevu/test/runtime-register-extra.test.ts e2e-apps/github-issues/src/pages/issue-581/index.vue e2e-apps/github-issues/weapp-vite.config.ts e2e/ci/github-issues.build.test.ts e2e/ide/github-issues.runtime.issue581.test.ts`
- `pnpm exec stylelint e2e-apps/github-issues/src/pages/issue-581/index.vue`
- `pnpm --filter wevu typecheck`
- `pnpm exec vitest run packages-runtime/wevu/test/runtime-register-extra.test.ts packages-runtime/wevu/test/runtime-setdata-scheduler.test.ts`
- `pnpm --filter wevu build`
- `pnpm exec vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #581"`
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`
- `node --import tsx scripts/check-catalog-changeset.ts`

## 已知情况

- DevTools runtime 定向用例已补充，但本地两次运行均未进入 issue 页面，失败在 harness warmup `/pages/block-slot/index`，DevTools 日志出现 `Cannot read property 'subPackages' of undefined` simulator 启动错误。CI build 断言和 wevu 单测均已通过。

Closes #581
