### PR TITLE
fix(weapp-vite): 完善 build watch 对外部依赖的处理

### DIFF
--- a/.changeset/fresh-clouds-watch.md
+++ b/.changeset/fresh-clouds-watch.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复小程序 dev/build 的 watch 行为：dev 模式会继承 `build.watch.include` 并响应配置依赖变更，生产 build 不再因为用户配置 `build.watch` 而进入监听模式。

--- a/e2e/ci/external-linked-vue-component.hmr.test.ts
+++ b/e2e/ci/external-linked-vue-component.hmr.test.ts
@@ -1,6 +1,7 @@
 import { fs } from '@weapp-core/shared/node'
 import path from 'pathe'
-import { afterEach, beforeEach, describe, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runWeappViteBuildWithLogCapture } from '../utils/buildLog'
 import { startDevProcess } from '../utils/dev-process'
 import { cleanupResidualDevProcesses } from '../utils/dev-process-cleanup'
 import { createDevProcessEnv } from '../utils/dev-process-env'
@@ -13,6 +14,9 @@ const DIST_ROOT = path.join(PROJECT_ROOT, 'dist')
 const MONOREPO_BADGE = path.join(TEMP_ROOT, 'packages/monorepo-ui/MonorepoBadge.vue')
 const LINK_BADGE_SOURCE_ROOT = path.join(TEMP_ROOT, 'packages/linked-ui')
 const LINK_BADGE = path.join(LINK_BADGE_SOURCE_ROOT, 'LinkedBadge.vue')
