### PR TITLE
feat(weapp-vite): 控制 wevu 压缩和运行时入口

### DIFF
--- a/.changeset/tall-wings-rest.md
+++ b/.changeset/tall-wings-rest.md
@@ -3,4 +3,4 @@
 "create-weapp-vite": patch
 ---
 
-为 `weapp.wevu` 新增独立的 `minify` 开关，可按需控制 wevu 相关脚本输出是否压缩。默认保持当前可读输出行为，显式开启后仅影响 wevu 编译生成的脚本代码，不改变其他构建产物。
+为 `weapp.wevu` 新增独立的 `minify` 与 `runtime` 开关，可按需控制 wevu 编译生成脚本是否压缩，并允许指定 wevu 运行时入口版本。`runtime` 默认使用 `auto`，开发模式走 `wevu/dist/dev` 可读入口，构建模式走默认压缩入口；显式配置为 `dev` 或 `build` 时会覆盖该自动选择。

--- a/.changeset/tall-wings-rest.md
+++ b/.changeset/tall-wings-rest.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+为 `weapp.wevu` 新增独立的 `minify` 开关，可按需控制 wevu 相关脚本输出是否压缩。默认保持当前可读输出行为，显式开启后仅影响 wevu 编译生成的脚本代码，不改变其他构建产物。

--- a/.github/workflows/ci-create-weapp-vite.yml
+++ b/.github/workflows/ci-create-weapp-vite.yml
@@ -25,7 +25,7 @@ on:
       node-version:
         description: target Node.js version when full matrix is disabled
         required: false
-        default: '20'
+        default: '24'
         type: choice
         options:
           - '20'
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Resolve workflow inputs
         id: inputs
@@ -93,7 +93,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_FULL_MATRIX: ${{ github.event.inputs['full-matrix'] || 'false' }}
           INPUT_OS: ${{ github.event.inputs.os || 'ubuntu-latest' }}
-          INPUT_NODE_VERSION: ${{ github.event.inputs['node-version'] || '20' }}
+          INPUT_NODE_VERSION: ${{ github.event.inputs['node-version'] || '24' }}
         run: |
           full_matrix='{"include":[
             {"os":"ubuntu-latest","node-version":"20"},

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -29,6 +29,9 @@ jobs:
             os: ubuntu-latest
             node-version: 22
           - platform: weapp
+            os: ubuntu-latest
+            node-version: 24
+          - platform: weapp
             os: windows-latest
             node-version: 20
           - platform: weapp
@@ -94,11 +97,11 @@ jobs:
 
   web-e2e-baseline-pr:
     if: github.event_name != 'schedule'
-    name: Web E2E Baseline (Node 20)
+    name: Web E2E Baseline (Node 24)
     uses: ./.github/workflows/reusable-node-command.yml
     with:
       runs_on: ubuntu-latest
-      node_version: '20'
+      node_version: '24'
       timeout_minutes: 20
       build_command: pnpm build:pkgs:ci
       main_command: pnpm e2e:web
@@ -107,11 +110,11 @@ jobs:
 
   workspace-hmr-pr:
     if: github.event_name != 'schedule'
-    name: Workspace HMR Changed Projects (Node 20)
+    name: Workspace HMR Changed Projects (Node 24)
     uses: ./.github/workflows/reusable-node-command.yml
     with:
       runs_on: ubuntu-latest
-      node_version: '20'
+      node_version: '24'
       timeout_minutes: 60
       fetch_depth: 0
       build_command: pnpm build:pkgs:ci
@@ -123,11 +126,11 @@ jobs:
 
   workspace-hmr-nightly:
     if: github.event_name == 'schedule'
-    name: Workspace HMR Nightly Full (Node 20)
+    name: Workspace HMR Nightly Full (Node 24)
     uses: ./.github/workflows/reusable-node-command.yml
     with:
       runs_on: ubuntu-latest
-      node_version: '20'
+      node_version: '24'
       timeout_minutes: 120
       fetch_depth: 0
       build_command: pnpm build:pkgs:ci

--- a/.github/workflows/ci-performance.yml
+++ b/.github/workflows/ci-performance.yml
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   auto-import-performance:
-    name: Auto Import Performance (Ubuntu / Node 20)
+    name: Auto Import Performance (Ubuntu / Node 24)
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -43,7 +43,7 @@ jobs:
 
       - uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Resolve benchmark inputs
         shell: bash

--- a/.github/workflows/ci-policy.yml
+++ b/.github/workflows/ci-policy.yml
@@ -17,11 +17,11 @@ permissions:
 jobs:
   policy-pr:
     if: github.event_name != 'schedule'
-    name: Policy Checks (Node 20)
+    name: Policy Checks (Node 24)
     uses: ./.github/workflows/reusable-node-command.yml
     with:
       runs_on: ubuntu-latest
-      node_version: '20'
+      node_version: '24'
       timeout_minutes: 10
       main_command: |
         pnpm check:changeset:frontmatter

--- a/.github/workflows/ci-vscode-extension.yml
+++ b/.github/workflows/ci-vscode-extension.yml
@@ -21,18 +21,18 @@ permissions:
 
 jobs:
   vscode-extension:
-    name: VSCode Extension Checks (Node 20)
+    name: VSCode Extension Checks (Node 24)
     uses: ./.github/workflows/reusable-node-command.yml
     with:
       runs_on: ubuntu-latest
-      node_version: '20'
+      node_version: '24'
       timeout_minutes: 10
       main_command: |
         pnpm --dir extensions/vscode run check:publish
     secrets: inherit
 
   vscode-extension-package:
-    name: VSCode Extension Package Dry Run (Node 20)
+    name: VSCode Extension Package Dry Run (Node 24)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs:
@@ -45,7 +45,7 @@ jobs:
 
       - uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Build VSIX dry run
         run: pnpm --dir extensions/vscode run package:dry-run
@@ -59,7 +59,7 @@ jobs:
           include-hidden-files: true
 
   vscode-extension-host-smoke:
-    name: VSCode Extension Host Smoke (Node 20)
+    name: VSCode Extension Host Smoke (Node 24)
     runs-on: macos-latest
     timeout-minutes: 15
     needs: vscode-extension
@@ -69,7 +69,7 @@ jobs:
 
       - uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Build extension
         run: pnpm --dir extensions/vscode run build
@@ -78,7 +78,7 @@ jobs:
         run: pnpm --dir extensions/vscode run test:host:smoke
 
   vscode-extension-vsix-e2e:
-    name: VSCode Extension VSIX E2E (Node 20)
+    name: VSCode Extension VSIX E2E (Node 24)
     runs-on: macos-latest
     timeout-minutes: 20
     needs: vscode-extension
@@ -88,7 +88,7 @@ jobs:
 
       - uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Run VSIX install-mode e2e
         run: pnpm --dir extensions/vscode run test:vsix:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
             node-version: 20
           - os: ubuntu-latest
             node-version: 22
+          - os: ubuntu-latest
+            node-version: 24
           - os: windows-latest
             node-version: 20
           - os: macos-latest
@@ -70,11 +72,11 @@ jobs:
 
   weapi-compat-pr:
     if: github.event_name != 'schedule'
-    name: Weapi Compatibility Guard (Node 20)
+    name: Weapi Compatibility Guard (Node 24)
     uses: ./.github/workflows/reusable-node-command.yml
     with:
       runs_on: ubuntu-latest
-      node_version: '20'
+      node_version: '24'
       timeout_minutes: 15
       main_command: |
         pnpm --filter @wevu/api catalog:check

--- a/.github/workflows/miniprogram-ci.yml
+++ b/.github/workflows/miniprogram-ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install workspace dependencies
         run: pnpm install --config.confirmModulesPurge=false

