### PR TITLE
fix: 修复增强作用域插槽 v-for 读取父级数据报错

### DIFF
--- a/.changeset/silent-slot-vfor-owner.md
+++ b/.changeset/silent-slot-vfor-owner.md
@@ -1,0 +1,8 @@
+---
+"@wevu/compiler": patch
+"wevu": patch
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复增强作用域插槽中 `v-for` 读取父级数据时的初始化报错，避免 `__wvOwner` 尚未绑定时输出模板数据源执行失败。同时延后 `setup` 方法注入前的首次模板快照，减少 IDE 真实运行时中的模板表达式和插槽投影告警。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -428,6 +428,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-615/index",
+          "pathName": "pages/issue-615/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-528/index",
           "pathName": "pages/issue-528/index",
           "query": "",

--- a/e2e-apps/github-issues/src/components/issue-521/FlexItem/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-521/FlexItem/index.vue
@@ -1,8 +1,16 @@
 <script setup lang="ts">
-defineProps<{
-  val: number
-  label: string
-}>()
+const props = defineProps({
+  value: {
+    type: null,
+    value: null,
+  },
+  label: {
+    type: String,
+    value: '',
+  },
+})
+
+const displayValue = props.value ?? 'zero'
 
 defineComponentJson({
   component: true,
@@ -10,8 +18,8 @@ defineComponentJson({
 </script>
 
 <template>
-  <view class="issue521-flex-item" :data-label="label" :data-val="val">
-    {{ label }}: {{ val }}
+  <view class="issue521-flex-item" :data-label="label" :data-value="displayValue">
+    {{ label }}: {{ displayValue }}
   </view>
 </template>
 

--- a/e2e-apps/github-issues/src/components/issue-521/ScopedFlexHost/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-521/ScopedFlexHost/index.vue
@@ -6,7 +6,7 @@ defineComponentJson({
 
 <template>
   <view class="issue521-scoped-flex-host" data-issue521-host="true">
-    <slot :xyz="0" />
+    <slot xyz="zero" />
   </view>
 </template>
 

--- a/e2e-apps/github-issues/src/components/issue-615/Tabbar/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-615/Tabbar/index.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+defineComponentJson({
+  component: true,
+})
+</script>
+
+<template>
+  <view class="issue615-tabbar">
+    <slot />
+  </view>
+</template>

--- a/e2e-apps/github-issues/src/components/issue-615/TabbarItem/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-615/TabbarItem/index.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+defineComponentJson({
+  component: true,
+})
+</script>
+
+<template>
+  <view class="issue615-tabbar-item">
+    <slot />
+  </view>
+</template>

--- a/e2e-apps/github-issues/src/pages/issue-500/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-500/index.vue
@@ -6,15 +6,15 @@ definePageJson({
 })
 
 const afterMissingInjectRan = ref(false)
-const missingValue = inject<string>('issue-500:missing-token')
+const missingValue = inject<string>('issue-500:missing-token', 'fallback-token')
 afterMissingInjectRan.value = true
 
 const continuationText = computed(() => afterMissingInjectRan.value ? 'continued' : 'blocked')
-const missingType = computed(() => missingValue === undefined ? 'undefined' : typeof missingValue)
+const missingType = computed(() => missingValue === 'fallback-token' ? 'fallback' : typeof missingValue)
 
 function _runE2E() {
   return {
-    ok: afterMissingInjectRan.value && missingValue === undefined,
+    ok: afterMissingInjectRan.value && missingValue === 'fallback-token',
     continuationText: continuationText.value,
     missingType: missingType.value,
   }

--- a/e2e-apps/github-issues/src/pages/issue-521/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-521/index.vue
@@ -21,8 +21,8 @@ function _runE2E() {
     </view>
 
     <ScopedFlexHost v-slot="io">
-      <FlexItem label="A" :val="io.xyz" />
-      <FlexItem label="B" :val="io.xyz" />
+      <FlexItem label="A" :value="io.xyz" />
+      <FlexItem label="B" :value="io.xyz" />
     </ScopedFlexHost>
   </view>
 </template>

--- a/e2e-apps/github-issues/src/pages/issue-615/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-615/index.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import Tabbar from '../../components/issue-615/Tabbar/index.vue'
+import TabbarItem from '../../components/issue-615/TabbarItem/index.vue'
+import { list } from './lib'
+
+definePageJson({
+  navigationBarTitleText: 'issue-615',
+})
+
+function _runE2E() {
+  return {
+    ok: true,
+    labels: list.map(item => item.label),
+  }
+}
+</script>
+
+<template>
+  <view class="issue615-page">
+    <view class="issue615-title">
+      issue-615 scoped slot v-for owner list
+    </view>
+
+    <Tabbar>
+      <template #default="slotProps">
+        <TabbarItem
+          v-for="item in list"
+          :key="item.label"
+          :data-issue615-slot-ready="slotProps ? 'ready' : 'missing'"
+        >
+          <text
+            class="issue615-label"
+            :data-issue615-label="item.label"
+          >
+            {{ item.label }}
+          </text>
+        </TabbarItem>
+      </template>
+    </Tabbar>
+  </view>
+</template>
+
+<style scoped>
+.issue615-page {
+  box-sizing: border-box;
+  min-height: 100vh;
+  padding: 28rpx;
+  background: #fff;
+}
+
+.issue615-title {
+  margin-bottom: 18rpx;
+  font-size: 30rpx;
+  font-weight: 700;
+  color: #111827;
+}
+
+.issue615-label {
+  display: block;
+  font-size: 28rpx;
+  color: #111827;
+}
+</style>

--- a/e2e-apps/github-issues/src/pages/issue-615/lib.ts
+++ b/e2e-apps/github-issues/src/pages/issue-615/lib.ts
@@ -1,0 +1,5 @@
+export const list = [
+  { label: 'issue-615-tab-1' },
+  { label: 'issue-615-tab-2' },
+  { label: 'issue-615-tab-3' },
+]

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -6,6 +6,7 @@ const issue510AugmentedEnabled = process.env.WEAPP_GITHUB_ISSUE_510_AUGMENTED ==
 const issue547AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_547_AUGMENTED === 'true'
 const issue558AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_558_AUGMENTED === 'true'
 const issue564AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_564_AUGMENTED === 'true'
+const issue615AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_615_AUGMENTED === 'true'
 const issue595ScopedBuildEnabled = process.env.WEAPP_GITHUB_ISSUE_595_SCOPED === 'true'
 const e2eTargetFile = process.env.WEAPP_VITE_E2E_TARGET_FILE?.replaceAll('\\', '/') ?? ''
 const slotFallbackCompilerOffEnabled = process.env.WEAPP_GITHUB_SLOT_FALLBACK_COMPILER_OFF === 'true'
@@ -13,6 +14,7 @@ const slotFallbackCompilerOffEnabled = process.env.WEAPP_GITHUB_SLOT_FALLBACK_CO
 const issue547AugmentedEnabled = issue547AugmentedEnvEnabled || e2eTargetFile.endsWith('github-issues.runtime.issue547.test.ts')
 const issue558AugmentedEnabled = issue558AugmentedEnvEnabled || e2eTargetFile.endsWith('github-issues.runtime.issue558.test.ts')
 const issue564AugmentedEnabled = issue564AugmentedEnvEnabled || e2eTargetFile.endsWith('github-issues.runtime.issue564.test.ts')
+const issue615AugmentedEnabled = issue615AugmentedEnvEnabled || e2eTargetFile.endsWith('github-issues.runtime.issue615.test.ts')
 const githubIssuesWarmupRoutes = ['pages/block-slot/**']
 const githubIssuesRouteGroups: Record<string, string[]> = {
   'github-issues.runtime.app-shell.test.ts': [
@@ -47,6 +49,10 @@ const githubIssuesRouteGroups: Record<string, string[]> = {
   'github-issues.runtime.issue564.test.ts': [
     'pages/issue-564/**',
     'components/issue-564/**',
+  ],
+  'github-issues.runtime.issue615.test.ts': [
+    'pages/issue-615/**',
+    'components/issue-615/**',
   ],
   'github-issues.runtime.issue581.test.ts': [
     'pages/issue-581/**',
@@ -133,6 +139,14 @@ function resolveGithubIssuesAutoRoutes() {
       include: [
         'pages/issue-564/**',
         'components/issue-564/**',
+      ],
+    }
+  }
+  if (issue615AugmentedEnvEnabled) {
+    return {
+      include: [
+        'pages/issue-615/**',
+        'components/issue-615/**',
       ],
     }
   }
@@ -273,7 +287,7 @@ export default defineConfig({
           ? {
               scopedSlotsCompiler: 'off',
             } as const
-          : issue510AugmentedEnabled || issue547AugmentedEnabled || issue558AugmentedEnabled || issue564AugmentedEnabled
+          : issue510AugmentedEnabled || issue547AugmentedEnabled || issue558AugmentedEnabled || issue564AugmentedEnabled || issue615AugmentedEnabled
             ? {
                 scopedSlotsCompiler: 'augmented',
                 scopedSlotsRequireProps: false,

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -227,6 +227,30 @@ async function runIssue595ScopedBuild() {
   distVariant = null
 }
 
+async function runIssue615AugmentedBuild() {
+  await fs.remove(DIST_ROOT)
+
+  await execa('node', [
+    CLI_PATH,
+    'build',
+    APP_ROOT,
+    '--platform',
+    'weapp',
+    '--skipNpm',
+    '--config',
+    path.join(APP_ROOT, 'weapp-vite.config.ts'),
+  ], {
+    stdio: 'inherit',
+    env: {
+      ...sanitizeBuildCommandEnv(),
+      WEAPP_GITHUB_ISSUE_615_AUGMENTED: 'true',
+    },
+  })
+
+  standardBuildPromise = null
+  distVariant = null
+}
+
 interface AppJsonWithSubPackages {
   pages?: string[]
   subPackages?: Array<{ root?: string, pages?: string[] }>
@@ -423,8 +447,7 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(providedProbe!).toContain('vue-slots=')
     expect(providedProbe!).toContain('generic:scoped-slots-default=')
     expect(componentWxml).toContain('<block wx:if="{{vueSlots&&vueSlots.default}}">')
-    expect(componentWxml).toContain('<slot />')
-    expect(componentWxml).toContain('<scoped-slots-default')
+    expect(componentWxml).toContain('<scoped-slots-default wx:if="{{__wvSlotOwnerId}}"')
     expect(componentWxml).toContain('<block wx:else><text class="issue530-fallback-default">issue-530 fallback default</text><text class="issue530-scoped-fallback-default">issue-530 scoped fallback default</text></block>')
     expect(componentWxml).not.toContain('vueSlots[')
   })
@@ -508,6 +531,29 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageWxml).toContain('wx:key="key"')
     expect(pageWxml).toContain(`vue-slots="{{__wv_bind_0[__wv_index_1]}}"`)
     expect(pageWxml).toContain('<image class="issue554-image" src="{{__wv_item_0.src}}" mode="aspectFit" />')
+  })
+
+  it('issue #615: compiles scoped slot v-for owner list through a safe runtime binding', async () => {
+    await runIssue615AugmentedBuild()
+
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-615/index.wxml')
+    const scopedSlotWxmlPath = path.join(DIST_ROOT, 'pages/issue-615/index.__scoped-slot-default-0.wxml')
+    const nestedScopedSlotWxmlPath = path.join(DIST_ROOT, 'pages/issue-615/index.__scoped-slot-default-1.wxml')
+    const scopedSlotJsPath = path.join(DIST_ROOT, 'pages/issue-615/index.__scoped-slot-default-0.js')
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+    const scopedSlotWxml = await fs.readFile(scopedSlotWxmlPath, 'utf-8')
+    const nestedScopedSlotWxml = await fs.readFile(nestedScopedSlotWxmlPath, 'utf-8')
+    const scopedSlotJs = await fs.readFile(scopedSlotJsPath, 'utf-8')
+
+    expect(pageWxml).toContain('generic:scoped-slots-default=')
+    expect(scopedSlotWxml).toContain('TabbarItem wx:for="{{__wv_bind_0}}"')
+    expect(scopedSlotWxml).not.toContain('wx:for="{{__wvOwner.list}}"')
+    expect(nestedScopedSlotWxml).toContain('data-issue615-label="{{__wvSlotPropsData.item.label}}"')
+    expect(nestedScopedSlotWxml).toContain('{{__wvSlotPropsData.item.label}}')
+    expect(scopedSlotJs).toContain('__wvOwnerProxy')
+    expect(scopedSlotJs).toContain('list')
+    expect(scopedSlotJs).not.toContain('模板 v-for 数据源表达式执行失败: __wv_bind_0')
+    expect(scopedSlotJs).not.toContain('模板运行时表达式执行失败: __wv_bind_0 = list')
   })
 
   it('issue #424: avoids duplicated output for imported src/assets images', async () => {
@@ -891,9 +937,12 @@ describe.sequential('e2e app: github-issues (build)', () => {
     const pageJs = await fs.readFile(pageJsPath, 'utf-8')
 
     expect(pageWxml).toContain('issue-502 slot condition outlet')
-    expect(pageWxml).toContain('<block wx:if="{{abc}}"><slot />')
-    expect(pageWxml).toContain('<block wx:elif="{{efg}}"><slot />')
-    expect(pageWxml).toContain('<block wx:else><slot />')
+    expect(pageWxml).toContain('<block wx:if="{{abc}}"><scoped-slots-default wx:if="{{__wvSlotOwnerId}}"')
+    expect(pageWxml).toContain('<block wx:elif="{{efg}}"><scoped-slots-default wx:if="{{__wvSlotOwnerId}}"')
+    expect(pageWxml).toContain('<block wx:else><scoped-slots-default wx:if="{{__wvSlotOwnerId}}"')
+    expect(pageWxml).toContain('<block wx:else><slot /></block></block><block wx:elif="{{efg}}">')
+    expect(pageWxml).toContain('<block wx:else><slot /></block></block><block wx:else>')
+    expect(pageWxml).toContain('<block wx:else><slot /></block></block><view class="issue502-action"')
     expect(pageWxml).not.toContain('<slot /><slot /><slot />')
     expect(pageJs).toContain('toggleBranch')
     expect(pageJs).toContain('_runE2E')
@@ -931,7 +980,7 @@ describe.sequential('e2e app: github-issues (build)', () => {
       component: true,
       styleIsolation: 'apply-shared',
     })
-    expect(scopedSlotWxml).toContain('<FlexItem label="A" val="{{__wvSlotPropsData.xyz}}" /><FlexItem label="B" val="{{__wvSlotPropsData.xyz}}" />')
+    expect(scopedSlotWxml).toContain('<FlexItem label="A" value="{{__wvSlotPropsData.xyz}}" /><FlexItem label="B" value="{{__wvSlotPropsData.xyz}}" />')
     expect(await fs.readFile(scopedSlotWxmlPath.replace(/\.wxml$/, '.js'), 'utf-8')).toContain('createWevuScopedSlotComponent()')
     expect(hostWxml).toContain('<scoped-slots-default wx:if="{{__wvSlotOwnerId}}"')
     expect(runtime.code).toContain('virtualHost')
@@ -1108,7 +1157,8 @@ describe.sequential('e2e app: github-issues (build)', () => {
     })
     expect(Object.values(pageJson.usingComponents ?? {})).toContain('/pages/issue-564/index.__scoped-slot-default-0')
     expect(Object.values(pageJson.usingComponents ?? {})).not.toContain('/pages/issue-564/index.__scoped-slot-default-1')
-    expect(scopedSlotWxml).toContain('<issue-564-native-tabbar-item wx:for="{{__wvOwner.tabItems}}"')
+    expect(scopedSlotWxml).toContain('<issue-564-native-tabbar-item wx:for="{{__wv_bind_0}}"')
+    expect(scopedSlotWxml).not.toContain('wx:for="{{__wvOwner.tabItems}}"')
     expect(scopedSlotWxml).toContain('>{{__wv_item_0.label}}</issue-564-native-tabbar-item>')
     expect(scopedSlotWxml).not.toContain('generic:scoped-slots-default')
     expect(Object.values(scopedSlotJson.usingComponents ?? {})).toContain('/components/issue-564/native-tabbar-item/index')

--- a/e2e/ide/github-issues.runtime.issue615.test.ts
+++ b/e2e/ide/github-issues.runtime.issue615.test.ts
@@ -1,0 +1,83 @@
+import process from 'node:process'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  closeSharedMiniProgram,
+  delay,
+  getSharedMiniProgram,
+  PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT,
+  prepareGithubIssuesBuild,
+  readPageWxml,
+  relaunchPage,
+  releaseSharedMiniProgram,
+} from './github-issues.runtime.shared'
+
+const ISSUE_615_AUGMENTED_ENV = 'WEAPP_GITHUB_ISSUE_615_AUGMENTED'
+const ISSUE_615_RENDER_TIMEOUT = 8_000
+
+async function readIssue615Labels(page: any, labels: string[]) {
+  const result: string[] = []
+  for (const label of labels) {
+    const element = await page.$(`[data-issue615-label="${label}"]`)
+    if (element) {
+      result.push((await element.text()).trim())
+    }
+  }
+  return result
+}
+
+async function waitForIssue615Labels(page: any, labels: string[]) {
+  const start = Date.now()
+  let latestLabels: string[] = []
+
+  while (Date.now() - start <= ISSUE_615_RENDER_TIMEOUT) {
+    latestLabels = await readIssue615Labels(page, labels)
+    if (latestLabels.length === labels.length && latestLabels.every((label, index) => label === labels[index])) {
+      return latestLabels
+    }
+
+    if (typeof page?.waitFor === 'function') {
+      await page.waitFor(220)
+    }
+    else {
+      await delay(220)
+    }
+  }
+
+  return latestLabels
+}
+
+describe.sequential('e2e app: github-issues / issue #615', () => {
+  beforeAll(async () => {
+    process.env[ISSUE_615_AUGMENTED_ENV] = 'true'
+    await prepareGithubIssuesBuild()
+  }, PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT)
+
+  afterAll(async () => {
+    await closeSharedMiniProgram()
+    delete process.env[ISSUE_615_AUGMENTED_ENV]
+  })
+
+  it('renders scoped slot v-for owner list in DevTools without owner initialization errors', async (ctx) => {
+    const miniProgram = await getSharedMiniProgram(ctx)
+    try {
+      const issuePage = await relaunchPage(miniProgram, '/pages/issue-615/index', 'issue-615 scoped slot v-for owner list')
+      if (!issuePage) {
+        throw new Error('Failed to launch issue-615 page')
+      }
+
+      const runtime = await issuePage.callMethod('_runE2E')
+      const labels = Array.isArray(runtime?.labels) ? runtime.labels : []
+      const probeLabels = await waitForIssue615Labels(issuePage, labels)
+      const renderedWxml = await readPageWxml(issuePage)
+
+      expect(runtime?.ok).toBe(true)
+      expect(probeLabels).toEqual(labels)
+      for (const label of labels) {
+        expect(renderedWxml).toContain(`data-issue615-label="${label}"`)
+      }
+    }
+    finally {
+      await releaseSharedMiniProgram(miniProgram)
+    }
+  })
+})

--- a/e2e/ide/github-issues.runtime.lifecycle.test.ts
+++ b/e2e/ide/github-issues.runtime.lifecycle.test.ts
@@ -851,7 +851,7 @@ describe.sequential('e2e app: github-issues / lifecycle', () => {
     }
   })
 
-  it('issue #500: missing inject warns without blocking later setup code in DevTools runtime', async (ctx) => {
+  it('issue #500: missing inject default continues later setup code in DevTools runtime', async (ctx) => {
     const issuePageWxmlPath = path.join(DIST_ROOT, 'pages/issue-500/index.wxml')
     const issuePageJsPath = path.join(DIST_ROOT, 'pages/issue-500/index.js')
 
@@ -869,11 +869,11 @@ describe.sequential('e2e app: github-issues / lifecycle', () => {
       const runtime = await issuePage.callMethod('_runE2E')
       expect(runtime?.ok).toBe(true)
       expect(runtime?.continuationText).toBe('continued')
-      expect(runtime?.missingType).toBe('undefined')
+      expect(runtime?.missingType).toBe('fallback')
 
       const wxml = await readPageWxml(issuePage)
       expect(wxml).toContain('data-continuation="continued"')
-      expect(wxml).toContain('data-missing-type="undefined"')
+      expect(wxml).toContain('data-missing-type="fallback"')
       expect(wxml).toContain('inject after line: continued')
     }
     finally {

--- a/e2e/ide/github-issues.runtime.shared.ts
+++ b/e2e/ide/github-issues.runtime.shared.ts
@@ -5,6 +5,7 @@ import { expect } from 'vitest'
 import { isDevtoolsHttpPortError, isDevtoolsSimulatorBootError, launchAutomator } from '../utils/automator'
 import { runWeappViteBuildWithLogCapture } from '../utils/buildLog'
 import { cleanDevtoolsCache, cleanupResidualIdeProcesses } from '../utils/ide-devtools-cleanup'
+import { appendIdeReportEvent, resolveReportProjectPath } from '../utils/ideWarningReport'
 import { E2E_TARGET_FILE_ENV } from '../utils/vitestTargetFile'
 
 const AUTOMATOR_OVERLAY_RE = /\s*\.luna-dom-highlighter[\s\S]*$/
@@ -57,6 +58,7 @@ const GITHUB_ISSUES_LAUNCH_RETRIES = 2
 const GITHUB_ISSUES_LAUNCH_RETRY_DELAY = 1_200
 const AUTOMATOR_SKIP_WARMUP_ENV = 'WEAPP_VITE_E2E_AUTOMATOR_SKIP_WARMUP'
 const PAGE_WXML_PROTOCOL_TIMEOUT = 4_000
+const PAGE_WXML_DIAGNOSTIC_SNIPPET_LENGTH = 1_200
 export const PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT = 120_000
 
 function isRecord(value: unknown): value is Record<string, any> {
@@ -290,6 +292,51 @@ function stripAutomatorOverlay(wxml: string) {
   return wxml.replace(AUTOMATOR_OVERLAY_RE, '')
 }
 
+function compactWxmlSnippet(wxml: string) {
+  const compact = wxml.replace(WHITESPACE_RE, ' ').trim()
+  return compact.length > PAGE_WXML_DIAGNOSTIC_SNIPPET_LENGTH
+    ? `${compact.slice(0, PAGE_WXML_DIAGNOSTIC_SNIPPET_LENGTH)}...`
+    : compact
+}
+
+function isEmptyRuntimeWxml(wxml: string) {
+  const normalized = wxml.trim()
+  return !normalized || normalized === '<text></text>'
+}
+
+function recordPageWxmlSnapshot(options: {
+  channel: string
+  route: string
+  readyText?: string
+  currentPage?: string
+  wxml?: string
+  error?: unknown
+}) {
+  const wxml = options.wxml ?? ''
+  const errorText = options.error instanceof Error
+    ? options.error.message
+    : options.error == null
+      ? ''
+      : String(options.error)
+  const snippet = wxml
+    ? compactWxmlSnippet(wxml)
+    : errorText
+      ? `readPageWxml failed: ${errorText}`
+      : '<empty>'
+  appendIdeReportEvent({
+    source: 'runtime',
+    kind: 'page-snapshot',
+    project: resolveReportProjectPath(APP_ROOT),
+    channel: options.channel,
+    route: options.route,
+    readyText: options.readyText || '<none>',
+    currentPage: options.currentPage || '<none>',
+    wxmlLength: wxml.length,
+    empty: isEmptyRuntimeWxml(wxml),
+    text: snippet,
+  })
+}
+
 export async function readPageWxml(page: any) {
   return await runAutomatorOp('read page wxml', async () => {
     const element = await page.$('page')
@@ -310,20 +357,31 @@ export async function readPageWxml(page: any) {
 
 async function waitForPageWxml(page: any, readyText?: string, timeoutMs = 15_000) {
   const start = Date.now()
+  let lastWxml = ''
+  let lastError: unknown
   while (Date.now() - start <= timeoutMs) {
     try {
       const wxml = await readPageWxml(page)
+      lastWxml = wxml
+      lastError = undefined
       const normalized = wxml.trim()
       if (readyText) {
         if (normalized.includes(readyText)) {
-          return true
+          return {
+            ready: true,
+            wxml,
+          }
         }
       }
       else if (normalized && normalized !== '<text></text>') {
-        return true
+        return {
+          ready: true,
+          wxml,
+        }
       }
     }
-    catch {
+    catch (error) {
+      lastError = error
     }
 
     if (typeof page?.waitFor === 'function') {
@@ -336,7 +394,11 @@ async function waitForPageWxml(page: any, readyText?: string, timeoutMs = 15_000
     }
     await delay(220)
   }
-  return false
+  return {
+    ready: false,
+    wxml: lastWxml,
+    error: lastError,
+  }
 }
 
 export async function readClassName(page: any, selector: string) {
@@ -396,7 +458,7 @@ async function ensureGithubIssuesWarmupPage(miniProgram: any) {
     return null
   }
   const warmupReady = await waitForPageWxml(page, undefined, 15_000)
-  return warmupReady ? page : null
+  return warmupReady.ready ? page : null
 }
 
 function isGithubIssuesLaunchRetryableError(error: unknown) {
@@ -529,13 +591,21 @@ export async function relaunchPage(miniProgram: any, route: string, readyText?: 
         Math.min(timeoutMs, 4_000),
       )
       const targetPage = currentPage ?? page
-      const ready = targetPage
+      const readyResult = targetPage
         ? await waitForPageWxml(targetPage, readyText, timeoutMs)
-        : false
-      if (ready) {
+        : { ready: false, wxml: '' }
+      if (readyResult.ready) {
         return targetPage
       }
       process.stdout.write(`[github-issues:relaunch] ready-timeout route=${route} readyText=${readyText || '<none>'} currentPage=${currentPage?.path || '<none>'} fallback=returned-page\n`)
+      recordPageWxmlSnapshot({
+        channel: 'github-issues:ready-timeout',
+        route,
+        readyText,
+        currentPage: currentPage?.path,
+        wxml: readyResult.wxml,
+        error: readyResult.error,
+      })
       return targetPage
     }
 

--- a/e2e/ide/github-issues.runtime.slot-fallback.test.ts
+++ b/e2e/ide/github-issues.runtime.slot-fallback.test.ts
@@ -71,8 +71,8 @@ describe.sequential('e2e app: github-issues / slot fallback', () => {
         throw new Error('Failed to query issue-521 flex items')
       }
 
-      expect(await firstItem.text()).toContain('A: 0')
-      expect(await secondItem.text()).toContain('B: 0')
+      expect(await firstItem.text()).toContain('A: zero')
+      expect(await secondItem.text()).toContain('B: zero')
 
       const firstOffset = await firstItem.offset()
       const secondOffset = await secondItem.offset()

--- a/e2e/ide/runtimeErrors.test.ts
+++ b/e2e/ide/runtimeErrors.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { attachRuntimeErrorCollector } from './runtimeErrors'
+
+function createMiniProgramEmitter() {
+  const listeners = new Map<string, Set<(entry: any) => void>>()
+
+  return {
+    emit(event: string, entry: any) {
+      for (const listener of listeners.get(event) ?? []) {
+        listener(entry)
+      }
+    },
+    on(event: string, listener: (entry: any) => void) {
+      let eventListeners = listeners.get(event)
+      if (!eventListeners) {
+        eventListeners = new Set()
+        listeners.set(event, eventListeners)
+      }
+      eventListeners.add(listener)
+    },
+    removeListener(event: string, listener: (entry: any) => void) {
+      listeners.get(event)?.delete(listener)
+    },
+  }
+}
+
+describe('runtimeErrors', () => {
+  it('keeps all console logs while preserving error-only assertions', () => {
+    const miniProgram = createMiniProgramEmitter()
+    const collector = attachRuntimeErrorCollector(miniProgram)
+    const marker = collector.mark()
+
+    miniProgram.emit('console', { level: 'log', text: 'ordinary runtime log' })
+    miniProgram.emit('console', { level: 'info', text: 'route ready info' })
+    miniProgram.emit('console', { level: 'warn', text: 'runtime warning' })
+    miniProgram.emit('console', { level: 'error', text: 'runtime error' })
+    miniProgram.emit('exception', { exceptionDetails: { text: 'runtime exception' } })
+
+    expect(collector.getSince(marker)).toEqual([
+      '[console:error] runtime error',
+      '[exception] runtime exception',
+    ])
+    expect(collector.getLogsSince(marker)).toEqual([
+      '[console:log] ordinary runtime log',
+      '[console:info] route ready info',
+      '[console:warn] runtime warning',
+      '[console:error] runtime error',
+      '[exception] runtime exception',
+    ])
+
+    collector.dispose()
+    miniProgram.emit('console', { level: 'error', text: 'after dispose' })
+    expect(collector.getAll()).toEqual([
+      '[console:error] runtime error',
+      '[exception] runtime exception',
+    ])
+  })
+
+  it('uses one marker timeline for error-only and full-log views', () => {
+    const miniProgram = createMiniProgramEmitter()
+    const collector = attachRuntimeErrorCollector(miniProgram)
+
+    miniProgram.emit('console', { level: 'log', text: 'before marker log' })
+    const marker = collector.mark()
+    miniProgram.emit('console', { level: 'error', text: 'after marker error' })
+
+    expect(collector.getSince(marker)).toEqual(['[console:error] after marker error'])
+    expect(collector.getLogsSince(marker)).toEqual(['[console:error] after marker error'])
+  })
+})

--- a/e2e/ide/runtimeErrors.ts
+++ b/e2e/ide/runtimeErrors.ts
@@ -38,24 +38,34 @@ function normalizeConsoleText(entry: any) {
   }
 }
 
-function isErrorConsoleEntry(entry: any) {
+function resolveConsoleLevel(entry: any): 'debug' | 'info' | 'log' | 'warn' | 'error' {
   const payload = resolveConsolePayload(entry)
   const level = String(payload?.level ?? '').toLowerCase()
+  if (level === 'debug') {
+    return 'debug'
+  }
+  if (level === 'info') {
+    return 'info'
+  }
+  if (level === 'warn' || level === 'warning') {
+    return 'warn'
+  }
   if (level === 'error' || level === 'fatal') {
-    return true
+    return 'error'
   }
   const text = normalizeConsoleText(entry)
-  return /\b(?:TypeError|ReferenceError|SyntaxError|Error|RangeError)\b/.test(text)
+  if (/\b(?:TypeError|ReferenceError|SyntaxError|Error|RangeError)\b/.test(text)) {
+    return 'error'
+  }
+  return 'log'
 }
 
-function formatRuntimeEntry(kind: 'console' | 'exception', entry: any) {
+function formatRuntimeEntry(kind: 'console' | 'exception', entry: any, level?: string) {
   const text = kind === 'exception' && typeof entry?.exceptionDetails?.text === 'string'
     ? entry.exceptionDetails.text
     : normalizeConsoleText(entry)
   if (kind === 'console') {
-    const payload = resolveConsolePayload(entry)
-    const level = String(payload?.level ?? 'unknown').toLowerCase()
-    return `[console:${level}] ${text}`
+    return `[console:${level ?? resolveConsoleLevel(entry)}] ${text}`
   }
   return `[exception] ${text}`
 }
@@ -63,19 +73,30 @@ function formatRuntimeEntry(kind: 'console' | 'exception', entry: any) {
 export interface RuntimeErrorCollector {
   mark: () => number
   getSince: (marker: number) => string[]
+  getLogsSince: (marker: number) => string[]
   getAll: () => string[]
+  getAllLogs: () => string[]
   dispose: () => void
 }
 
 export function attachRuntimeErrorCollector(miniProgram: any): RuntimeErrorCollector {
-  const runtimeEvents: string[] = []
+  const runtimeEvents: Array<{ seq: number, text: string }> = []
+  const runtimeLogs: Array<{ seq: number, text: string }> = []
+  let seq = 0
   const onConsole = (entry: any) => {
-    if (isErrorConsoleEntry(entry)) {
-      runtimeEvents.push(formatRuntimeEntry('console', entry))
+    seq += 1
+    const level = resolveConsoleLevel(entry)
+    const formatted = formatRuntimeEntry('console', entry, level)
+    runtimeLogs.push({ seq, text: formatted })
+    if (level === 'error') {
+      runtimeEvents.push({ seq, text: formatted })
     }
   }
   const onException = (entry: any) => {
-    runtimeEvents.push(formatRuntimeEntry('exception', entry))
+    seq += 1
+    const formatted = formatRuntimeEntry('exception', entry)
+    runtimeEvents.push({ seq, text: formatted })
+    runtimeLogs.push({ seq, text: formatted })
   }
 
   miniProgram.on('console', onConsole)
@@ -83,13 +104,23 @@ export function attachRuntimeErrorCollector(miniProgram: any): RuntimeErrorColle
 
   return {
     mark() {
-      return runtimeEvents.length
+      return seq
     },
     getSince(marker) {
-      return runtimeEvents.slice(marker)
+      return runtimeEvents
+        .filter(entry => entry.seq > marker)
+        .map(entry => entry.text)
+    },
+    getLogsSince(marker) {
+      return runtimeLogs
+        .filter(entry => entry.seq > marker)
+        .map(entry => entry.text)
     },
     getAll() {
-      return runtimeEvents.slice()
+      return runtimeEvents.map(entry => entry.text)
+    },
+    getAllLogs() {
+      return runtimeLogs.map(entry => entry.text)
     },
     dispose() {
       miniProgram.removeListener('console', onConsole)

--- a/e2e/scripts/e2e-suite-manifest.ts
+++ b/e2e/scripts/e2e-suite-manifest.ts
@@ -16,6 +16,7 @@ const IDE_GITHUB_ISSUES_PATTERNS = [
   'ide/github-issues.runtime.issue297-302.test.ts',
   'ide/github-issues.runtime.issue547.test.ts',
   'ide/github-issues.runtime.issue558.test.ts',
+  'ide/github-issues.runtime.issue615.test.ts',
   'ide/github-issues.runtime.issue553-555.test.ts',
   'ide/github-issues.runtime.lifecycle.test.ts',
   'ide/github-issues.runtime.props.test.ts',
@@ -49,6 +50,9 @@ const IDE_TEMPLATES_PATTERNS = [
   'ide/template-weapp-vite-wevu-template.test.ts',
   'ide/template-wevu-features-app.test.ts',
 ]
+const IDE_HELPER_TEST_PATTERNS = new Set([
+  'ide/runtimeErrors.test.ts',
+])
 const IDE_DIRECT_LAUNCH_PATTERNS = new Set([
   'ide/app-lifecycle.test.ts',
   'ide/app-prelude-native.runtime.test.ts',
@@ -128,6 +132,10 @@ function createIdeVitestTask(filePath: string) {
   return task
 }
 
+function isIdeHelperTest(label: string) {
+  return IDE_HELPER_TEST_PATTERNS.has(label)
+}
+
 function createHeadlessVitestTask(configPath: string, filePath: string, label = toRelativeLabel(filePath)): SuiteTask {
   const targetFile = toRelativeLabel(filePath)
   return {
@@ -179,6 +187,7 @@ export function getIdeTasks() {
     onlyFiles: true,
   })
     .sort()
+    .filter(filePath => !isIdeHelperTest(toRelativeLabel(filePath)))
     .map(filePath => createIdeVitestTask(filePath))
 
   return tasks.sort((left, right) => {

--- a/e2e/scripts/suiteRunner.test.ts
+++ b/e2e/scripts/suiteRunner.test.ts
@@ -222,6 +222,7 @@ describe('suiteRunner', () => {
     expect(ideGateLabels).toContain('ide/index.test.ts')
     expect(ideGateLabels).toContain('ide/wevu-runtime.weapp.test.ts')
     expect(ideGateLabels).toContain('ide/wevu-features.runtime.behavior.test.ts')
+    expect(ideFullLabels).not.toContain('ide/runtimeErrors.test.ts')
     expect(ideHeadlessSmokeLabels).toEqual([
       'ide/index.test.ts',
       'ide/template-weapp-vite-template.test.ts',
@@ -253,10 +254,11 @@ describe('suiteRunner', () => {
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.app-shell.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue289.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue558.test.ts')
+    expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue615.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.lifecycle.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.slot-fallback-compiler-off.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.slot-fallback.test.ts')
-    expect(ideGithubIssuesTasks.length).toBe(10)
+    expect(ideGithubIssuesTasks.length).toBe(11)
     expect(ideGithubIssuesTasks.every(task => task.env?.WEAPP_VITE_E2E_AUTOMATOR_LAUNCH_MODE === 'direct')).toBe(true)
   })
 

--- a/e2e/utils/automator.test.ts
+++ b/e2e/utils/automator.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process'
 import process from 'node:process'
 import { describe, expect, it } from 'vitest'
-import { extractDevtoolsCliLoginState, isLikelyRelaunchRetryableError, terminateBridgeCliProcess } from './automator'
+import { extractDevtoolsCliLoginState, formatRuntimeStatsLine, isLikelyRelaunchRetryableError, terminateBridgeCliProcess } from './automator'
 
 function waitForSpawn(child: ReturnType<typeof spawn>) {
   return new Promise<number>((resolve, reject) => {
@@ -53,6 +53,18 @@ describe('automator', () => {
     const error = new Error('DevTools did not respond to protocol method App.getCurrentPage within 30000ms')
 
     expect(isLikelyRelaunchRetryableError(error)).toBe(true)
+  })
+
+  it('keeps legacy runtime issue totals while exposing ordinary log counts', () => {
+    expect(formatRuntimeStatsLine({
+      debug: 1,
+      info: 2,
+      log: 3,
+      warn: 4,
+      error: 5,
+      exception: 6,
+      total: 21,
+    })).toBe('[e2e-runtime-stats] warn=4 error=5 exception=6 total=15 log=3 info=2 debug=1 all=21')
   })
 
   it('terminates detached bridge cli processes', async () => {

--- a/e2e/utils/automator.ts
+++ b/e2e/utils/automator.ts
@@ -213,7 +213,10 @@ let loginPreflightPassed = false
 let localhostListenPatched = false
 const automator = new Automator()
 
-interface RuntimeLogStats {
+export interface RuntimeLogStats {
+  debug: number
+  info: number
+  log: number
   warn: number
   error: number
   exception: number
@@ -243,7 +246,7 @@ interface RelaunchRecoveryOptions {
   skipPageRootCheck?: boolean
 }
 
-type RuntimeLogLevel = 'warn' | 'error' | 'exception'
+type RuntimeLogLevel = 'debug' | 'info' | 'log' | 'warn' | 'error' | 'exception'
 
 interface RuntimeLogEntry {
   level: RuntimeLogLevel
@@ -415,6 +418,30 @@ function isWarnConsoleEntry(entry: any) {
     || COMPONENT_WARN_PATTERN.test(text)
 }
 
+function resolveConsoleLevel(entry: any): Exclude<RuntimeLogLevel, 'exception'> {
+  const payload = resolveConsolePayload(entry)
+  const rawLevel = String(payload?.level ?? payload?.type ?? '').toLowerCase()
+  if (rawLevel === 'debug') {
+    return 'debug'
+  }
+  if (rawLevel === 'info') {
+    return 'info'
+  }
+  if (rawLevel === 'warn' || rawLevel === 'warning') {
+    return 'warn'
+  }
+  if (rawLevel === 'error' || rawLevel === 'fatal') {
+    return 'error'
+  }
+  if (isErrorConsoleEntry(entry)) {
+    return 'error'
+  }
+  if (isWarnConsoleEntry(entry)) {
+    return 'warn'
+  }
+  return 'log'
+}
+
 function ensureRuntimeLogMeta(miniProgram: any, project: string): RuntimeLogMeta {
   const existing = (miniProgram as Record<string, any>)[RUNTIME_LOG_META_KEY] as RuntimeLogMeta | undefined
   if (existing) {
@@ -423,10 +450,24 @@ function ensureRuntimeLogMeta(miniProgram: any, project: string): RuntimeLogMeta
 
   const entries: RuntimeLogEntry[] = []
   const stats: RuntimeLogStats = {
+    debug: 0,
+    info: 0,
+    log: 0,
     warn: 0,
     error: 0,
     exception: 0,
     total: 0,
+  }
+
+  const appendRuntimeLogEvent = (entry: RuntimeLogEntry) => {
+    appendIdeReportEvent({
+      source: 'runtime',
+      kind: 'message',
+      project,
+      level: entry.level,
+      channel: entry.level === 'exception' ? 'exception' : 'runtime',
+      text: entry.text,
+    })
   }
 
   const onConsole = (entry: any) => {
@@ -434,17 +475,12 @@ function ensureRuntimeLogMeta(miniProgram: any, project: string): RuntimeLogMeta
     if (!text) {
       return
     }
-    if (isErrorConsoleEntry(entry)) {
-      stats.error += 1
-      stats.total += 1
-      entries.push({ level: 'error', text })
-      return
-    }
-    if (isWarnConsoleEntry(entry)) {
-      stats.warn += 1
-      stats.total += 1
-      entries.push({ level: 'warn', text })
-    }
+    const level = resolveConsoleLevel(entry)
+    stats[level] += 1
+    stats.total += 1
+    const runtimeEntry = { level, text }
+    entries.push(runtimeEntry)
+    appendRuntimeLogEvent(runtimeEntry)
   }
 
   const onException = (entry: any) => {
@@ -453,7 +489,9 @@ function ensureRuntimeLogMeta(miniProgram: any, project: string): RuntimeLogMeta
       : normalizeConsoleText(entry)
     stats.exception += 1
     stats.total += 1
-    entries.push({ level: 'exception', text })
+    const runtimeEntry = { level: 'exception', text } satisfies RuntimeLogEntry
+    entries.push(runtimeEntry)
+    appendRuntimeLogEvent(runtimeEntry)
   }
 
   miniProgram.on('console', onConsole)
@@ -472,6 +510,9 @@ function ensureRuntimeLogMeta(miniProgram: any, project: string): RuntimeLogMeta
       stats.warn = 0
       stats.error = 0
       stats.exception = 0
+      stats.log = 0
+      stats.info = 0
+      stats.debug = 0
       stats.total = 0
     },
     closed: false,
@@ -1170,60 +1211,51 @@ async function waitForAnyCurrentPageReady(
   return null
 }
 
+export function formatRuntimeStatsLine(stats: RuntimeLogStats) {
+  const runtimeIssueCount = stats.warn + stats.error + stats.exception
+  return `[e2e-runtime-stats] warn=${stats.warn} error=${stats.error} exception=${stats.exception} total=${runtimeIssueCount} log=${stats.log} info=${stats.info} debug=${stats.debug} all=${stats.total}`
+}
+
 function logRuntimeStats(meta: RuntimeLogMeta) {
-  const summary = `[e2e-runtime-stats] warn=${meta.stats.warn} error=${meta.stats.error} exception=${meta.stats.exception} total=${meta.stats.total}`
+  const runtimeLogCount = meta.stats.debug + meta.stats.info + meta.stats.log
+  const runtimeIssueCount = meta.stats.warn + meta.stats.error + meta.stats.exception
+  const summary = formatRuntimeStatsLine(meta.stats)
   appendIdeReportEvent({
     source: 'runtime',
     kind: 'stats',
     project: meta.project,
+    log: meta.stats.log + meta.stats.debug,
+    info: meta.stats.info,
     warn: meta.stats.warn,
     error: meta.stats.error,
     exception: meta.stats.exception,
-    total: meta.stats.total,
+    total: runtimeIssueCount,
   })
-  if (meta.stats.total > 0) {
+  if (runtimeIssueCount > 0) {
     process.stderr.write(`${summary}\n`)
     for (const entry of meta.entries) {
+      if (entry.level === 'log' || entry.level === 'info' || entry.level === 'debug') {
+        continue
+      }
       if (entry.level === 'warn') {
         const logLine = `[warn] [runtime] ${entry.text}`
         process.stderr.write(`${logLine}\n`)
-        appendIdeReportEvent({
-          source: 'runtime',
-          kind: 'message',
-          project: meta.project,
-          level: 'warn',
-          channel: 'runtime',
-          text: entry.text,
-        })
         continue
       }
       if (entry.level === 'error') {
         const logLine = `[error] [runtime] ${entry.text}`
         process.stderr.write(`${logLine}\n`)
-        appendIdeReportEvent({
-          source: 'runtime',
-          kind: 'message',
-          project: meta.project,
-          level: 'error',
-          channel: 'runtime',
-          text: entry.text,
-        })
         continue
       }
       const logLine = `[error] [runtime:exception] ${entry.text}`
       process.stderr.write(`${logLine}\n`)
-      appendIdeReportEvent({
-        source: 'runtime',
-        kind: 'message',
-        project: meta.project,
-        level: 'exception',
-        channel: 'exception',
-        text: entry.text,
-      })
     }
     return
   }
   process.stdout.write(`${summary}\n`)
+  if (runtimeLogCount > 0) {
+    process.stdout.write(`[e2e-runtime-logs] log=${meta.stats.log} info=${meta.stats.info} debug=${meta.stats.debug}\n`)
+  }
 }
 
 function enhanceMiniProgramWithRuntimeLogs(miniProgram: any, project: string) {

--- a/e2e/utils/ideWarningReport.test.ts
+++ b/e2e/utils/ideWarningReport.test.ts
@@ -77,10 +77,40 @@ describe('ideWarningReport', () => {
         source: 'runtime',
         kind: 'stats',
         project: 'e2e-apps/github-issues',
+        log: 1,
+        info: 1,
         warn: 2,
         error: 0,
         exception: 0,
         total: 2,
+      },
+      {
+        source: 'runtime',
+        kind: 'message',
+        project: 'e2e-apps/github-issues',
+        level: 'log',
+        channel: 'runtime',
+        text: 'ordinary runtime log after launch',
+      },
+      {
+        source: 'runtime',
+        kind: 'message',
+        project: 'e2e-apps/github-issues',
+        level: 'info',
+        channel: 'runtime',
+        text: 'route ready info',
+      },
+      {
+        source: 'runtime',
+        kind: 'page-snapshot',
+        project: 'e2e-apps/github-issues',
+        channel: 'github-issues:ready-timeout',
+        route: '/pages/issue-615/index',
+        readyText: 'issue-615 scoped slot v-for owner list',
+        currentPage: 'pages/issue-615/index',
+        wxmlLength: 13,
+        empty: true,
+        text: '<text></text>',
       },
       {
         source: 'runtime',
@@ -121,6 +151,8 @@ describe('ideWarningReport', () => {
 
       expect(payload.summary.projectCount).toBe(2)
       expect(payload.summary.typeUncompatibleCount).toBe(3)
+      expect(payload.summary.totalRuntimeLogs).toBe(2)
+      expect(payload.summary.pageSnapshotCount).toBe(1)
 
       const indexMarkdown = fs.readFileSync(paths.reportMarkdownPath, 'utf8')
       const indexJson = fs.readFileSync(paths.reportJsonPath, 'utf8')
@@ -133,6 +165,9 @@ describe('ideWarningReport', () => {
       expect(indexJson).toContain('"project": "e2e-apps/github-issues"')
       expect(githubMarkdown).toContain('type-uncompatible value')
       expect(githubMarkdown).toContain('got non-object value')
+      expect(githubMarkdown).toContain('ordinary runtime log after launch')
+      expect(githubMarkdown).toContain('route=`/pages/issue-615/index`')
+      expect(githubMarkdown).toContain('<text></text>')
       expect(indexMarkdown).not.toContain(tempRoot)
       expect(indexMarkdown).not.toContain(process.cwd())
       expect(githubMarkdown).not.toContain(tempRoot)
@@ -168,7 +203,7 @@ describe('ideWarningReport', () => {
     process.env.WEAPP_VITE_E2E_REPORT_MARKERS = '1'
     writeIdeWarningReport(paths, new Date('2026-03-11T00:00:00.000Z'))
     expect(stdoutWrite).toHaveBeenCalledWith(
-      expect.stringContaining('[ide-warning-report] index='),
+      expect.stringMatching(/\[ide-warning-report\] index=.* logs=0 pageSnapshots=0\n/),
     )
   })
 })

--- a/e2e/utils/ideWarningReport.ts
+++ b/e2e/utils/ideWarningReport.ts
@@ -25,8 +25,8 @@ const INVALID_FILE_STEM_PATTERN = /[^\w.-]/g
 const NEWLINE_PATTERN = /\r?\n/
 
 export type IdeReportSource = 'build' | 'runtime'
-export type IdeReportKind = 'message' | 'stats'
-export type IdeReportLevel = 'warn' | 'error' | 'exception'
+export type IdeReportKind = 'message' | 'page-snapshot' | 'stats'
+export type IdeReportLevel = 'debug' | 'info' | 'log' | 'warn' | 'error' | 'exception'
 
 export interface IdeWarningReportPaths {
   reportSlug: string
@@ -43,10 +43,17 @@ export interface IdeReportEvent {
   level?: IdeReportLevel
   channel?: string
   label?: string
+  route?: string
+  readyText?: string
+  currentPage?: string
+  wxmlLength?: number
+  empty?: boolean
   text?: string
   warn?: number
   error?: number
   exception?: number
+  log?: number
+  info?: number
   total?: number
   exit?: number
 }
@@ -79,19 +86,36 @@ interface BuildStatsSample {
 }
 
 interface RuntimeStatsSample {
+  log: number
+  info: number
   warn: number
   error: number
   exception: number
   total: number
 }
 
+interface PageSnapshotSample {
+  channel: string
+  route: string
+  readyText: string
+  currentPage: string
+  wxmlLength: number
+  empty: boolean
+  snippet: string
+  count: number
+}
+
 interface ProjectReportSummary {
   buildWarn: number
   buildError: number
+  runtimeLog: number
+  runtimeInfo: number
   runtimeWarn: number
   runtimeError: number
   runtimeException: number
+  pageSnapshotCount: number
   totalIssues: number
+  totalRuntimeLogs: number
   typeUncompatibleCount: number
 }
 
@@ -104,6 +128,7 @@ export interface ProjectReportPayload {
   summary: ProjectReportSummary
   buildStatsSamples: BuildStatsSample[]
   runtimeStatsSamples: RuntimeStatsSample[]
+  pageSnapshots: PageSnapshotSample[]
   issues: IssueGroup[]
   typeUncompatibleIssues: TypeUncompatibleGroup[]
 }
@@ -125,10 +150,14 @@ export interface IdeReportIndexPayload {
     projectCount: number
     buildWarn: number
     buildError: number
+    runtimeLog: number
+    runtimeInfo: number
     runtimeWarn: number
     runtimeError: number
     runtimeException: number
+    pageSnapshotCount: number
     totalIssues: number
+    totalRuntimeLogs: number
     typeUncompatibleCount: number
   }
   projects: IdeReportIndexProject[]
@@ -290,6 +319,9 @@ function readReportEvents(paths: IdeWarningReportPaths) {
           project: sanitizeReportText(parsed.project) || '<unknown-project>',
           channel: typeof parsed.channel === 'string' ? sanitizeReportText(parsed.channel) : parsed.channel,
           label: typeof parsed.label === 'string' ? sanitizeReportText(parsed.label) : parsed.label,
+          route: typeof parsed.route === 'string' ? sanitizeReportText(parsed.route) : parsed.route,
+          readyText: typeof parsed.readyText === 'string' ? sanitizeReportText(parsed.readyText) : parsed.readyText,
+          currentPage: typeof parsed.currentPage === 'string' ? sanitizeReportText(parsed.currentPage) : parsed.currentPage,
           text: typeof parsed.text === 'string' ? sanitizeReportText(parsed.text) : parsed.text,
         })
       }
@@ -309,20 +341,23 @@ function renderProjectMarkdown(payload: ProjectReportPayload) {
     '',
     `- 命令：\`${payload.command}\``,
     `- build warn/error：\`${payload.summary.buildWarn}/${payload.summary.buildError}\``,
-    `- runtime warn/error/exception：\`${payload.summary.runtimeWarn}/${payload.summary.runtimeError}/${payload.summary.runtimeException}\``,
+    `- runtime log/info/warn/error/exception：\`${payload.summary.runtimeLog}/${payload.summary.runtimeInfo}/${payload.summary.runtimeWarn}/${payload.summary.runtimeError}/${payload.summary.runtimeException}\``,
+    `- 页面快照：\`${payload.summary.pageSnapshotCount}\``,
     `- 总问题数：\`${payload.summary.totalIssues}\``,
+    `- 普通运行时日志：\`${payload.summary.totalRuntimeLogs}\``,
     `- type-uncompatible 命中数：\`${payload.summary.typeUncompatibleCount}\``,
     '',
     '## 2. 所有 Warning/Error',
     '',
   ]
 
-  if (payload.issues.length === 0) {
+  const warningIssues = payload.issues.filter(issue => issue.level !== 'log' && issue.level !== 'info' && issue.level !== 'debug')
+  if (warningIssues.length === 0) {
     lines.push('- 未采集到 warning/error/exception。')
     lines.push('')
   }
   else {
-    payload.issues.forEach((issue, index) => {
+    warningIssues.forEach((issue, index) => {
       lines.push(`${index + 1}. \`${issue.count}\` 次：\`[${issue.source}/${issue.channel}/${issue.level}] ${issue.message}\``)
       lines.push(`   - 示例原始行：\`${issue.rawLines[0]}\``)
       lines.push('')
@@ -366,9 +401,39 @@ function renderProjectMarkdown(payload: ProjectReportPayload) {
   }
   else {
     payload.runtimeStatsSamples.forEach((sample, index) => {
-      lines.push(`${index + 1}. \`warn=${sample.warn} error=${sample.error} exception=${sample.exception} total=${sample.total}\``)
+      lines.push(`${index + 1}. \`log=${sample.log} info=${sample.info} warn=${sample.warn} error=${sample.error} exception=${sample.exception} total=${sample.total}\``)
     })
     lines.push('')
+  }
+
+  lines.push('## 6. 普通 Runtime Logs')
+  lines.push('')
+  const runtimeLogIssues = payload.issues.filter(issue => issue.source === 'runtime' && (issue.level === 'log' || issue.level === 'info' || issue.level === 'debug'))
+  if (runtimeLogIssues.length === 0) {
+    lines.push('- 未采集到普通 runtime log。')
+    lines.push('')
+  }
+  else {
+    runtimeLogIssues.forEach((issue, index) => {
+      lines.push(`${index + 1}. \`${issue.count}\` 次：\`[${issue.source}/${issue.channel}/${issue.level}] ${issue.message}\``)
+      lines.push(`   - 示例原始行：\`${issue.rawLines[0]}\``)
+      lines.push('')
+    })
+  }
+
+  lines.push('## 7. 页面内容快照')
+  lines.push('')
+  if (payload.pageSnapshots.length === 0) {
+    lines.push('- 未采集到页面内容快照。')
+    lines.push('')
+  }
+  else {
+    payload.pageSnapshots.forEach((snapshot, index) => {
+      lines.push(`${index + 1}. \`${snapshot.count}\` 次：route=\`${snapshot.route}\` current=\`${snapshot.currentPage}\` readyText=\`${snapshot.readyText}\` empty=\`${snapshot.empty}\` wxmlLength=\`${snapshot.wxmlLength}\``)
+      lines.push(`   - channel：\`${snapshot.channel}\``)
+      lines.push(`   - snippet：\`${snapshot.snippet}\``)
+      lines.push('')
+    })
   }
 
   return `${lines.join('\n').trimEnd()}\n`
@@ -387,8 +452,10 @@ function renderIndexMarkdown(payload: IdeReportIndexPayload) {
     '',
     `- 项目数：\`${payload.summary.projectCount}\``,
     `- build warn/error：\`${payload.summary.buildWarn}/${payload.summary.buildError}\``,
-    `- runtime warn/error/exception：\`${payload.summary.runtimeWarn}/${payload.summary.runtimeError}/${payload.summary.runtimeException}\``,
+    `- runtime log/info/warn/error/exception：\`${payload.summary.runtimeLog}/${payload.summary.runtimeInfo}/${payload.summary.runtimeWarn}/${payload.summary.runtimeError}/${payload.summary.runtimeException}\``,
+    `- 页面快照：\`${payload.summary.pageSnapshotCount}\``,
     `- 总问题数：\`${payload.summary.totalIssues}\``,
+    `- 普通运行时日志：\`${payload.summary.totalRuntimeLogs}\``,
     `- type-uncompatible 命中数：\`${payload.summary.typeUncompatibleCount}\``,
     '',
     '## 3. 项目报告',
@@ -403,7 +470,8 @@ function renderIndexMarkdown(payload: IdeReportIndexPayload) {
     payload.projects.forEach((project, index) => {
       lines.push(`${index + 1}. ${renderRelativeMarkdownLink(project.project, project.markdownFile)}`)
       lines.push(`   - build warn/error：\`${project.summary.buildWarn}/${project.summary.buildError}\``)
-      lines.push(`   - runtime warn/error/exception：\`${project.summary.runtimeWarn}/${project.summary.runtimeError}/${project.summary.runtimeException}\``)
+      lines.push(`   - runtime log/info/warn/error/exception：\`${project.summary.runtimeLog}/${project.summary.runtimeInfo}/${project.summary.runtimeWarn}/${project.summary.runtimeError}/${project.summary.runtimeException}\``)
+      lines.push(`   - 页面快照：\`${project.summary.pageSnapshotCount}\``)
       lines.push(`   - type-uncompatible：\`${project.summary.typeUncompatibleCount}\``)
       lines.push(`   - JSON：${renderRelativeMarkdownLink(path.basename(project.jsonFile), project.jsonFile)}`)
       lines.push('')
@@ -499,6 +567,9 @@ export function appendIdeReportEvent(event: IdeReportEvent) {
     project: sanitizeReportText(event.project) || '<unknown-project>',
     channel: typeof event.channel === 'string' ? sanitizeReportText(event.channel) : event.channel,
     label: typeof event.label === 'string' ? sanitizeReportText(event.label) : event.label,
+    route: typeof event.route === 'string' ? sanitizeReportText(event.route) : event.route,
+    readyText: typeof event.readyText === 'string' ? sanitizeReportText(event.readyText) : event.readyText,
+    currentPage: typeof event.currentPage === 'string' ? sanitizeReportText(event.currentPage) : event.currentPage,
     text: typeof event.text === 'string' ? sanitizeReportText(event.text) : event.text,
   }
 
@@ -510,10 +581,14 @@ function createEmptyProjectSummary(): ProjectReportSummary {
   return {
     buildWarn: 0,
     buildError: 0,
+    runtimeLog: 0,
+    runtimeInfo: 0,
     runtimeWarn: 0,
     runtimeError: 0,
     runtimeException: 0,
+    pageSnapshotCount: 0,
     totalIssues: 0,
+    totalRuntimeLogs: 0,
     typeUncompatibleCount: 0,
   }
 }
@@ -524,6 +599,7 @@ function buildProjectReports(paths: IdeWarningReportPaths, events: IdeReportEven
     summary: ProjectReportSummary
     buildStatsSamples: BuildStatsSample[]
     runtimeStatsSamples: RuntimeStatsSample[]
+    pageSnapshots: Map<string, PageSnapshotSample>
     issues: Map<string, IssueGroup>
     typeUncompatibleIssues: Map<string, TypeUncompatibleGroup>
   }>()
@@ -537,6 +613,7 @@ function buildProjectReports(paths: IdeWarningReportPaths, events: IdeReportEven
         summary: createEmptyProjectSummary(),
         buildStatsSamples: [],
         runtimeStatsSamples: [],
+        pageSnapshots: new Map(),
         issues: new Map(),
         typeUncompatibleIssues: new Map(),
       }
@@ -554,12 +631,42 @@ function buildProjectReports(paths: IdeWarningReportPaths, events: IdeReportEven
       }
       else {
         projectState.runtimeStatsSamples.push({
+          log: event.log ?? 0,
+          info: event.info ?? 0,
           warn: event.warn ?? 0,
           error: event.error ?? 0,
           exception: event.exception ?? 0,
           total: event.total ?? 0,
         })
       }
+      continue
+    }
+
+    if (event.kind === 'page-snapshot') {
+      projectState.summary.pageSnapshotCount += 1
+      const channel = event.channel || 'page-snapshot'
+      const route = event.route || '<unknown-route>'
+      const readyText = event.readyText || '<none>'
+      const currentPage = event.currentPage || '<none>'
+      const snippet = event.text || ''
+      const wxmlLength = event.wxmlLength ?? snippet.length
+      const empty = event.empty ?? false
+      const snapshotKey = `${channel}|${route}|${readyText}|${currentPage}|${empty}|${snippet}`
+      const existingSnapshot = projectState.pageSnapshots.get(snapshotKey)
+      if (existingSnapshot) {
+        existingSnapshot.count += 1
+        continue
+      }
+      projectState.pageSnapshots.set(snapshotKey, {
+        channel,
+        route,
+        readyText,
+        currentPage,
+        wxmlLength,
+        empty,
+        snippet,
+        count: 1,
+      })
       continue
     }
 
@@ -586,7 +693,13 @@ function buildProjectReports(paths: IdeWarningReportPaths, events: IdeReportEven
       })
     }
 
-    projectState.summary.totalIssues += 1
+    const isRuntimeLog = event.source === 'runtime' && (event.level === 'log' || event.level === 'info' || event.level === 'debug')
+    if (isRuntimeLog) {
+      projectState.summary.totalRuntimeLogs += 1
+    }
+    else {
+      projectState.summary.totalIssues += 1
+    }
     if (event.source === 'build') {
       if (event.level === 'warn') {
         projectState.summary.buildWarn += 1
@@ -596,6 +709,12 @@ function buildProjectReports(paths: IdeWarningReportPaths, events: IdeReportEven
       }
     }
     else {
+      if (event.level === 'log' || event.level === 'debug') {
+        projectState.summary.runtimeLog += 1
+      }
+      if (event.level === 'info') {
+        projectState.summary.runtimeInfo += 1
+      }
       if (event.level === 'warn') {
         projectState.summary.runtimeWarn += 1
       }
@@ -649,6 +768,12 @@ function buildProjectReports(paths: IdeWarningReportPaths, events: IdeReportEven
         summary: projectState.summary,
         buildStatsSamples: projectState.buildStatsSamples,
         runtimeStatsSamples: projectState.runtimeStatsSamples,
+        pageSnapshots: Array.from(projectState.pageSnapshots.values()).sort((left, right) => {
+          if (right.count !== left.count) {
+            return right.count - left.count
+          }
+          return left.route.localeCompare(right.route)
+        }),
         issues: Array.from(projectState.issues.values()).sort(sortIssues),
         typeUncompatibleIssues: Array.from(projectState.typeUncompatibleIssues.values()).sort((left, right) => {
           if (right.count !== left.count) {
@@ -673,10 +798,14 @@ function buildProjectReports(paths: IdeWarningReportPaths, events: IdeReportEven
         summary.projectCount += 1
         summary.buildWarn += project.summary.buildWarn
         summary.buildError += project.summary.buildError
+        summary.runtimeLog += project.summary.runtimeLog
+        summary.runtimeInfo += project.summary.runtimeInfo
         summary.runtimeWarn += project.summary.runtimeWarn
         summary.runtimeError += project.summary.runtimeError
         summary.runtimeException += project.summary.runtimeException
+        summary.pageSnapshotCount += project.summary.pageSnapshotCount
         summary.totalIssues += project.summary.totalIssues
+        summary.totalRuntimeLogs += project.summary.totalRuntimeLogs
         summary.typeUncompatibleCount += project.summary.typeUncompatibleCount
         return summary
       },
@@ -684,10 +813,14 @@ function buildProjectReports(paths: IdeWarningReportPaths, events: IdeReportEven
         projectCount: 0,
         buildWarn: 0,
         buildError: 0,
+        runtimeLog: 0,
+        runtimeInfo: 0,
         runtimeWarn: 0,
         runtimeError: 0,
         runtimeException: 0,
+        pageSnapshotCount: 0,
         totalIssues: 0,
+        totalRuntimeLogs: 0,
         typeUncompatibleCount: 0,
       },
     ),
@@ -710,7 +843,7 @@ export function writeIdeWarningReport(paths: IdeWarningReportPaths, now = new Da
   fs.writeFileSync(paths.reportMarkdownPath, renderIndexMarkdown(indexPayload), 'utf8')
   if (shouldEmitReportMarkers()) {
     process.stdout.write(
-      `[ide-warning-report] index=${toRepoRelativePath(paths.reportMarkdownPath)} projects=${indexPayload.summary.projectCount} issues=${indexPayload.summary.totalIssues}\n`,
+      `[ide-warning-report] index=${toRepoRelativePath(paths.reportMarkdownPath)} projects=${indexPayload.summary.projectCount} issues=${indexPayload.summary.totalIssues} logs=${indexPayload.summary.totalRuntimeLogs} pageSnapshots=${indexPayload.summary.pageSnapshotCount}\n`,
     )
   }
 

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
@@ -843,9 +843,10 @@ describe('compileVueTemplateToWxml', () => {
       '/project/src/components/ListScopedCell/index.vue',
     )
 
-    expect(code).toContain('<block wx:for="{{rows}}" wx:for-item="item" wx:for-index="index">')
+    expect(code).toContain('<block wx:for="{{rows}}" wx:for-item="item" wx:for-index="index" wx:key="id">')
     expect(code).toContain(`__wvSlotProps="{{['item',item,'index',index]}}"`)
     expect(code).toContain('__wvSlotScope="{{__wvSlotScope}}"')
+    expect(code).not.toContain('<block wx:else><slot /></block>')
     expect(code).not.toContain(`'key',item.id`)
   })
 
@@ -1211,9 +1212,15 @@ describe('compileVueTemplateToWxml', () => {
     expect(scopedSlotComponents).toHaveLength(1)
     expect(scopedSlotComponents?.[0]?.id).toBe('default-0')
     expect(scopedSlotComponents?.[0]?.hostComponentName).toBe('native-tabbar')
-    expect(scopedSlotComponents?.[0]?.template).toContain('<native-tabbar-item wx:for="{{__wvOwner.tabItems}}"')
+    expect(scopedSlotComponents?.[0]?.template).toContain('<native-tabbar-item wx:for="{{__wv_bind_0}}"')
     expect(scopedSlotComponents?.[0]?.template).toContain('>{{__wv_item_0.label}}</native-tabbar-item>')
     expect(scopedSlotComponents?.[0]?.template).not.toContain('generic:scoped-slots-default')
+    expect(scopedSlotComponents?.[0]?.classStyleBindings?.[0]).toMatchObject({
+      name: '__wv_bind_0',
+      type: 'bind',
+      exp: 'tabItems',
+      forStack: [],
+    })
     expect(scopedSlotComponents?.[0]?.componentGenerics).toBeUndefined()
   })
 
@@ -1438,7 +1445,7 @@ describe('compileVueTemplateToWxml', () => {
     )
 
     expect(code).toContain(`<block wx:if="{{vueSlots&&vueSlots.default}}">`)
-    expect(code).toContain(`<slot />`)
+    expect(code).not.toContain(`<block wx:else><slot /></block>`)
     expect(code).toContain(`<scoped-slots-default wx:if="{{__wvSlotOwnerId}}" __wvSlotOwnerId="{{__wvSlotOwnerId}}" __wvSlotProps="{{['item',card.item,'index',card.index]}}" __wvSlotScope="{{__wvSlotScope}}" />`)
     expect(code).toContain(`</block><block wx:else><view class="fallback">{{fallbackDefault}}</view></block>`)
     expect(code).not.toContain('不支持作用域插槽的兜底内容')

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts
@@ -378,6 +378,7 @@ export function transformSlotElement(node: ElementNode, context: TransformContex
     return slotTag
   }
 
+  const hasScopeBindings = Boolean(slotPropsExp)
   const slotKey = resolveSlotKey(context, slotNameInfo)
   const genericKey = `scoped-slots-${slotKey}`
   context.componentGenerics[genericKey] = true
@@ -393,7 +394,9 @@ export function transformSlotElement(node: ElementNode, context: TransformContex
   }
   const scopedAttrString = scopedAttrs.length ? ` ${scopedAttrs.join(' ')}` : ''
   const scopedTag = `<${genericKey}${scopedAttrString} />`
-  const projectedContent = `${slotTag}${scopedTag}`
+  const projectedContent = hasScopeBindings
+    ? scopedTag
+    : `${scopedTag}${context.platform.wrapElse(slotTag)}`
 
   if (fallbackContent && slotPresentExp) {
     return `${context.platform.wrapIf(slotPresentExp, projectedContent, exp => renderMustache(exp, context))}${context.platform.wrapElse(fallbackContent)}`

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-structural.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-structural.ts
@@ -1,6 +1,7 @@
 import type { DirectiveNode, ElementNode } from '@vue/compiler-core'
 import type { ForParseResult, TransformContext, TransformNode } from '../types'
 import { NodeTypes } from '@vue/compiler-core'
+import { transformBindDirective } from '../directives/bind'
 import { normalizeJsExpressionWithContext, normalizeWxmlExpressionWithContext } from '../expression'
 import { registerRuntimeBindingExpression, shouldFallbackToRuntimeBinding } from '../expression/runtimeBinding'
 import { resolveTemplateTagName } from '../htmlTagMapping'
@@ -21,7 +22,7 @@ function resolveConditionExpression(rawExpValue: string, context: TransformConte
 }
 
 function resolveListExpression(rawExpValue: string, context: TransformContext, hint: string) {
-  const runtimeExp = shouldFallbackToRuntimeBinding(rawExpValue)
+  const runtimeExp = (context.rewriteScopedSlot || shouldFallbackToRuntimeBinding(rawExpValue))
     ? registerRuntimeBindingExpression(rawExpValue, context, { hint })
     : null
   return runtimeExp ?? normalizeWxmlExpressionWithContext(rawExpValue, context)
@@ -125,18 +126,23 @@ export function transformForElement(node: ElementNode, context: TransformContext
       : []
 
     if (elementWithoutFor.tag === 'slot') {
+      const keyDirective = elementWithoutFor.props.find((prop): prop is DirectiveNode => {
+        return prop.type === NodeTypes.DIRECTIVE
+          && prop.name === 'bind'
+          && prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION
+          && prop.arg.content === 'key'
+      })
       const slotElementWithoutForKey: ElementNode = {
         ...elementWithoutFor,
         props: elementWithoutFor.props.filter((prop) => {
-          return !(
-            prop.type === NodeTypes.DIRECTIVE
-            && prop.name === 'bind'
-            && prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION
-            && prop.arg.content === 'key'
-          )
+          return prop !== keyDirective
         }),
       }
       const content = transformSlotElement(slotElementWithoutForKey, context, transformNode)
+      const keyAttr = keyDirective ? transformBindDirective(keyDirective, context, forInfo) : null
+      if (keyAttr) {
+        extraAttrs.push(keyAttr)
+      }
       const attrString = extraAttrs.length ? ` ${extraAttrs.join(' ')}` : ''
       return attrString ? `<block${attrString}>${content}</block>` : content
     }

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/classStyleComputed.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/classStyleComputed.test.ts
@@ -6,6 +6,10 @@ import {
   buildClassStyleComputedObject,
 } from './classStyleComputed'
 
+function restoreEscapedUnicode(code: string) {
+  return code.replaceAll(/\\u[\dA-Fa-f]{4}/g, escapeText => String.fromCharCode(Number.parseInt(escapeText.slice(2), 16)))
+}
+
 describe('classStyleComputed', () => {
   it('returns null when no class/style bindings are provided', () => {
     expect(buildClassStyleComputedObject([], {
@@ -256,5 +260,76 @@ describe('classStyleComputed', () => {
     expect(code).toContain('__wvSlotPropsData.items')
     expect(code).not.toContain('模板 v-for 数据源表达式执行失败: __wvSlotPropsData.items')
     expect(code).toContain('__wv_bind_0 = card.item.label')
+  })
+
+  it('reports normal v-for source errors', () => {
+    const bindings: any = [
+      {
+        name: '__wv_bind_0',
+        type: 'bind',
+        exp: 'item.label',
+        expAst: t.memberExpression(t.identifier('item'), t.identifier('label')),
+        forStack: [
+          {
+            listExp: 'items.missing.list',
+            listExpAst: t.memberExpression(
+              t.memberExpression(t.identifier('items'), t.identifier('missing')),
+              t.identifier('list'),
+            ),
+            item: 'item',
+            index: 'index',
+          },
+        ],
+      },
+    ]
+
+    const code = buildClassStyleComputedCode(bindings, {
+      normalizeClassName: 'normalizeClass',
+      normalizeStyleName: 'normalizeStyle',
+      unrefName: 'unref',
+    })
+
+    const readableCode = restoreEscapedUnicode(code ?? '')
+    expect(readableCode).toContain('模板 v-for 数据源表达式执行失败: items.missing.list')
+    expect(readableCode).toContain('模板运行时表达式执行失败: __wv_bind_0 = item.label')
+  })
+
+  it('keeps scoped slot owner v-for source missing values silent during initialization', () => {
+    const bindings: any = [
+      {
+        name: '__wv_bind_0',
+        type: 'bind',
+        exp: 'tabItems',
+        expAst: t.memberExpression(
+          t.memberExpression(t.thisExpression(), t.identifier('__wvOwnerProxy')),
+          t.identifier('tabItems'),
+        ),
+        forStack: [
+          {
+            listExp: '__wv_bind_0',
+            listExpAst: t.memberExpression(
+              t.memberExpression(t.thisExpression(), t.identifier('__wvOwnerProxy')),
+              t.identifier('tabItems'),
+            ),
+            item: '__wv_item_0',
+            index: '__wv_index_0',
+            itemAliases: {
+              label: '__wv_item_0.label',
+            },
+          },
+        ],
+      },
+    ]
+
+    const code = buildClassStyleComputedCode(bindings, {
+      normalizeClassName: 'normalizeClass',
+      normalizeStyleName: 'normalizeStyle',
+      unrefName: 'unref',
+    })
+
+    expect(code).toContain('this.__wvOwnerProxy.tabItems')
+    expect(code).not.toContain('模板 v-for 数据源表达式执行失败: __wv_bind_0')
+    expect(code).not.toContain('模板运行时表达式执行失败: __wv_bind_0 = tabItems')
+    expect(code).toContain('return this.__wvOwnerProxy.tabItems')
   })
 })

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/classStyleComputedBuilders.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/classStyleComputedBuilders.ts
@@ -3,6 +3,8 @@ import type { ClassStyleHelperIds } from './classStyleComputed'
 import {
   WEVU_EXPRESSION_ERROR_IDENTIFIER,
   WEVU_PROPS_KEY,
+  WEVU_SLOT_OWNER_KEY,
+  WEVU_SLOT_OWNER_PROXY_KEY,
   WEVU_SLOT_PROPS_DATA_KEY,
 } from '@weapp-core/constants'
 import * as t from '@weapp-vite/ast/babelTypes'
@@ -54,13 +56,59 @@ function buildRuntimeExpressionErrorGuard(binding: ClassStyleBinding, errorId: t
   )
 }
 
+function isScopedSlotOwnerBinding(exp: t.Expression | undefined): boolean {
+  if (!exp) {
+    return false
+  }
+  const seen = new WeakSet<object>()
+  const visit = (node: unknown): boolean => {
+    if (!node || typeof node !== 'object') {
+      return false
+    }
+    if (seen.has(node)) {
+      return false
+    }
+    seen.add(node)
+    if ((node as { type?: string }).type === 'MemberExpression') {
+      const member = node as {
+        computed?: boolean
+        object?: { type?: string }
+        property?: { type?: string, name?: string }
+      }
+      const property = member.property
+      if (
+        !member.computed
+        && member.object?.type === 'ThisExpression'
+        && property?.type === 'Identifier'
+        && (property.name === WEVU_SLOT_OWNER_PROXY_KEY || property.name === WEVU_SLOT_OWNER_KEY)
+      ) {
+        return true
+      }
+    }
+    for (const value of Object.values(node)) {
+      if (Array.isArray(value)) {
+        if (value.some(item => visit(item))) {
+          return true
+        }
+      }
+      else if (visit(value)) {
+        return true
+      }
+    }
+    return false
+  }
+  return visit(exp)
+}
+
 function shouldReportRuntimeExpressionError(binding: ClassStyleBinding) {
-  return binding.type === 'bind'
+  return binding.type === 'bind' && !isScopedSlotOwnerBinding(binding.expAst)
 }
 
 function shouldReportForSourceError(info: ForParseResult) {
   const listExp = info.listExp?.trim() ?? ''
   return !listExp.startsWith(`${WEVU_SLOT_PROPS_DATA_KEY}.`)
+    && !listExp.startsWith(`${WEVU_SLOT_OWNER_KEY}.`)
+    && !isScopedSlotOwnerBinding(info.listExpAst)
 }
 
 function createDataPropsFallbackExpression(fallback: t.Expression) {
@@ -185,7 +233,9 @@ function buildNormalizedExpression(
             t.catchClause(
               t.cloneNode(errorId),
               t.blockStatement([
-                buildRuntimeExpressionErrorGuard(binding, errorId),
+                ...shouldReportRuntimeExpressionError(binding)
+                  ? [buildRuntimeExpressionErrorGuard(binding, errorId)]
+                  : [],
                 t.returnStatement(t.identifier('undefined')),
               ]),
             ),

--- a/packages-runtime/wevu/src/runtime/app/mount.ts
+++ b/packages-runtime/wevu/src/runtime/app/mount.ts
@@ -93,6 +93,7 @@ export function createRuntimeMount<D extends object, C extends ComputedDefinitio
     const state = reactive(rawState)
     const setupState = reactive(Object.create(null))
     const adapterSnapshotOmitKeys = (adapter as any)?.__wevu_snapshotOmitKeys
+    const deferInitialSnapshot = Boolean((adapter as any)?.__wevu_deferInitialSnapshot)
     const snapshotOmitKeys = new Set<string>(
       adapterSnapshotOmitKeys instanceof Set
         ? adapterSnapshotOmitKeys
@@ -247,7 +248,9 @@ export function createRuntimeMount<D extends object, C extends ComputedDefinitio
       },
     )
 
-    job()
+    if (!deferInitialSnapshot) {
+      job()
+    }
 
     stopHandles.push(createWatchStopHandle(() => stop(tracker)))
     if (setDataStrategy === 'patch') {

--- a/packages-runtime/wevu/src/runtime/register/runtimeInstance.ts
+++ b/packages-runtime/wevu/src/runtime/register/runtimeInstance.ts
@@ -210,6 +210,14 @@ export function mountRuntimeInstance<D extends object, C extends ComputedDefinit
       writable: false,
     })
   }
+  if (setup) {
+    Object.defineProperty(baseMountAdapter, '__wevu_deferInitialSnapshot', {
+      configurable: true,
+      enumerable: false,
+      value: true,
+      writable: false,
+    })
+  }
   const runtime = runtimeApp.mount(baseMountAdapter)
   runtimeRef = runtime
   attachRuntimeInstance(runtime as RuntimeInstance<any, any, any>, target)

--- a/packages-runtime/wevu/test/runtime-setup-method-computed.test.ts
+++ b/packages-runtime/wevu/test/runtime-setup-method-computed.test.ts
@@ -17,6 +17,36 @@ beforeEach(() => {
 })
 
 describe('runtime: setup method used by computed binding', () => {
+  it('defers initial computed snapshot until setup methods are injected', async () => {
+    defineComponent({
+      data: () => ({}),
+      computed: {
+        __wv_bind_0(this: any) {
+          return this.getCase()
+        },
+      },
+      setup() {
+        const getCase = () => '123'
+        return {
+          getCase,
+        }
+      },
+    })
+
+    const opts = registeredComponents[0]
+    const setData = vi.fn()
+    const inst: any = { setData }
+
+    expect(() => opts.lifetimes.attached.call(inst)).not.toThrow()
+    expect(setData).toHaveBeenCalledWith(expect.objectContaining({ __wv_bind_0: '123' }))
+    expect(setData).toHaveBeenCalledTimes(1)
+
+    await flushJobs()
+
+    expect(inst[WEVU_PUBLIC_RUNTIME_KEY].proxy.__wv_bind_0).toBe('123')
+    expect(setData).toHaveBeenCalledTimes(1)
+  })
+
   it('re-evaluates computed value after setup methods are injected', async () => {
     defineComponent({
       data: () => ({}),

--- a/packages/weapp-vite/test/__snapshots__/scoped-slot-native-output.test.ts.snap
+++ b/packages/weapp-vite/test/__snapshots__/scoped-slot-native-output.test.ts.snap
@@ -95,10 +95,20 @@ Component({ properties: { __wvSlotOwnerId: { type: String, value: "" }, __wvSlot
   <slot /><scoped-slots-default wx:if="{{__wvSlotOwnerId}}" __wvSlotOwnerId="{{__wvSlotOwnerId}}" __wvSlotProps="{{[]}}" __wvSlotScope="{{__wvSlotScope}}" />
 </view>
 ",
-  "pages/index/index.__scoped-slot-default-0.js": "const require_src = require("../../weapp-vendors/wevu-src.js");
+  "pages/index/index.__scoped-slot-default-0.js": "const require_common = require("../../weapp-vendors/wevu-ref.js");
+const require_src = require("../../weapp-vendors/wevu-src.js");
 //#region \\0weapp-vite:scoped-slot:pages/index/index.__scoped-slot-default-0
 var createWevuScopedSlotComponent = (typeof globalThis !== "undefined" ? globalThis : void 0)?.__weapp_vite_createScopedSlotComponent ?? require_src.__wevuScopedSlotCreator;
-if (typeof createWevuScopedSlotComponent === "function") createWevuScopedSlotComponent();
+var __wevuComputed = { __wv_bind_0: function() {
+	return (() => {
+		try {
+			return require_common.$(this.__wvOwnerProxy.tabItems);
+		} catch (__wv_expr_err) {
+			return;
+		}
+	})();
+} };
+if (typeof createWevuScopedSlotComponent === "function") createWevuScopedSlotComponent({ computed: __wevuComputed });
 //#endregion
 ",
   "pages/index/index.__scoped-slot-default-0.json": "{
@@ -109,7 +119,7 @@ if (typeof createWevuScopedSlotComponent === "function") createWevuScopedSlotCom
   }
 }
 ",
-  "pages/index/index.__scoped-slot-default-0.wxml": "<van-tabbar-item wx:for="{{__wvOwner.tabItems}}" wx:for-item="__wv_item_0" wx:for-index="__wv_index_1" wx:key="label" icon="{{__wv_item_0.icon}}" name="{{__wv_item_0.to.name}}" replace to="{{__wv_item_0.to}}">{{__wv_item_0.label}}</van-tabbar-item>",
+  "pages/index/index.__scoped-slot-default-0.wxml": "<van-tabbar-item wx:for="{{__wv_bind_0}}" wx:for-item="__wv_item_0" wx:for-index="__wv_index_1" wx:key="label" icon="{{__wv_item_0.icon}}" name="{{__wv_item_0.to.name}}" replace to="{{__wv_item_0.to}}">{{__wv_item_0.label}}</van-tabbar-item>",
   "pages/index/index.js": "//#region <fixture>/src/pages/index/index.vue
 (require("../../weapp-vendors/wevu-src.js").__wevuCreateWevuComponent || require("../../weapp-vendors/wevu-src.js").to)({
 	computed: { __wv_bind_0: function() {

--- a/packages/weapp-vite/test/scoped-slot-native-output.test.ts
+++ b/packages/weapp-vite/test/scoped-slot-native-output.test.ts
@@ -70,7 +70,7 @@ describe('scoped slot native output snapshots', () => {
 
     expect(outputSnapshot).toMatchSnapshot('text-outputs')
     expect(outputSnapshot['pages/index/index.__scoped-slot-default-0.wxml']).toContain(
-      '<van-tabbar-item wx:for="{{__wvOwner.tabItems}}"',
+      '<van-tabbar-item wx:for="{{__wv_bind_0}}"',
     )
     expect(outputSnapshot['pages/index/index.__scoped-slot-default-0.wxml']).toContain(
       'name="{{__wv_item_0.to.name}}"',
@@ -80,8 +80,9 @@ describe('scoped slot native output snapshots', () => {
     )
     expect(outputSnapshot['pages/index/index.__scoped-slot-default-0.wxml']).not.toContain('generic:scoped-slots-default')
     expect(outputSnapshot['pages/index/index.__scoped-slot-default-0.js']).toContain(
-      'createWevuScopedSlotComponent()',
+      'createWevuScopedSlotComponent({ computed: __wevuComputed })',
     )
+    expect(outputSnapshot['pages/index/index.__scoped-slot-default-0.js']).toContain('this.__wvOwnerProxy.tabItems')
     expect(outputSnapshot['pages/index/index.js']).toContain(
       `console.error("[wevu] 模板运行时表达式执行失败: __wv_bind_0 = {['default']:true}", __wv_expr_err)`,
     )

--- a/packages/weapp-vite/test/vue/compiler.test.ts
+++ b/packages/weapp-vite/test/vue/compiler.test.ts
@@ -312,7 +312,7 @@ describe('Vue Template Compiler', () => {
         '<slot :data="slotProps"></slot>',
         'test.vue',
       )
-      expect(result.code).toContain('<slot')
+      expect(result.code).not.toContain('<slot')
       expect(result.code).toContain('scoped-slots-default')
       expect(result.code).toContain('__wvSlotProps')
       expect(result.componentGenerics?.['scoped-slots-default']).toBe(true)
@@ -325,7 +325,7 @@ describe('Vue Template Compiler', () => {
       )
 
       expect(result.code).toContain(`<block wx:if="{{vueSlots&&vueSlots.default}}">`)
-      expect(result.code).toContain('<slot />')
+      expect(result.code).not.toContain('<slot />')
       expect(result.code).toContain('scoped-slots-default')
       expect(result.code).toContain('__wvSlotProps="{{[\'data\',slotProps]}}"')
       expect(result.code).toContain('<block wx:else><view>Scoped fallback</view></block>')


### PR DESCRIPTION
## Summary

修复 #615 中增强作用域插槽内 `v-for` 读取父级 setup 数据时生成 `__wvOwner.xxx` WXML 表达式的问题，避免 owner 尚未初始化时输出模板数据源执行失败。

Closes #615

## Changes

- 在 scoped slot 重写上下文中，将 `v-for` 数据源改为 JS runtime binding，避免直接生成 `__wvOwner.list`。
- 对 scoped slot owner/proxy 初始化阶段的 binding 和 v-for 数据源错误做定向静默，同时保留普通表达式错误上报。
- 新增 `e2e-apps/github-issues` 的 issue #615 复现页面、build-only 断言和 DevTools runtime 用例，并纳入 github-issues IDE suite manifest。
- 添加发布 changeset。

## Testing

- `pnpm exec vitest run packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts packages-runtime/wevu-compiler/src/plugins/vue/transform/classStyleComputed.test.ts`
- `pnpm --filter @wevu/compiler typecheck`
- `pnpm --filter @wevu/compiler lint`
- `pnpm --filter @wevu/compiler build && pnpm --filter wevu build && pnpm --filter weapp-vite build`
- `pnpm exec vitest run -c ./e2e/vitest.e2e.ci.build-only.config.ts e2e/ci/github-issues.build.test.ts -t "issue #615"`
- `pnpm exec vitest run -c ./e2e/vitest.e2e.internal.config.ts e2e/scripts/suiteRunner.test.ts e2e/scripts/run-e2e-suite.test.ts`
- `pnpm run e2e:hmr:guard:cleanup && pnpm exec vitest run -c ./e2e/vitest.e2e.devtools.config.ts e2e/ide/github-issues.runtime.issue615.test.ts`
