### PR TITLE
fix: 支持 Vue 内联事件 ref 赋值

### DIFF
--- a/.changeset/fix-inline-event-ref-assignment.md
+++ b/.changeset/fix-inline-event-ref-assignment.md
@@ -1,0 +1,7 @@
+---
+"@wevu/compiler": patch
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复 Vue SFC 内联事件表达式中 `<script setup>` 顶层 ref 赋值没有写回 `.value` 的问题，覆盖自增、自减、复合赋值、普通赋值、三元表达式、逗号表达式、函数参数和对象简写等 Vue 3 常见写法，避免小程序运行时点击事件无法正确更新响应式状态。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -435,6 +435,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-621/index",
+          "pathName": "pages/issue-621/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-528/index",
           "pathName": "pages/issue-528/index",
           "query": "",

--- a/e2e-apps/github-issues/src/pages/issue-621/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-621/index.vue
@@ -1,0 +1,202 @@
+<script setup lang="ts">
+import { ref } from 'wevu'
+
+const count = ref(0)
+const explicitCount = ref(0)
+const derivedCount = ref(0)
+const prefixCount = ref(0)
+const conditionalCount = ref(0)
+const sequenceCount = ref(0)
+const argumentCount = ref(0)
+const shorthandCount = ref(0)
+const nestedState = {
+  count: ref(0),
+}
+
+definePageJson({
+  navigationBarTitleText: 'issue-621',
+})
+
+function _runE2E() {
+  return {
+    count: count.value,
+    explicitCount: explicitCount.value,
+    derivedCount: derivedCount.value,
+    prefixCount: prefixCount.value,
+    conditionalCount: conditionalCount.value,
+    sequenceCount: sequenceCount.value,
+    argumentCount: argumentCount.value,
+    shorthandCount: shorthandCount.value,
+    nestedCount: nestedState.count.value,
+    ok: count.value >= 0 && explicitCount.value >= 0,
+  }
+}
+
+function assignArgument(value: number) {
+  argumentCount.value = value + 1
+}
+
+function assignShorthand(state: { shorthandCount: number }) {
+  shorthandCount.value = state.shorthandCount + 1
+}
+</script>
+
+<template>
+  <view class="issue621-page">
+    <view class="issue621-title">
+      issue-621 inline assignment event
+    </view>
+    <button
+      class="issue621-button issue621-button-count"
+      data-issue621-action="count"
+      @tap="count += 1"
+    >
+      count {{ count }}
+    </button>
+    <button
+      class="issue621-button issue621-button-explicit"
+      data-issue621-action="explicit"
+      @tap="explicitCount.value += 1"
+    >
+      explicit {{ explicitCount }}
+    </button>
+    <button
+      class="issue621-button issue621-button-derived"
+      data-issue621-action="derived"
+      @tap="derivedCount = derivedCount + 1"
+    >
+      derived {{ derivedCount }}
+    </button>
+    <button
+      class="issue621-button issue621-button-prefix"
+      data-issue621-action="prefix"
+      @tap="++prefixCount"
+    >
+      prefix {{ prefixCount }}
+    </button>
+    <button
+      class="issue621-button issue621-button-conditional"
+      data-issue621-action="conditional"
+      @tap="conditionalCount > 0 ? conditionalCount = conditionalCount + 2 : conditionalCount = conditionalCount + 1"
+    >
+      conditional {{ conditionalCount }}
+    </button>
+    <button
+      class="issue621-button issue621-button-sequence"
+      data-issue621-action="sequence"
+      @tap="sequenceCount = sequenceCount + 1, sequenceCount++"
+    >
+      sequence {{ sequenceCount }}
+    </button>
+    <button
+      class="issue621-button issue621-button-argument"
+      data-issue621-action="argument"
+      @tap="assignArgument(argumentCount)"
+    >
+      argument {{ argumentCount }}
+    </button>
+    <button
+      class="issue621-button issue621-button-shorthand"
+      data-issue621-action="shorthand"
+      @tap="assignShorthand({ shorthandCount })"
+    >
+      shorthand {{ shorthandCount }}
+    </button>
+    <button
+      class="issue621-button issue621-button-nested"
+      data-issue621-action="nested"
+      @tap="nestedState.count.value += 1"
+    >
+      nested {{ nestedState.count }}
+    </button>
+    <text
+      class="issue621-count"
+      :data-issue621-count="count"
+    >
+      {{ count }}
+    </text>
+    <text
+      class="issue621-explicit-count"
+      :data-issue621-explicit-count="explicitCount"
+    >
+      {{ explicitCount }}
+    </text>
+    <text
+      class="issue621-derived-count"
+      :data-issue621-derived-count="derivedCount"
+    >
+      {{ derivedCount }}
+    </text>
+    <text
+      class="issue621-prefix-count"
+      :data-issue621-prefix-count="prefixCount"
+    >
+      {{ prefixCount }}
+    </text>
+    <text
+      class="issue621-conditional-count"
+      :data-issue621-conditional-count="conditionalCount"
+    >
+      {{ conditionalCount }}
+    </text>
+    <text
+      class="issue621-sequence-count"
+      :data-issue621-sequence-count="sequenceCount"
+    >
+      {{ sequenceCount }}
+    </text>
+    <text
+      class="issue621-argument-count"
+      :data-issue621-argument-count="argumentCount"
+    >
+      {{ argumentCount }}
+    </text>
+    <text
+      class="issue621-shorthand-count"
+      :data-issue621-shorthand-count="shorthandCount"
+    >
+      {{ shorthandCount }}
+    </text>
+    <text
+      class="issue621-nested-count"
+      :data-issue621-nested-count="nestedState.count"
+    >
+      {{ nestedState.count }}
+    </text>
+  </view>
+</template>
+
+<style scoped>
+.issue621-page {
+  box-sizing: border-box;
+  min-height: 100vh;
+  padding: 28rpx;
+  background: #f8fafc;
+}
+
+.issue621-title {
+  margin-bottom: 24rpx;
+  font-size: 30rpx;
+  font-weight: 700;
+  color: #111827;
+}
+
+.issue621-button {
+  margin-bottom: 18rpx;
+}
+
+.issue621-count,
+.issue621-explicit-count,
+.issue621-derived-count,
+.issue621-prefix-count,
+.issue621-conditional-count,
+.issue621-sequence-count,
+.issue621-argument-count,
+.issue621-shorthand-count,
+.issue621-nested-count {
+  display: block;
+  margin-top: 12rpx;
+  font-size: 28rpx;
+  color: #0f172a;
+}
+</style>

