### PR TITLE
feat(weapp-vite): 支持 scoped build

### DIFF
--- a/.changeset/swift-scope-build.md
+++ b/.changeset/swift-scope-build.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+新增 scoped build 配置和 CLI 参数，支持通过 `weapp.buildScope` 或 `wv dev/build --scope` 只构建主包与指定分包，并同步裁剪自动路由、typed router、分包声明、preloadRule 与开发态监听范围。

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -6,6 +6,7 @@ const issue510AugmentedEnabled = process.env.WEAPP_GITHUB_ISSUE_510_AUGMENTED ==
 const issue547AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_547_AUGMENTED === 'true'
 const issue558AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_558_AUGMENTED === 'true'
 const issue564AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_564_AUGMENTED === 'true'
+const issue595ScopedBuildEnabled = process.env.WEAPP_GITHUB_ISSUE_595_SCOPED === 'true'
 const e2eTargetFile = process.env.WEAPP_VITE_E2E_TARGET_FILE?.replaceAll('\\', '/') ?? ''
 const slotFallbackCompilerOffEnabled = process.env.WEAPP_GITHUB_SLOT_FALLBACK_COMPILER_OFF === 'true'
   || e2eTargetFile.endsWith('github-issues.runtime.slot-fallback-compiler-off.test.ts')
@@ -312,5 +313,11 @@ export default defineConfig({
               outDir: 'dist-slot-fallback-compiler-off',
             },
           }
