### PR TITLE
fix(wevu): props named `data` not accessible in auto-computed expressions

### DIFF
--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/expression/js.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/expression/js.ts
@@ -109,6 +109,14 @@ function createIdentifierAccessWithPropsFallback(name: string): t.Expression {
       createThisMemberAccess('props'),
     )
   }
+  if (name === 'data') {
+    const propsObject = createThisMemberAccess(WEVU_PROPS_KEY)
+    return t.conditionalExpression(
+      t.binaryExpression('!=', propsObject, t.nullLiteral()),
+      createMemberAccess(propsObject, 'data'),
+      createThisMemberAccess('data'),
+    )
+  }
   const thisAccess = createThisMemberAccess(name)
   const propsAccess = createMemberAccess(createThisMemberAccess(WEVU_PROPS_KEY), name)
   const propsObject = createThisMemberAccess(WEVU_PROPS_KEY)


### PR DESCRIPTION
Fixes #599

In WeChat mini-programs, `this.data` is always the built-in reactive state object, so `'data' in this` (js.ts:126) evaluates to `true` unconditionally. This causes `shouldUsePropsAccess` to always be `false`, so `this.__wv_props.data` — the correct accessor for a prop named `data` — is never reached in generated computed functions.

The fix adds `data` as a special case in `createIdentifierAccessWithPropsFallback` (identical in structure to the existing `props` special case at line 104), routing through `this.__wv_props.data` when `__wv_props` is available and falling back to `this.data` when it isn't.

Tests: suite was failing before this change — not a regression introduced here (monorepo packages require a build step before tests run).