--- a/e2e-apps/github-issues/src/typed-router.d.ts
+++ b/e2e-apps/github-issues/src/typed-router.d.ts
@@ -24,6 +24,7 @@ declare module 'weapp-vite/auto-routes' {
         "pages/issue-318/index",
         "pages/issue-320/index",
         "pages/issue-322/index",
+        "pages/issue-621/index",
         "pages/issue-328/index"
     ];
     export type AutoRoutesEntries = [
@@ -44,6 +45,7 @@ declare module 'weapp-vite/auto-routes' {
         "pages/issue-318/index",
         "pages/issue-320/index",
         "pages/issue-322/index",
+        "pages/issue-621/index",
         "pages/issue-328/index",
         "subpackages/issue-327/index",
         "subpackages/item/index",

--- a/e2e-apps/github-issues/typed-router.d.ts
+++ b/e2e-apps/github-issues/typed-router.d.ts
@@ -24,6 +24,7 @@ declare module 'weapp-vite/auto-routes' {
         "pages/issue-318/index",
         "pages/issue-320/index",
         "pages/issue-322/index",
+        "pages/issue-621/index",
         "pages/issue-328/index"
     ];
     export type AutoRoutesEntries = [
@@ -44,6 +45,7 @@ declare module 'weapp-vite/auto-routes' {
         "pages/issue-318/index",
         "pages/issue-320/index",
         "pages/issue-322/index",
+        "pages/issue-621/index",
         "pages/issue-328/index"
     ];
     export type AutoRoutesSubPackages = [];

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -7,6 +7,7 @@ const issue547AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_547_AUGMENTED
 const issue558AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_558_AUGMENTED === 'true'
 const issue564AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_564_AUGMENTED === 'true'
 const issue615AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_615_AUGMENTED === 'true'
+const issue621AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_621_AUGMENTED === 'true'
 const issue595ScopedBuildEnabled = process.env.WEAPP_GITHUB_ISSUE_595_SCOPED === 'true'
 const e2eTargetFile = process.env.WEAPP_VITE_E2E_TARGET_FILE?.replaceAll('\\', '/') ?? ''
 const slotFallbackCompilerOffEnabled = process.env.WEAPP_GITHUB_SLOT_FALLBACK_COMPILER_OFF === 'true'
@@ -53,6 +54,9 @@ const githubIssuesRouteGroups: Record<string, string[]> = {
   'github-issues.runtime.issue615.test.ts': [
     'pages/issue-615/**',
     'components/issue-615/**',
+  ],
+  'github-issues.runtime.issue621.test.ts': [
+    'pages/issue-621/**',
   ],
   'github-issues.runtime.issue581.test.ts': [
     'pages/issue-581/**',
@@ -149,6 +153,13 @@ function resolveGithubIssuesAutoRoutes() {
       include: [
         'pages/issue-615/**',
         'components/issue-615/**',
+      ],
+    }
+  }
+  if (issue621AugmentedEnvEnabled) {
+    return {
+      include: [
+        'pages/issue-621/**',
       ],
     }
   }

--- a/e2e/ci/external-linked-vue-component.hmr.test.ts
+++ b/e2e/ci/external-linked-vue-component.hmr.test.ts
@@ -54,9 +54,32 @@ async function writeFixtureProject() {
     },
     devDependencies: {},
   }, { spaces: 2 })
+  await fs.writeJson(path.join(PROJECT_ROOT, 'tsconfig.json'), {
+    extends: './.weapp-vite/tsconfig.shared.json',
+    compilerOptions: {
+      types: [
+        'miniprogram-api-typings',
+      ],
+    },
+    include: [
+      'src/**/*',
+      '../packages/**/*.vue',
+    ],
+  }, { spaces: 2 })
+  await fs.writeJson(path.join(TEMP_ROOT, 'tsconfig.json'), {
+    extends: './app/.weapp-vite/tsconfig.shared.json',
+    include: [
+      'app/src/**/*',
+      'packages/**/*.vue',
+    ],
+  }, { spaces: 2 })
 
   await fs.writeFile(path.join(PROJECT_ROOT, 'weapp-vite.config.ts'), [
+    'import path from \'node:path\'',
+    'import { fileURLToPath } from \'node:url\'',
     'import { defineConfig } from \'weapp-vite\'',
+    '',
+    'const projectRoot = path.dirname(fileURLToPath(import.meta.url))',
     '',
     'export default defineConfig({',
     '  weapp: {',
@@ -67,6 +90,9 @@ async function writeFixtureProject() {
     '  },',
     '  build: {',
     '    minify: false,',
+    '    rolldownOptions: {',
+    '      tsconfig: path.join(projectRoot, \'tsconfig.json\'),',
+    '    },',
     '  },',
     '})',
     '',
@@ -167,7 +193,8 @@ describe.sequential('external linked Vue component HMR', () => {
     await fs.remove(DIST_ROOT)
 
     // @ts-expect-error execa v9 overload resolution
-    const dev = startDevProcess('node', [CLI_PATH, 'dev', PROJECT_ROOT, '--platform', 'weapp', '--skipNpm'], {
+    const dev = startDevProcess('node', [CLI_PATH, 'dev', '.', '--platform', 'weapp', '--skipNpm'], {
+      cwd: PROJECT_ROOT,
       env: createDevProcessEnv(),
       stdio: 'inherit',
     })

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -251,6 +251,30 @@ async function runIssue615AugmentedBuild() {
   distVariant = null
 }
 
+async function runIssue621AugmentedBuild() {
+  await fs.remove(DIST_ROOT)
+
+  await execa('node', [
+    CLI_PATH,
+    'build',
+    APP_ROOT,
+    '--platform',
+    'weapp',
+    '--skipNpm',
+    '--config',
+    path.join(APP_ROOT, 'weapp-vite.config.ts'),
+  ], {
+    stdio: 'inherit',
+    env: {
+      ...sanitizeBuildCommandEnv(),
+      WEAPP_GITHUB_ISSUE_621_AUGMENTED: 'true',
+    },
+  })
+
+  standardBuildPromise = null
+  distVariant = null
+}
+
 interface AppJsonWithSubPackages {
   pages?: string[]
   subPackages?: Array<{ root?: string, pages?: string[] }>
@@ -554,6 +578,33 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(scopedSlotJs).toContain('list')
     expect(scopedSlotJs).not.toContain('模板 v-for 数据源表达式执行失败: __wv_bind_0')
     expect(scopedSlotJs).not.toContain('模板运行时表达式执行失败: __wv_bind_0 = list')
+  })
+
+  it('issue #621: compiles inline assignment events against setup ref values', async () => {
+    await runIssue621AugmentedBuild()
+
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-621/index.wxml')
+    const pageJsPath = path.join(DIST_ROOT, 'pages/issue-621/index.js')
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+    const pageJs = await fs.readFile(pageJsPath, 'utf-8')
+
+    expect(pageWxml).toContain('issue-621 inline assignment event')
+    expect(pageWxml).toContain('data-wi-tap="i0"')
+    expect(pageWxml).toContain('data-wi-tap="i1"')
+    expect(pageWxml).toContain('bindtap="__weapp_vite_inline"')
+    expect(pageJs).toContain('__weapp_vite_inline_map')
+    expect(pageJs).toContain('ctx.count.value += 1')
+    expect(pageJs).toContain('ctx.explicitCount.value += 1')
+    expect(pageJs).toContain('ctx.derivedCount.value = ctx.derivedCount.value + 1')
+    expect(pageJs).toContain('++ctx.prefixCount.value')
+    expect(pageJs).toContain('ctx.conditionalCount.value > 0 ? ctx.conditionalCount.value = ctx.conditionalCount.value + 2 : ctx.conditionalCount.value = ctx.conditionalCount.value + 1')
+    expect(pageJs).toContain('ctx.sequenceCount.value = ctx.sequenceCount.value + 1, ctx.sequenceCount.value++')
+    expect(pageJs).toContain('ctx.assignArgument(ctx.argumentCount.value)')
+    expect(pageJs).toContain('ctx.assignShorthand({ shorthandCount: ctx.shorthandCount.value })')
+    expect(pageJs).toContain('ctx.nestedState.count.value += 1')
+    expect(pageJs).not.toContain('ReferenceError')
+    expect(pageJs).not.toContain('ctx.explicitCount.value.value')
+    expect(pageJs).not.toContain('ctx.nestedState.count.value.value')
   })
 
   it('issue #424: avoids duplicated output for imported src/assets images', async () => {

--- a/e2e/ide/__snapshots__/template-wevu-features-app.test.ts.snap
+++ b/e2e/ide/__snapshots__/template-wevu-features-app.test.ts.snap
@@ -428,9 +428,6 @@ exports[`template e2e: wevu-features-app > renders all pages from app config > w
       </view>
       <view class="index--use-attrs-feature__extra" id="attrs-extra">extra-label = seed-1</view>
       <view class="index--use-attrs-feature__rows">
-        <view class="index--use-attrs-feature__row">__wv_cls_0: use-attrs-feature__badge</view>
-        <view class="index--use-attrs-feature__row">__wv_cls_1: use-attrs-feature__flag</view>
-        <view class="index--use-attrs-feature__row">__wv_style_0:</view>
         <view class="index--use-attrs-feature__row">
           badge-style: border: 2rpx dashed #64748b; padding: 8rpx 16rpx;
         </view>

--- a/e2e/ide/github-issues.runtime.issue621.test.ts
+++ b/e2e/ide/github-issues.runtime.issue621.test.ts
@@ -1,0 +1,107 @@
+import process from 'node:process'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  closeSharedMiniProgram,
+  getSharedMiniProgram,
+  PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT,
+  prepareGithubIssuesBuild,
+  readPageWxml,
+  relaunchPage,
+  releaseSharedMiniProgram,
+  tapElement,
+} from './github-issues.runtime.shared'
+
+const ISSUE_621_AUGMENTED_ENV = 'WEAPP_GITHUB_ISSUE_621_AUGMENTED'
+
+describe.sequential('e2e app: github-issues / issue #621', () => {
+  beforeAll(async () => {
+    process.env[ISSUE_621_AUGMENTED_ENV] = 'true'
+    await prepareGithubIssuesBuild()
+  }, PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT)
+
+  afterAll(async () => {
+    await closeSharedMiniProgram()
+    delete process.env[ISSUE_621_AUGMENTED_ENV]
+  })
+
+  it('keeps inline assignment events writable for setup refs in DevTools', async (ctx) => {
+    const miniProgram = await getSharedMiniProgram(ctx)
+    try {
+      const issuePage = await relaunchPage(miniProgram, '/pages/issue-621/index', 'issue-621 inline assignment event')
+      if (!issuePage) {
+        throw new Error('Failed to launch issue-621 page')
+      }
+
+      const initialRuntime = await issuePage.callMethod('_runE2E')
+      expect(initialRuntime).toMatchObject({
+        count: 0,
+        explicitCount: 0,
+        derivedCount: 0,
+        prefixCount: 0,
+        conditionalCount: 0,
+        sequenceCount: 0,
+        argumentCount: 0,
+        shorthandCount: 0,
+        nestedCount: 0,
+        ok: true,
+      })
+
+      await tapElement(issuePage, '.issue621-button-count')
+      const afterCountRuntime = await issuePage.callMethod('_runE2E')
+      const afterCountWxml = await readPageWxml(issuePage)
+
+      expect(afterCountRuntime).toMatchObject({
+        count: 1,
+        explicitCount: 0,
+        ok: true,
+      })
+      expect(afterCountWxml).toContain('data-issue621-count="1"')
+
+      await tapElement(issuePage, '.issue621-button-explicit')
+      const afterExplicitRuntime = await issuePage.callMethod('_runE2E')
+      const afterExplicitWxml = await readPageWxml(issuePage)
+
+      expect(afterExplicitRuntime).toMatchObject({
+        count: 1,
+        explicitCount: 1,
+        ok: true,
+      })
+      expect(afterExplicitWxml).toContain('data-issue621-explicit-count="1"')
+
+      await tapElement(issuePage, '.issue621-button-derived')
+      await tapElement(issuePage, '.issue621-button-prefix')
+      await tapElement(issuePage, '.issue621-button-conditional')
+      await tapElement(issuePage, '.issue621-button-conditional')
+      await tapElement(issuePage, '.issue621-button-sequence')
+      await tapElement(issuePage, '.issue621-button-argument')
+      await tapElement(issuePage, '.issue621-button-shorthand')
+      await tapElement(issuePage, '.issue621-button-nested')
+
+      const finalRuntime = await issuePage.callMethod('_runE2E')
+      const finalWxml = await readPageWxml(issuePage)
+
+      expect(finalRuntime).toMatchObject({
+        count: 1,
+        explicitCount: 1,
+        derivedCount: 1,
+        prefixCount: 1,
+        conditionalCount: 3,
+        sequenceCount: 2,
+        argumentCount: 1,
+        shorthandCount: 1,
+        nestedCount: 1,
+        ok: true,
+      })
+      expect(finalWxml).toContain('data-issue621-derived-count="1"')
+      expect(finalWxml).toContain('data-issue621-prefix-count="1"')
+      expect(finalWxml).toContain('data-issue621-conditional-count="3"')
+      expect(finalWxml).toContain('data-issue621-sequence-count="2"')
+      expect(finalWxml).toContain('data-issue621-argument-count="1"')
+      expect(finalWxml).toContain('data-issue621-shorthand-count="1"')
+      expect(finalWxml).toContain('data-issue621-nested-count="1"')
+    }
+    finally {
+      await releaseSharedMiniProgram(miniProgram)
+    }
+  })
+})

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.ts
@@ -97,6 +97,7 @@ export function compileVueTemplateToWxml(
       platform: options?.platform ?? getMiniProgramTemplatePlatform(),
       propsAliases: options?.propsAliases,
       propsDerivedKeys: options?.propsDerivedKeys,
+      scriptSetupBindings: options?.scriptSetupBindings,
       htmlTagToWxmlMap,
       htmlTagToWxmlTagClass: options?.htmlTagToWxmlTagClass ?? true,
       scopedSlotsCompiler: options?.scopedSlotsCompiler ?? 'auto',

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/expression/inline.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/expression/inline.ts
@@ -64,12 +64,26 @@ const INLINE_GLOBALS = new Set([
 
 const IDENTIFIER_RE = /^[A-Z_$][\w$]*$/i
 const SIMPLE_PATH_RE = /^[A-Z_$][\w$]*(?:\.[A-Z_$][\w$]*)*$/i
+const SCRIPT_SETUP_REF_BINDINGS = new Set([
+  'setup-ref',
+  'setup-maybe-ref',
+])
 
 function createMemberAccess(target: string, prop: string) {
   if (IDENTIFIER_RE.test(prop)) {
     return t.memberExpression(t.identifier(target), t.identifier(prop))
   }
   return t.memberExpression(t.identifier(target), t.stringLiteral(prop), true)
+}
+
+function replaceIdentifierWithExpression(path: import('@weapp-vite/ast/babelTraverse').NodePath<t.Identifier>, replacement: t.Expression) {
+  const parent = path.parentPath
+  if (parent.isObjectProperty() && parent.node.shorthand && parent.node.key === path.node) {
+    parent.node.shorthand = false
+    parent.node.value = replacement
+    return
+  }
+  path.replaceWith(replacement)
 }
 
 function resolveSlotPropBinding(slotProps: Record<string, string>, name: string): string | null {
@@ -107,13 +121,13 @@ function rewriteExpressionAst(
       }
       if (locals.has(name)) {
         options?.markLocal?.(name)
-        path.replaceWith(createMemberAccess('scope', name))
+        replaceIdentifierWithExpression(path, createMemberAccess('scope', name) as t.Expression)
         return
       }
       if (INLINE_GLOBALS.has(name)) {
         return
       }
-      path.replaceWith(createMemberAccess('ctx', name))
+      replaceIdentifierWithExpression(path, createMemberAccess('ctx', name) as t.Expression)
     },
     ThisExpression(path) {
       path.replaceWith(t.identifier('ctx'))
@@ -203,6 +217,89 @@ function collectForAliasMapping(context: TransformContext): Record<string, strin
   return mapping
 }
 
+function getScriptSetupBindingType(context: TransformContext, name: string): string | undefined {
+  const binding = context.scriptSetupBindings?.[name]
+  return typeof binding === 'string' ? binding : undefined
+}
+
+function isScriptSetupBinding(context: TransformContext, name: string) {
+  return Boolean(getScriptSetupBindingType(context, name))
+}
+
+function isScriptSetupRefLikeBinding(context: TransformContext, name: string) {
+  const bindingType = getScriptSetupBindingType(context, name)
+  return bindingType ? SCRIPT_SETUP_REF_BINDINGS.has(bindingType) : false
+}
+
+function isRefLikeCtxMember(node: t.Node, context: TransformContext): node is t.MemberExpression {
+  return (
+    t.isMemberExpression(node)
+    && t.isIdentifier(node.object, { name: 'ctx' })
+    && t.isIdentifier(node.property)
+    && !node.computed
+    && isScriptSetupRefLikeBinding(context, node.property.name)
+  )
+}
+
+function buildCtxValueAccess(member: t.MemberExpression) {
+  return t.memberExpression(t.cloneNode(member), t.identifier('value'))
+}
+
+function isValueMemberObject(node: t.MemberExpression, parent: t.Node | undefined) {
+  return (
+    t.isMemberExpression(parent)
+    && parent.object === node
+    && t.isIdentifier(parent.property, { name: 'value' })
+    && !parent.computed
+  )
+}
+
+function rewriteTopLevelRefLikeAccess(ast: t.File, context: TransformContext) {
+  traverse(ast, {
+    AssignmentExpression(path) {
+      const left = path.node.left
+      if (t.isIdentifier(left) && isScriptSetupRefLikeBinding(context, left.name)) {
+        path.node.left = buildCtxValueAccess(
+          t.memberExpression(t.identifier('ctx'), t.identifier(left.name)),
+        ) as any
+      }
+      else if (t.isIdentifier(left) && isScriptSetupBinding(context, left.name)) {
+        path.node.left = t.memberExpression(t.identifier('ctx'), t.identifier(left.name))
+      }
+      else if (isRefLikeCtxMember(left, context)) {
+        path.node.left = buildCtxValueAccess(left)
+      }
+    },
+    UpdateExpression(path) {
+      const arg = path.node.argument
+      if (t.isIdentifier(arg) && isScriptSetupRefLikeBinding(context, arg.name)) {
+        path.node.argument = buildCtxValueAccess(
+          t.memberExpression(t.identifier('ctx'), t.identifier(arg.name)),
+        )
+      }
+      else if (t.isIdentifier(arg) && isScriptSetupBinding(context, arg.name)) {
+        path.node.argument = t.memberExpression(t.identifier('ctx'), t.identifier(arg.name))
+      }
+      else if (isRefLikeCtxMember(arg, context)) {
+        path.node.argument = buildCtxValueAccess(arg)
+      }
+    },
+  })
+
+  traverse(ast, {
+    MemberExpression(path) {
+      if (!isRefLikeCtxMember(path.node, context)) {
+        return
+      }
+      if (isValueMemberObject(path.node, path.parentPath?.node)) {
+        return
+      }
+      path.replaceWith(buildCtxValueAccess(path.node))
+      path.skip()
+    },
+  })
+}
+
 export interface InlineExpressionBinding {
   id: string
   scopeBindings: string[]
@@ -233,6 +330,7 @@ export function registerInlineExpression(exp: string, context: TransformContext)
   }
 
   rewriteExpressionAst(ast, locals, { markLocal })
+  rewriteTopLevelRefLikeAccess(ast, context)
   const forAliases = collectForAliasMapping(context)
 
   const updatedStmt = ast.program.body[0]

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/types.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/types.ts
@@ -75,6 +75,7 @@ export interface TransformContext {
    */
   propsAliases?: Record<string, string>
   propsDerivedKeys?: string[]
+  scriptSetupBindings?: Record<string, unknown>
   htmlTagToWxmlMap?: Record<string, string>
   htmlTagToWxmlTagClass: boolean
   scopedSlotsCompiler: ScopedSlotsCompilerMode
@@ -136,6 +137,7 @@ export interface TemplateCompileOptions {
    */
   propsAliases?: Record<string, string>
   propsDerivedKeys?: string[]
+  scriptSetupBindings?: Record<string, unknown>
   htmlTagToWxml?: boolean | Record<string, string>
   htmlTagToWxmlTagClass?: boolean
   scopedSlotsCompiler?: ScopedSlotsCompilerMode

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/index.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/index.ts
@@ -74,12 +74,14 @@ export async function compileVueFile(
         ...options?.template,
         propsAliases,
         propsDerivedKeys,
+        scriptSetupBindings: scriptCompiled?.bindings as Record<string, unknown> | undefined,
         scopedSlotsRequireProps: true,
       }
     : {
         ...options?.template,
         propsAliases,
         propsDerivedKeys,
+        scriptSetupBindings: scriptCompiled?.bindings as Record<string, unknown> | undefined,
       }
 
   const templateOptions = componentSourceInfo.wevuComponentTags.size

--- a/packages-runtime/wevu/test/runtime-inline-event.test.ts
+++ b/packages-runtime/wevu/test/runtime-inline-event.test.ts
@@ -513,6 +513,58 @@ describe('runtime: inline event handler', () => {
     expect(result).toBe(3)
   })
 
+  it('executes inline assignment expressions against setup refs', () => {
+    const inlineMap = {
+      __wv_inline_0: {
+        keys: [],
+        fn: (ctx: any) => {
+          ctx.count.value += 1
+          return ctx.count.value
+        },
+      },
+    }
+
+    defineComponent({
+      data: () => ({}),
+      methods: {
+        __weapp_vite_inline_map: inlineMap,
+      } as any,
+      setup() {
+        const count = ref(0)
+        function readCount() {
+          return count.value
+        }
+        return {
+          count,
+          readCount,
+        }
+      },
+    })
+
+    const opts = registeredComponents.pop()!
+    expect(opts).toBeTruthy()
+    const inst: any = {
+      setData() {},
+      properties: {},
+    }
+    opts.lifetimes.created.call(inst)
+    opts.lifetimes.attached.call(inst)
+
+    const event = {
+      type: 'tap',
+      currentTarget: {
+        dataset: {
+          wvInlineIdTap: '__wv_inline_0',
+        },
+      },
+    }
+
+    const result = opts.methods.__weapp_vite_inline.call(inst, event)
+
+    expect(result).toBe(1)
+    expect(inst.readCount()).toBe(1)
+  })
+
   it('executes inline map from options methods after mount', () => {
     const handle = vi.fn((value: string) => value)
     const inlineMap = {

--- a/packages/weapp-vite/src/plugins/vue/transform/compileVueFile.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/compileVueFile.test.ts
@@ -234,6 +234,67 @@ const handle = (value: string) => value
     expect(result.script).toContain('ctx.handle')
   })
 
+  it('rewrites inline event assignments to script setup ref values', async () => {
+    const result = await compileVueFile(
+      `
+<template>
+  <view @tap="count += 1" />
+  <view @longpress="count.value += 1" />
+  <view @touchstart="count++" />
+  <view @touchmove="count = count + 1" />
+  <view @touchend="++count" />
+  <view @touchcancel="count > 1 ? count = count - 1 : count = count + 1" />
+  <view @animationend="handle(count, { count })" />
+</template>
+<script setup lang="ts">
+import { ref } from 'wevu'
+
+const count = ref(0)
+function handle(value: number, state: { count: number }) {
+  return value + state.count
+}
+</script>
+      `.trim(),
+      '/project/src/pages/index/index.vue',
+    )
+
+    expect(result.template).toContain('bindtap="__weapp_vite_inline"')
+    expect(result.template).toContain('bindlongpress="__weapp_vite_inline"')
+    expect(result.template).toContain('bindtouchstart="__weapp_vite_inline"')
+    expect(result.script).toContain('ctx.count.value += 1')
+    expect(result.script).toContain('ctx.count.value++')
+    expect(result.script).toContain('ctx.count.value = ctx.count.value + 1')
+    expect(result.script).toContain('++ctx.count.value')
+    expect(result.script).toContain('ctx.count.value > 1 ? ctx.count.value = ctx.count.value - 1 : ctx.count.value = ctx.count.value + 1')
+    expect(result.script).toContain('ctx.handle(ctx.count.value, { count: ctx.count.value })')
+    expect(result.script).not.toContain('ctx.count.value.value')
+  })
+
+  it('does not rewrite non-top-level or non-ref inline event targets as ref values', async () => {
+    const result = await compileVueFile(
+      `
+<template>
+  <view @tap="plain = plain + 1" />
+  <view @longpress="nested.count = nested.count + 1" />
+</template>
+<script setup lang="ts">
+import { ref } from 'wevu'
+
+let plain = 0
+const nested = {
+  count: ref(0),
+}
+</script>
+      `.trim(),
+      '/project/src/pages/index/index.vue',
+    )
+
+    expect(result.script).toContain('ctx.plain = ctx.plain + 1')
+    expect(result.script).toContain('ctx.nested.count = ctx.nested.count + 1')
+    expect(result.script).not.toContain('ctx.plain.value')
+    expect(result.script).not.toContain('ctx.nested.count.value')
+  })
+
   it('applies htmlTagToWxml mapping in final compiled vue template output', async () => {
     const result = await compileVueFile(
       `


### PR DESCRIPTION
## 摘要

- 修复 #621：内联事件表达式中 `<script setup>` 顶层 ref / maybe-ref 绑定会自动写回 `.value`。
- 覆盖 `+=`、`++`、`=`、前置自增、三元表达式、逗号表达式、函数参数、对象简写、显式 `.value` 和嵌套 ref 等 Vue 3 常见写法。
- 新增单元测试、github-issues CI E2E 用例和 IDE E2E 运行时用例。

## 验证

- `pnpm build:core`
- `pnpm test`：641 files passed，5395 tests passed
- `pnpm e2e:ci`：51/51 passed
- `caffeinate -dimsu -- pnpm e2e:ide:full`：66/66 passed

## 说明

- `inline.ts` 当前超过 300 行；本次评估后暂不拆分，因为新增逻辑只服务同一条内联表达式 AST 重写流水线，保留在同一文件能避免为单一局部流程增加跨文件跳转。若后续继续扩展表达式重写能力，再将 ref binding helpers 拆到独立模块。

Closes #621