### PR TITLE
fix(weapp-vite): 支持外部组件入口参与 watch

### DIFF
--- a/.changeset/quiet-horses-smile.md
+++ b/.changeset/quiet-horses-smile.md
@@ -1,0 +1,6 @@
+---
+'create-weapp-vite': patch
+'weapp-vite': patch
+---
+
+开发态现在会保留并监听 `build.watch.include` 的外部路径，同时把配置文件依赖纳入重建；`srcRoot` 之外的已解析组件也会进入编译与 HMR 流程。

--- a/packages/weapp-vite/src/plugins/core/lifecycle/transform.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/transform.test.ts
@@ -331,6 +331,28 @@ describe('core lifecycle transform hook injectWeapi', () => {
     expect(result).toBeNull()
   })
 
+  it('rewrites resolved entry files outside src root', async () => {
+    const externalEntry = '/project/node_modules/pkg/index.js'
+    const transform = createTransformHook({
+      ctx: {
+        configService: createConfigServiceMock({
+          weappViteConfig: {
+            injectWeapi: {
+              enabled: true,
+              replaceWx: true,
+            },
+          },
+        }),
+      },
+      resolvedEntryMap: new Map([[externalEntry, { id: externalEntry }]]),
+    } as any)
+
+    const result = await transform('export const a = wx.showToast({ title: "ok" })', externalEntry)
+    const code = result && typeof result === 'object' && 'code' in result ? result.code : ''
+
+    expect(code).toContain('__weappViteInjectedApi__.showToast')
+  })
+
   it('skips style requests under src root', async () => {
     const transform = createTransformHook({
       ctx: {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/transform/index.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/transform/index.ts
@@ -77,7 +77,11 @@ export function createTransformHook(state: CorePluginState) {
 
   const transform: NonNullable<Plugin['transform']> = async function transform(code, id) {
     const injectOptions = resolveInjectWeapiOptions(configService)
-    if (!shouldTransformId(id, configService.absoluteSrcRoot)) {
+    if (!shouldTransformId(id, {
+      absoluteSrcRoot: configService.absoluteSrcRoot,
+      isEntry: sourceId => state.loadedEntrySet?.has(sourceId) === true
+        || state.resolvedEntryMap?.has(sourceId) === true,
+    })) {
       return null
     }
     const startedAt = performance.now()

--- a/packages/weapp-vite/src/plugins/core/lifecycle/transform/shared.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/transform/shared.ts
@@ -22,7 +22,13 @@ export function resolveInjectWeapiOptions(configService: CorePluginState['ctx'][
   }
 }
 
-export function shouldTransformId(id: string, absoluteSrcRoot: string) {
+export function shouldTransformId(
+  id: string,
+  options: {
+    absoluteSrcRoot: string
+    isEntry?: (sourceId: string) => boolean
+  },
+) {
   if (isCSSRequest(id)) {
     return false
   }
@@ -33,11 +39,14 @@ export function shouldTransformId(id: string, absoluteSrcRoot: string) {
   }
 
   const sourceId = normalizeFsResolvedId(id)
-  if (!sourceId || sourceId.includes('/node_modules/')) {
+  if (!sourceId) {
     return false
   }
-  if (sourceId === absoluteSrcRoot) {
+  if (sourceId === options.absoluteSrcRoot) {
     return true
   }
-  return sourceId.startsWith(`${absoluteSrcRoot}/`)
+  if (sourceId.startsWith(`${options.absoluteSrcRoot}/`)) {
+    return true
+  }
+  return options.isEntry?.(sourceId) === true
 }

--- a/packages/weapp-vite/src/plugins/core/lifecycle/watch.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/watch.test.ts
@@ -1,6 +1,6 @@
 import { fs } from '@weapp-core/shared/fs'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createWatchChangeHook } from './watch'
+import { createBuildStartHook, createWatchChangeHook } from './watch'
 
 const invalidateFileCacheMock = vi.hoisted(() => vi.fn())
 const invalidateEntryForSidecarMock = vi.hoisted(() => vi.fn(async () => {}))
@@ -71,6 +71,8 @@ function createState(overrides: Record<string, any> = {}) {
         relativeAbsoluteSrcRoot: (id: string) => id.replace('/project/src/', ''),
         relativeCwd: (id: string) => id.replace('/project/', ''),
         weappViteConfig: {},
+        isDev: true,
+        configFileDependencies: [],
       },
       wxmlService: {
         scan: vi.fn(async () => null),
@@ -96,6 +98,7 @@ function createState(overrides: Record<string, any> = {}) {
     loadEntry: {
       invalidateResolveCache: vi.fn(),
     },
+    emitDirtyEntries: vi.fn(async () => {}),
     loadedEntrySet: new Set<string>(),
     entriesMap: new Map<string, { type: string }>(),
     layoutEntryDependents: new Map<string, Set<string>>(),
@@ -122,6 +125,21 @@ describe('core lifecycle watch hook', () => {
     isTemplateMock.mockReturnValue(false)
     collectAffectedEntriesMock.mockReturnValue(new Set())
     collectAffectedEntriesFromSharedChunksMock.mockReturnValue(new Set())
+  })
+
+  it('adds loaded config dependencies to dev build watch files', async () => {
+    const state = createState()
+    state.ctx.configService.configFileDependencies = [
+      '/project/vite.config.mts',
+      '/project/config/shared.ts',
+    ]
+    const addWatchFile = vi.fn()
+    const buildStart = createBuildStartHook(state)
+
+    await buildStart.call({ addWatchFile })
+
+    expect(addWatchFile).toHaveBeenCalledWith('/project/vite.config.mts')
+    expect(addWatchFile).toHaveBeenCalledWith('/project/config/shared.ts')
   })
 
   afterEach(() => {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/watch.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/watch.ts
@@ -19,6 +19,7 @@ import { ensureSidecarWatcher, invalidateEntryForSidecar } from '../../utils/inv
 import { collectAffectedScriptsAndImporters } from '../../utils/invalidateEntry/cssGraph'
 import { watchedScriptModuleExts, watchedTemplateExts } from '../../utils/invalidateEntry/shared'
 import { isLayoutSourcePath } from '../../utils/layoutSourcePath'
+import { addNormalizedWatchFiles } from '../../utils/watchFiles'
 import { isAppVueFile } from '../../vue/transform/appShell'
 import { collectAffectedEntries, collectAffectedEntriesFromSharedChunks } from '../helpers'
 
@@ -86,6 +87,7 @@ export function createBuildStartHook(state: CorePluginState) {
   return async function buildStart(this: any) {
     resetTakeImportRegistry({ preserveSharedChunkNameCache: configService.isDev })
     if (configService.isDev) {
+      addNormalizedWatchFiles(this, configService.configFileDependencies)
       if (isPluginBuild) {
         if (configService.absolutePluginRoot) {
           ensureSidecarWatcher(ctx, configService.absolutePluginRoot)

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry.test.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry.test.ts
@@ -1170,6 +1170,65 @@ import FooBar from '../../components/foo-bar/index.vue'
     })
   })
 
+  it('tracks external <script setup> component output mapping for compile flow', async () => {
+    const pageScript = '/project/src/pages/external/index.js'
+    const vueEntryPath = '/project/src/pages/external/index.vue'
+    const externalComponent = '/workspace/packages/ui/card/index.vue'
+
+    mockFindVueEntry.mockResolvedValue(vueEntryPath)
+    mockExtractConfigFromVue.mockResolvedValue({
+      navigationBarTitleText: 'External',
+    })
+    readFileMock.mockImplementation(async (target: string) => {
+      if (target === vueEntryPath) {
+        return `
+<template>
+  <UiCard />
+</template>
+<script setup lang="ts">
+import UiCard from '@workspace/ui/card'
+</script>
+        `.trim()
+      }
+      return 'console.log("noop")'
+    })
+
+    const { loader, registerJsonAsset, runtimeState, configService, emitEntriesChunks } = createLoader()
+    configService.relativeOutputPath = vi.fn((id: string) => {
+      if (id.startsWith('/workspace/packages/ui/card')) {
+        return '__weapp_vite_external__/card/index'
+      }
+      return id.replace('/project/src/', '')
+    })
+    const pluginCtx = createPluginContext()
+    pluginCtx.resolve = vi.fn(async (source: string, importer?: string) => {
+      if (source === '@workspace/ui/card') {
+        return { id: externalComponent } as any
+      }
+      if (!importer) {
+        return { id: source } as any
+      }
+      if (source.startsWith('.')) {
+        return { id: path.resolve(path.dirname(importer), source) } as any
+      }
+      return { id: source } as any
+    })
+    existsMock.mockImplementation(async (target: string) => {
+      return target === externalComponent
+    })
+
+    await loader.call(pluginCtx, pageScript, 'page')
+
+    expect(registerJsonAsset).toHaveBeenCalled()
+    const payload = registerJsonAsset.mock.calls[0][0]
+    expect(payload.json.usingComponents.UiCard).toBe('/__weapp_vite_external__/card/index')
+    expect(runtimeState.build.hmr.externalComponentEntryMap.get('__weapp_vite_external__/card/index')).toBe(externalComponent)
+    const emittedResolvedIds = emitEntriesChunks.mock.calls.flatMap(
+      ([resolvedIds]) => resolvedIds.map((resolvedId: any) => resolvedId?.id),
+    )
+    expect(emittedResolvedIds).toContain(externalComponent)
+  })
+
   it('suppresses transient ENOENT warnings while deleted vue entries are being removed during dev hmr', async () => {
     const pageScript = '/project/src/pages/auto-delete/index.js'
     const vueEntryPath = '/project/src/pages/auto-delete/index.vue'

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/emit.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/emit.ts
@@ -88,7 +88,11 @@ interface EmitEntryOutputOptions {
   pluginResolvedRecords?: ResolvedEntryRecord[]
   pluginJsonPathForRegistration?: string
   pluginJsonForRegistration?: any
-  resolveEntriesWithCache: (pluginCtx: PluginContext, entries: string[], absoluteRoot: string) => Promise<ResolvedEntryRecord[]>
+  resolveEntriesWithCache: (pluginCtx: PluginContext, entries: string[], absoluteRoot: string, options?: {
+    fallbackRoots?: string[]
+    resolveMappedEntry?: (entry: string) => string | undefined
+  }) => Promise<ResolvedEntryRecord[]>
+  resolveMappedEntry?: (entry: string) => string | undefined
   configService: CompilerContext['configService']
   wxmlService?: CompilerContext['wxmlService']
   resolvedEntryMap: Map<string, ResolvedId>
@@ -122,6 +126,7 @@ export async function emitEntryOutput(options: EmitEntryOutputOptions) {
     pluginJsonPathForRegistration,
     pluginJsonForRegistration,
     resolveEntriesWithCache,
+    resolveMappedEntry,
     entryResolveRoot,
     configService,
     wxmlService,
@@ -242,6 +247,10 @@ export async function emitEntryOutput(options: EmitEntryOutputOptions) {
           pluginCtx,
           normalizedEntries,
           entryResolveRoot,
+          {
+            fallbackRoots: [configService.cwd],
+            resolveMappedEntry,
+          },
         )
       : []
 

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/index.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/index.ts
@@ -354,6 +354,7 @@ export function createEntryLoader(options: EntryLoaderOptions) {
           configService,
           wxmlService,
           reExportResolutionCache,
+          externalComponentEntryMap: ctx.runtimeState.build.hmr.externalComponentEntryMap,
         })
 
         if (type === 'page') {
@@ -466,6 +467,7 @@ export function createEntryLoader(options: EntryLoaderOptions) {
       pluginJsonPathForRegistration,
       pluginJsonForRegistration,
       resolveEntriesWithCache: entryResolver.resolveEntriesWithCache,
+      resolveMappedEntry: entry => ctx.runtimeState.build.hmr.externalComponentEntryMap.get(entry),
       entryResolveRoot,
       configService,
       wxmlService,

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/resolve.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/resolve.ts
@@ -48,17 +48,39 @@ export function createEntryResolver(configService?: { isDev?: boolean }) {
     pluginCtx: PluginContext,
     entries: string[],
     absoluteRoot: string,
+    options?: {
+      fallbackRoots?: string[]
+      resolveMappedEntry?: (entry: string) => string | undefined
+    },
   ): Promise<ResolvedEntryRecord[]> {
     return Promise.all(
       entries
         .filter(entry => !entry.includes(':'))
         .map(async (entry) => {
+          const cleanedEntry = entry.replace(LEADING_ROOT_SLASH_RE, '')
+          const mappedEntry = options?.resolveMappedEntry?.(cleanedEntry)
+          if (mappedEntry) {
+            return {
+              entry,
+              resolvedId: await resolveEntryWithCache(pluginCtx, mappedEntry),
+            }
+          }
+
           const absPath = path.isAbsolute(entry) && await fs.pathExists(entry)
             ? entry
-            : path.resolve(absoluteRoot, entry.replace(LEADING_ROOT_SLASH_RE, ''))
+            : path.resolve(absoluteRoot, cleanedEntry)
+          let resolvedId = await resolveEntryWithCache(pluginCtx, absPath)
+          if (!resolvedId) {
+            for (const fallbackRoot of options?.fallbackRoots ?? []) {
+              resolvedId = await resolveEntryWithCache(pluginCtx, path.resolve(fallbackRoot, cleanedEntry))
+              if (resolvedId) {
+                break
+              }
+            }
+          }
           return {
             entry,
-            resolvedId: await resolveEntryWithCache(pluginCtx, absPath),
+            resolvedId,
           }
         }),
     )

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/template.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/template.ts
@@ -54,6 +54,7 @@ export async function applyScriptSetupUsingComponents(options: {
   configService: CompilerContext['configService']
   wxmlService?: CompilerContext['wxmlService']
   reExportResolutionCache: Map<string, Map<string, string | undefined>>
+  externalComponentEntryMap?: Map<string, string>
 }) {
   const {
     pluginCtx,
@@ -63,6 +64,7 @@ export async function applyScriptSetupUsingComponents(options: {
     configService,
     wxmlService,
     reExportResolutionCache,
+    externalComponentEntryMap,
   } = options
 
   try {
@@ -94,7 +96,7 @@ export async function applyScriptSetupUsingComponents(options: {
           )
 
           for (const { localName, importSource, importedName, kind } of imports) {
-            let { from } = await resolveUsingComponentReference(
+            const resolved = await resolveUsingComponentReference(
               pluginCtx,
               configService,
               reExportResolutionCache,
@@ -107,6 +109,7 @@ export async function applyScriptSetupUsingComponents(options: {
                 fallbackRelativeImporterDir: true,
               },
             )
+            let { from } = resolved
 
             if (!from && importSource.startsWith('/')) {
               from = removeExtensionDeep(importSource)
@@ -123,6 +126,9 @@ export async function applyScriptSetupUsingComponents(options: {
             }
 
             usingComponents[localName] = from
+            if (resolved.resolvedId) {
+              externalComponentEntryMap?.set(removeExtensionDeep(from).replace(/^\/+/, ''), resolved.resolvedId)
+            }
           }
 
           json.usingComponents = usingComponents

--- a/packages/weapp-vite/src/plugins/utils/watchFiles.ts
+++ b/packages/weapp-vite/src/plugins/utils/watchFiles.ts
@@ -18,10 +18,10 @@ export function addNormalizedWatchFiles(
   pluginCtx: {
     addWatchFile?: (id: string) => void
   },
-  files: Iterable<string | undefined>,
+  files: Iterable<string | undefined> | undefined,
 ) {
   let count = 0
-  for (const file of files) {
+  for (const file of files ?? []) {
     if (addNormalizedWatchFile(pluginCtx, file)) {
       count += 1
     }

--- a/packages/weapp-vite/src/runtime/config/createConfigService.test.ts
+++ b/packages/weapp-vite/src/runtime/config/createConfigService.test.ts
@@ -113,6 +113,7 @@ function createBaseOptions(overrides: Record<string, any> = {}) {
       targets: ALL_MP_PLATFORMS,
     },
     configFilePath: '/project/weapp-vite.config.ts',
+    configFileDependencies: [],
     weappWeb: undefined,
     weappLib: undefined,
     weappLibOutputMap: undefined,
@@ -350,6 +351,31 @@ describe('createConfigService', () => {
 
     expect(service.relativeAbsoluteSrcRoot('/project/src/pages/index.ts')).toBe('pages/index.ts')
     expect(service.relativeAbsoluteSrcRoot('/project/other/file.ts')).toBe('other/file.ts')
+  })
+
+  it('maps node_modules and cwd-external output paths into a generated external namespace', () => {
+    const service = createConfigService(createCtx())
+
+    expect(service.relativeOutputPath('/project/node_modules/ui-lib/card/index.vue')).toMatch(
+      /^__weapp_vite_external__\/[a-f0-9]{10}\/index\.vue$/,
+    )
+    expect(service.relativeOutputPath('/workspace/packages/ui/card/index.vue')).toMatch(
+      /^__weapp_vite_external__\/[a-f0-9]{10}\/index\.vue$/,
+    )
+  })
+
+  it('exposes config file dependencies from loaded options', () => {
+    const service = createConfigService(createCtx({
+      configFileDependencies: [
+        '/project/vite.config.mts',
+        '/project/config/shared.ts',
+      ],
+    }))
+
+    expect(service.configFileDependencies).toEqual([
+      '/project/vite.config.mts',
+      '/project/config/shared.ts',
+    ])
   })
 
   it('normalizes symlinked temp paths before computing src-relative output names', () => {

--- a/packages/weapp-vite/src/runtime/config/createConfigService.ts
+++ b/packages/weapp-vite/src/runtime/config/createConfigService.ts
@@ -1,6 +1,7 @@
 import type { MutableCompilerContext } from '../../context'
 import type { OutputExtensions } from '../../platforms/types'
 import type { ConfigService, LoadConfigOptions, LoadConfigResult } from './types'
+import { createHash } from 'node:crypto'
 import fs from 'node:fs'
 import process from 'node:process'
 import { defu, removeExtensionDeep } from '@weapp-core/shared'
@@ -137,6 +138,13 @@ function createConfigService(ctx: MutableCompilerContext): ConfigService {
     return normalizedRelative
   }
 
+  const resolveExternalOutputPath = (filePath: string) => {
+    const normalizedPath = normalizeComparablePath(filePath)
+    const normalizedDir = path.dirname(normalizedPath)
+    const dirHash = createHash('sha256').update(normalizedDir).digest('hex').slice(0, 10)
+    return normalizeRelativePath(path.join('__weapp_vite_external__', dirHash, path.basename(normalizedPath)))
+  }
+
   function setOptions(value: LoadConfigResult) {
     options = value
     configState.options = value
@@ -239,6 +247,7 @@ function createConfigService(ctx: MutableCompilerContext): ConfigService {
       configFilePath: undefined,
       currentSubPackageRoot: undefined,
       weappWeb: undefined,
+      configFileDependencies: [],
     })
 
     setOptions(resolvedConfig)
@@ -378,6 +387,9 @@ function createConfigService(ctx: MutableCompilerContext): ConfigService {
     get configFilePath() {
       return options.configFilePath
     },
+    get configFileDependencies() {
+      return options.configFileDependencies
+    },
     get weappWebConfig() {
       return options.weappWeb
     },
@@ -422,6 +434,9 @@ function createConfigService(ctx: MutableCompilerContext): ConfigService {
       const relative = this.relativeAbsoluteSrcRoot(p)
       if (!relative) {
         return relative
+      }
+      if (relative.startsWith('..') || relative === 'node_modules' || relative.startsWith('node_modules/')) {
+        return resolveExternalOutputPath(p)
       }
       const libOutputMap = options.weappLibOutputMap
       if (libOutputMap && libOutputMap.size > 0) {

--- a/packages/weapp-vite/src/runtime/config/internal/loadConfig.test.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/loadConfig.test.ts
@@ -419,6 +419,10 @@ describe('runtime config internal loadConfig', () => {
           },
         },
         path: '/project/vite.config.ts',
+        dependencies: [
+          '/project/vite.config.ts',
+          './config/shared.ts',
+        ],
       })
       .mockResolvedValueOnce({
         config: {
@@ -448,6 +452,10 @@ describe('runtime config internal loadConfig', () => {
           },
         },
         path: '/project/weapp-vite.config.ts',
+        dependencies: [
+          '/project/config/shared.ts',
+          '/project/weapp-vite.config.ts',
+        ],
       })
     resolveWeappConfigFileMock.mockResolvedValueOnce('/project/weapp-vite.config.ts')
 
@@ -495,6 +503,11 @@ describe('runtime config internal loadConfig', () => {
       },
     ])
     expect(result.configFilePath).toBe('/project/weapp-vite.config.ts')
+    expect(result.configFileDependencies).toEqual([
+      '/project/vite.config.ts',
+      '/project/config/shared.ts',
+      '/project/weapp-vite.config.ts',
+    ])
     expect(result.configMergeInfo).toEqual({
       merged: true,
       viteConfigPath: '/project/vite.config.ts',

--- a/packages/weapp-vite/src/runtime/config/internal/loadConfig.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/loadConfig.ts
@@ -49,6 +49,39 @@ export function shouldReuseLoadedWeappConfig(
   return path.resolve(loadedPath) === path.resolve(weappConfigFilePath)
 }
 
+function collectConfigFileDependencies(
+  cwd: string,
+  ...entries: Array<{
+    path?: string
+    dependencies?: string[]
+  } | string | null | undefined>
+) {
+  const dependencySet = new Set<string>()
+
+  const add = (filePath: string | undefined) => {
+    if (!filePath) {
+      return
+    }
+    dependencySet.add(path.isAbsolute(filePath) ? path.normalize(filePath) : path.resolve(cwd, filePath))
+  }
+
+  for (const entry of entries) {
+    if (!entry) {
+      continue
+    }
+    if (typeof entry === 'string') {
+      add(entry)
+      continue
+    }
+    add(entry.path)
+    for (const dependency of entry.dependencies ?? []) {
+      add(dependency)
+    }
+  }
+
+  return Array.from(dependencySet)
+}
+
 function injectDefaultSrcAlias(config: InlineConfig, cwd: string, srcRoot: string) {
   if (!srcRoot) {
     return
@@ -415,6 +448,12 @@ export function createLoadConfig(options: LoadConfigFactoryOptions) {
     }
 
     const configFilePath = weappLoaded?.path ?? loaded?.path ?? resolvedConfigFile
+    const configFileDependencies = collectConfigFileDependencies(
+      cwd,
+      loaded,
+      weappLoaded,
+      resolvedConfigFile,
+    )
     const configMergeInfo = loaded?.path && weappLoaded?.path && !shouldReuseLoadedWeappConfig(weappLoaded.path, loaded.path)
       ? {
           merged: true,
@@ -458,6 +497,7 @@ export function createLoadConfig(options: LoadConfigFactoryOptions) {
       srcRoot,
       pluginOnly,
       configFilePath,
+      configFileDependencies,
       currentSubPackageRoot: undefined,
       weappWeb: resolvedWebConfig,
       weappLib: resolvedLibConfig,

--- a/packages/weapp-vite/src/runtime/config/internal/merge/index.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/merge/index.ts
@@ -66,6 +66,7 @@ export function createMergeFactories(options: MergeFactoryOptions): MergeFactory
       cwd: currentOptions.cwd,
       srcRoot: currentOptions.srcRoot,
       mpDistRoot: currentOptions.mpDistRoot,
+      configFileDependencies: currentOptions.configFileDependencies,
       packageJson: currentOptions.packageJson,
       isDev: currentOptions.isDev,
       applyRuntimePlatform,

--- a/packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.test.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.test.ts
@@ -84,6 +84,7 @@ describe('runtime config merge miniprogram', () => {
         cwd: '/project',
         srcRoot: 'src',
         mpDistRoot: 'custom-dist',
+        configFileDependencies: [],
         packageJson: {
           dependencies: {
             '@scope/pkg': '^1.0.0',
@@ -168,6 +169,7 @@ describe('runtime config merge miniprogram', () => {
         } as any,
         cwd: '/project',
         srcRoot: 'src',
+        configFileDependencies: [],
         packageJson: undefined,
         isDev: true,
         applyRuntimePlatform: vi.fn(),
@@ -209,6 +211,7 @@ describe('runtime config merge miniprogram', () => {
         } as any,
         cwd: '/project',
         srcRoot: 'src',
+        configFileDependencies: [],
         packageJson: undefined,
         isDev: true,
         applyRuntimePlatform: vi.fn(),
@@ -241,6 +244,7 @@ describe('runtime config merge miniprogram', () => {
           build: {
             watch: {
               buildDelay: 500,
+              include: ['/workspace/packages/ui/**'],
               watcher: {
                 useDebounce: false,
               },
@@ -249,6 +253,7 @@ describe('runtime config merge miniprogram', () => {
         } as any,
         cwd: '/project',
         srcRoot: 'src',
+        configFileDependencies: ['/project/vite.config.mts'],
         packageJson: undefined,
         isDev: true,
         applyRuntimePlatform: vi.fn(),
@@ -262,7 +267,11 @@ describe('runtime config merge miniprogram', () => {
 
     expect(result.build?.watch?.buildDelay).toBe(500)
     expect(result.build?.watch?.watcher?.useDebounce).toBe(false)
-    expect(result.build?.watch?.include).toEqual(['/project/src/**'])
+    expect(result.build?.watch?.include).toEqual([
+      '/workspace/packages/ui/**',
+      '/project/src/**',
+      '/project/vite.config.mts',
+    ])
   })
 
   it('builds production inline config and sets current subpackage root', () => {

--- a/packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.ts
@@ -16,6 +16,7 @@ import { arrangePlugins } from './plugins'
 
 const PACKAGE_NAME_REGEX = /[-/\\^$*+?.()|[\]{}]/g
 const PATH_SEPARATOR_SPLIT_REGEX = /[/\\]+/
+type WatchIncludePattern = string | RegExp
 
 function escapeRegex(value: string) {
   return value.replace(PACKAGE_NAME_REGEX, '\\$&')
@@ -65,6 +66,7 @@ interface MergeMiniprogramOptions {
   cwd: string
   srcRoot: string
   mpDistRoot?: string
+  configFileDependencies?: string[]
   packageJson: { dependencies?: Record<string, string> } | undefined
   isDev: boolean
   applyRuntimePlatform: (runtime: 'miniprogram' | 'web') => void
@@ -79,9 +81,11 @@ export function resolveMiniprogramWatchInclude(options: {
   srcRoot: string
   pluginRoot?: string
   buildScope?: ReturnType<typeof resolveBuildScope>
+  userInclude?: WatchIncludePattern | WatchIncludePattern[]
+  configFileDependencies?: string[]
 }) {
   const srcRoot = path.join(options.cwd, options.srcRoot)
-  const watchInclude: string[] = options.buildScope?.enabled
+  const watchInclude: WatchIncludePattern[] = options.buildScope?.enabled
     ? [
         ...options.buildScope.includeMainPackage ? [path.join(srcRoot, 'pages', '**')] : [],
         ...options.buildScope.subPackageRoots.map(root => path.join(srcRoot, root, '**')),
@@ -90,21 +94,39 @@ export function resolveMiniprogramWatchInclude(options: {
         path.join(srcRoot, '**'),
       ]
 
-  if (!options.pluginRoot) {
-    return watchInclude
+  if (options.pluginRoot) {
+    const absolutePluginRoot = path.resolve(options.cwd, options.pluginRoot)
+    const relativeToSrc = path.relative(
+      path.resolve(options.cwd, options.srcRoot),
+      absolutePluginRoot,
+    )
+    const pluginPatternBase = relativeToSrc.startsWith('..')
+      ? absolutePluginRoot
+      : path.join(options.cwd, options.srcRoot, relativeToSrc)
+
+    watchInclude.push(path.join(pluginPatternBase, '**'))
   }
 
-  const absolutePluginRoot = path.resolve(options.cwd, options.pluginRoot)
-  const relativeToSrc = path.relative(
-    path.resolve(options.cwd, options.srcRoot),
-    absolutePluginRoot,
-  )
-  const pluginPatternBase = relativeToSrc.startsWith('..')
-    ? absolutePluginRoot
-    : path.join(options.cwd, options.srcRoot, relativeToSrc)
+  for (const dependency of options.configFileDependencies ?? []) {
+    watchInclude.push(dependency)
+  }
 
-  watchInclude.push(path.join(pluginPatternBase, '**'))
-  return watchInclude
+  const userInclude = Array.isArray(options.userInclude)
+    ? options.userInclude
+    : options.userInclude
+      ? [options.userInclude]
+      : []
+  const seen = new Set<string>()
+  return [...userInclude, ...watchInclude].filter((item) => {
+    if (typeof item !== 'string') {
+      return true
+    }
+    if (seen.has(item)) {
+      return false
+    }
+    seen.add(item)
+    return true
+  })
 }
 
 export function mergeMiniprogram(options: MergeMiniprogramOptions, ...configs: Partial<InlineConfig | undefined>[]) {
@@ -115,6 +137,7 @@ export function mergeMiniprogram(options: MergeMiniprogramOptions, ...configs: P
     cwd,
     srcRoot,
     mpDistRoot,
+    configFileDependencies = [],
     packageJson,
     isDev,
     applyRuntimePlatform,
@@ -172,6 +195,7 @@ export function mergeMiniprogram(options: MergeMiniprogramOptions, ...configs: P
       srcRoot,
       pluginRoot: config.weapp?.pluginRoot,
       buildScope: resolveBuildScope(config.weapp?.buildScope),
+      configFileDependencies,
     })
 
     const inline = defu<InlineConfig, (InlineConfig | undefined)[]>(

--- a/packages/weapp-vite/src/runtime/config/types.ts
+++ b/packages/weapp-vite/src/runtime/config/types.ts
@@ -44,6 +44,7 @@ export interface LoadConfigResult {
   srcRoot: string
   pluginOnly?: boolean
   configFilePath?: string
+  configFileDependencies: string[]
   currentSubPackageRoot?: string
   weappWeb?: ResolvedWeappWebConfig
   configMergeInfo?: ResolvedConfigMergeInfo
@@ -114,6 +115,7 @@ export interface ConfigService {
   readonly aliasEntries: ResolvedAlias[]
   readonly platform: MpPlatform
   readonly configFilePath?: string
+  readonly configFileDependencies: string[]
   readonly weappWebConfig?: ResolvedWeappWebConfig
   readonly weappLibConfig?: ResolvedWeappLibConfig
   readonly weappLibOutputMap?: Map<string, string>

--- a/packages/weapp-vite/src/runtime/runtimeState.ts
+++ b/packages/weapp-vite/src/runtime/runtimeState.ts
@@ -53,6 +53,7 @@ function createDefaultLoadConfigResult(): LoadConfigResult {
     platform: DEFAULT_MP_PLATFORM,
     srcRoot: '',
     configFilePath: undefined,
+    configFileDependencies: [],
     weappWeb: undefined,
     configMergeInfo: undefined,
   }
@@ -108,6 +109,7 @@ export interface RuntimeState {
       dirtyEntrySet: Set<string>
       dirtyEntryReasons: Map<string, 'direct' | 'dependency' | 'metadata'>
       resolvedEntryMap: Map<string, ResolvedId>
+      externalComponentEntryMap: Map<string, string>
       entriesMap: Map<string, Entry | undefined>
       layoutEntryDependents: Map<string, Set<string>>
       entryLayoutDependencies: Map<string, Set<string>>
@@ -241,6 +243,7 @@ export function createRuntimeState(): RuntimeState {
         dirtyEntrySet: new Set<string>(),
         dirtyEntryReasons: new Map<string, 'direct' | 'dependency' | 'metadata'>(),
         resolvedEntryMap: new Map<string, ResolvedId>(),
+        externalComponentEntryMap: new Map<string, string>(),
         entriesMap: new Map<string, Entry | undefined>(),
         layoutEntryDependents: new Map<string, Set<string>>(),
         entryLayoutDependencies: new Map<string, Set<string>>(),

--- a/packages/weapp-vite/test/plugins/coreLifecycle.test.ts
+++ b/packages/weapp-vite/test/plugins/coreLifecycle.test.ts
@@ -70,6 +70,7 @@ describe('core plugin watchChange', () => {
           targets: ['weapp'],
         },
         absoluteSrcRoot: '/project/src',
+        configFileDependencies: [],
         relativeAbsoluteSrcRoot: (p: string) => path.relative('/project/src', p) || '.',
         relativeCwd: (p: string) => path.relative('/project', p) || '.',
       },

--- a/packages/weapp-vite/test/utils.ts
+++ b/packages/weapp-vite/test/utils.ts
@@ -1,6 +1,6 @@
 import type { LoadConfigOptions } from '../src/context'
 import { existsSync } from 'node:fs'
-import { cp, lstat, mkdir, mkdtemp, readdir, readFile, readlink, rm, symlink } from 'node:fs/promises'
+import { cp, lstat, mkdir, mkdtemp, readFile, readlink, rm, symlink } from 'node:fs/promises'
 import { fdir } from 'fdir'
 import path from 'pathe'
 import { resetCompilerContext } from '../src/context/getInstance'
@@ -224,10 +224,6 @@ export async function createTempFixtureProject(
     tempDir,
     cleanup: async () => {
       await rm(tempDir, { recursive: true, force: true })
-      const remaining = await readdir(tempRoot).catch(() => null)
-      if (remaining && remaining.length === 0) {
-        await rm(tempRoot, { recursive: true, force: true })
-      }
     },
   }
 }


### PR DESCRIPTION
## 背景
修复 discussion #338 中提到的开发态问题：配置变更没有稳定触发重建，`srcRoot` 外部已解析组件在编译和 HMR 流程中也会被漏掉。

## 改动
- 记录并监听加载后的配置文件依赖，确保配置及其引入文件变更后能触发重建。
- 合并用户自定义 `build.watch.include`，同时补上开发态需要的配置依赖和插件目录监听。
- 允许 `srcRoot` 外部的已解析组件进入编译、入口解析和 HMR 处理流程。
- 为上述行为补充回归测试，并增加 changeset，联动 `weapp-vite` 与 `create-weapp-vite`。

## 验证
- `pnpm --filter weapp-vite build`
- `pnpm --filter @weapp-core/constants build`
- `pnpm --filter @weapp-core/logger build`
- `pnpm --filter @weapp-vite/ast build`
- `pnpm --filter rolldown-require build`
- `pnpm vitest run packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.test.ts packages/weapp-vite/src/runtime/config/internal/loadConfig.test.ts packages/weapp-vite/src/runtime/config/createConfigService.test.ts packages/weapp-vite/src/plugins/core/lifecycle/transform.test.ts packages/weapp-vite/src/plugins/core/lifecycle/watch.test.ts packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry.test.ts`
- `pnpm --filter weapp-vite typecheck`
