### PR TITLE
fix(wevu): 避免 props 派生字段触发 setData 反馈循环

### DIFF
--- a/.changeset/wevu-props-derived-loop.md
+++ b/.changeset/wevu-props-derived-loop.md
@@ -1,0 +1,6 @@
+---
+"wevu": patch
+"create-weapp-vite": patch
+---
+
+修复 `6.16.21` 起 `<script setup>` props 解构派生字段可能作为同名顶层 `setData` 数据回写的问题，避免小程序属性 observer 与 wevu props 同步之间形成重复触发循环；同时保留 props 别名字段在模板中的正常渲染更新。

--- a/packages-runtime/wevu/src/runtime/app/mount.ts
+++ b/packages-runtime/wevu/src/runtime/app/mount.ts
@@ -11,6 +11,7 @@ import type {
 } from '../types'
 import {
   WEVU_ATTRS_KEY,
+  WEVU_PROPS_DERIVED_KEYS_KEY,
   WEVU_PROPS_KEY,
   WEVU_SETUP_STATE_KEY,
 } from '@weapp-core/constants'
@@ -91,6 +92,14 @@ export function createRuntimeMount<D extends object, C extends ComputedDefinitio
     }
     const state = reactive(rawState)
     const setupState = reactive(Object.create(null))
+    const adapterSnapshotOmitKeys = (adapter as any)?.__wevu_snapshotOmitKeys
+    const snapshotOmitKeys = new Set<string>(
+      adapterSnapshotOmitKeys instanceof Set
+        ? adapterSnapshotOmitKeys
+        : Array.isArray(adapterSnapshotOmitKeys)
+          ? adapterSnapshotOmitKeys
+          : [],
+    )
     if (rawState && typeof rawState === 'object' && !hasOwn(rawState as object, WEVU_SETUP_STATE_KEY)) {
       try {
         Object.defineProperty(rawState as object, WEVU_SETUP_STATE_KEY, {
@@ -179,6 +188,7 @@ export function createRuntimeMount<D extends object, C extends ComputedDefinitio
     const scheduler = createSetDataScheduler({
       state: state as any,
       setupState: setupState as any,
+      snapshotOmitKeys,
       computedRefs,
       dirtyComputedKeys,
       includeComputed,
@@ -361,6 +371,18 @@ export function createRuntimeMount<D extends object, C extends ComputedDefinitio
       ;(runtimeInstance as RuntimeInstanceWithSetupMethodsVersion<D, C, M>).__wevu_trackSetupReactiveKey = (key: string) => {
         trackedSetupReactiveKeys.add(key)
       }
+    }
+
+    try {
+      Object.defineProperty(runtimeInstance, WEVU_PROPS_DERIVED_KEYS_KEY, {
+        value: snapshotOmitKeys,
+        configurable: true,
+        enumerable: false,
+        writable: false,
+      })
+    }
+    catch {
+      ;(runtimeInstance as any)[WEVU_PROPS_DERIVED_KEYS_KEY] = snapshotOmitKeys
     }
 
     return runtimeInstance

--- a/packages-runtime/wevu/src/runtime/app/setData/scheduler.ts
+++ b/packages-runtime/wevu/src/runtime/app/setData/scheduler.ts
@@ -10,6 +10,7 @@ import { collectSnapshot } from './snapshot'
 export function createSetDataScheduler(options: {
   state: Record<string, any>
   setupState?: Record<string, any>
+  snapshotOmitKeys?: Set<string>
   computedRefs: Record<string, { value: any }>
   dirtyComputedKeys: Set<string>
   includeComputed: boolean
@@ -39,6 +40,7 @@ export function createSetDataScheduler(options: {
   const {
     state,
     setupState,
+    snapshotOmitKeys,
     computedRefs,
     dirtyComputedKeys,
     includeComputed,
@@ -153,13 +155,15 @@ export function createSetDataScheduler(options: {
     return (left as any).raw === (right as any).raw && (left as any).version === (right as any).version
   }
 
+  const shouldIncludeSnapshotKey = (key: string) => shouldIncludeKey(key) && !snapshotOmitKeys?.has(key)
+
   const resolveTopKeysByRoot = (root: object) => {
     const matches: string[] = []
     const rawSetupState = setupState && typeof setupState === 'object'
       ? (isReactive(setupState) ? toRaw(setupState as any) : setupState)
       : undefined
     for (const key of new Set([...Object.keys(state), ...(rawSetupState ? Object.keys(rawSetupState) : [])])) {
-      if (!shouldIncludeKey(key)) {
+      if (!shouldIncludeSnapshotKey(key)) {
         continue
       }
       const value = rawSetupState && hasOwn(rawSetupState, key) ? rawSetupState[key] : state[key]
@@ -198,7 +202,7 @@ export function createSetDataScheduler(options: {
     setupState,
     computedRefs,
     includeComputed,
-    shouldIncludeKey,
+    shouldIncludeKey: shouldIncludeSnapshotKey,
     plainCache,
     toPlainMaxDepth,
     toPlainMaxKeys,
@@ -218,7 +222,7 @@ export function createSetDataScheduler(options: {
     const replacedTopLevelKeys = new Set<string>()
 
     for (const key of new Set([...Object.keys(rawState), ...(rawSetupState ? Object.keys(rawSetupState) : [])])) {
-      if (!shouldIncludeKey(key)) {
+      if (!shouldIncludeSnapshotKey(key)) {
         continue
       }
       includedStateKeys.add(key)
@@ -271,7 +275,7 @@ export function createSetDataScheduler(options: {
     }
 
     for (const key of Object.keys(computedRefs)) {
-      if (!shouldIncludeKey(key)) {
+      if (!shouldIncludeSnapshotKey(key)) {
         continue
       }
       includedComputedKeys.add(key)
@@ -293,7 +297,7 @@ export function createSetDataScheduler(options: {
     for (const key of Object.keys(latestComputedTokens)) {
       if (!includedComputedKeys.has(key)) {
         delete latestComputedTokens[key]
-        if (!hasOwn(rawState, key) || !shouldIncludeKey(key)) {
+        if (!hasOwn(rawState, key) || !shouldIncludeSnapshotKey(key)) {
           delete nextSnapshot[key]
         }
       }
@@ -329,7 +333,7 @@ export function createSetDataScheduler(options: {
     if (setDataStrategy === 'patch' && includeComputed) {
       latestComputedSnapshot = Object.create(null)
       for (const key of Object.keys(computedRefs)) {
-        if (!shouldIncludeKey(key)) {
+        if (!shouldIncludeSnapshotKey(key)) {
           continue
         }
         latestComputedSnapshot[key] = snapshot[key]
@@ -378,7 +382,7 @@ export function createSetDataScheduler(options: {
       return
     }
     const topKey = record.path.split('.', 1)[0]
-    if (!shouldIncludeKey(topKey)) {
+    if (!shouldIncludeSnapshotKey(topKey)) {
       return
     }
     pendingPatches.set(record.path, { kind: record.kind, op: record.op })
@@ -409,7 +413,7 @@ export function createSetDataScheduler(options: {
         computedCompareMaxDepth,
         computedCompareMaxKeys,
         currentAdapter,
-        shouldIncludeKey,
+        shouldIncludeKey: shouldIncludeSnapshotKey,
         maxPatchKeys,
         maxPayloadBytes,
         mergeSiblingThreshold,

--- a/packages-runtime/wevu/src/runtime/register/component.ts
+++ b/packages-runtime/wevu/src/runtime/register/component.ts
@@ -131,7 +131,7 @@ export function registerComponent<D extends object, C extends ComputedDefinition
     ...(userOptions as any),
   }
 
-  const { attachWevuPropKeys, syncWevuPropsFromInstance, syncWevuPropsFromValues, finalObservers } = createPropsSync({
+  const { attachWevuPropKeys, directPropsDerivedKeys, syncWevuPropsFromInstance, syncWevuPropsFromValues, finalObservers } = createPropsSync({
     restOptions,
     propsAliases,
     propsDerivedKeys,
@@ -199,6 +199,7 @@ export function registerComponent<D extends object, C extends ComputedDefinition
     setupLifecycle,
     syncWevuPropsFromInstance,
     syncWevuPropsFromValues,
+    directPropsDerivedKeys,
     isPage,
     legacyCreated,
     getRuntimeOwnerLabel,

--- a/packages-runtime/wevu/src/runtime/register/component/props.ts
+++ b/packages-runtime/wevu/src/runtime/register/component/props.ts
@@ -3,6 +3,7 @@ import {
   WEVU_ATTRS_KEY,
   WEVU_PENDING_PROP_VALUES_KEY,
   WEVU_PROP_KEYS_KEY,
+  WEVU_PROPS_DERIVED_KEYS_KEY,
   WEVU_PROPS_KEY,
 } from '@weapp-core/constants'
 import { hasOwn } from '../../../utils'
@@ -22,7 +23,29 @@ export function createPropsSync(options: {
   const propsDerivedKeySet = new Set(propsDerivedKeys ?? [])
   const aliasEntries = Object.entries(propsAliases ?? {})
     .filter(([alias, propName]) => alias && propName)
+  const aliasKeySet = new Set(aliasEntries.map(([alias]) => alias))
+  const directPropsDerivedKeys = [...propsDerivedKeySet]
+    .filter(key => propKeySet.has(key) && !aliasKeySet.has(key))
   const syncedAliases = new WeakMap<InternalRuntimeState, Set<string>>()
+
+  const updateSnapshotOmitKeys = (instance: InternalRuntimeState) => {
+    const runtime = (instance as any).__wevu
+    const snapshotOmitKeys = runtime?.[WEVU_PROPS_DERIVED_KEYS_KEY]
+    if (!(snapshotOmitKeys instanceof Set)) {
+      return
+    }
+    for (const key of directPropsDerivedKeys) {
+      snapshotOmitKeys.add(key)
+    }
+  }
+
+  const setIfChanged = (target: Record<string, unknown>, key: string, value: unknown) => {
+    if (hasOwn(target, key) && Object.is(target[key], value)) {
+      return false
+    }
+    target[key] = value
+    return true
+  }
 
   const syncSetupStatePropsAliases = (instance: InternalRuntimeState, propsProxy: Record<string, unknown>) => {
     if (!aliasEntries.length) {
@@ -34,6 +57,7 @@ export function createPropsSync(options: {
     if (!setupState || typeof setupState !== 'object') {
       return
     }
+    updateSnapshotOmitKeys(instance)
     const aliases = syncedAliases.get(instance) ?? new Set<string>()
     syncedAliases.set(instance, aliases)
     for (const [alias, propName] of aliasEntries) {
@@ -42,7 +66,7 @@ export function createPropsSync(options: {
       }
       const value = propsProxy[propName]
       try {
-        ;(setupState as any)[alias] = value
+        setIfChanged(setupState as Record<string, unknown>, alias, value)
         aliases.add(alias)
       }
       catch {
@@ -50,7 +74,7 @@ export function createPropsSync(options: {
       }
       if (state && typeof state === 'object' && (!hasOwn(state, alias) || aliases.has(alias))) {
         try {
-          ;(state as any)[alias] = value
+          setIfChanged(state as Record<string, unknown>, alias, value)
         }
         catch {
           // 旧兼容 state 写入失败时不阻断运行时。
@@ -68,6 +92,7 @@ export function createPropsSync(options: {
     if (!setupState || typeof setupState !== 'object') {
       return
     }
+    updateSnapshotOmitKeys(instance)
     const aliasToPropName = new Map<string, string>(aliasEntries)
     for (const key of propsDerivedKeySet) {
       const propName = aliasToPropName.get(key) ?? key
@@ -75,7 +100,7 @@ export function createPropsSync(options: {
         continue
       }
       try {
-        ;(setupState as any)[key] = propsProxy[propName]
+        setIfChanged(setupState as Record<string, unknown>, key, propsProxy[propName])
       }
       catch {
         // 忽略 props-derived 同步失败，保持主 props 链路可用。
@@ -289,6 +314,7 @@ export function createPropsSync(options: {
 
   return {
     attachWevuPropKeys,
+    directPropsDerivedKeys,
     syncWevuPropsFromInstance,
     syncWevuPropsFromValues,
     finalObservers,

--- a/packages-runtime/wevu/src/runtime/register/component/registerDefinition.ts
+++ b/packages-runtime/wevu/src/runtime/register/component/registerDefinition.ts
@@ -41,6 +41,7 @@ export function registerComponentDefinition<D extends object, C extends Computed
   setupLifecycle: 'created' | 'attached'
   syncWevuPropsFromInstance: (instance: InternalRuntimeState) => void
   syncWevuPropsFromValues: (instance: InternalRuntimeState, values: Record<string, unknown> | undefined) => void
+  directPropsDerivedKeys: string[]
   isPage: boolean
   legacyCreated: unknown
   getRuntimeOwnerLabel: (instance: InternalRuntimeState) => string
@@ -62,6 +63,7 @@ export function registerComponentDefinition<D extends object, C extends Computed
     attachWevuPropKeys,
     setupLifecycle,
     syncWevuPropsFromInstance,
+    directPropsDerivedKeys,
     isPage,
     legacyCreated,
     getRuntimeOwnerLabel,
@@ -130,7 +132,10 @@ export function registerComponentDefinition<D extends object, C extends Computed
         attachWevuPropKeys(this)
         if (setupLifecycle === 'created') {
           try {
-            mountRuntimeInstance(this, runtimeApp, watch, setup, { deferSetData: true })
+            mountRuntimeInstance(this, runtimeApp, watch, setup, {
+              deferSetData: true,
+              snapshotOmitKeys: directPropsDerivedKeys,
+            })
           }
           catch (error) {
             const label = getRuntimeOwnerLabel(this)
@@ -166,7 +171,9 @@ export function registerComponentDefinition<D extends object, C extends Computed
         attachWevuPropKeys(this)
         if (setupLifecycle !== 'created' || !(this as any).__wevu) {
           try {
-            mountRuntimeInstance(this, runtimeApp, watch, setup)
+            mountRuntimeInstance(this, runtimeApp, watch, setup, {
+              snapshotOmitKeys: directPropsDerivedKeys,
+            })
           }
           catch (error) {
             const label = getRuntimeOwnerLabel(this)

--- a/packages-runtime/wevu/src/runtime/register/runtimeInstance.ts
+++ b/packages-runtime/wevu/src/runtime/register/runtimeInstance.ts
@@ -88,7 +88,7 @@ export function mountRuntimeInstance<D extends object, C extends ComputedDefinit
   runtimeApp: RuntimeApp<D, C, M>,
   watchMap: WatchMap | undefined,
   setup?: RuntimeSetupFunction<D, C, M>,
-  options?: { deferSetData?: boolean },
+  options?: { deferSetData?: boolean, snapshotOmitKeys?: string[] },
 ) {
   if (target.__wevu) {
     return target.__wevu as RuntimeInstance<D, C, M>
@@ -199,9 +199,18 @@ export function mountRuntimeInstance<D extends object, C extends ComputedDefinit
     },
   }
 
-  const runtime = runtimeApp.mount({
+  const baseMountAdapter = {
     ...(adapter as any),
-  })
+  }
+  if (Array.isArray(options?.snapshotOmitKeys) && options.snapshotOmitKeys.length) {
+    Object.defineProperty(baseMountAdapter, '__wevu_snapshotOmitKeys', {
+      configurable: true,
+      enumerable: false,
+      value: options.snapshotOmitKeys,
+      writable: false,
+    })
+  }
+  const runtime = runtimeApp.mount(baseMountAdapter)
   runtimeRef = runtime
   attachRuntimeInstance(runtime as RuntimeInstance<any, any, any>, target)
   const runtimeProxy = runtime?.proxy ?? {}

--- a/packages-runtime/wevu/test/runtime-props-sync.test.ts
+++ b/packages-runtime/wevu/test/runtime-props-sync.test.ts
@@ -1,4 +1,4 @@
-import { WEVU_PROPS_ALIASES_KEY, WEVU_PUBLIC_RUNTIME_KEY } from '@weapp-core/constants'
+import { WEVU_PROPS_ALIASES_KEY, WEVU_PROPS_DERIVED_KEYS_KEY, WEVU_PUBLIC_RUNTIME_KEY } from '@weapp-core/constants'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick } from '@/index'
 import { resolvePropValue } from '@/runtime'
@@ -455,5 +455,80 @@ describe('runtime: props sync', () => {
     expect(inst[WEVU_PUBLIC_RUNTIME_KEY].proxy.props.callback).toBe(callback)
     expect(inst[WEVU_PUBLIC_RUNTIME_KEY].proxy.props.callback()).toBe('ok')
     expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not emit direct prop-derived setup keys as top-level setData fields', async () => {
+    defineComponent({
+      props: {
+        title: { type: String, default: '' },
+      } as any,
+      [WEVU_PROPS_DERIVED_KEYS_KEY]: ['title'],
+      setup(props: any) {
+        const { title } = props as any
+        return { title, props }
+      },
+    } as any)
+
+    const opts = registeredComponents[0]
+    let observerFeedbackCount = 0
+    const inst: any = {
+      setData: vi.fn((payload: Record<string, any>) => {
+        if (!Object.hasOwn(payload, 'title')) {
+          return
+        }
+        observerFeedbackCount += 1
+        if (observerFeedbackCount < 5) {
+          opts.observers.title.call(inst, payload.title, inst.properties.title)
+        }
+      }),
+      triggerEvent: vi.fn(),
+      properties: { title: 'initial' },
+    }
+    opts.lifetimes.created.call(inst)
+    opts.lifetimes.attached.call(inst)
+    await nextTick()
+    inst.setData.mockClear()
+    observerFeedbackCount = 0
+
+    inst.properties.title = 'Hello'
+    opts.observers.title.call(inst, 'Hello', 'initial')
+    await nextTick()
+
+    expect(inst[WEVU_PUBLIC_RUNTIME_KEY].proxy.title).toBe('Hello')
+    expect(inst[WEVU_PUBLIC_RUNTIME_KEY].proxy.props.title).toBe('Hello')
+    expect(inst.setData).toHaveBeenCalledWith({ 'props.title': 'Hello' })
+
+    const payloads = inst.setData.mock.calls.map(([payload]: any[]) => payload ?? {})
+    expect(payloads.some((payload: any) => Object.hasOwn(payload, 'title'))).toBe(false)
+    expect(observerFeedbackCount).toBe(0)
+  })
+
+  it('keeps alias-derived setup keys visible to template setData output', async () => {
+    defineComponent({
+      props: {
+        title: { type: String, default: '' },
+      } as any,
+      [WEVU_PROPS_ALIASES_KEY]: {
+        aliasTitle: 'title',
+      },
+      [WEVU_PROPS_DERIVED_KEYS_KEY]: ['aliasTitle'],
+      setup() {
+        return {}
+      },
+    } as any)
+
+    const opts = registeredComponents[0]
+    const inst: any = { setData: vi.fn(), triggerEvent: vi.fn(), properties: { title: 'initial' } }
+    opts.lifetimes.created.call(inst)
+    opts.lifetimes.attached.call(inst)
+    await nextTick()
+    inst.setData.mockClear()
+
+    inst.properties.title = 'Hello'
+    opts.observers.title.call(inst, 'Hello', 'initial')
+    await nextTick()
+
+    expect(inst[WEVU_PUBLIC_RUNTIME_KEY].proxy.aliasTitle).toBe('Hello')
+    expect(inst.setData).toHaveBeenCalledWith(expect.objectContaining({ aliasTitle: 'Hello' }))
   })
 })


### PR DESCRIPTION
## 背景

`6.16.21` 为 `<script setup>` props 解构派生字段补充了 `setupState` 同步，但直接同名 prop 派生 key 会进入顶层 `setData` 快照。小程序运行时可能把 `setData({ propName })` 反馈到同名 property observer，导致 props 同步和 setData 之间重复触发，严重时形成运行时死循环。

## 修改

- 为 wevu setData scheduler 增加内部 snapshot omit key，过滤直接同名 prop 派生字段的顶层输出。
- 在 runtime mount 前传入 omit 信息，避免首次 flush 就输出可自激的同名字段。
- 保留 props alias 派生字段的模板 setData 输出，避免破坏 `x -> y` 这类别名渲染。
- props 派生同步增加同值短路，减少无意义响应式写入。
- 新增运行时守卫测试，模拟 `setData({ title })` 反打 property observer，防止未来再次引入反馈循环。
- 补充 wevu 与 create-weapp-vite patch changeset。

## 验证

- `vitest run packages-runtime/wevu/test/runtime-props-sync.test.ts packages-runtime/wevu/test/runtime-setdata-snapshot.test.ts packages-runtime/wevu/test/runtime-setdata-patch.test.ts`
- `tsc --noEmit -p packages-runtime/wevu/tsconfig.json`
- `eslint packages-runtime/wevu/src/runtime/app/mount.ts packages-runtime/wevu/src/runtime/app/setData/scheduler.ts packages-runtime/wevu/src/runtime/register/component.ts packages-runtime/wevu/src/runtime/register/component/props.ts packages-runtime/wevu/src/runtime/register/component/registerDefinition.ts packages-runtime/wevu/src/runtime/register/runtimeInstance.ts packages-runtime/wevu/test/runtime-props-sync.test.ts`
- `pnpm --filter wevu build`
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`
- `node --import tsx scripts/check-catalog-changeset.ts`