+const RESOLVER_BADGE = path.join(TEMP_ROOT, 'packages/resolver-ui/ResolverBadge.vue')
+const SHARED_MESSAGE = path.join(TEMP_ROOT, 'packages/shared-state/message.ts')
+const CONFIG_VALUE = path.join(TEMP_ROOT, 'config/config-values.ts')
 
 function createComponentSource(className: string, marker: string) {
   return [
@@ -41,8 +45,11 @@ async function writeFixtureProject() {
   await fs.remove(TEMP_ROOT)
   await fs.ensureDir(path.join(PROJECT_ROOT, 'src/pages/index'))
   await fs.ensureDir(path.join(PROJECT_ROOT, 'node_modules/@e2e'))
+  await fs.ensureDir(path.join(TEMP_ROOT, 'config'))
   await fs.ensureDir(path.join(TEMP_ROOT, 'packages/monorepo-ui'))
   await fs.ensureDir(LINK_BADGE_SOURCE_ROOT)
+  await fs.ensureDir(path.dirname(RESOLVER_BADGE))
+  await fs.ensureDir(path.dirname(SHARED_MESSAGE))
 
   await fs.writeJson(path.join(PROJECT_ROOT, 'package.json'), {
     name: 'external-linked-vue-component-hmr',
@@ -64,6 +71,7 @@ async function writeFixtureProject() {
     include: [
       'src/**/*',
       '../packages/**/*.vue',
+      '../packages/**/*.ts',
     ],
   }, { spaces: 2 })
   await fs.writeJson(path.join(TEMP_ROOT, 'tsconfig.json'), {
@@ -71,13 +79,16 @@ async function writeFixtureProject() {
     include: [
       'app/src/**/*',
       'packages/**/*.vue',
+      'packages/**/*.ts',
     ],
   }, { spaces: 2 })
+  await fs.writeFile(CONFIG_VALUE, 'export const configMarker = \'CONFIG-MARKER-V1\'\n', 'utf8')
 
   await fs.writeFile(path.join(PROJECT_ROOT, 'weapp-vite.config.ts'), [
     'import path from \'node:path\'',
     'import { fileURLToPath } from \'node:url\'',
     'import { defineConfig } from \'weapp-vite\'',
+    'import { configMarker } from \'../config/config-values\'',
     '',
     'const projectRoot = path.dirname(fileURLToPath(import.meta.url))',
     '',
@@ -87,9 +98,35 @@ async function writeFixtureProject() {
     '    hmr: {',
     '      logLevel: \'verbose\',',
     '    },',
+    '    autoImportComponents: {',
+    '      resolvers: [',
+    '        {',
+    '          resolve(componentName) {',
+    '            if (componentName === \'ResolverBadge\') {',
+    '              return {',
+    '                name: componentName,',
+    '                from: \'/__weapp_vite_external__/resolver-ui/ResolverBadge\',',
+    '                resolvedId: path.join(projectRoot, \'../packages/resolver-ui/ResolverBadge.vue\'),',
+    '              }',
+    '            }',
+    '          },',
+    '        },',
+    '      ],',
+    '    },',
+    '  },',
+    '  define: {',
+    '    __E2E_CONFIG_MARKER__: JSON.stringify(configMarker),',
     '  },',
     '  build: {',
     '    minify: false,',
+    '    watch: {',
+    '      include: [path.join(projectRoot, \'../packages/shared-state/**/*.ts\')],',
+    '      buildDelay: 80,',
+    '      chokidar: {',
+    '        usePolling: true,',
+    '        interval: 100,',
+    '      },',
+    '    },',
     '    rolldownOptions: {',
     '      tsconfig: path.join(projectRoot, \'tsconfig.json\'),',
     '    },',
@@ -126,6 +163,9 @@ async function writeFixtureProject() {
     '<script setup lang="ts">',
     'import MonorepoBadge from \'../../../../packages/monorepo-ui/MonorepoBadge.vue\'',
     'import LinkedBadge from \'@e2e/linked-ui/LinkedBadge.vue\'',
+    'import { sharedMessage } from \'../../../../packages/shared-state/message\'',
+    '',
+    'const configMarker = __E2E_CONFIG_MARKER__',
     '',
     'definePageJson({',
     '  navigationBarTitleText: \'external linked hmr\',',
@@ -136,12 +176,17 @@ async function writeFixtureProject() {
     '  <view class="page">',
     '    <MonorepoBadge />',
     '    <LinkedBadge />',
+    '    <ResolverBadge />',
+    '    <view class="shared-message">{{ sharedMessage }}</view>',
+    '    <view class="config-marker">{{ configMarker }}</view>',
     '  </view>',
     '</template>',
     '',
   ].join('\n'), 'utf8')
 
   await fs.writeFile(MONOREPO_BADGE, createComponentSource('monorepo-badge', 'MONOREPO-BADGE-V1'), 'utf8')
+  await fs.writeFile(RESOLVER_BADGE, createComponentSource('resolver-badge', 'RESOLVER-BADGE-V1'), 'utf8')
+  await fs.writeFile(SHARED_MESSAGE, 'export const sharedMessage = \'SHARED-MESSAGE-V1\'\n', 'utf8')
   await fs.writeJson(path.join(LINK_BADGE_SOURCE_ROOT, 'package.json'), {
     name: '@e2e/linked-ui',
     type: 'module',
@@ -151,6 +196,39 @@ async function writeFixtureProject() {
   }, { spaces: 2 })
   await fs.writeFile(LINK_BADGE, createComponentSource('linked-badge', 'LINKED-BADGE-V1'), 'utf8')
   await fs.ensureSymlink(LINK_BADGE_SOURCE_ROOT, path.join(PROJECT_ROOT, 'node_modules/@e2e/linked-ui'), 'junction')
+}
+
+async function waitForDistJsContains(marker: string, timeoutMs = 90_000) {
+  const start = Date.now()
+
+  while (Date.now() - start < timeoutMs) {
+    if (await fs.pathExists(DIST_ROOT)) {
+      const files: string[] = []
+      const visit = async (dir: string) => {
+        for (const entry of await fs.readdir(dir)) {
+          const candidate = path.join(dir, entry)
+          const stat = await fs.stat(candidate)
+          if (stat.isDirectory()) {
+            await visit(candidate)
+            continue
+          }
+          if (candidate.endsWith('.js')) {
+            files.push(candidate)
+          }
+        }
+      }
+      await visit(DIST_ROOT)
+      for (const file of files) {
+        const content = await fs.readFile(file, 'utf8')
+        if (content.includes(marker)) {
+          return content
+        }
+      }
+    }
+    await new Promise(resolve => setTimeout(resolve, 250))
+  }
+
+  throw new Error(`Timed out waiting for dist js to contain marker: ${marker}`)
 }
 
 async function waitForExternalComponentContains(sourcePath: string, marker: string, timeoutMs = 90_000) {
@@ -189,14 +267,14 @@ afterEach(async () => {
 })
 
 describe.sequential('external linked Vue component HMR', () => {
-  it('updates monorepo sibling and node_modules symlink Vue components outside srcRoot', async () => {
+  it('updates srcRoot-external Vue components and emits external plain/config deps in dev', async () => {
     await fs.remove(DIST_ROOT)
 
     // @ts-expect-error execa v9 overload resolution
     const dev = startDevProcess('node', [CLI_PATH, 'dev', '.', '--platform', 'weapp', '--skipNpm'], {
       cwd: PROJECT_ROOT,
       env: createDevProcessEnv(),
-      stdio: 'inherit',
+      stdio: 'pipe',
     })
 
     try {
@@ -208,6 +286,18 @@ describe.sequential('external linked Vue component HMR', () => {
       await dev.waitFor(
         waitForExternalComponentContains(LINK_BADGE, 'LINKED-BADGE-V1'),
         'initial linked component marker',
+      )
+      await dev.waitFor(
+        waitForExternalComponentContains(RESOLVER_BADGE, 'RESOLVER-BADGE-V1'),
+        'initial resolver component marker',
+      )
+      await dev.waitFor(
+        waitForDistJsContains('SHARED-MESSAGE-V1'),
+        'initial external shared dependency marker',
+      )
+      await dev.waitFor(
+        waitForDistJsContains('CONFIG-MARKER-V1'),
+        'initial config dependency marker',
       )
 
       await replaceFileByRename(MONOREPO_BADGE, createComponentSource('monorepo-badge', 'MONOREPO-BADGE-V2'))
@@ -221,9 +311,33 @@ describe.sequential('external linked Vue component HMR', () => {
         waitForExternalComponentContains(LINK_BADGE, 'LINKED-BADGE-V2'),
         'updated linked component marker',
       )
+
+      await replaceFileByRename(RESOLVER_BADGE, createComponentSource('resolver-badge', 'RESOLVER-BADGE-V2'))
+      await dev.waitFor(
+        waitForExternalComponentContains(RESOLVER_BADGE, 'RESOLVER-BADGE-V2'),
+        'updated resolver component marker',
+      )
     }
     finally {
       await dev.stop(5_000)
     }
+  })
+
+  it('ignores build.watch in production build and exits normally', async () => {
+    await fs.remove(DIST_ROOT)
+
+    await runWeappViteBuildWithLogCapture({
+      cliPath: CLI_PATH,
+      projectRoot: PROJECT_ROOT,
+      platform: 'weapp',
+      skipNpm: true,
+      label: 'external-linked-vue-component:build-watch-ignored',
+    })
+
+    await waitForFile(path.join(DIST_ROOT, 'app.json'), 90_000)
+    await waitForExternalComponentContains(MONOREPO_BADGE, 'MONOREPO-BADGE-V1')
+    await waitForExternalComponentContains(LINK_BADGE, 'LINKED-BADGE-V1')
+    await waitForExternalComponentContains(RESOLVER_BADGE, 'RESOLVER-BADGE-V1')
+    await expect(waitForDistJsContains('SHARED-MESSAGE-V1')).resolves.toContain('SHARED-MESSAGE-V1')
   })
 })

--- a/packages/weapp-vite/src/plugins/core/helpers/graph.test.ts
+++ b/packages/weapp-vite/src/plugins/core/helpers/graph.test.ts
@@ -52,14 +52,17 @@ describe('core helpers graph', () => {
   it('collects affected entries through importer graph traversal', () => {
     const state = createState()
     state.entryModuleIds = new Set(['/src/app.ts', '/src/admin.ts'])
+    state.resolvedEntryMap.set('/src/components/card.vue', { id: '/src/components/card.vue' })
     state.moduleImporters = new Map<string, Set<string>>([
       ['/src/shared.ts', new Set(['/src/mid.ts'])],
       ['/src/mid.ts', new Set(['/src/app.ts', '/src/loop-a.ts'])],
       ['/src/loop-a.ts', new Set(['/src/loop-b.ts'])],
       ['/src/loop-b.ts', new Set(['/src/loop-a.ts'])],
+      ['/src/external-state.ts', new Set(['/src/components/card.vue'])],
     ])
 
     expect(collectAffectedEntries(state, '/src/shared.ts')).toEqual(new Set(['/src/app.ts']))
+    expect(collectAffectedEntries(state, '/src/external-state.ts')).toEqual(new Set(['/src/components/card.vue']))
     expect(collectAffectedEntries(state, '/src/unknown.ts')).toEqual(new Set())
   })
 

--- a/packages/weapp-vite/src/plugins/core/helpers/graph.ts
+++ b/packages/weapp-vite/src/plugins/core/helpers/graph.ts
@@ -15,7 +15,7 @@ export function collectAffectedEntries(state: CorePluginState, startId: string) 
     }
     visited.add(current)
 
-    if (state.entryModuleIds.has(current)) {
+    if (state.entryModuleIds.has(current) || state.resolvedEntryMap.has(current)) {
       affected.add(current)
       continue
     }

--- a/packages/weapp-vite/src/plugins/core/lifecycle/watch.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/watch.test.ts
@@ -58,6 +58,7 @@ function createState(overrides: Record<string, any> = {}) {
       },
       buildService: {
         invalidateIndependentOutput: vi.fn(),
+        requestConfigRestart: vi.fn(),
       },
       configService: {
         platform: 'weapp',
@@ -100,6 +101,7 @@ function createState(overrides: Record<string, any> = {}) {
       invalidateResolveCache: vi.fn(),
     },
     emitDirtyEntries: vi.fn(async () => {}),
+    buildTarget: 'app',
     loadedEntrySet: new Set<string>(),
     entriesMap: new Map<string, { type: string }>(),
     layoutEntryDependents: new Map<string, Set<string>>(),
@@ -287,6 +289,31 @@ describe('core lifecycle watch hook', () => {
     expect(state.ctx.runtimeState.build.hmr.profile.file).toBe(entryId)
     expect(state.ctx.runtimeState.build.hmr.profile.watchToDirtyMs).toBeTypeOf('number')
     expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['entry-direct:1'])
+  })
+
+  it('treats config dependency updates as full dev rebuild triggers', async () => {
+    const entryA = '/project/src/pages/a/index.ts'
+    const entryB = '/project/src/components/card/index.ts'
+    const state = createState({
+      resolvedEntryMap: new Map([
+        [entryA, { id: entryA }],
+        [entryB, { id: entryB }],
+      ]),
+    })
+    state.ctx.configService.configFileDependencies = [
+      '/project/vite.config.mts',
+      '/project/config/shared.ts',
+    ]
+    const hook = createWatchChangeHook(state)
+
+    await hook('/project/vite.config.mts', { event: 'update' })
+
+    expect(state.loadEntry.invalidateResolveCache).toHaveBeenCalledTimes(1)
+    expect(state.ctx.scanService.markDirty).toHaveBeenCalledTimes(1)
+    expect(state.ctx.buildService.requestConfigRestart).toHaveBeenCalledWith('app')
+    expect(state.markEntryDirty).toHaveBeenCalledWith(entryA, 'direct')
+    expect(state.markEntryDirty).toHaveBeenCalledWith(entryB, 'direct')
+    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['config-restart:2'])
   })
 
   it('ignores generated output changes inside outDir', async () => {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/watch.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/watch.ts
@@ -50,6 +50,11 @@ function isAutoRoutesGeneratedFileChange(state: CorePluginState, normalizedId: s
   })
 }
 
+function isConfigFileDependencyChange(state: CorePluginState, normalizedId: string) {
+  return state.ctx.configService.configFileDependencies
+    .some(dependency => normalizeFsResolvedId(dependency) === normalizedId)
+}
+
 function isCurrentSubPackageFile(relativeSrc: string, subPackageMeta: SubPackageMetaValue | null | undefined) {
   const root = subPackageMeta?.subPackage.root
   return !root || relativeSrc === root || relativeSrc.startsWith(`${root}/`)
@@ -497,6 +502,16 @@ async function processChangedFile(
   const relativeCwd = configService.relativeCwd(normalizedId)
   let handledByIndependentWatcher = false
   let independentMeta: SubPackageMetaValue | undefined
+  const isConfigDependency = isConfigFileDependencyChange(state, normalizedId)
+
+  if (isConfigDependency) {
+    ;(loadEntry as any)?.invalidateResolveCache?.()
+    scanService.markDirty()
+    buildService.requestConfigRestart?.(state.buildTarget)
+    for (const entryId of resolvedEntryMap.keys()) {
+      markEntryDirtyWithCause(entryId, 'direct', 'config-restart')
+    }
+  }
 
   if (event === 'create' || event === 'delete') {
     ;(loadEntry as any)?.invalidateResolveCache?.()
@@ -515,7 +530,7 @@ async function processChangedFile(
       shouldMarkProjectConfigDirty = relativeCwd.startsWith(platformConfigPrefix)
     }
 
-    if (relativeSrc === 'app.json' || shouldMarkProjectConfigDirty) {
+    if (!isConfigDependency && (relativeSrc === 'app.json' || shouldMarkProjectConfigDirty)) {
       scanService.markDirty()
     }
 

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/autoImport.test.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/autoImport.test.ts
@@ -92,6 +92,42 @@ describe('createAutoImportAugmenter', () => {
     })
   })
 
+  it('tracks resolver resolvedId so external Vue components join the compile flow', () => {
+    const resolve = vi.fn((name: string) => {
+      if (name === 'ResolverBadge') {
+        return {
+          value: {
+            name: 'ResolverBadge',
+            from: '/__weapp_vite_external__/resolver-ui/ResolverBadge',
+            resolvedId: '/workspace/packages/resolver-ui/ResolverBadge.vue',
+          },
+        }
+      }
+      return undefined
+    })
+    const externalComponentEntryMap = new Map<string, string>()
+
+    const applyAutoImports = createAutoImportAugmenter(
+      { resolve, getVersion: vi.fn(() => 0) } as any,
+      {
+        getAggregatedAutoImportComponents: vi.fn(() => ({ ResolverBadge: [{ start: 0, end: 0 }] })),
+        getAggregatedComponents: vi.fn(() => ({ ResolverBadge: [{ start: 0, end: 0 }] })),
+      } as any,
+      externalComponentEntryMap,
+    )
+
+    const json: Record<string, any> = {}
+    const injectedEntries = applyAutoImports('/project/src/pages/index/index', json)
+
+    expect(json.usingComponents).toEqual({
+      ResolverBadge: '/__weapp_vite_external__/resolver-ui/ResolverBadge',
+    })
+    expect(injectedEntries).toEqual(['/__weapp_vite_external__/resolver-ui/ResolverBadge'])
+    expect(externalComponentEntryMap.get('__weapp_vite_external__/resolver-ui/ResolverBadge')).toBe(
+      '/workspace/packages/resolver-ui/ResolverBadge.vue',
+    )
+  })
+
   it('reuses resolved auto imports when aggregated template graph and version are unchanged', () => {
     const hit = { 'van-button': [{ start: 0, end: 0 }] }
     const resolve = vi.fn(() => {

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/autoImport.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/autoImport.ts
@@ -4,11 +4,12 @@ import { get, isObject, set } from '@weapp-core/shared'
 export function createAutoImportAugmenter(
   autoImportService: CompilerContext['autoImportService'],
   wxmlService: CompilerContext['wxmlService'],
+  externalComponentEntryMap?: Map<string, string>,
 ) {
   const cache = new Map<string, {
     hit: Record<string, unknown>
     version: number
-    usingComponents: Record<string, string>
+    resolvedComponents: Record<string, { from: string, resolvedId?: string }>
   }>()
 
   return function applyAutoImports(baseName: string, json: any) {
@@ -20,35 +21,41 @@ export function createAutoImportAugmenter(
 
     const version = autoImportService.getVersion()
     const cached = cache.get(baseName)
-    const resolvedUsingComponents = cached && cached.hit === hit && cached.version === version
-      ? cached.usingComponents
+    const resolvedComponents = cached && cached.hit === hit && cached.version === version
+      ? cached.resolvedComponents
       : (() => {
-          const usingComponents: Record<string, string> = {}
+          const resolvedComponents: Record<string, { from: string, resolvedId?: string }> = {}
           for (const depComponentName of Object.keys(hit)) {
             const match = autoImportService.resolve(depComponentName, baseName)
             if (!match) {
               continue
             }
 
-            usingComponents[match.value.name] = match.value.from
+            resolvedComponents[match.value.name] = {
+              from: match.value.from,
+              resolvedId: match.value.resolvedId,
+            }
           }
           cache.set(baseName, {
             hit,
             version,
-            usingComponents,
+            resolvedComponents,
           })
-          return usingComponents
+          return resolvedComponents
         })()
 
     const injectedEntries: string[] = []
-    for (const [name, from] of Object.entries(resolvedUsingComponents)) {
+    for (const [name, resolved] of Object.entries(resolvedComponents)) {
       const usingComponents = get(json, 'usingComponents')
       if (isObject(usingComponents) && Reflect.has(usingComponents, name)) {
         continue
       }
 
-      set(json, `usingComponents.${name}`, from)
-      injectedEntries.push(from)
+      set(json, `usingComponents.${name}`, resolved.from)
+      injectedEntries.push(resolved.from)
+      if (resolved.resolvedId) {
+        externalComponentEntryMap?.set(resolved.from.replace(/^\/+/, ''), resolved.resolvedId)
+      }
     }
 
     return injectedEntries

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts
@@ -862,6 +862,28 @@ describe('useLoadEntry emitDirtyEntries', () => {
     expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual(['full-rebuild'])
   })
 
+  it('records config restart explanation for config dependency updates', async () => {
+    const ctx = createContext()
+    ctx.runtimeState.build.hmr.profile = {
+      dirtyReasonSummary: ['config-restart:2'],
+    }
+    const hook = useLoadEntry(ctx, {
+      hmr: {
+        sharedChunks: 'off',
+      },
+    })
+
+    const ids = ['/project/src/a.js', '/project/src/b.js']
+    seedResolvedEntries(hook.resolvedEntryMap, ids)
+    hook.markEntryDirty(ids[0], 'direct')
+    hook.markEntryDirty(ids[1], 'direct')
+
+    const pluginCtx = createPluginContext()
+    await hook.emitDirtyEntries.call(pluginCtx)
+
+    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual(['config-restart'])
+  })
+
   it('derives layout propagation explanation from upstream dirty causes', async () => {
     const ctx = createContext()
     ctx.runtimeState.build.hmr.profile = {

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.ts
@@ -54,6 +54,11 @@ function resolveUpstreamPendingReasonSummary(dirtyReasonSummary?: string[]) {
   const hasLayoutFallback = dirtyReasonSummary.some(item => item.startsWith('layout-fallback-full:'))
   const hasLayoutPropagation = dirtyReasonSummary.some(item => item.startsWith('layout-self:') || item.startsWith('layout-dependent:'))
   const hasAutoRoutesTopology = dirtyReasonSummary.some(item => item.startsWith('auto-routes-topology:'))
+  const hasConfigRestart = dirtyReasonSummary.some(item => item.startsWith('config-restart:'))
+
+  if (hasConfigRestart) {
+    pendingReasonSummary.push('config-restart')
+  }
 
   if (hasLayoutFallback) {
     pendingReasonSummary.push('layout-fallback-full')

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.ts
@@ -292,7 +292,11 @@ export function useLoadEntry(
       await loadEntry.call(this, resolvedId.id, entryType)
     },
   )
-  const applyAutoImports = createAutoImportAugmenter(ctx.autoImportService, ctx.wxmlService)
+  const applyAutoImports = createAutoImportAugmenter(
+    ctx.autoImportService,
+    ctx.wxmlService,
+    ctx.runtimeState.build.hmr.externalComponentEntryMap,
+  )
   const extendedLibManager = createExtendedLibManager()
 
   loadEntry = createEntryLoader({

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
@@ -210,6 +210,7 @@ function createMockContext(overrides: Record<string, unknown> = {}) {
       projectConfigPath: '/project/project.config.json',
       projectPrivateConfigPath: '/project/project.private.config.json',
       isDev: true,
+      configFileDependencies: [],
     },
     watcherService: {
       rollupWatcherMap,
@@ -522,6 +523,43 @@ describe('runtime buildPlugin service', () => {
 
     expect(buildMock).toHaveBeenCalledTimes(1)
     expect(loggerSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('watches user build.watch.include entries with snapshot sidecar watcher', async () => {
+    const watcher = createManualWatcher()
+    const sidecarWatcher = createManualSidecarWatcher()
+    chokidarWatchMock.mockReturnValue(sidecarWatcher)
+    buildMock
+      .mockResolvedValueOnce(watcher)
+      .mockResolvedValue({ output: [] })
+    const ctx = createMockContext()
+    ctx.configService.inlineConfig = {
+      build: {
+        watch: {
+          include: ['/workspace/packages/shared/**'],
+        },
+      },
+    }
+    ctx.runtimeState.build.hmr.resolvedEntryMap.set('/project/src/pages/logs/index.ts', {
+      id: '/project/src/pages/logs/index.ts',
+    })
+    const service = createBuildService(ctx)
+
+    const firstBuild = service.build({ skipNpm: true })
+    await watcher.subscribed
+    watcher.emit('START')
+    watcher.emit('END')
+    await firstBuild
+
+    const [patterns] = chokidarWatchMock.mock.calls[0]!
+    expect(patterns).toContain('/workspace/packages/shared/**')
+
+    sidecarWatcher.emit('change', '/workspace/packages/shared/message.ts')
+    await waitForMockCalls(buildMock, 2)
+
+    expect(ctx.runtimeState.build.hmr.dirtyEntrySet).toEqual(new Set([
+      '/project/src/pages/logs/index.ts',
+    ]))
   })
 
   it('ignores generated output updates in snapshot sidecar watcher', async () => {

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
@@ -186,6 +186,12 @@ function createMockContext(overrides: Record<string, unknown> = {}) {
     configService: {
       weappViteConfig: {},
       weappLibConfig: undefined,
+      loadOptions: {
+        cwd: '/project',
+        isDev: true,
+        mode: 'development',
+      },
+      load: vi.fn(async () => {}),
       merge: vi.fn((_meta: any, _inline: any, next: any) => next ?? {}),
       outDir: '/project/dist',
       outputExtensions: { wxss: 'wxss' },
@@ -563,6 +569,43 @@ describe('runtime buildPlugin service', () => {
     expect(sidecarWatcher.close).toHaveBeenCalledTimes(1)
     expect(ctx.watcherService.sidecarWatcherMap.size).toBe(0)
     expect(ctx.watcherService.rollupWatcherMap.size).toBe(0)
+  })
+
+  it('restarts the dev watcher after config dependency changes request a restart', async () => {
+    const watcher = createManualWatcher()
+    const restartedWatcher = createManualWatcher()
+    const sidecarWatcher = createManualSidecarWatcher()
+    const restartedSidecarWatcher = createManualSidecarWatcher()
+    chokidarWatchMock
+      .mockReturnValueOnce(sidecarWatcher)
+      .mockReturnValueOnce(restartedSidecarWatcher)
+    buildMock
+      .mockResolvedValueOnce(watcher)
+      .mockResolvedValueOnce(restartedWatcher)
+    const ctx = createMockContext()
+    const service = createBuildService(ctx)
+
+    const firstBuild = service.build({ skipNpm: true })
+    await watcher.subscribed
+    watcher.emit('START')
+    watcher.emit('END')
+    await firstBuild
+
+    service.requestConfigRestart('app')
+    watcher.emit('START')
+    watcher.emit('END')
+
+    await restartedWatcher.subscribed
+    restartedWatcher.emit('START')
+    restartedWatcher.emit('END')
+    await flushAsyncTasks()
+
+    expect(sidecarWatcher.close).toHaveBeenCalledTimes(1)
+    expect(ctx.configService.load).toHaveBeenCalledWith(ctx.configService.loadOptions)
+    expect(ctx.scanService.loadAppEntry).toHaveBeenCalledTimes(1)
+    expect(buildMock).toHaveBeenCalledTimes(2)
+    expect(ctx.watcherService.rollupWatcherMap.get('/')).toBe(restartedWatcher)
+    expect(loggerInfoMock).toHaveBeenCalledWith('检测到 Vite 配置变更，正在重启小程序开发构建...')
   })
 
   it('narrows snapshot sidecar watcher to sidecar globs and ignores generated roots', async () => {

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.ts
@@ -29,6 +29,7 @@ import { syncProjectConfigToOutput } from '../../utils/projectConfig'
 import { normalizeFsResolvedId } from '../../utils/resolvedId'
 import { generateLibDts } from '../libDts'
 import { hasLocalSubPackageNpmConfig } from '../npmPlugin/service'
+import { createRuntimeState } from '../runtimeState'
 import { createSharedBuildConfig } from '../sharedBuildConfig'
 import { createSidecarWatchOptions } from '../watch/options'
 import { createHmrProfileMetricsPlugin } from './hmrProfileMetricsPlugin'
@@ -44,6 +45,7 @@ export interface BuildOptions {
 export interface BuildService {
   queue: PQueue
   build: (options?: BuildOptions) => Promise<RolldownOutput | RolldownOutput[] | RolldownWatcher>
+  requestConfigRestart: (target?: BuildTarget) => void
   buildIndependentBundle: (root: string, meta: SubPackageMetaValue) => Promise<RolldownOutput>
   getIndependentOutput: (root: string) => RolldownOutput | undefined
   invalidateIndependentOutput: (root: string) => void
@@ -489,6 +491,7 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
   }
   const buildState = ctx.runtimeState.build
   const { queue } = buildState
+  const requestedConfigRestartBuilds = new Set<BuildTarget>()
   let autoTouchResolved = false
   let autoTouchChecked = false
 
@@ -522,6 +525,26 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
     const normalizedOutDir = normalizeFsResolvedId(configService.outDir)
     const normalizedFile = normalizeFsResolvedId(filePath)
     return normalizedFile === normalizedOutDir || normalizedFile.startsWith(`${normalizedOutDir}/`)
+  }
+
+  function shouldRestartDevBuild(target: BuildTarget) {
+    if (!configService.isDev) {
+      return false
+    }
+    return requestedConfigRestartBuilds.delete(target)
+  }
+
+  function resetRuntimeStateForConfigRestart() {
+    const fresh = createRuntimeState()
+    ctx.runtimeState.autoRoutes = fresh.autoRoutes
+    ctx.runtimeState.autoImport = fresh.autoImport
+    ctx.runtimeState.build.hmr = fresh.build.hmr
+    ctx.runtimeState.json = fresh.json
+    ctx.runtimeState.asset = fresh.asset
+    ctx.runtimeState.css = fresh.css
+    ctx.runtimeState.wxml = fresh.wxml
+    ctx.runtimeState.scan = fresh.scan
+    ctx.runtimeState.lib = fresh.lib
   }
 
   async function runDev(target: BuildTarget) {
@@ -709,6 +732,15 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
             void touch(appWxssPath).catch(() => {})
           }
           resolveWatcher(e)
+          if (shouldRestartDevBuild(target)) {
+            await watcher.close()
+            logger.info('检测到 Vite 配置变更，正在重启小程序开发构建...')
+            resetRuntimeStateForConfigRestart()
+            await configService.load(configService.loadOptions)
+            await scanService.loadAppEntry().catch(() => {})
+            logger.success('Vite 配置已重新加载，小程序开发构建已重启。')
+            await runDev(target)
+          }
         })().catch((error) => {
           resetHmrProfile()
           rejectWatcher(error)
@@ -909,6 +941,7 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
   async function runBuildTarget(target: BuildTarget) {
     ctx.currentBuildTarget = target
     if (configService.isDev) {
+      requestedConfigRestartBuilds.delete(target)
       return await runDev(target)
     }
     return await runProd(target)
@@ -966,6 +999,9 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
   return {
     queue,
     build: buildEntry,
+    requestConfigRestart(target: BuildTarget = 'app') {
+      requestedConfigRestartBuilds.add(target)
+    },
     buildIndependentBundle,
     getIndependentOutput,
     invalidateIndependentOutput,

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.ts
@@ -13,6 +13,7 @@ import path from 'pathe'
 import { build } from 'vite'
 import { debug, logger } from '../../context/shared'
 import { createCompilerContext } from '../../createContext'
+import { invalidateFileCache } from '../../plugins/utils/cache'
 import {
   configSuffixes,
   defaultIgnoredDirNames,
@@ -84,17 +85,70 @@ interface SnapshotBuildReason {
   file?: string
 }
 
-function shouldHandleSnapshotSidecarFile(filePath: string) {
-  return isSidecarFile(filePath)
+type ActiveConfigService = NonNullable<MutableCompilerContext['configService']>
+
+function shouldHandleSnapshotSidecarFile(filePath: string, configService: ActiveConfigService) {
+  if (isSidecarFile(filePath)) {
+    return true
+  }
+  const normalizedFile = normalizeFsResolvedId(filePath)
+  const normalizedSrcRoot = normalizeFsResolvedId(configService.absoluteSrcRoot)
+  if (normalizedFile === normalizedSrcRoot || normalizedFile.startsWith(`${normalizedSrcRoot}/`)) {
+    return false
+  }
+  return path.extname(filePath) !== ''
 }
 
-function createSnapshotSidecarWatchPatterns(root: string) {
-  return [
+function isGeneratedMiniprogramWatchInclude(pattern: string, configService: ActiveConfigService) {
+  if (pattern === '**') {
+    return true
+  }
+  const normalizedPattern = normalizeFsResolvedId(
+    path.isAbsolute(pattern) ? pattern : path.resolve(configService.cwd, pattern),
+  )
+  const normalizedSrcRoot = normalizeFsResolvedId(configService.absoluteSrcRoot)
+  if (normalizedPattern === normalizedSrcRoot || normalizedPattern.startsWith(`${normalizedSrcRoot}/`)) {
+    return true
+  }
+  if (configService.absolutePluginRoot) {
+    const normalizedPluginRoot = normalizeFsResolvedId(configService.absolutePluginRoot)
+    if (normalizedPattern === normalizedPluginRoot || normalizedPattern.startsWith(`${normalizedPluginRoot}/`)) {
+      return true
+    }
+  }
+  return (configService.configFileDependencies ?? []).some((dependency) => {
+    const normalizedDependency = normalizeFsResolvedId(dependency)
+    return normalizedPattern === normalizedDependency
+  })
+}
+
+function resolveUserBuildWatchInclude(configService: ActiveConfigService, inlineConfig?: InlineConfig) {
+  const buildWatch = inlineConfig?.build?.watch ?? configService?.inlineConfig?.build?.watch
+  if (!buildWatch || typeof buildWatch !== 'object') {
+    return []
+  }
+  const include = buildWatch.include
+  const includeList = Array.isArray(include)
+    ? include
+    : include ? [include] : []
+  return includeList
+    .filter((pattern): pattern is string => typeof pattern === 'string')
+    .filter(pattern => !isGeneratedMiniprogramWatchInclude(pattern, configService))
+    .map(pattern => path.normalize(path.isAbsolute(pattern) ? pattern : path.resolve(configService.cwd, pattern)))
+}
+
+function createSnapshotSidecarWatchPatterns(configService: ActiveConfigService, inlineConfig?: InlineConfig) {
+  const root = configService.absoluteSrcRoot
+  const patterns: string[] = [
     ...configSuffixes.map(suffix => path.join(root, `**/*${suffix}`)),
     ...Array.from(watchedCssExts).map(ext => path.join(root, `**/*${ext}`)),
     ...Array.from(watchedTemplateExts).map(ext => path.join(root, `**/*${ext}`)),
     ...Array.from(watchedScriptModuleExts).map(ext => path.join(root, `**/*${ext}`)),
   ]
+  for (const include of resolveUserBuildWatchInclude(configService, inlineConfig)) {
+    patterns.push(include)
+  }
+  return patterns
 }
 
 function createSnapshotSidecarIgnoredMatcher(ctx: MutableCompilerContext) {
@@ -642,6 +696,9 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
           return
         }
         if (reason?.event || reason?.file) {
+          if (reason.file) {
+            invalidateFileCache(reason.file)
+          }
           ctx.runtimeState.build.hmr.profile = {
             ...ctx.runtimeState.build.hmr.profile,
             eventId: createHmrProfileEventId(),
@@ -758,7 +815,7 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
       : '/'
     if (target === 'app' && !watcherService.sidecarWatcherMap.has(snapshotWatcherRoot)) {
       const snapshotWatcher = chokidar.watch(
-        createSnapshotSidecarWatchPatterns(configService.absoluteSrcRoot),
+        createSnapshotSidecarWatchPatterns(configService, buildOptions),
         createSidecarWatchOptions(configService, {
           persistent: true,
           ignoreInitial: true,
@@ -772,7 +829,7 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
         if (isDevOutputFile(id)) {
           return
         }
-        if (!shouldHandleSnapshotSidecarFile(id)) {
+        if (!shouldHandleSnapshotSidecarFile(id, configService)) {
           return
         }
         const sidecarStartedAt = performance.now()

--- a/packages/weapp-vite/src/runtime/config/createConfigService.ts
+++ b/packages/weapp-vite/src/runtime/config/createConfigService.ts
@@ -241,6 +241,7 @@ function createConfigService(ctx: MutableCompilerContext): ConfigService {
       emitDefaultAutoImportOutputs: true,
       projectConfig: {},
       config: {},
+      loadOptions: input,
       packageJson: {},
       platform: 'weapp',
       multiPlatform: resolveMultiPlatformConfig(false),
@@ -341,6 +342,9 @@ function createConfigService(ctx: MutableCompilerContext): ConfigService {
     },
     get inlineConfig() {
       return options.config
+    },
+    get loadOptions() {
+      return options.loadOptions
     },
     get weappViteConfig() {
       return options.config.weapp!

--- a/packages/weapp-vite/src/runtime/config/internal/loadConfig.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/loadConfig.ts
@@ -492,6 +492,7 @@ export function createLoadConfig(options: LoadConfigFactoryOptions) {
 
     return {
       config,
+      loadOptions: opts,
       aliasEntries,
       outputExtensions,
       packageJson,

--- a/packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.test.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.test.ts
@@ -464,6 +464,38 @@ describe('runtime config merge miniprogram', () => {
     })
   })
 
+  it('removes user build.watch from production inline config', () => {
+    const result = mergeMiniprogram(
+      {
+        ctx: {
+          configService: {
+            platform: 'weapp',
+          },
+        } as any,
+        subPackageMeta: undefined,
+        config: {
+          build: {
+            watch: {
+              include: ['/workspace/packages/ui/**'],
+            },
+          },
+        } as any,
+        cwd: '/project',
+        srcRoot: 'src',
+        packageJson: undefined,
+        isDev: false,
+        applyRuntimePlatform: vi.fn(),
+        injectBuiltinAliases: vi.fn(),
+        getDefineImportMetaEnv: () => ({}),
+        setOptions: vi.fn(),
+        oxcRolldownPlugin: undefined,
+      },
+      undefined,
+    )
+
+    expect(result.build?.watch).toBeUndefined()
+  })
+
   it('externalizes explicit npm build candidates and matching builtin alias paths', () => {
     resolveBuiltinPackageAliasesMock.mockReturnValue([
       {

--- a/packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.ts
@@ -132,8 +132,9 @@ export function resolveMiniprogramWatchInclude(options: {
     : options.userInclude
       ? [options.userInclude]
       : []
+  const include = [...userInclude, ...watchInclude]
   const seen = new Set<string>()
-  return [...userInclude, ...watchInclude].filter((item) => {
+  return include.filter((item) => {
     if (typeof item !== 'string') {
       return true
     }
@@ -206,6 +207,7 @@ export function mergeMiniprogram(options: MergeMiniprogramOptions, ...configs: P
 
   if (isDev) {
     const hmrWatchBuildDelay = 60
+    const userBuildWatch = config.build?.watch
     const watchInclude = resolveMiniprogramWatchInclude({
       cwd,
       srcRoot,
@@ -226,6 +228,9 @@ export function mergeMiniprogram(options: MergeMiniprogramOptions, ...configs: P
           modulePreload: false,
           watch: {
             buildDelay: hmrWatchBuildDelay,
+            ...(typeof userBuildWatch === 'object' && userBuildWatch
+              ? userBuildWatch
+              : {}),
             exclude: [
               ...defaultExcluded,
               mpDistRoot
@@ -244,6 +249,14 @@ export function mergeMiniprogram(options: MergeMiniprogramOptions, ...configs: P
         },
       },
     )
+    inline.build!.watch!.include = resolveMiniprogramWatchInclude({
+      cwd,
+      srcRoot,
+      pluginRoot: config.weapp?.pluginRoot,
+      buildScope: resolveBuildScope(config.weapp?.buildScope),
+      userInclude: inline.build?.watch?.include,
+      configFileDependencies,
+    })
     normalizeInlineConfigAfterDefu(inline, {
       cwd,
       ctx,
@@ -273,6 +286,9 @@ export function mergeMiniprogram(options: MergeMiniprogramOptions, ...configs: P
       },
     },
   )
+  if (inlineConfig.build) {
+    delete inlineConfig.build.watch
+  }
   normalizeInlineConfigAfterDefu(inlineConfig, {
     cwd,
     ctx,

--- a/packages/weapp-vite/src/runtime/config/types.ts
+++ b/packages/weapp-vite/src/runtime/config/types.ts
@@ -22,6 +22,7 @@ export interface LoadConfigOptions {
 }
 
 export interface LoadConfigResult {
+  loadOptions: LoadConfigOptions
   config: InlineConfig
   aliasEntries: ResolvedAlias[]
   outputExtensions: OutputExtensions
@@ -78,6 +79,7 @@ export interface PackageInfo {
 
 export interface ConfigService {
   options: LoadConfigResult
+  readonly loadOptions: LoadConfigOptions
   outputExtensions: OutputExtensions
   defineEnv: Record<string, any>
   packageManager: DetectResult

--- a/packages/weapp-vite/src/runtime/runtimeState.ts
+++ b/packages/weapp-vite/src/runtime/runtimeState.ts
@@ -34,6 +34,12 @@ interface LibEntryState {
 function createDefaultLoadConfigResult(): LoadConfigResult {
   return {
     config: {},
+    loadOptions: {
+      cwd: process.cwd(),
+      isDev: false,
+      mode: 'development',
+      emitDefaultAutoImportOutputs: true,
+    },
     aliasEntries: [],
     outputExtensions: getOutputExtensions(DEFAULT_MP_PLATFORM),
     packageJson: {},


### PR DESCRIPTION
## 变更说明

- dev 模式继承 `build.watch.*`，补齐 srcRoot 外依赖与配置依赖的监听入口
- 支持 autoImport resolver 通过 `resolvedId` 将 srcRoot 外 Vue 组件加入编译流，同时保留 `from` 作为输出路径
- 修复配置依赖变更后的 dev watcher 重启流程，并让生产 build 忽略 `build.watch`
- 补充外部 Vue、resolver、普通依赖、配置依赖与 build 退出相关的单测和 e2e 覆盖

## 验证

- `pnpm vitest run packages/weapp-vite/src/runtime/config/internal/merge/miniprogram.test.ts packages/weapp-vite/src/plugins/core/lifecycle/watch.test.ts packages/weapp-vite/src/runtime/buildPlugin/service.test.ts packages/weapp-vite/src/runtime/watch/options.test.ts packages/weapp-vite/src/plugins/core/helpers/graph.test.ts packages/weapp-vite/src/plugins/hooks/useLoadEntry/autoImport.test.ts packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry.test.ts`
- `pnpm --filter weapp-vite typecheck`
- `pnpm --filter weapp-vite lint:src`（仅剩既有 warning）
- `pnpm --filter weapp-vite build`
- `pnpm vitest run -c e2e/vitest.e2e.hmr-guard.config.ts e2e/ci/external-linked-vue-component.hmr.test.ts`
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`