--- a/e2e/ci/auto-import-vue-sfc.test.ts
+++ b/e2e/ci/auto-import-vue-sfc.test.ts
@@ -165,13 +165,12 @@ async function rewriteVueSourceForWatch(
 ) {
   const eol = detectEol(targetSource)
   const marker = `<!-- auto-import-e2e-retry-${Date.now()} -->`
-  await fs.writeFile(
+  await replaceFileByRename(
     sourcePath,
     `${targetSource}${eol}${marker}${eol}`,
-    'utf8',
   )
   await new Promise(resolve => setTimeout(resolve, 120))
-  await fs.writeFile(sourcePath, targetSource, 'utf8')
+  await replaceFileByRename(sourcePath, targetSource)
 }
 
 async function waitForTaskWithSourceHeartbeat<T>(
@@ -776,12 +775,12 @@ describeAutoImportSuite('auto import local components (e2e)', () => {
               waitForFileContains(hotCardTemplatePath, ['hot-card-e2e'], 1_000),
             [
               {
-                touchFilePath: PAGE_SOURCE_PATH,
-                touchContent: pageSourceWithHotCard,
-              },
-              {
                 touchFilePath: HOT_COMPONENT_SOURCE_PATH,
                 touchContent: hotCardSource,
+              },
+              {
+                touchFilePath: PAGE_SOURCE_PATH,
+                touchContent: pageSourceWithHotCard,
               },
             ],
             HOT_COMPONENT_TEMPLATE_TIMEOUT_MS,

--- a/packages-runtime/wevu-compiler/src/plugins/jsx/compileJsxFile.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/jsx/compileJsxFile.ts
@@ -107,6 +107,7 @@ export async function compileJsxFile(
     skipComponentTransform: options?.isApp,
     isApp: options?.isApp,
     isPage: options?.isPage,
+    minify: options?.minify,
     warn: options?.warn,
     wevuDefaults: options?.wevuDefaults,
     inlineExpressions,

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/script.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/script.ts
@@ -70,6 +70,7 @@ export async function compileScriptPhase(
       skipComponentTransform: isAppFile,
       isApp: isAppFile,
       isPage: options?.isPage === true,
+      minify: options?.minify,
       warn: options?.warn,
       templateComponentMeta: Object.keys(autoComponentMeta).length ? autoComponentMeta : undefined,
       wevuDefaults: options?.wevuDefaults,

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/types.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/types.ts
@@ -73,6 +73,10 @@ export interface CompileVueFileOptions {
   astEngine?: AstEngineName
   isPage?: boolean
   isApp?: boolean
+  /**
+   * 是否压缩生成的 wevu 脚本输出。
+   */
+  minify?: boolean
   warn?: (message: string) => void
   autoUsingComponents?: AutoUsingComponentsOptions
   autoImportTags?: AutoImportTagsOptions

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/transformScript/index.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/transformScript/index.ts
@@ -72,7 +72,9 @@ export function transformScript(source: string, options?: TransformScriptOptions
   }
 
   const generated = generate(ast, {
-    retainLines: true,
+    compact: options?.minify === true,
+    minified: options?.minify === true,
+    retainLines: options?.minify !== true,
     sourceMaps: true,
     sourceFileName: 'inline.ts',
   }, source)

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/transformScript/minify.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/transformScript/minify.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { transformScript } from './index'
+
+describe('transformScript minify option', () => {
+  const source = `
+export default {
+  data() {
+    return {
+      count: 1,
+    }
+  },
+}
+  `.trim()
+
+  it('keeps readable output by default', () => {
+    const result = transformScript(source)
+    expect(result.code).toContain('data()')
+    expect(result.code).toContain('count: 1')
+    expect(result.code).toContain('\n')
+  })
+
+  it('emits compact output when minify is enabled', () => {
+    const result = transformScript(source, { minify: true })
+    expect(result.code).toContain('count:1')
+    expect(result.code).not.toContain('count: 1')
+  })
+})

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/transformScript/utils.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/transformScript/utils.ts
@@ -39,6 +39,10 @@ export interface TransformScriptOptions {
    */
   wevuDefaults?: WevuDefaults
   /**
+   * 是否压缩生成的脚本代码。
+   */
+  minify?: boolean
+  /**
    * 编译期警告回调
    */
   warn?: (message: string) => void

--- a/packages-runtime/wevu-compiler/src/plugins/wevu/pageFeatures/inject.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/wevu/pageFeatures/inject.test.ts
@@ -50,6 +50,23 @@ defineComponent({
     expect(result.code).toContain('enableOnShareTimeline')
   })
 
+  it('emits compact output when minify is enabled', () => {
+    const result = injectWevuPageFeaturesInJs(`
+import { defineComponent, onShareTimeline } from 'wevu'
+defineComponent({
+  setup() {
+    onShareTimeline(() => ({}))
+  },
+})
+    `.trim(), {
+      minify: true,
+    })
+
+    expect(result.transformed).toBe(true)
+    expect(result.code).toContain('enableOnShareTimeline')
+    expect(result.code).toContain('features:{')
+  })
+
   it('injects features resolved from setup reachable imported functions', async () => {
     const pageId = '/project/src/pages/index.ts'
     const helperId = '/project/src/pages/useShare.ts'

--- a/packages-runtime/wevu-compiler/src/plugins/wevu/pageFeatures/inject.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/wevu/pageFeatures/inject.ts
@@ -14,6 +14,7 @@ export function injectWevuPageFeaturesInJs(
   source: string,
   options?: {
     astEngine?: AstEngineName
+    minify?: boolean
   },
 ): { code: string, transformed: boolean, map?: EncodedSourceMapLike | null } {
   const enabled = collectWevuPageFeatureFlagsFromCode(source, options)
@@ -37,7 +38,9 @@ export function injectWevuPageFeaturesInJs(
   }
 
   const generated = generate(ast, {
-    retainLines: true,
+    compact: options?.minify === true,
+    minified: options?.minify === true,
+    retainLines: options?.minify !== true,
     sourceMaps: true,
     sourceFileName: 'inline.js',
   }, source)
@@ -49,7 +52,7 @@ export function injectWevuPageFeaturesInJs(
  */
 export async function injectWevuPageFeaturesInJsWithResolver(
   source: string,
-  options: { id: string, resolver: ModuleResolver, astEngine?: AstEngineName },
+  options: { id: string, resolver: ModuleResolver, astEngine?: AstEngineName, minify?: boolean },
 ): Promise<{ code: string, transformed: boolean, map?: EncodedSourceMapLike | null }> {
   const preflight = collectTargetOptionsObjectsFromCode(source, options.id, {
     astEngine: options.astEngine,
@@ -98,7 +101,9 @@ export async function injectWevuPageFeaturesInJsWithResolver(
   }
 
   const generated = generate(ast, {
-    retainLines: true,
+    compact: options?.minify === true,
+    minified: options?.minify === true,
+    retainLines: options?.minify !== true,
     sourceMaps: true,
     sourceFileName: 'inline.js',
   }, source)

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/compile.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/compile.ts
@@ -78,7 +78,7 @@ export async function finalizeCompiledVueLikeResult(options: {
   if (isPage && result.script) {
     const injected = await injectWevuPageFeaturesInJsWithViteResolver(pluginCtx, result.script, filename, {
       checkMtime: configService.isDev,
-      minify: isWevuMinifyEnabled(configService.weappViteConfig),
+      minify: isWevuMinifyEnabled(configService.weappViteConfig, configService.isDev),
     })
     if (injected.transformed) {
       result.script = injected.code

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/compile.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/compile.ts
@@ -11,6 +11,7 @@ import { injectWevuPageFeaturesInJsWithViteResolver } from '../../injectPageFeat
 import { collectSetDataPickKeysFromTemplate, injectScopedSlotHostPropertiesInJs, injectSetDataPickInJs, isAutoSetDataPickEnabled, mayNeedInjectSetDataPickInJs } from '../../injectSetDataPick'
 import { applyPageLayoutPlan, resolvePageLayoutPlan } from '../../pageLayout'
 import { resolveTransformAutoRoutesSource } from '../../plugin/shared'
+import { isWevuMinifyEnabled } from '../../wevuPreset'
 import { getEntryBaseName, isAppVueLikeFile } from './layout'
 import { setVueBundlePageLayoutPlan } from './types'
 
@@ -77,6 +78,7 @@ export async function finalizeCompiledVueLikeResult(options: {
   if (isPage && result.script) {
     const injected = await injectWevuPageFeaturesInJsWithViteResolver(pluginCtx, result.script, filename, {
       checkMtime: configService.isDev,
+      minify: isWevuMinifyEnabled(configService.weappViteConfig),
     })
     if (injected.transformed) {
       result.script = injected.code

--- a/packages/weapp-vite/src/plugins/vue/transform/compileOptions.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/compileOptions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createCompileVueFileOptions, resolveVueTemplatePlatformOptions } from './compileOptions'
 
 const loggerWarnMock = vi.hoisted(() => vi.fn())
@@ -19,7 +19,7 @@ const createUsingComponentPathResolverMock = vi.hoisted(() => vi.fn(() => 'resol
 const resolveWevuDefaultsWithPresetMock = vi.hoisted(() => vi.fn(() => ({
   preset: 'default',
 })))
-const isWevuMinifyEnabledMock = vi.hoisted(() => vi.fn(() => false))
+const isWevuMinifyEnabledMock = vi.hoisted(() => vi.fn((_config: any, isDev = false) => !isDev))
 
 vi.mock('../../../logger', () => ({
   default: {
@@ -45,6 +45,10 @@ vi.mock('./wevuPreset', () => ({
 }))
 
 describe('resolveVueTemplatePlatformOptions', () => {
+  beforeEach(() => {
+    isWevuMinifyEnabledMock.mockClear()
+  })
+
   it('resolves template platform and wxs runtime support', () => {
     const weappOptions = resolveVueTemplatePlatformOptions({
       platform: 'weapp',
@@ -117,6 +121,7 @@ describe('resolveVueTemplatePlatformOptions', () => {
       false,
       {
         platform: 'alipay',
+        isDev: true,
         outputExtensions: {
           wxs: 'sjs',
         },
@@ -191,6 +196,7 @@ describe('resolveVueTemplatePlatformOptions', () => {
       false,
       {
         platform: 'weapp',
+        isDev: true,
         outputExtensions: {},
         weappViteConfig: {
           wxs: false,
@@ -289,6 +295,7 @@ describe('resolveVueTemplatePlatformOptions', () => {
       false,
       {
         platform: 'weapp',
+        isDev: true,
         outputExtensions: {},
         weappViteConfig: {
           vue: {
@@ -317,6 +324,7 @@ describe('resolveVueTemplatePlatformOptions', () => {
       false,
       {
         platform: 'weapp',
+        isDev: true,
         outputExtensions: {},
         weappViteConfig: {
           vue: {
@@ -346,6 +354,7 @@ describe('resolveVueTemplatePlatformOptions', () => {
       false,
       {
         platform: 'weapp',
+        isDev: false,
         outputExtensions: {},
         weappViteConfig: {
           vue: {
@@ -443,6 +452,7 @@ describe('resolveVueTemplatePlatformOptions', () => {
       false,
       {
         platform: 'weapp',
+        isDev: false,
         outputExtensions: {},
         weappViteConfig: {
           vue: {
@@ -477,6 +487,7 @@ describe('resolveVueTemplatePlatformOptions', () => {
       false,
       {
         platform: 'weapp',
+        isDev: false,
         outputExtensions: {},
         weappViteConfig: {
           wevu: {
@@ -522,6 +533,7 @@ describe('resolveVueTemplatePlatformOptions', () => {
       false,
       {
         platform: 'weapp',
+        isDev: false,
         outputExtensions: {},
         weappViteConfig: {
           wevu: {
@@ -537,6 +549,35 @@ describe('resolveVueTemplatePlatformOptions', () => {
     )
 
     expect(options.minify).toBe(true)
+    expect(isWevuMinifyEnabledMock).toHaveBeenCalledWith({
+      wevu: {
+        minify: true,
+      },
+    }, false)
+  })
+
+  it('passes dev mode to the wevu minify resolver', () => {
+    const options = createCompileVueFileOptions(
+      {} as any,
+      {} as any,
+      '/project/src/components/card.vue',
+      false,
+      false,
+      {
+        platform: 'weapp',
+        isDev: true,
+        outputExtensions: {},
+        weappViteConfig: {},
+        relativeOutputPath: () => undefined,
+      } as any,
+      {
+        reExportResolutionCache: new Map(),
+        classStyleRuntimeWarned: { value: false },
+      },
+    )
+
+    expect(options.minify).toBe(false)
+    expect(isWevuMinifyEnabledMock).toHaveBeenCalledWith({}, true)
   })
 
   it('reuses cached compile options for the same vue entry', () => {

--- a/packages/weapp-vite/src/plugins/vue/transform/compileOptions.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/compileOptions.test.ts
@@ -19,6 +19,7 @@ const createUsingComponentPathResolverMock = vi.hoisted(() => vi.fn(() => 'resol
 const resolveWevuDefaultsWithPresetMock = vi.hoisted(() => vi.fn(() => ({
   preset: 'default',
 })))
+const isWevuMinifyEnabledMock = vi.hoisted(() => vi.fn(() => false))
 
 vi.mock('../../../logger', () => ({
   default: {
@@ -40,6 +41,7 @@ vi.mock('./usingComponentResolver', () => ({
 
 vi.mock('./wevuPreset', () => ({
   resolveWevuDefaultsWithPreset: resolveWevuDefaultsWithPresetMock,
+  isWevuMinifyEnabled: isWevuMinifyEnabledMock,
 }))
 
 describe('resolveVueTemplatePlatformOptions', () => {
@@ -165,6 +167,7 @@ describe('resolveVueTemplatePlatformOptions', () => {
       },
       mergeStrategy: 'merge',
     })
+    expect(options.minify).toBe(false)
     expect(options.wevuDefaults).toEqual({ preset: 'default' })
     expect(createUsingComponentPathResolverMock).toHaveBeenCalled()
     expect(await options.autoImportTags.resolveUsingComponent('FooCard')).toEqual({
@@ -506,6 +509,34 @@ describe('resolveVueTemplatePlatformOptions', () => {
         },
       },
     })
+  })
+
+  it('passes the wevu minify flag from config', () => {
+    isWevuMinifyEnabledMock.mockReturnValueOnce(true)
+
+    const options = createCompileVueFileOptions(
+      {} as any,
+      {} as any,
+      '/project/src/components/card.vue',
+      false,
+      false,
+      {
+        platform: 'weapp',
+        outputExtensions: {},
+        weappViteConfig: {
+          wevu: {
+            minify: true,
+          },
+        },
+        relativeOutputPath: () => undefined,
+      } as any,
+      {
+        reExportResolutionCache: new Map(),
+        classStyleRuntimeWarned: { value: false },
+      },
+    )
+
+    expect(options.minify).toBe(true)
   })
 
   it('reuses cached compile options for the same vue entry', () => {

--- a/packages/weapp-vite/src/plugins/vue/transform/compileOptions.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/compileOptions.ts
@@ -101,7 +101,7 @@ function buildCompileVueFileOptions(
   }
   const jsonConfig = configService.weappViteConfig?.json
   const wevuDefaults = resolveWevuDefaultsWithPreset(configService.weappViteConfig)
-  const wevuMinify = isWevuMinifyEnabled(configService.weappViteConfig)
+  const wevuMinify = isWevuMinifyEnabled(configService.weappViteConfig, configService.isDev)
   const jsonKind = isApp ? 'app' : isPage ? 'page' : 'component'
 
   async function resolveAutoImportComponentSourceType(match: NonNullable<ReturnType<NonNullable<CompilerContext['autoImportService']>['resolve']>>) {

--- a/packages/weapp-vite/src/plugins/vue/transform/compileOptions.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/compileOptions.ts
@@ -9,7 +9,7 @@ import { createCachedEntryResolveOptions, resolveEntryPath } from '../../../util
 import { createSfcResolveSrcOptions } from '../../utils/vueSfc'
 import { resolveClassStyleWxsLocationForBase } from './classStyle'
 import { createUsingComponentPathResolver } from './usingComponentResolver'
-import { resolveWevuDefaultsWithPreset } from './wevuPreset'
+import { isWevuMinifyEnabled, resolveWevuDefaultsWithPreset } from './wevuPreset'
 
 export type CompileVueFileResolvedOptions = CompileVueFileOptions
 
@@ -101,6 +101,7 @@ function buildCompileVueFileOptions(
   }
   const jsonConfig = configService.weappViteConfig?.json
   const wevuDefaults = resolveWevuDefaultsWithPreset(configService.weappViteConfig)
+  const wevuMinify = isWevuMinifyEnabled(configService.weappViteConfig)
   const jsonKind = isApp ? 'app' : isPage ? 'page' : 'component'
 
   async function resolveAutoImportComponentSourceType(match: NonNullable<ReturnType<NonNullable<CompilerContext['autoImportService']>['resolve']>>) {
@@ -211,6 +212,7 @@ function buildCompileVueFileOptions(
     },
     sfcSrc: createSfcResolveSrcOptions(pluginCtx, configService),
     wevuDefaults,
+    minify: wevuMinify,
   } as const
 }
 

--- a/packages/weapp-vite/src/plugins/vue/transform/injectPageFeatures.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/injectPageFeatures.ts
@@ -12,7 +12,7 @@ export async function injectWevuPageFeaturesInJsWithViteResolver(
   ctx: VitePluginResolveLike,
   source: string,
   id: string,
-  options?: { checkMtime?: boolean },
+  options?: { checkMtime?: boolean, minify?: boolean },
 ): Promise<{ code: string, transformed: boolean, map?: EncodedSourceMapLike | null }> {
   const checkMtime = options?.checkMtime ?? true
   const injected = await injectWevuPageFeaturesInJsWithResolver(source, {
@@ -22,6 +22,7 @@ export async function injectWevuPageFeaturesInJsWithViteResolver(
       { readFile: readFileCached },
       { checkMtime },
     ),
+    minify: options?.minify,
   })
   return {
     ...injected,

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/shared/compile.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/shared/compile.ts
@@ -57,7 +57,7 @@ export async function finalizeTransformEntryScript(options: {
     if (forcePageFeatureInjection || mayNeedTransformPageFeatureInjection(result.script)) {
       const injected = await injectWevuPageFeaturesInJsWithViteResolver(pluginCtx, result.script, filename, {
         checkMtime: configService.isDev,
-        minify: isWevuMinifyEnabled(configService.weappViteConfig),
+        minify: isWevuMinifyEnabled(configService.weappViteConfig, configService.isDev),
       })
       if (injected.transformed) {
         result.script = injected.code

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/shared/compile.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/shared/compile.ts
@@ -14,6 +14,7 @@ import { injectWevuPageFeaturesInJsWithViteResolver } from '../../injectPageFeat
 import { collectSetDataPickKeysFromTemplate, injectScopedSlotHostPropertiesInJs, injectSetDataPickInJs, isAutoSetDataPickEnabled, mayNeedInjectSetDataPickInJs } from '../../injectSetDataPick'
 import { registerVueTemplateToken, resolveVueOutputBase } from '../../shared'
 import { buildWeappVueStyleRequests } from '../../styleRequest'
+import { isWevuMinifyEnabled } from '../../wevuPreset'
 import { handleTransformEntryPageLayoutFlow } from './layout'
 import {
   mayNeedTransformPageFeatureInjection,
@@ -56,6 +57,7 @@ export async function finalizeTransformEntryScript(options: {
     if (forcePageFeatureInjection || mayNeedTransformPageFeatureInjection(result.script)) {
       const injected = await injectWevuPageFeaturesInJsWithViteResolver(pluginCtx, result.script, filename, {
         checkMtime: configService.isDev,
+        minify: isWevuMinifyEnabled(configService.weappViteConfig),
       })
       if (injected.transformed) {
         result.script = injected.code

--- a/packages/weapp-vite/src/plugins/vue/transform/wevuPreset.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/wevuPreset.test.ts
@@ -52,12 +52,18 @@ describe('wevu performance preset', () => {
     expect(resolved?.component?.setData?.includeComputed).toBe(false)
   })
 
-  it('defaults wevu minify to false and respects explicit flag', () => {
-    expect(isWevuMinifyEnabled({} as any)).toBe(false)
+  it('defaults wevu minify by mode and respects explicit flag', () => {
+    expect(isWevuMinifyEnabled({} as any, true)).toBe(false)
+    expect(isWevuMinifyEnabled({} as any, false)).toBe(true)
     expect(isWevuMinifyEnabled({
       wevu: {
         minify: true,
       },
-    } as any)).toBe(true)
+    } as any, true)).toBe(true)
+    expect(isWevuMinifyEnabled({
+      wevu: {
+        minify: false,
+      },
+    } as any, false)).toBe(false)
   })
 })

--- a/packages/weapp-vite/src/plugins/vue/transform/wevuPreset.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/wevuPreset.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isAutoSetDataPickEnabledWithPreset, resolveWevuDefaultsWithPreset, resolveWevuPreset } from './wevuPreset'
+import { isAutoSetDataPickEnabledWithPreset, isWevuMinifyEnabled, resolveWevuDefaultsWithPreset, resolveWevuPreset } from './wevuPreset'
 
 describe('wevu performance preset', () => {
   it('resolves preset name', () => {
@@ -50,5 +50,14 @@ describe('wevu performance preset', () => {
     expect(resolved?.component?.setData?.strategy).toBe('patch')
     expect(resolved?.component?.setData?.diagnostics).toBe('fallback')
     expect(resolved?.component?.setData?.includeComputed).toBe(false)
+  })
+
+  it('defaults wevu minify to false and respects explicit flag', () => {
+    expect(isWevuMinifyEnabled({} as any)).toBe(false)
+    expect(isWevuMinifyEnabled({
+      wevu: {
+        minify: true,
+      },
+    } as any)).toBe(true)
   })
 })

--- a/packages/weapp-vite/src/plugins/vue/transform/wevuPreset.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/wevuPreset.ts
@@ -108,3 +108,10 @@ export function isAutoSetDataPickEnabledWithPreset(config?: WeappViteConfig): bo
   }
   return resolveWevuPreset(config) === 'performance'
 }
+
+/**
+ * 读取 wevu 输出是否压缩。
+ */
+export function isWevuMinifyEnabled(config?: WeappViteConfig): boolean {
+  return config?.wevu?.minify === true
+}

--- a/packages/weapp-vite/src/plugins/vue/transform/wevuPreset.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/wevuPreset.ts
@@ -112,6 +112,10 @@ export function isAutoSetDataPickEnabledWithPreset(config?: WeappViteConfig): bo
 /**
  * 读取 wevu 输出是否压缩。
  */
-export function isWevuMinifyEnabled(config?: WeappViteConfig): boolean {
-  return config?.wevu?.minify === true
+export function isWevuMinifyEnabled(config: WeappViteConfig | undefined, isDev = false): boolean {
+  const explicit = config?.wevu?.minify
+  if (typeof explicit === 'boolean') {
+    return explicit
+  }
+  return !isDev
 }

--- a/packages/weapp-vite/src/runtime/config/createConfigService.test.ts
+++ b/packages/weapp-vite/src/runtime/config/createConfigService.test.ts
@@ -15,6 +15,9 @@ const {
   mergeMock,
   mergeWebMock,
   mergeInlineConfigMock,
+  resolveBuiltinPackageAliasesMock,
+  injectBuiltinAliasesMock,
+  loadConfigFactoryOptionsMock,
 } = vi.hoisted(() => ({
   configureLoggerMock: vi.fn(),
   loggerInfoMock: vi.fn(),
@@ -24,6 +27,11 @@ const {
   mergeMock: vi.fn(),
   mergeWebMock: vi.fn(),
   mergeInlineConfigMock: vi.fn(),
+  resolveBuiltinPackageAliasesMock: vi.fn(() => []),
+  injectBuiltinAliasesMock: vi.fn((entries: any[]) => entries),
+  loadConfigFactoryOptionsMock: {
+    value: undefined as any,
+  },
 }))
 
 vi.mock('../../logger', () => ({
@@ -45,7 +53,7 @@ vi.mock('package-manager-detector/detect', () => ({
 }))
 
 vi.mock('../packageAliases', () => ({
-  resolveBuiltinPackageAliases: vi.fn(() => ({})),
+  resolveBuiltinPackageAliases: resolveBuiltinPackageAliasesMock,
 }))
 
 vi.mock('../oxcRuntime', () => ({
@@ -58,12 +66,15 @@ vi.mock('../oxcRuntime', () => ({
 
 vi.mock('./internal/alias', () => ({
   createAliasManager: vi.fn(() => ({
-    injectBuiltinAliases: vi.fn((entries: any[]) => entries),
+    injectBuiltinAliases: injectBuiltinAliasesMock,
   })),
 }))
 
 vi.mock('./internal/loadConfig', () => ({
-  createLoadConfig: vi.fn(() => loadConfigImplMock),
+  createLoadConfig: vi.fn((options: any) => {
+    loadConfigFactoryOptionsMock.value = options
+    return loadConfigImplMock
+  }),
 }))
 
 vi.mock('./internal/merge', () => ({
@@ -139,6 +150,7 @@ function createCtx(optionsOverrides: Record<string, any> = {}) {
 describe('createConfigService', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    resolveBuiltinPackageAliasesMock.mockReturnValue([])
     detectMock.mockResolvedValue({
       agent: 'pnpm',
       name: 'pnpm',
@@ -205,6 +217,48 @@ describe('createConfigService', () => {
     expect(define['import.meta.env.CUSTOM_FLAG']).toBe('1')
     expect(define['import.meta.env']).toBe('{"PLATFORM":"weapp","MP_PLATFORM":"weapp","IS_WEB":false,"IS_MINIPROGRAM":true,"CUSTOM_FLAG":1}')
     expect(JSON.parse(define['import.meta.env']).CUSTOM_FLAG).toBe(1)
+  })
+
+  it('resolves builtin aliases from dev mode and configured wevu runtime', async () => {
+    loadConfigImplMock.mockImplementationOnce(async () => {
+      const config = {
+        weapp: {
+          wevu: {
+            runtime: 'build',
+          },
+        },
+      }
+      loadConfigFactoryOptionsMock.value.injectBuiltinAliases(config)
+      return createBaseOptions({
+        cwd: '/work',
+        isDev: true,
+        mode: 'development',
+        config,
+        srcRoot: 'src',
+        platform: 'weapp',
+        mpDistRoot: 'dist',
+        outputExtensions: {
+          script: '.js',
+        },
+        configMergeInfo: {
+          merged: false,
+        },
+        aliasEntries: [],
+        relativeSrcRoot: (p: string) => path.relative('/work/src', p) || '.',
+      })
+    })
+
+    const service = createConfigService(createCtx())
+    await service.load({
+      cwd: '/work',
+      isDev: true,
+      mode: 'development',
+    })
+
+    expect(resolveBuiltinPackageAliasesMock).toHaveBeenCalledWith({
+      isDev: true,
+      wevuRuntime: 'build',
+    })
   })
 
   it('preserves user-defined import.meta.env member overrides for downstream preprocessors', () => {

--- a/packages/weapp-vite/src/runtime/config/createConfigService.ts
+++ b/packages/weapp-vite/src/runtime/config/createConfigService.ts
@@ -25,10 +25,17 @@ function createConfigService(ctx: MutableCompilerContext): ConfigService {
   const defineEnv = configState.defineEnv
   let packageManager = configState.packageManager
   let options = configState.options
+  let loadingOptions: LoadConfigOptions | undefined
 
-  const builtinAliases = resolveBuiltinPackageAliases()
   const oxcRuntimeSupport = createOxcRuntimeSupport()
-  const aliasManager = createAliasManager(oxcRuntimeSupport.alias, builtinAliases)
+  const aliasManager = createAliasManager(oxcRuntimeSupport.alias, resolveBuiltinPackageAliases())
+
+  function injectBuiltinAliases(config: LoadConfigResult['config']) {
+    aliasManager.injectBuiltinAliases(config, resolveBuiltinPackageAliases({
+      isDev: loadingOptions?.isDev ?? options.isDev,
+      wevuRuntime: config.weapp?.wevu?.runtime,
+    }))
+  }
 
   const normalizeComparablePath = (input: string) => {
     const resolved = path.resolve(input)
@@ -190,7 +197,7 @@ function createConfigService(ctx: MutableCompilerContext): ConfigService {
   applyRuntimePlatform('miniprogram')
 
   const loadConfigImpl = createLoadConfig({
-    injectBuiltinAliases: aliasManager.injectBuiltinAliases,
+    injectBuiltinAliases,
     oxcRolldownPlugin: oxcRuntimeSupport.rolldownPlugin,
     oxcVitePlugin: oxcRuntimeSupport.vitePlugin,
   })
@@ -212,7 +219,14 @@ function createConfigService(ctx: MutableCompilerContext): ConfigService {
       emitDefaultAutoImportOutputs: true,
     })
 
-    const rawConfig = await loadConfigImpl(input)
+    loadingOptions = input
+    let rawConfig: LoadConfigResult
+    try {
+      rawConfig = await loadConfigImpl(input)
+    }
+    finally {
+      loadingOptions = undefined
+    }
     const resolvedConfig = defu<Required<LoadConfigResult>, Partial<LoadConfigResult>[]>(rawConfig, {
       cwd: input.cwd ?? defaultCwd,
       isDev: false,
@@ -247,7 +261,7 @@ function createConfigService(ctx: MutableCompilerContext): ConfigService {
     ctx,
     getOptions,
     setOptions,
-    injectBuiltinAliases: aliasManager.injectBuiltinAliases,
+    injectBuiltinAliases,
     getDefineImportMetaEnv,
     applyRuntimePlatform,
     oxcRolldownPlugin: oxcRuntimeSupport.rolldownPlugin,

--- a/packages/weapp-vite/src/runtime/config/internal/alias.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/alias.ts
@@ -6,7 +6,7 @@ export interface AliasEntry {
 }
 
 export interface AliasManager {
-  injectBuiltinAliases: (config: InlineConfig) => void
+  injectBuiltinAliases: (config: InlineConfig, builtinAliases?: AliasEntry[]) => void
 }
 
 type RawAliasOption = NonNullable<NonNullable<InlineConfig['resolve']>['alias']>
@@ -28,9 +28,9 @@ export function normalizeAliasOptions(alias?: RawAliasOption | null): AliasEntry
 
 export function createAliasManager(
   oxcAlias: AliasEntry & { find: RegExp },
-  builtinAliases: AliasEntry[],
+  defaultBuiltinAliases: AliasEntry[],
 ): AliasManager {
-  function injectBuiltinAliases(config: InlineConfig) {
+  function injectBuiltinAliases(config: InlineConfig, builtinAliases: AliasEntry[] = defaultBuiltinAliases) {
     const resolve = config.resolve ?? (config.resolve = {})
     const aliasArray = normalizeAliasOptions(resolve.alias)
 

--- a/packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.test.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.test.ts
@@ -377,6 +377,60 @@ describe('runtime config merge miniprogram', () => {
     expect(external.some(pattern => pattern.test('/project/node_modules/@vant/weapp/dist/index.js'))).toBe(false)
   })
 
+  it('resolves builtin alias externals with the configured wevu runtime mode', () => {
+    resolveBuiltinPackageAliasesMock.mockReturnValue([
+      {
+        find: 'wevu',
+        replacement: '/project/node_modules/wevu/dist/dev/index.mjs',
+      },
+    ])
+
+    const result = mergeMiniprogram(
+      {
+        ctx: {
+          configService: {
+            cwd: '/project',
+            weappViteConfig: {
+              npm: {
+                include: ['wevu'],
+              },
+            },
+          },
+        } as any,
+        subPackageMeta: undefined,
+        config: {
+          weapp: {
+            wevu: {
+              runtime: 'dev',
+            },
+          },
+        } as any,
+        cwd: '/project',
+        srcRoot: 'src',
+        packageJson: {
+          dependencies: {
+            wevu: '^1.0.0',
+          },
+        } as any,
+        isDev: false,
+        applyRuntimePlatform: vi.fn(),
+        injectBuiltinAliases: vi.fn(),
+        getDefineImportMetaEnv: () => ({}),
+        setOptions: vi.fn(),
+        oxcRolldownPlugin: undefined,
+      },
+      undefined,
+    )
+
+    const external = ((result.build as any)?.rolldownOptions?.external ?? []) as RegExp[]
+
+    expect(resolveBuiltinPackageAliasesMock).toHaveBeenCalledWith({
+      isDev: false,
+      wevuRuntime: 'dev',
+    })
+    expect(external.some(pattern => pattern.test('/project/node_modules/wevu/dist/dev/index.mjs'))).toBe(true)
+  })
+
   it('does not externalize ordinary dependencies in explicit mode when they are not npm build candidates', () => {
     resolveBuiltinPackageAliasesMock.mockReturnValue([
       {

--- a/packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.ts
@@ -128,7 +128,10 @@ export function mergeMiniprogram(options: MergeMiniprogramOptions, ...configs: P
     ? resolveNpmBuildCandidateDependenciesSync(ctx, packageJson)
     : []
   if (npmBuildCandidates.length > 0) {
-    const builtinAliases = resolveBuiltinPackageAliases()
+    const builtinAliases = resolveBuiltinPackageAliases({
+      isDev,
+      wevuRuntime: config.weapp?.wevu?.runtime,
+    })
     external.push(
       ...npmBuildCandidates.map((pkg) => {
         return new RegExp(`^${escapeRegex(pkg)}(\\/|$)`)

--- a/packages/weapp-vite/src/runtime/packageAliases.test.ts
+++ b/packages/weapp-vite/src/runtime/packageAliases.test.ts
@@ -58,6 +58,66 @@ describe('runtime package aliases', () => {
     ]))
   })
 
+  it('uses development wevu entries in dev mode by default', () => {
+    getPackageInfoSyncMock.mockImplementation((packageName: string) => {
+      if (packageName === 'class-variance-authority') {
+        return { rootPath: '/project/node_modules/class-variance-authority' }
+      }
+      if (packageName === 'wevu') {
+        return { rootPath: '/project/node_modules/wevu' }
+      }
+      return undefined
+    })
+    existsSyncMock.mockReturnValue(true)
+
+    const aliases = resolveBuiltinPackageAliases({ isDev: true })
+
+    expect(aliases).toEqual(expect.arrayContaining([
+      {
+        find: 'wevu',
+        replacement: '/project/node_modules/wevu/dist/dev/index.mjs',
+      },
+      {
+        find: 'wevu/compiler',
+        replacement: '/project/node_modules/wevu/dist/dev/compiler.mjs',
+      },
+      {
+        find: 'wevu/router',
+        replacement: '/project/node_modules/wevu/dist/dev/router.mjs',
+      },
+      {
+        find: 'vue-demi',
+        replacement: '/project/node_modules/wevu/dist/dev/vue-demi.mjs',
+      },
+    ]))
+  })
+
+  it('allows forcing the wevu runtime entry mode', () => {
+    getPackageInfoSyncMock.mockImplementation((packageName: string) => {
+      if (packageName === 'wevu') {
+        return { rootPath: '/project/node_modules/wevu' }
+      }
+      return undefined
+    })
+    existsSyncMock.mockReturnValue(true)
+
+    const buildAliases = resolveBuiltinPackageAliases({ isDev: true, wevuRuntime: 'build' })
+    const devAliases = resolveBuiltinPackageAliases({ isDev: false, wevuRuntime: 'dev' })
+
+    expect(buildAliases).toEqual(expect.arrayContaining([
+      {
+        find: 'wevu',
+        replacement: '/project/node_modules/wevu/dist/index.mjs',
+      },
+    ]))
+    expect(devAliases).toEqual(expect.arrayContaining([
+      {
+        find: 'wevu',
+        replacement: '/project/node_modules/wevu/dist/dev/index.mjs',
+      },
+    ]))
+  })
+
   it('falls back to workspace dist entry when workspace package lookup is unavailable', () => {
     getPackageInfoSyncMock.mockImplementation((packageName: string) => {
       if (packageName === 'class-variance-authority') {
@@ -94,6 +154,31 @@ describe('runtime package aliases', () => {
       expect.objectContaining({
         find: 'vue-demi',
         replacement: expect.stringMatching(/packages-runtime\/wevu\/dist\/vue-demi\.mjs$/),
+      }),
+    ]))
+  })
+
+  it('falls back to workspace development dist entry in dev mode', () => {
+    getPackageInfoSyncMock.mockReturnValue(undefined)
+    existsSyncMock.mockImplementation((filePath: string) =>
+      filePath.endsWith('/pnpm-workspace.yaml')
+      || /\/packages-runtime\/wevu\/dist\/dev\/(?:index|compiler|jsx-runtime|store|api|fetch|router|web-apis|vue-demi)\.mjs$/.test(filePath),
+    )
+
+    const aliases = resolveBuiltinPackageAliases({ isDev: true })
+
+    expect(aliases).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        find: 'wevu',
+        replacement: expect.stringMatching(/packages-runtime\/wevu\/dist\/dev\/index\.mjs$/),
+      }),
+      expect.objectContaining({
+        find: 'wevu/api',
+        replacement: expect.stringMatching(/packages-runtime\/wevu\/dist\/dev\/api\.mjs$/),
+      }),
+      expect.objectContaining({
+        find: 'vue-demi',
+        replacement: expect.stringMatching(/packages-runtime\/wevu\/dist\/dev\/vue-demi\.mjs$/),
       }),
     ]))
   })

--- a/packages/weapp-vite/src/runtime/packageAliases.ts
+++ b/packages/weapp-vite/src/runtime/packageAliases.ts
@@ -8,10 +8,18 @@ export interface BuiltinPackageAliasEntry {
   replacement: string
 }
 
+export type WevuRuntimeAliasMode = 'auto' | 'dev' | 'build'
+
+export interface ResolveBuiltinPackageAliasesOptions {
+  isDev?: boolean
+  wevuRuntime?: WevuRuntimeAliasMode
+}
+
 interface PackageAliasTarget {
   find: string
   packageName: string
   distEntry: string
+  devDistEntry?: string
   fallbackWorkspacePackagePath?: string
 }
 
@@ -27,57 +35,80 @@ const PACKAGE_ALIASES: PackageAliasTarget[] = [
     find: 'wevu',
     packageName: 'wevu',
     distEntry: 'dist/index.mjs',
+    devDistEntry: 'dist/dev/index.mjs',
     fallbackWorkspacePackagePath: WEVU_WORKSPACE_PACKAGE_PATH,
   },
   {
     find: 'wevu/compiler',
     packageName: 'wevu',
     distEntry: 'dist/compiler.mjs',
+    devDistEntry: 'dist/dev/compiler.mjs',
     fallbackWorkspacePackagePath: WEVU_WORKSPACE_PACKAGE_PATH,
   },
   {
     find: 'wevu/jsx-runtime',
     packageName: 'wevu',
     distEntry: 'dist/jsx-runtime.mjs',
+    devDistEntry: 'dist/dev/jsx-runtime.mjs',
     fallbackWorkspacePackagePath: WEVU_WORKSPACE_PACKAGE_PATH,
   },
   {
     find: 'wevu/store',
     packageName: 'wevu',
     distEntry: 'dist/store.mjs',
+    devDistEntry: 'dist/dev/store.mjs',
     fallbackWorkspacePackagePath: WEVU_WORKSPACE_PACKAGE_PATH,
   },
   {
     find: 'wevu/api',
     packageName: 'wevu',
     distEntry: 'dist/api.mjs',
+    devDistEntry: 'dist/dev/api.mjs',
     fallbackWorkspacePackagePath: WEVU_WORKSPACE_PACKAGE_PATH,
   },
   {
     find: 'wevu/fetch',
     packageName: 'wevu',
     distEntry: 'dist/fetch.mjs',
+    devDistEntry: 'dist/dev/fetch.mjs',
     fallbackWorkspacePackagePath: WEVU_WORKSPACE_PACKAGE_PATH,
   },
   {
     find: 'wevu/web-apis',
     packageName: 'wevu',
     distEntry: 'dist/web-apis.mjs',
+    devDistEntry: 'dist/dev/web-apis.mjs',
     fallbackWorkspacePackagePath: WEVU_WORKSPACE_PACKAGE_PATH,
   },
   {
     find: 'wevu/router',
     packageName: 'wevu',
     distEntry: 'dist/router.mjs',
+    devDistEntry: 'dist/dev/router.mjs',
     fallbackWorkspacePackagePath: WEVU_WORKSPACE_PACKAGE_PATH,
   },
   {
     find: 'vue-demi',
     packageName: 'wevu',
     distEntry: 'dist/vue-demi.mjs',
+    devDistEntry: 'dist/dev/vue-demi.mjs',
     fallbackWorkspacePackagePath: WEVU_WORKSPACE_PACKAGE_PATH,
   },
 ]
+
+function resolveWevuRuntimeDistEntry(
+  target: PackageAliasTarget,
+  options: ResolveBuiltinPackageAliasesOptions,
+) {
+  if (!target.devDistEntry || target.packageName !== 'wevu') {
+    return target.distEntry
+  }
+  const mode = options.wevuRuntime ?? 'auto'
+  if (mode === 'dev' || (mode === 'auto' && options.isDev)) {
+    return target.devDistEntry
+  }
+  return target.distEntry
+}
 
 function resolveRepoRoot(fromDir: string) {
   let currentDir = fromDir
@@ -124,10 +155,12 @@ function resolvePackageEntry(
   return undefined
 }
 
-export function resolveBuiltinPackageAliases(): BuiltinPackageAliasEntry[] {
+export function resolveBuiltinPackageAliases(options: ResolveBuiltinPackageAliasesOptions = {}): BuiltinPackageAliasEntry[] {
   const aliases: BuiltinPackageAliasEntry[] = []
 
-  for (const { find, packageName, distEntry, fallbackWorkspacePackagePath } of PACKAGE_ALIASES) {
+  for (const target of PACKAGE_ALIASES) {
+    const { find, packageName, fallbackWorkspacePackagePath } = target
+    const distEntry = resolveWevuRuntimeDistEntry(target, options)
     const resolvedEntry = resolvePackageEntry(packageName, distEntry, fallbackWorkspacePackagePath)
     if (!resolvedEntry) {
       continue

--- a/packages/weapp-vite/src/runtime/sharedBuildConfig.test.ts
+++ b/packages/weapp-vite/src/runtime/sharedBuildConfig.test.ts
@@ -186,10 +186,13 @@ describe('sharedBuildConfig', () => {
       facadeModuleId: '/project/packages-runtime/wevu/dist/src-BdXSqz-9.mjs',
     })).toBe('weapp-vendors/wevu-src.js')
     expect(resolveStableHashedDistChunkFileName({
+      facadeModuleId: '/project/packages-runtime/wevu/dist/dev/src-BD3I133J.mjs',
+    })).toBe('weapp-vendors/wevu-src.js')
+    expect(resolveStableHashedDistChunkFileName({
       facadeModuleId: '/project/packages-runtime/wevu/dist/store-BD3I133J.mjs',
       moduleIds: [
         '/project/packages-runtime/wevu/dist/store-BD3I133J.mjs',
-        '/project/packages-runtime/wevu/dist/src-BD3I133J.mjs',
+        '/project/packages-runtime/wevu/dist/dev/src-BD3I133J.mjs',
       ],
     })).toBe('weapp-vendors/wevu-store.js')
     expect(resolveStableHashedDistChunkFileName({
@@ -217,7 +220,7 @@ describe('sharedBuildConfig', () => {
     })
     expect(output.chunkFileNames({
       name: 'src-BD3I133J',
-      facadeModuleId: '/project/packages-runtime/wevu/dist/src-BD3I133J.mjs',
+      facadeModuleId: '/project/packages-runtime/wevu/dist/dev/src-BD3I133J.mjs',
     })).toBe('weapp-vendors/wevu-src.js')
   })
 

--- a/packages/weapp-vite/src/runtime/sharedBuildConfig.ts
+++ b/packages/weapp-vite/src/runtime/sharedBuildConfig.ts
@@ -17,7 +17,7 @@ import { DEFAULT_SHARED_CHUNK_STRATEGY } from './chunkStrategy'
 const REG_NODE_MODULES_DIR = /[\\/]node_modules[\\/]/gi
 const REG_COMMONJS_HELPERS = /commonjsHelpers\.js$/
 const REG_REQUEST_GLOBAL_RUNTIME_VENDOR_ID = /(?:^|[/\\])(?:@wevu[/\\]web-apis|web-apis[/\\]dist[/\\]index\.(?:m?js|cjs)|weapp-vite[/\\](?:dist[/\\]web-apis\.mjs|src[/\\](?:webApis\.ts|runtime[/\\]webApis[/\\]index\.ts)))(?:$|[?#])/
-const REG_HASHED_DIST_CHUNK_ID = /(?:^|[/\\])dist[/\\]([^/\\-]+)-([\w-]{6,})\.(?:m?js|cjs)(?:$|[?#])/
+const REG_HASHED_DIST_CHUNK_ID = /(?:^|[/\\])dist[/\\](?:dev[/\\])?([^/\\-]+)-([\w-]{6,})\.(?:m?js|cjs)(?:$|[?#])/
 const STABLE_HASHED_DIST_CHUNK_PRIORITY = ['src']
 
 function resolveSharedPathRoot(

--- a/packages/weapp-vite/src/types/config/features.ts
+++ b/packages/weapp-vite/src/types/config/features.ts
@@ -302,6 +302,11 @@ export interface WeappWevuConfig {
   preset?: 'performance'
   defaults?: WevuDefaults
   autoSetDataPick?: boolean
+  /**
+   * @description 是否压缩 wevu 相关脚本输出。
+   * @description 默认保持当前可读输出行为，开启后仅影响 wevu 编译生成的脚本代码。
+   */
+  minify?: boolean
 }
 
 export interface WeappRouteRule {

--- a/packages/weapp-vite/src/types/config/features.ts
+++ b/packages/weapp-vite/src/types/config/features.ts
@@ -307,6 +307,10 @@ export interface WeappWevuConfig {
    * @description 默认保持当前可读输出行为，开启后仅影响 wevu 编译生成的脚本代码。
    */
   minify?: boolean
+  /**
+   * @description wevu 运行时入口版本。`auto` 表示开发模式使用 `dist/dev`，构建模式使用 `dist`。
+   */
+  runtime?: 'auto' | 'dev' | 'build'
 }
 
 export interface WeappRouteRule {

--- a/packages/weapp-vite/test-d/config-define-config/index.test-d.ts
+++ b/packages/weapp-vite/test-d/config-define-config/index.test-d.ts
@@ -6,6 +6,7 @@ const objectConfig = defineConfig({
   weapp: {
     srcRoot: 'src',
     wevu: {
+      minify: true,
       defaults: {
         component: {
           allowNullPropInput: false,
@@ -62,6 +63,7 @@ const objectConfig = defineConfig({
 })
 expectAssignable<string | undefined>(objectConfig.weapp?.srcRoot)
 expectAssignable<boolean | undefined>(objectConfig.weapp?.wevu?.defaults?.component?.allowNullPropInput)
+expectAssignable<boolean | undefined>(objectConfig.weapp?.wevu?.minify)
 expectAssignable<boolean | {
   enabled?: boolean
   mode?: 'inline' | 'entry' | 'require'

--- a/packages/weapp-vite/test-d/config-define-config/index.test-d.ts
+++ b/packages/weapp-vite/test-d/config-define-config/index.test-d.ts
@@ -7,6 +7,7 @@ const objectConfig = defineConfig({
     srcRoot: 'src',
     wevu: {
       minify: true,
+      runtime: 'auto' as const,
       defaults: {
         component: {
           allowNullPropInput: false,
@@ -64,6 +65,7 @@ const objectConfig = defineConfig({
 expectAssignable<string | undefined>(objectConfig.weapp?.srcRoot)
 expectAssignable<boolean | undefined>(objectConfig.weapp?.wevu?.defaults?.component?.allowNullPropInput)
 expectAssignable<boolean | undefined>(objectConfig.weapp?.wevu?.minify)
+expectAssignable<'auto' | 'dev' | 'build' | undefined>(objectConfig.weapp?.wevu?.runtime)
 expectAssignable<boolean | {
   enabled?: boolean
   mode?: 'inline' | 'entry' | 'require'

--- a/packages/weapp-vite/test/issue-446-watch-auto-import-template-ref.test.ts
+++ b/packages/weapp-vite/test/issue-446-watch-auto-import-template-ref.test.ts
@@ -88,21 +88,39 @@ function resolveComputedExportName(pageOutput: string) {
   return computedCall[1] ?? 'computed'
 }
 
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function hasWevuComputedRuntimeExport(code: string, exportName: string) {
+  const escapedExportName = escapeRegExp(exportName)
+  return [
+    new RegExp(`Object\\.defineProperty\\(exports, "${escapedExportName}"`),
+    new RegExp(`exports(?:\\.${escapedExportName}|\\["${escapedExportName}"\\])\\s*=`),
+    new RegExp(`\\b${escapedExportName}\\s*:\\s*\\(\\)\\s*=>`),
+    new RegExp(`export\\s*\\{[^}]*\\b(?:[\\w$]+\\s+as\\s+${escapedExportName}|${escapedExportName})\\b[^}]*\\}`),
+  ].some(pattern => pattern.test(code))
+}
+
 async function readWevuComputedRuntime(outDir: string, exportName: string) {
   const vendorRoot = path.resolve(outDir, 'weapp-vendors')
   const files = await fs.readdir(vendorRoot)
+  const computedCandidates: string[] = []
   for (const file of files) {
     if (!file.endsWith('.js')) {
       continue
     }
     const filePath = path.join(vendorRoot, file)
     const code = await fs.readFile(filePath, 'utf8')
-    if (code.includes(`Object.defineProperty(exports, "${exportName}"`)) {
+    if (code.includes('computed')) {
+      computedCandidates.push(file)
+    }
+    if (hasWevuComputedRuntimeExport(code, exportName)) {
       return code
     }
   }
 
-  throw new Error(`watch build output missing wevu computed export: ${exportName}`)
+  throw new Error(`watch build output missing wevu computed export: ${exportName}; vendor files: ${files.join(', ')}; computed candidates: ${computedCandidates.join(', ')}`)
 }
 
 describe.sequential('issue #446 watch auto-import component template ref', () => {
@@ -149,7 +167,7 @@ describe.sequential('issue #446 watch auto-import component template ref', () =>
 
       expect(initialPageOutput).toMatch(/(?:computed|require_[\w$]+\.[\w$]+)\(\(\) => nativeAnchorRef\.value != null\)/)
       expect(initialPageOutput).toMatch(/(?:computed|require_[\w$]+\.[\w$]+)\(\(\) => typeof shortBindProbeRef\.value\?\.snapshot === "function"\)/)
-      expect(initialRuntimeOutput).toContain(`Object.defineProperty(exports, "${initialComputedExport}"`)
+      expect(hasWevuComputedRuntimeExport(initialRuntimeOutput, initialComputedExport)).toBe(true)
 
       const originalSource = await fs.readFile(pageSourcePath, 'utf8')
       const updatedSource = originalSource.replaceAll('issue-446-short-bind', 'issue-446-short-bind-updated')
@@ -167,7 +185,7 @@ describe.sequential('issue #446 watch auto-import component template ref', () =>
       expect(updatedPageOutput).toContain('issue-446-short-bind-updated')
       expect(updatedPageOutput).toMatch(/(?:computed|require_[\w$]+\.[\w$]+)\(\(\) => nativeAnchorRef\.value != null\)/)
       expect(updatedPageOutput).toMatch(/(?:computed|require_[\w$]+\.[\w$]+)\(\(\) => typeof shortBindProbeRef\.value\?\.snapshot === "function"\)/)
-      expect(updatedRuntimeOutput).toContain(`Object.defineProperty(exports, "${updatedComputedExport}"`)
+      expect(hasWevuComputedRuntimeExport(updatedRuntimeOutput, updatedComputedExport)).toBe(true)
     }
     finally {
       await watcher?.close()

--- a/scripts/workspace-hmr/templates-baseline.json
+++ b/scripts/workspace-hmr/templates-baseline.json
@@ -100,7 +100,7 @@
           "dirtyCount": 1,
           "pendingCount": 1,
           "emittedCount": 1,
-          "impactFiles": 1
+          "impactFiles": 5
         }
       }
     },


### PR DESCRIPTION
## 摘要

- 增加 `weapp.wevu.minify` 配置，默认在 dev 为 `false`、build 为 `true`
- dev 模式默认使用 `wevu/dist/dev` 未压缩运行时，build 模式默认使用压缩运行时
- 显式配置 `weapp.wevu.minify` 时同时控制脚本压缩和运行时入口选择
- 将 PR CI 的关键默认执行环境切到 Node 24，同时保留全量矩阵里的 Node 20/22/24 兼容覆盖

## 验证

- `pnpm --filter @wevu/compiler test -- transformScript/minify.test.ts pageFeatures/inject.test.ts`
- `pnpm --filter weapp-vite test -- compileOptions.test.ts wevuPreset.test.ts createConfigService.test.ts miniprogram.test.ts packageAliases.test.ts sharedBuildConfig.test.ts issue-446-watch-auto-import-template-ref.test.ts`
- `pnpm --filter @wevu/compiler typecheck`
- `pnpm --filter weapp-vite typecheck`
- `pnpm --filter weapp-vite test:types`
- `pnpm build:pkgs`
- `pnpm test`
- `pnpm e2e:ci`
- `git diff --check`
- YAML 解析校验：`.github/workflows/ci-create-weapp-vite.yml`、`.github/workflows/ci-performance.yml`、`.github/workflows/ci-vscode-extension.yml`、`.github/workflows/miniprogram-ci.yml`

Closes #593