-        : {}),
+        : issue595ScopedBuildEnabled
+          ? {
+              build: {
+                outDir: 'dist-issue-595',
+              },
+            }
+          : {}),
 })

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -12,6 +12,7 @@ const APP_ROOT = path.resolve(import.meta.dirname, '../../e2e-apps/github-issues
 const DIST_ROOT = path.join(APP_ROOT, 'dist')
 const ISSUE_393_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-393')
 const ISSUE_510_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-510')
+const ISSUE_595_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-595')
 const SLOT_FALLBACK_COMPILER_OFF_DIST_ROOT = path.join(APP_ROOT, 'dist-slot-fallback-compiler-off')
 let standardBuildPromise: Promise<void> | null = null
 let distVariant: 'standard' | 'sourcemap' | null = null
@@ -198,6 +199,38 @@ async function runIssue558AugmentedBuild() {
 
   standardBuildPromise = null
   distVariant = null
+}
+
+async function runIssue595ScopedBuild() {
+  await fs.remove(ISSUE_595_DIST_ROOT)
+
+  await execa('node', [
+    CLI_PATH,
+    'build',
+    APP_ROOT,
+    '--platform',
+    'weapp',
+    '--skipNpm',
+    '--scope',
+    'main,subpackages/item',
+    '--config',
+    path.join(APP_ROOT, 'weapp-vite.config.ts'),
+  ], {
+    stdio: 'inherit',
+    env: {
+      ...sanitizeBuildCommandEnv(),
+      WEAPP_GITHUB_ISSUE_595_SCOPED: 'true',
+    },
+  })
+
+  standardBuildPromise = null
+  distVariant = null
+}
+
+interface AppJsonWithSubPackages {
+  pages?: string[]
+  subPackages?: Array<{ root?: string, pages?: string[] }>
+  subpackages?: Array<{ root?: string, pages?: string[] }>
 }
 
 async function runIssue564AugmentedBuild() {
@@ -769,6 +802,23 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(componentJs).toContain('__wevuProps')
     expect(componentJs).toContain('issue590-badge')
     expect(componentJs).toContain('issue-590 badge')
+  })
+
+  it('issue #595: builds scoped main package and selected subpackage only', async () => {
+    await runIssue595ScopedBuild()
+
+    const appJson = await fs.readJSON(path.join(ISSUE_595_DIST_ROOT, 'app.json')) as AppJsonWithSubPackages
+    const subPackageRoots = (appJson.subPackages ?? appJson.subpackages ?? []).map(entry => entry.root)
+    const files = await scanFiles(ISSUE_595_DIST_ROOT)
+
+    expect(appJson.pages).toContain('pages/block-slot/index')
+    expect(appJson.pages).toContain('pages/issue-590/index')
+    expect(subPackageRoots).toEqual(['subpackages/item'])
+    expect(files).toContain('pages/issue-590/index.js')
+    expect(files).toContain('subpackages/item/index.js')
+    expect(files).toContain('subpackages/item/login-required/index.js')
+    expect(files).not.toContain('subpackages/user/index.js')
+    expect(files).not.toContain('subpackages/issue-466/index.js')
   })
 
   it('issue #500: compiles missing inject continuation probe', async () => {

--- a/packages/weapp-vite/docs/packaged/weapp-config.md
+++ b/packages/weapp-vite/docs/packaged/weapp-config.md
@@ -24,6 +24,30 @@ export default defineConfig({
 
 适合希望用约定生成页面路由的项目。启用后要保持 pages 目录与输出约定稳定。
 
+### `buildScope`
+
+用于只构建主包和指定分包。常用在大项目里只调试某几个业务分包：
+
+```bash
+wv dev --scope main,packages/order
+wv build --scope packages/order
+```
+
+也可以写在配置里：
+
+```ts
+export default defineConfig({
+  weapp: {
+    buildScope: {
+      includeMainPackage: true,
+      include: ['packages/order'],
+    },
+  },
+})
+```
+
+`main` 表示主包，`packages/order` 匹配 `app.json.subPackages[].root`。启用后，产物 `app.json.subPackages` 只保留参与 scope 的分包，`preloadRule`、自动路由和 typed router 也会按同一范围裁剪。发布前建议再跑不带 scope 的完整构建。
+
 ### `autoImportComponents`
 
 适合用目录扫描自动注册组件的项目。组件重名时要先解决命名冲突，不要让自动引入规则长期处于歧义状态。

--- a/packages/weapp-vite/src/cli/commands/build.ts
+++ b/packages/weapp-vite/src/cli/commands/build.ts
@@ -72,11 +72,12 @@ export function registerBuildCommand(cli: CAC) {
     .option('--trust-project', '[boolean] auto trust Wechat DevTools project on open', { default: true })
     .option('--ui', `[boolean] 启动调试 UI（当前提供分析视图）`, { default: false })
     .option('--analyze', `[boolean] 输出分包分析仪表盘`, { default: false })
+    .option('--scope <scope>', `[string] 局部构建范围，例如 main,packages/order`)
     .action(async (root: string, options: GlobalCLIOptions) => {
       filterDuplicateOptions(options)
       const configFile = resolveConfigFile(options)
       const targets = resolveRuntimeTargets(options)
-      const inlineConfig = createInlineConfig(targets.platform)
+      const inlineConfig = createInlineConfig(targets.platform, options.scope)
       const ctx = await createCompilerContext({
         cwd: root,
         mode: options.mode ?? 'production',

--- a/packages/weapp-vite/src/cli/commands/serve/index.ts
+++ b/packages/weapp-vite/src/cli/commands/serve/index.ts
@@ -28,11 +28,12 @@ export function registerServeCommand(cli: CAC) {
     .option('--host [host]', `[string] web dev server host`)
     .option('--ui', `[boolean] 启动调试 UI（当前提供分析视图）`, { default: false })
     .option('--analyze', `[boolean] 启动分包分析仪表盘 (实验特性)`, { default: false })
+    .option('--scope <scope>', `[string] 局部构建范围，例如 main,packages/order`)
     .action(async (root: string, options: GlobalCLIOptions) => {
       filterDuplicateOptions(options)
       const configFile = resolveConfigFile(options)
       const targets = resolveRuntimeTargets(options)
-      let inlineConfig = createInlineConfig(targets.platform)
+      let inlineConfig = createInlineConfig(targets.platform, options.scope)
       if (targets.runWeb) {
         const host = resolveWebHost(options.host)
         if (host !== undefined) {

--- a/packages/weapp-vite/src/cli/runtime.ts
+++ b/packages/weapp-vite/src/cli/runtime.ts
@@ -1,6 +1,7 @@
 import type { InlineConfig } from 'vite'
 import type { MpPlatform } from '../types'
 import logger, { colors } from '../logger'
+import { createBuildScopeConfigFromCli } from '../runtime/buildScope'
 import { resolveWeappViteTarget } from '../runtimeTarget'
 
 export interface RuntimeTargets {
@@ -49,13 +50,15 @@ export function resolveRuntimeTargets(options: { platform?: string, p?: string }
   }
 }
 
-export function createInlineConfig(platform: MpPlatform | undefined): InlineConfig | undefined {
-  if (!platform) {
+export function createInlineConfig(platform: MpPlatform | undefined, scope?: string): InlineConfig | undefined {
+  const buildScope = createBuildScopeConfigFromCli(scope)
+  if (!platform && !buildScope) {
     return undefined
   }
   return {
     weapp: {
-      platform,
+      ...(platform ? { platform } : {}),
+      ...(buildScope ? { buildScope } : {}),
     },
   }
 }

--- a/packages/weapp-vite/src/cli/types.ts
+++ b/packages/weapp-vite/src/cli/types.ts
@@ -27,6 +27,7 @@ export interface GlobalCLIOptions {
   'trustProject'?: boolean
   'analyze'?: boolean
   'ui'?: boolean
+  'scope'?: string
 }
 
 export interface AnalyzeCLIOptions extends GlobalCLIOptions {

--- a/packages/weapp-vite/src/runtime/autoRoutesPlugin/routes/scan.ts
+++ b/packages/weapp-vite/src/runtime/autoRoutesPlugin/routes/scan.ts
@@ -3,6 +3,7 @@ import type { AutoRoutes, AutoRoutesSubPackage } from '../../../types/routes'
 import type { CandidateEntry } from '../candidates'
 import path from 'pathe'
 import { toPosixPath } from '../../../utils/path'
+import { applyBuildScopeToAutoRoutes, resolveBuildScope } from '../../buildScope'
 import { createAutoRoutesArtifacts } from '../service/shared'
 import { resolveAutoRoutesMatcherContext } from '../shared'
 import { resolveRoute } from './resolve'
@@ -158,11 +159,11 @@ export async function scanRoutes(
   sortAutoRoutesEntries(entries)
   sortAutoRoutesSubPackages(subPackageList)
 
-  const snapshot: AutoRoutes = {
+  const snapshot: AutoRoutes = applyBuildScopeToAutoRoutes({
     pages,
     entries,
     subPackages: subPackageList,
-  }
+  }, resolveBuildScope(configService.weappViteConfig.buildScope))
 
   const { serialized, moduleCode, typedDefinition } = createAutoRoutesArtifacts(snapshot)
 

--- a/packages/weapp-vite/src/runtime/autoRoutesPlugin/subPackageRoots.ts
+++ b/packages/weapp-vite/src/runtime/autoRoutesPlugin/subPackageRoots.ts
@@ -1,4 +1,5 @@
 import type { MutableCompilerContext } from '../../context'
+import { applyBuildScopeToSubPackageRoots, resolveBuildScope } from '../buildScope'
 
 interface AppJsonLikeSubPackage {
   root?: string
@@ -30,5 +31,8 @@ export function getAutoRoutesSubPackageRoots(
     roots.add(root)
   }
 
-  return [...roots]
+  return applyBuildScopeToSubPackageRoots(
+    [...roots],
+    resolveBuildScope(ctx.configService?.weappViteConfig?.buildScope),
+  )
 }

--- a/packages/weapp-vite/src/runtime/buildScope.test.ts
+++ b/packages/weapp-vite/src/runtime/buildScope.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyBuildScopeToAppConfig,
+  applyBuildScopeToAutoRoutes,
+  applyBuildScopeToSubPackageRoots,
+  createBuildScopeConfigFromCli,
+  resolveBuildScope,
+  resolveBuildScopeFromCli,
+} from './buildScope'
+
+describe('buildScope', () => {
+  it('normalizes cli scope with main package enabled by default', () => {
+    expect(resolveBuildScopeFromCli('main, packages/order, packages\\user')).toEqual({
+      enabled: true,
+      includeMainPackage: true,
+      subPackageRoots: ['packages/order', 'packages/user'],
+      source: 'cli',
+    })
+
+    expect(createBuildScopeConfigFromCli('packages/order')).toMatchObject({
+      includeMainPackage: true,
+      include: ['packages/order'],
+    })
+  })
+
+  it('allows config to disable main package explicitly', () => {
+    expect(resolveBuildScope({
+      includeMainPackage: false,
+      include: ['packages/order'],
+    })).toEqual({
+      enabled: true,
+      includeMainPackage: false,
+      subPackageRoots: ['packages/order'],
+      source: 'config',
+    })
+  })
+
+  it('filters app config pages, subpackages and preload rules by scope', () => {
+    const appConfig = {
+      pages: ['pages/home/index'],
+      subPackages: [
+        { root: 'packages/order', pages: ['pages/list/index'] },
+        { root: 'packages/user', pages: ['pages/profile/index'] },
+      ],
+      preloadRule: {
+        'pages/home/index': {
+          network: 'all',
+          packages: ['packages/order', 'packages/user'],
+        },
+        'packages/user/pages/profile/index': {
+          packages: ['packages/order'],
+        },
+      },
+    }
+
+    applyBuildScopeToAppConfig(appConfig, resolveBuildScope({
+      include: ['packages/order'],
+    }))
+
+    expect(appConfig.pages).toEqual(['pages/home/index'])
+    expect(appConfig.subPackages).toEqual([
+      { root: 'packages/order', pages: ['pages/list/index'] },
+    ])
+    expect(appConfig).not.toHaveProperty('subpackages')
+    expect(appConfig.preloadRule).toEqual({
+      'pages/home/index': {
+        network: 'all',
+        packages: ['packages/order'],
+      },
+    })
+  })
+
+  it('can build only a target subpackage when main package is disabled', () => {
+    const appConfig = {
+      pages: ['pages/home/index'],
+      subpackages: [
+        { root: 'packages/order', pages: ['pages/list/index'] },
+        { root: 'packages/user', pages: ['pages/profile/index'] },
+      ],
+      preloadRule: {
+        'pages/home/index': {
+          packages: ['packages/order'],
+        },
+        'packages/order/pages/list/index': {
+          packages: ['packages/user'],
+        },
+      },
+    }
+
+    applyBuildScopeToAppConfig(appConfig, resolveBuildScope({
+      includeMainPackage: false,
+      include: ['packages/order'],
+    }))
+
+    expect(appConfig.pages).toEqual([])
+    expect(appConfig.subPackages).toEqual([
+      { root: 'packages/order', pages: ['pages/list/index'] },
+    ])
+    expect(appConfig.preloadRule).toBeUndefined()
+  })
+
+  it('filters auto-routes module snapshot by build scope', () => {
+    const scopedRoutes = applyBuildScopeToAutoRoutes({
+      pages: ['pages/home/index'],
+      entries: [
+        'pages/home/index',
+        'packages/order/pages/list/index',
+        'packages/user/pages/profile/index',
+      ],
+      subPackages: [
+        { root: 'packages/order', pages: ['pages/list/index'] },
+        { root: 'packages/user', pages: ['pages/profile/index'] },
+      ],
+    }, resolveBuildScope({ include: ['packages/order'] }))
+
+    expect(scopedRoutes).toEqual({
+      pages: ['pages/home/index'],
+      entries: [
+        'pages/home/index',
+        'packages/order/pages/list/index',
+      ],
+      subPackages: [
+        { root: 'packages/order', pages: ['pages/list/index'] },
+      ],
+    })
+  })
+
+  it('filters auto-routes subpackage roots before candidate matching', () => {
+    expect(applyBuildScopeToSubPackageRoots(
+      ['packages/order', 'packages/user'],
+      resolveBuildScope({ include: ['packages/order'] }),
+    )).toEqual(['packages/order'])
+  })
+})

--- a/packages/weapp-vite/src/runtime/buildScope.ts
+++ b/packages/weapp-vite/src/runtime/buildScope.ts
@@ -1,0 +1,231 @@
+import type { App as AppJson } from '@weapp-core/schematics'
+import type { WeappBuildScopeConfig } from '../types'
+import type { AutoRoutes } from '../types/routes'
+import { normalizeRoot } from '../utils/path'
+
+export interface ResolvedBuildScope {
+  enabled: boolean
+  includeMainPackage: boolean
+  subPackageRoots: string[]
+  source: 'cli' | 'config'
+}
+
+type BuildScopeSubPackage = NonNullable<AppJson['subPackages']>[number]
+
+export type BuildScopeAppJson = AppJson & {
+  subpackages?: BuildScopeSubPackage[]
+  subPackages?: BuildScopeSubPackage[]
+  preloadRule?: Record<string, unknown>
+}
+
+const MAIN_SCOPE_TOKEN = 'main'
+const BUILD_SCOPE_CLI_SOURCE = '__weappViteBuildScopeSource'
+
+function normalizeScopeRoot(value: string) {
+  return normalizeRoot(value.trim())
+}
+
+function parseScopeTokens(value: string | string[] | undefined) {
+  const rawTokens = Array.isArray(value) ? value : typeof value === 'string' ? value.split(',') : []
+  const tokens = rawTokens
+    .map(token => normalizeScopeRoot(token))
+    .filter(token => token.length > 0)
+  return [...new Set(tokens)]
+}
+
+function normalizeBuildScopeConfig(
+  config: WeappBuildScopeConfig | undefined,
+  source: ResolvedBuildScope['source'],
+): ResolvedBuildScope | undefined {
+  if (!config) {
+    return undefined
+  }
+
+  if (typeof config === 'string' || Array.isArray(config)) {
+    const tokens = parseScopeTokens(config)
+    if (tokens.length === 0) {
+      return undefined
+    }
+    return {
+      enabled: true,
+      includeMainPackage: true,
+      subPackageRoots: tokens.filter(token => token !== MAIN_SCOPE_TOKEN),
+      source,
+    }
+  }
+
+  const include = parseScopeTokens(config.include)
+  const includeMainPackage = config.includeMainPackage ?? true
+  const subPackageRoots = include.filter(token => token !== MAIN_SCOPE_TOKEN)
+  if (!includeMainPackage && subPackageRoots.length === 0) {
+    return undefined
+  }
+
+  return {
+    enabled: true,
+    includeMainPackage,
+    subPackageRoots,
+    source: (config as Record<string, unknown>)[BUILD_SCOPE_CLI_SOURCE] === true ? 'cli' : source,
+  }
+}
+
+export function resolveBuildScope(config: WeappBuildScopeConfig | undefined) {
+  return normalizeBuildScopeConfig(config, 'config')
+}
+
+export function createBuildScopeConfigFromCli(value: string | undefined): WeappBuildScopeConfig | undefined {
+  const tokens = parseScopeTokens(value)
+  if (tokens.length === 0) {
+    return undefined
+  }
+  return {
+    includeMainPackage: true,
+    include: tokens.filter(token => token !== MAIN_SCOPE_TOKEN),
+    [BUILD_SCOPE_CLI_SOURCE]: true,
+  }
+}
+
+export function resolveBuildScopeFromCli(value: string | undefined) {
+  return normalizeBuildScopeConfig(createBuildScopeConfigFromCli(value), 'cli')
+}
+
+function isSubPackageInScope(subPackage: { root?: string }, roots: ReadonlySet<string>) {
+  const root = subPackage.root ? normalizeRoot(subPackage.root) : undefined
+  return Boolean(root && roots.has(root))
+}
+
+function normalizeScopedSubPackage<T extends { root?: string, pages?: string[] }>(subPackage: T): T & { root: string, pages: string[] } {
+  return {
+    ...subPackage,
+    root: normalizeRoot(subPackage.root ?? ''),
+    pages: Array.isArray(subPackage.pages) ? subPackage.pages : [],
+  }
+}
+
+function filterPreloadRule(
+  preloadRule: Record<string, unknown> | undefined,
+  scope: ResolvedBuildScope,
+  allSubPackageRoots: ReadonlySet<string>,
+) {
+  if (!preloadRule || typeof preloadRule !== 'object') {
+    return preloadRule
+  }
+
+  const scopedRoots = new Set(scope.subPackageRoots)
+  const scopedPreloadRule: Record<string, unknown> = {}
+  for (const [pagePath, rule] of Object.entries(preloadRule)) {
+    const normalizedPagePath = normalizeRoot(pagePath)
+    const pageSubPackageRoot = [...allSubPackageRoots]
+      .find(root => normalizedPagePath === root || normalizedPagePath.startsWith(`${root}/`))
+    const isPageInScope = pageSubPackageRoot
+      ? scopedRoots.has(pageSubPackageRoot)
+      : scope.includeMainPackage
+    if (!isPageInScope) {
+      continue
+    }
+
+    if (!rule || typeof rule !== 'object' || !('packages' in rule)) {
+      scopedPreloadRule[pagePath] = rule
+      continue
+    }
+
+    const packages = (rule as { packages?: unknown }).packages
+    if (!Array.isArray(packages)) {
+      scopedPreloadRule[pagePath] = rule
+      continue
+    }
+
+    const filteredPackages = packages.filter((packageRoot) => {
+      return typeof packageRoot === 'string' && scopedRoots.has(normalizeRoot(packageRoot))
+    })
+    if (filteredPackages.length > 0) {
+      scopedPreloadRule[pagePath] = {
+        ...rule,
+        packages: filteredPackages,
+      }
+    }
+  }
+
+  return Object.keys(scopedPreloadRule).length > 0 ? scopedPreloadRule : undefined
+}
+
+export function applyBuildScopeToAppConfig(
+  config: BuildScopeAppJson,
+  scope: ResolvedBuildScope | undefined,
+) {
+  if (!scope?.enabled) {
+    return config
+  }
+
+  const scopedRoots = new Set(scope.subPackageRoots)
+  const sourceSubPackages = Array.isArray(config.subPackages)
+    ? config.subPackages
+    : Array.isArray(config.subpackages)
+      ? config.subpackages
+      : []
+  const allSubPackageRoots = new Set(
+    sourceSubPackages
+      .map(subPackage => subPackage.root ? normalizeRoot(subPackage.root) : undefined)
+      .filter((root): root is string => Boolean(root)),
+  )
+  const scopedSubPackages = sourceSubPackages
+    .filter(subPackage => isSubPackageInScope(subPackage, scopedRoots))
+    .map(normalizeScopedSubPackage)
+
+  config.pages = scope.includeMainPackage && Array.isArray(config.pages)
+    ? config.pages
+    : []
+  ;(config as { subPackages: BuildScopeSubPackage[] }).subPackages = scopedSubPackages
+  delete config.subpackages
+
+  const preloadRule = filterPreloadRule(config.preloadRule, scope, allSubPackageRoots)
+  if (preloadRule) {
+    config.preloadRule = preloadRule
+  }
+  else {
+    delete config.preloadRule
+  }
+
+  return config
+}
+
+export function applyBuildScopeToAutoRoutes(
+  routes: AutoRoutes,
+  scope: ResolvedBuildScope | undefined,
+) {
+  if (!scope?.enabled) {
+    return routes
+  }
+
+  const scopedRoots = new Set(scope.subPackageRoots)
+  const subPackages = routes.subPackages
+    .filter(subPackage => scopedRoots.has(normalizeRoot(subPackage.root)))
+    .map(subPackage => ({
+      ...subPackage,
+      root: normalizeRoot(subPackage.root),
+    }))
+  const scopedEntries = new Set([
+    ...scope.includeMainPackage ? routes.pages : [],
+    ...subPackages.flatMap(subPackage => subPackage.pages.map(page => `${subPackage.root}/${page}`)),
+  ])
+
+  return {
+    pages: scope.includeMainPackage ? routes.pages : [],
+    entries: routes.entries.filter(entry => scopedEntries.has(entry)),
+    subPackages,
+  }
+}
+
+export function applyBuildScopeToSubPackageRoots(
+  roots: string[],
+  scope: ResolvedBuildScope | undefined,
+) {
+  if (!scope?.enabled) {
+    return roots
+  }
+
+  const scopedRoots = new Set(scope.subPackageRoots)
+  return roots
+    .map(root => normalizeRoot(root))
+    .filter(root => scopedRoots.has(root))
+}

--- a/packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.test.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.test.ts
@@ -47,6 +47,22 @@ describe('runtime config merge miniprogram', () => {
     ])
   })
 
+  it('narrows miniprogram watch include patterns when build scope is enabled', () => {
+    expect(resolveMiniprogramWatchInclude({
+      cwd: '/project',
+      srcRoot: 'src',
+      buildScope: {
+        enabled: true,
+        includeMainPackage: true,
+        subPackageRoots: ['packages/order'],
+        source: 'config',
+      },
+    })).toEqual([
+      '/project/src/pages/**',
+      '/project/src/packages/order/**',
+    ])
+  })
+
   it('builds development inline config with watch include/exclude and plugin root outside src', () => {
     const applyRuntimePlatform = vi.fn()
     const injectBuiltinAliases = vi.fn()

--- a/packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.ts
@@ -8,6 +8,7 @@ import path from 'pathe'
 import { createLogger } from 'vite'
 import { defaultExcluded } from '../../../../defaults'
 import { applyWeappViteHostMeta } from '../../../../pluginHost'
+import { resolveBuildScope } from '../../../buildScope'
 import { resolveNpmBuildCandidateDependenciesSync } from '../../../npmPlugin/service'
 import { resolveBuiltinPackageAliases } from '../../../packageAliases'
 import { stripRollupOptions } from './inline'
@@ -77,10 +78,17 @@ export function resolveMiniprogramWatchInclude(options: {
   cwd: string
   srcRoot: string
   pluginRoot?: string
+  buildScope?: ReturnType<typeof resolveBuildScope>
 }) {
-  const watchInclude: string[] = [
-    path.join(options.cwd, options.srcRoot, '**'),
-  ]
+  const srcRoot = path.join(options.cwd, options.srcRoot)
+  const watchInclude: string[] = options.buildScope?.enabled
+    ? [
+        ...options.buildScope.includeMainPackage ? [path.join(srcRoot, 'pages', '**')] : [],
+        ...options.buildScope.subPackageRoots.map(root => path.join(srcRoot, root, '**')),
+      ]
+    : [
+        path.join(srcRoot, '**'),
+      ]
 
   if (!options.pluginRoot) {
     return watchInclude
@@ -163,6 +171,7 @@ export function mergeMiniprogram(options: MergeMiniprogramOptions, ...configs: P
       cwd,
       srcRoot,
       pluginRoot: config.weapp?.pluginRoot,
+      buildScope: resolveBuildScope(config.weapp?.buildScope),
     })
 
     const inline = defu<InlineConfig, (InlineConfig | undefined)[]>(

--- a/packages/weapp-vite/src/runtime/scanPlugin/service.test.ts
+++ b/packages/weapp-vite/src/runtime/scanPlugin/service.test.ts
@@ -392,6 +392,47 @@ describe('scanPlugin service', () => {
     ])
   })
 
+  it('applies build scope after auto-routes hydrate app config', async () => {
+    findJsonEntryMock.mockResolvedValue({ path: undefined })
+    findJsEntryMock.mockResolvedValue({ path: undefined })
+    findVueEntryMock.mockResolvedValue('/project/src/app.vue')
+    extractConfigFromVueMock.mockResolvedValue({})
+
+    const autoRoutesService = {
+      isEnabled: vi.fn(() => true),
+      ensureFresh: vi.fn(async () => {}),
+      getReference: vi.fn(() => ({
+        pages: ['pages/home/index'],
+        entries: ['pages/home/index', 'pkgA/pages/a', 'pkgB/pages/b'],
+        subPackages: [
+          { root: 'pkgA', pages: ['pages/a'] },
+          { root: 'pkgB', pages: ['pages/b'] },
+        ],
+      })),
+    }
+
+    const ctx = createCtx({
+      configService: {
+        absoluteSrcRoot: '/project/src',
+        absolutePluginRoot: undefined,
+        weappViteConfig: {
+          autoRoutes: true,
+          buildScope: {
+            include: ['pkgB'],
+          },
+        },
+      },
+      autoRoutesService,
+    })
+
+    const { createScanService } = await import('./service')
+    const service = createScanService(ctx)
+    const entry = await service.loadAppEntry()
+
+    expect(entry.json.pages).toEqual(['pages/home/index'])
+    expect(entry.json.subPackages).toEqual([{ root: 'pkgB', pages: ['pages/b'] }])
+  })
+
   it('throws when app config resolves but is not an object', async () => {
     findJsonEntryMock.mockResolvedValue({ path: '/project/src/app.json' })
     findJsEntryMock.mockResolvedValue({ path: '/project/src/app.ts' })

--- a/packages/weapp-vite/src/runtime/scanPlugin/service/app.ts
+++ b/packages/weapp-vite/src/runtime/scanPlugin/service/app.ts
@@ -7,6 +7,7 @@ import { fs } from '@weapp-core/shared/fs'
 import path from 'pathe'
 import { jsExtensions } from '../../../constants'
 import { findJsEntry, findJsonEntry, findVueEntry } from '../../../utils'
+import { applyBuildScopeToAppConfig, resolveBuildScope } from '../../buildScope'
 import { createWarnOnce, mergeAutoRoutePages } from './shared'
 
 export function resolveScanAppBasename(absoluteSrcRoot: string) {
@@ -221,6 +222,7 @@ export async function loadAppEntry(ctx: MutableCompilerContext, scanState: ScanS
       }
     }
     await applyAutoRoutesToAppConfigIfNeeded(ctx, config)
+    applyBuildScopeToAppConfig(config, resolveBuildScope(ctx.configService.weappViteConfig.buildScope))
 
     if (isObject(config)) {
       normalizeAppConfigSubPackages(config)

--- a/packages/weapp-vite/src/types/config/features.ts
+++ b/packages/weapp-vite/src/types/config/features.ts
@@ -142,6 +142,27 @@ export interface WeappAutoRoutesConfig {
 }
 
 /**
+ * @description 局部构建范围配置。
+ */
+export interface WeappBuildScopeObjectConfig {
+  /**
+   * @description 是否包含主包页面。
+   */
+  includeMainPackage?: boolean
+  /**
+   * @description 参与构建的分包 root 列表。`main` 表示主包。
+   */
+  include?: string[]
+  /**
+   * @internal
+   * @description CLI 注入来源标记。
+   */
+  __weappViteBuildScopeSource?: boolean
+}
+
+export type WeappBuildScopeConfig = string | string[] | WeappBuildScopeObjectConfig
+
+/**
  * @description `@wevu/api` 注入配置
  */
 export interface WeappInjectWeapiConfig {

--- a/packages/weapp-vite/src/types/config/main.ts
+++ b/packages/weapp-vite/src/types/config/main.ts
@@ -7,6 +7,7 @@ import type {
   MultiPlatformConfig,
   WeappAppPreludeConfig,
   WeappAutoRoutesConfig,
+  WeappBuildScopeConfig,
   WeappHmrConfig,
   WeappInjectRequestGlobalsConfig,
   WeappInjectWeapiConfig,
@@ -185,6 +186,10 @@ export interface WeappViteConfig {
    * analyze 报告配置。
    */
   analyze?: WeappAnalyzeConfig
+  /**
+   * 局部构建范围。默认不启用，启用后只构建主包和指定分包。
+   */
+  buildScope?: WeappBuildScopeConfig
   jsonAlias?: AliasOptions
   npm?: WeappNpmConfig
   generate?: GenerateOptions

--- a/packages/weapp-vite/test-d/config-define-config/index.test-d.ts
+++ b/packages/weapp-vite/test-d/config-define-config/index.test-d.ts
@@ -36,6 +36,10 @@ const objectConfig = defineConfig({
         limit: 20,
       },
     },
+    buildScope: {
+      includeMainPackage: true,
+      include: ['main', 'subpackages/item'],
+    },
     vue: {
       template: {
         htmlTagToWxml: {
@@ -95,6 +99,10 @@ expectAssignable<{
     limit?: number
   }
 } | undefined>(objectConfig.weapp?.analyze)
+expectAssignable<string | string[] | {
+  includeMainPackage?: boolean
+  include?: string[]
+} | undefined>(objectConfig.weapp?.buildScope)
 expectAssignable<boolean | Record<string, string> | undefined>(objectConfig.weapp?.vue?.template?.htmlTagToWxml)
 expectAssignable<boolean | undefined>(objectConfig.weapp?.vue?.template?.htmlTagToWxmlTagClass)
 expectAssignable<boolean | 'auto' | undefined>(objectConfig.weapp?.vue?.template?.formatWxml)
@@ -103,6 +111,7 @@ expectAssignable<boolean | undefined>(objectConfig.weapp?.vue?.template?.slotSin
 const promiseConfig = defineConfig(Promise.resolve({
   weapp: {
     srcRoot: 'src',
+    buildScope: 'subpackages/item',
   },
 }))
 expectAssignable<Promise<UserConfig>>(promiseConfig)
@@ -111,6 +120,7 @@ const syncNoEnvConfig = defineConfig(() => ({
   weapp: {
     srcRoot: 'src',
     platform: 'alipay',
+    buildScope: ['main', 'subpackages/item'],
     autoImportComponents: {
       vueComponents: true,
     },

--- a/website/config/build-and-output.md
+++ b/website/config/build-and-output.md
@@ -116,6 +116,54 @@ export default defineConfig({
 - `build` 模式始终清空输出目录，不受此字段影响
 - 大项目若频繁冷启动，可按需关闭开发态清理换取速度
 
+## `weapp.buildScope` {#weapp-buildscope}
+
+- **类型**：`string | string[] | { includeMainPackage?: boolean; include?: string[] }`
+- **默认值**：不启用，完整构建
+
+用于只构建主包和指定分包。它适合中大型小程序按业务分包日常开发、局部验证或临时分析，不建议直接替代发布前的完整构建。
+
+```ts
+import { defineConfig } from 'weapp-vite/config'
+
+export default defineConfig({
+  weapp: {
+    buildScope: {
+      includeMainPackage: true,
+      include: ['packages/order', 'packages/user'],
+    },
+  },
+})
+```
+
+等价的 CLI 写法：
+
+```bash
+wv dev --scope main,packages/order,packages/user
+wv build --scope packages/order
+```
+
+语义说明：
+
+- `main` 表示主包。
+- `packages/order` 这类值匹配 `app.json.subPackages[].root` / `subpackages[].root`。
+- CLI `--scope` 优先级高于配置文件里的 `weapp.buildScope`。
+- 字符串写法会按逗号分隔，例如 `'main,packages/order'`。
+- 数组写法适合在配置里复用，例如 `['main', 'packages/order']`。
+- `includeMainPackage` 默认是 `true`，所以 `wv build --scope packages/order` 会构建主包和 `packages/order` 分包。
+- 如果确实要排除主包，可以使用对象写法并设置 `includeMainPackage: false`。
+
+构建效果：
+
+- 产物 `app.json.pages` 只在包含主包时保留。
+- 产物 `app.json.subPackages` 只保留参与 scope 的分包。
+- `preloadRule` 会同步过滤到参与 scope 的页面和分包。
+- 开启 `weapp.autoRoutes` 时，`weapp-vite/auto-routes` 导出的 `pages`、`subPackages`、typed router 也会基于 scope 后的结果生成。
+- 开发态 watcher 会收窄到主包 `pages/**` 与参与 scope 的分包 root。
+
+> [!NOTE]
+> `buildScope` 是入口级裁剪，不是构建完成后删除文件。未参与 scope 的分包不会进入本次 app 注册图，因此微信开发者工具读取到的 `app.json` 也只包含本次参与构建的分包。
+
 ## `weapp.packageSizeWarningBytes` {#weapp-packagesizewarningbytes}
 
 - **类型**：`number`

--- a/website/config/index.md
+++ b/website/config/index.md
@@ -17,7 +17,7 @@ keywords:
 `weapp-vite` 采用 **Vite 顶层配置 + `weapp` 小程序专属配置** 的组合模型：
 
 - 顶层字段仍然是标准 Vite 配置，例如 `build`、`resolve`、`css`、`server`
-- 小程序专属字段放在 `weapp` 下，例如 `srcRoot`、`autoRoutes`、`subPackages`、`mcp`
+- 小程序专属字段放在 `weapp` 下，例如 `srcRoot`、`autoRoutes`、`buildScope`、`subPackages`、`mcp`
 
 ```ts
 // vite.config.ts 或 weapp-vite.config.ts
@@ -133,7 +133,7 @@ export default defineConfig(env => ({
 | 主题 | 内容概览 |
 | --- | --- |
 | [基础目录与资源收集](./paths.md) | `srcRoot` / `pluginRoot` / `copy` / `isAdditionalWxml` |
-| [构建输出与兼容](./build-and-output.md) | `platform` / `multiPlatform` / `jsFormat` / `cleanOutputsInDev` / `packageSizeWarningBytes` / 顶层 `build.*` |
+| [构建输出与兼容](./build-and-output.md) | `platform` / `multiPlatform` / `buildScope` / `jsFormat` / `cleanOutputsInDev` / `packageSizeWarningBytes` / 顶层 `build.*` |
 | [TypeScript 支持文件](./typescript.md) | `.weapp-vite/tsconfig.*`、托管类型输出、`weapp.typescript` |
 | [Analyze 报告配置](./analyze.md) | `weapp.analyze.budgets`、历史快照、Markdown / PR 报告、HMR profile 分析 |
 | [共享配置](./shared.md) | `autoRoutes` / `debug` / `logger` / `appPrelude` / `forwardConsole` / `injectWeapi` / `injectWebRuntimeGlobals` / `mcp` |

--- a/website/guide/cli.md
+++ b/website/guide/cli.md
@@ -69,11 +69,13 @@ wv [root]
 | `--project-config <path>`   | 小程序 `project.config.json` 路径          |
 | `--host [host]`             | Web dev server host（`h5` 场景）           |
 | `--analyze`                 | 启动分包分析仪表盘（实验特性，小程序场景） |
+| `--scope <scope>`           | 局部构建范围，例如 `main,packages/order`   |
 
 补充说明：
 
 - 当目标平台为 `weapp` 且启用了 `weapp.forwardConsole` 时，`wv dev --open` 会在打开微信开发者工具后，自动尝试把小程序 `console` 日志桥接到当前终端。
 - 默认配置是 `enabled: 'auto'`，也就是仅在检测到 AI 终端时自动启用。
+- `--scope` 会只保留主包和指定分包进入开发构建，适合日常只调试某几个业务分包。产物 `app.json.subPackages` 也只包含参与 scope 的分包。
 
 ### 2) `build`
 
@@ -98,6 +100,24 @@ wv build [root]
 | `--skipNpm`                 | 跳过 npm 构建                                  |
 | `-o, --open`                | 构建后尝试打开 IDE                             |
 | `--analyze`                 | 输出分包分析仪表盘（小程序场景）               |
+| `--scope <scope>`           | 局部构建范围，例如 `main,packages/order`       |
+
+局部构建示例：
+
+```bash
+wv dev --scope main,packages/order
+wv build --scope packages/order
+wv build --scope main,packages/order --analyze
+```
+
+语义说明：
+
+- `main` 表示主包。
+- `packages/order` 这类值匹配 `app.json.subPackages[].root` / `subpackages[].root`。
+- CLI `--scope` 的优先级高于配置文件中的 `weapp.buildScope`。
+- 不传 `--scope` 时保持完整构建行为。
+- 传入 `--scope packages/order` 时默认仍包含主包，因此最终产物会包含主包页面和 `packages/order` 分包。
+- 生成的 `app.json` 会同步裁剪 `subPackages` 与 `preloadRule`，未参与 scope 的分包不会被注册到本次产物。
 
 ### 3) `analyze`
 

--- a/website/guide/subpackage.md
+++ b/website/guide/subpackage.md
@@ -139,6 +139,42 @@ flowchart LR
 - `App` 只能在主包里定义：独立分包里不要定义 `App()`，否则行为不可预期。
 - 独立分包中暂时不支持使用插件。
 
+### 只构建主包和指定分包
+
+如果你的项目有很多分包，但当前只需要开发订单、会员等少数业务域，可以使用 scoped build：
+
+```bash
+wv dev --scope main,packages/order
+wv build --scope packages/order
+```
+
+`--scope` 不是简单地在构建结束后删除目录，而是在入口阶段裁剪本次构建的 app 注册图：
+
+- `main` 表示主包。
+- `packages/order` 匹配 `app.json.subPackages[].root`。
+- `wv build --scope packages/order` 默认仍包含主包。
+- 最终产物 `app.json.subPackages` 只包含参与 scope 的分包。
+- 未参与 scope 的分包页面不会被注册到本次产物。
+- 开启 `autoRoutes` 时，`weapp-vite/auto-routes` 也只导出参与 scope 的主包页面和分包页面。
+
+也可以把常用 scope 固化到配置里：
+
+```ts
+import { defineConfig } from 'weapp-vite/config'
+
+export default defineConfig({
+  weapp: {
+    buildScope: {
+      includeMainPackage: true,
+      include: ['packages/order'],
+    },
+  },
+})
+```
+
+> [!NOTE]
+> scoped build 更适合开发和局部验证。发布前仍建议跑一次不带 scope 的完整构建，确认所有分包注册、依赖落位和包体分析都覆盖完整小程序。
+
 ### 单独开发某个分包（把它当成独立分包）
 
 当你想“只专注开发某个分包”（例如一个业务域由独立小组交付、或希望尽量隔离主包依赖）时，推荐把该分包按 **独立分包** 的方式组织与编译：运行时隔离、构建时独立上下文、依赖/样式/组件策略也能只对这个分包生效。


### PR DESCRIPTION
## 摘要
- 为 `wv dev/build` 新增 `--scope` 参数，并为 `weapp.buildScope` 增加配置与类型支持
- 在 app 配置、自动路由、typed routes 和分包 roots 进入构建图前应用 scope，避免构建后手动删除产物
- scope 启用时同步裁剪 `subPackages`、`preloadRule` 与开发态 watcher 范围

## 验证
- `pnpm --filter weapp-vite... build`
- `pnpm --filter weapp-vite typecheck`
- `pnpm vitest run packages/weapp-vite/src/runtime/buildScope.test.ts packages/weapp-vite/src/runtime/scanPlugin/service.test.ts packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.test.ts`
- `pnpm exec eslint packages/weapp-vite/src/runtime/buildScope.ts packages/weapp-vite/src/runtime/buildScope.test.ts packages/weapp-vite/src/cli/commands/build.ts packages/weapp-vite/src/cli/commands/serve/index.ts packages/weapp-vite/src/cli/runtime.ts packages/weapp-vite/src/cli/types.ts packages/weapp-vite/src/runtime/autoRoutesPlugin/routes/scan.ts packages/weapp-vite/src/runtime/autoRoutesPlugin/subPackageRoots.ts packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.test.ts packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.ts packages/weapp-vite/src/runtime/scanPlugin/service.test.ts packages/weapp-vite/src/runtime/scanPlugin/service/app.ts packages/weapp-vite/src/types/config/features.ts packages/weapp-vite/src/types/config/main.ts e2e-apps/github-issues/weapp-vite.config.ts e2e/ci/github-issues.build.test.ts`
- `pnpm --filter weapp-vite test:types`
- `pnpm exec eslint packages/weapp-vite/test-d/config-define-config/index.test-d.ts`
- `pnpm vitest run -c e2e/vitest.e2e.config.ts e2e/ci/github-issues.build.test.ts -t "issue #595"`

Closes #595