### PR TITLE
fix(weapp-vite): 优化 slot fallback wrapper 产物稳定性

### DIFF
--- a/.changeset/slot-wrapper-global-registration.md
+++ b/.changeset/slot-wrapper-global-registration.md
@@ -1,0 +1,8 @@
+---
+"@weapp-core/constants": patch
+"@wevu/compiler": patch
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+优化 Vue SFC 具名插槽 fallback wrapper 的产物稳定性：微信平台内部 `virtualHost` wrapper 改为固定输出到根级内部组件路径，并优先通过 `app.json` 全局注册，减少页面和组件 JSON 的重复变更；同时允许显式配置 `slot-wrapper="block"`，默认策略仍保持更稳妥的内部 wrapper。

--- a/@weapp-core/constants/src/index.ts
+++ b/@weapp-core/constants/src/index.ts
@@ -56,6 +56,7 @@ export const WEVU_SCOPED_SLOT_OWNER_STORE_KEY = '__wevuScopedSlotOwnerStore'
 export const WEVU_SCOPED_SLOT_OWNER_SEED_KEY = '__wevuScopedSlotOwnerSeed'
 export const WEVU_SLOT_FALLBACK_VIRTUAL_HOST_TAG_NAME = 'weapp-slot-wrapper'
 export const WEVU_SLOT_FALLBACK_VIRTUAL_HOST_BASE = '__weapp_vite_slot_wrapper'
+export const WEVU_SLOT_FALLBACK_VIRTUAL_HOST_GLOBAL_PATH = `/${WEVU_SLOT_FALLBACK_VIRTUAL_HOST_BASE}`
 
 export const WEVU_CLASS_STYLE_RUNTIME_MODULE = '__weapp_vite'
 export const WEVU_CLASS_STYLE_RUNTIME_FILE = '__weapp_vite_class_style'

--- a/@weapp-core/constants/test/index.test.ts
+++ b/@weapp-core/constants/test/index.test.ts
@@ -11,6 +11,7 @@ import {
   WEVU_PUBLIC_RUNTIME_KEY,
   WEVU_SETUP_STATE_KEY,
   WEVU_SLOT_FALLBACK_VIRTUAL_HOST_BASE,
+  WEVU_SLOT_FALLBACK_VIRTUAL_HOST_GLOBAL_PATH,
   WEVU_SLOT_FALLBACK_VIRTUAL_HOST_TAG_NAME,
   WEVU_SLOT_NAMES_ATTR,
   WEVU_SLOT_NAMES_PROP,
@@ -33,5 +34,6 @@ describe('@weapp-core/constants', () => {
     expect(WEVU_SLOT_NAMES_ATTR).toBe('vue-slots')
     expect(WEVU_SLOT_FALLBACK_VIRTUAL_HOST_TAG_NAME).toBe('weapp-slot-wrapper')
     expect(WEVU_SLOT_FALLBACK_VIRTUAL_HOST_BASE).toBe('__weapp_vite_slot_wrapper')
+    expect(WEVU_SLOT_FALLBACK_VIRTUAL_HOST_GLOBAL_PATH).toBe('/__weapp_vite_slot_wrapper')
   })
 })

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -1049,9 +1049,10 @@ describe.sequential('e2e app: github-issues (build)', () => {
     const componentWxmlPath = path.join(DIST_ROOT, 'components/issue-613/Issue613Card/index.wxml')
     const forwarderWxmlPath = path.join(DIST_ROOT, 'components/issue-613/Issue613ViewForwarder/index.wxml')
     const forwarderJsonPath = path.join(DIST_ROOT, 'components/issue-613/Issue613ViewForwarder/index.json')
-    const wrapperWxmlPath = path.join(DIST_ROOT, 'components/issue-613/Issue613ViewForwarder/index.__weapp_vite_slot_wrapper.wxml')
-    const wrapperJsonPath = path.join(DIST_ROOT, 'components/issue-613/Issue613ViewForwarder/index.__weapp_vite_slot_wrapper.json')
-    const wrapperJsPath = path.join(DIST_ROOT, 'components/issue-613/Issue613ViewForwarder/index.__weapp_vite_slot_wrapper.js')
+    const appJsonPath = path.join(DIST_ROOT, 'app.json')
+    const wrapperWxmlPath = path.join(DIST_ROOT, '__weapp_vite_slot_wrapper.wxml')
+    const wrapperJsonPath = path.join(DIST_ROOT, '__weapp_vite_slot_wrapper.json')
+    const wrapperJsPath = path.join(DIST_ROOT, '__weapp_vite_slot_wrapper.js')
     const legacyForwarderWxmlPath = path.join(DIST_ROOT, 'components/issue-613/Issue613LegacyViewForwarder/index.wxml')
     const legacyForwarderJsonPath = path.join(DIST_ROOT, 'components/issue-613/Issue613LegacyViewForwarder/index.json')
     const blockForwarderWxmlPath = path.join(DIST_ROOT, 'components/issue-613/block-forwarder/index.wxml')
@@ -1059,6 +1060,7 @@ describe.sequential('e2e app: github-issues (build)', () => {
     const pageJs = await fs.readFile(pageJsPath, 'utf-8')
     const componentWxml = await fs.readFile(componentWxmlPath, 'utf-8')
     const forwarderWxml = await fs.readFile(forwarderWxmlPath, 'utf-8')
+    const appJson = await fs.readJSON(appJsonPath) as { usingComponents?: Record<string, string> }
     const forwarderJson = await fs.readJSON(forwarderJsonPath) as { usingComponents?: Record<string, string> }
     const wrapperWxml = await fs.readFile(wrapperWxmlPath, 'utf-8')
     const wrapperJson = await fs.readJSON(wrapperJsonPath) as { component?: boolean }
@@ -1074,7 +1076,8 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(forwarderWxml).toContain('<Issue613Card vue-slots="{{__wv_bind_0}}"')
     expect(forwarderWxml).toContain('<weapp-slot-wrapper slot="header"><slot /></weapp-slot-wrapper>')
     expect(forwarderWxml).toContain('<weapp-slot-wrapper slot="footer"><slot name="footer" /></weapp-slot-wrapper>')
-    expect(forwarderJson.usingComponents?.['weapp-slot-wrapper']).toBe('/components/issue-613/Issue613ViewForwarder/index.__weapp_vite_slot_wrapper')
+    expect(appJson.usingComponents?.['weapp-slot-wrapper']).toBe('/__weapp_vite_slot_wrapper')
+    expect(forwarderJson.usingComponents?.['weapp-slot-wrapper']).toBeUndefined()
     expect(wrapperWxml).toBe('<slot></slot>')
     expect(wrapperJson.component).toBe(true)
     expect(wrapperJs).toContain('virtualHost:true')

--- a/e2e/ide/github-issues.runtime.props.test.ts
+++ b/e2e/ide/github-issues.runtime.props.test.ts
@@ -169,15 +169,17 @@ describe.sequential('e2e app: github-issues / props', () => {
 
   it('issue #613: compares forwarded slot outlets with view and native block wrappers in DevTools runtime', async (ctx) => {
     const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-613/index.wxml')
+    const appJsonPath = path.join(DIST_ROOT, 'app.json')
     const viewForwarderWxmlPath = path.join(DIST_ROOT, 'components/issue-613/Issue613ViewForwarder/index.wxml')
     const viewForwarderJsonPath = path.join(DIST_ROOT, 'components/issue-613/Issue613ViewForwarder/index.json')
-    const wrapperJsPath = path.join(DIST_ROOT, 'components/issue-613/Issue613ViewForwarder/index.__weapp_vite_slot_wrapper.js')
+    const wrapperJsPath = path.join(DIST_ROOT, '__weapp_vite_slot_wrapper.js')
     const legacyForwarderWxmlPath = path.join(DIST_ROOT, 'components/issue-613/Issue613LegacyViewForwarder/index.wxml')
     const blockForwarderWxmlPath = path.join(DIST_ROOT, 'components/issue-613/block-forwarder/index.wxml')
     const pageJsPath = path.join(DIST_ROOT, 'pages/issue-613/index.js')
 
     const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
     const viewForwarderWxml = await fs.readFile(viewForwarderWxmlPath, 'utf-8')
+    const appJson = await fs.readJSON(appJsonPath) as { usingComponents?: Record<string, string> }
     const viewForwarderJson = await fs.readJSON(viewForwarderJsonPath) as { usingComponents?: Record<string, string> }
     const wrapperJs = await fs.readFile(wrapperJsPath, 'utf-8')
     const legacyForwarderWxml = await fs.readFile(legacyForwarderWxmlPath, 'utf-8')
@@ -187,7 +189,8 @@ describe.sequential('e2e app: github-issues / props', () => {
     expect(pageWxml).toContain('data-issue613-case="native-block"')
     expect(viewForwarderWxml).toContain('<weapp-slot-wrapper slot="header"><slot /></weapp-slot-wrapper>')
     expect(viewForwarderWxml).toContain('<weapp-slot-wrapper slot="footer"><slot name="footer" /></weapp-slot-wrapper>')
-    expect(viewForwarderJson.usingComponents?.['weapp-slot-wrapper']).toBe('/components/issue-613/Issue613ViewForwarder/index.__weapp_vite_slot_wrapper')
+    expect(appJson.usingComponents?.['weapp-slot-wrapper']).toBe('/__weapp_vite_slot_wrapper')
+    expect(viewForwarderJson.usingComponents?.['weapp-slot-wrapper']).toBeUndefined()
     expect(wrapperJs).toContain('virtualHost:true')
     expect(legacyForwarderWxml).toContain('<view slot="header"><slot /></view>')
     expect(viewForwarderWxml).not.toContain('slot-wrapper=')

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
@@ -2053,7 +2053,7 @@ describe('compileVueTemplateToWxml', () => {
     expect(code).toContain('<view slot="footer" class="owner-icon"><slot /></view>')
   })
 
-  it('falls back from block slot fallback wrapper to view with a warning', () => {
+  it('allows explicit block slot fallback wrapper', () => {
     const template = `
 <Child>
   <template #header>
@@ -2070,9 +2070,9 @@ describe('compileVueTemplateToWxml', () => {
       },
     )
 
-    expect(code).toContain('<view slot="header"><slot /></view>')
-    expect(code).not.toContain('<block slot="header">')
-    expect(warnings).toContain('slot fallback wrapper 不支持配置为 block，已回退为 view。')
+    expect(code).toContain('<block slot="header"><slot /></block>')
+    expect(code).not.toContain('<view slot="header"><slot /></view>')
+    expect(warnings).toEqual([])
   })
 
   it('emits slot presence metadata for implicit default slots', () => {

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts
@@ -314,13 +314,8 @@ function matchesSlotFallbackWrapperMatcher(matcher: SlotFallbackWrapperMatcher |
     : matcher.test(value)
 }
 
-function normalizeSlotFallbackWrapperTag(tag: string | undefined, context: TransformContext) {
-  const normalized = tag?.trim() || 'view'
-  if (normalized === 'block') {
-    context.warnings.push('slot fallback wrapper 不支持配置为 block，已回退为 view。')
-    return 'view'
-  }
-  return normalized
+function normalizeSlotFallbackWrapperTag(tag: string | undefined) {
+  return tag?.trim() || 'view'
 }
 
 function mergeSlotFallbackWrapperAttrs(
@@ -344,7 +339,7 @@ function resolveSlotFallbackWrapper(
   info: SlotFallbackWrapperResolveContext,
 ): ResolvedSlotFallbackWrapper {
   const resolved: ResolvedSlotFallbackWrapper = {
-    tag: normalizeSlotFallbackWrapperTag(context.slotFallbackWrapper.tag, context),
+    tag: normalizeSlotFallbackWrapperTag(context.slotFallbackWrapper.tag),
     attrs: context.slotFallbackWrapper.attrs,
     singleRootNoWrapper: context.slotFallbackWrapper.singleRootNoWrapper ?? context.slotSingleRootNoWrapper,
   }
@@ -356,7 +351,7 @@ function resolveSlotFallbackWrapper(
       && matchesSlotFallbackWrapperMatcher(rule.slot, info.slot)
     ) {
       if (rule.tag) {
-        resolved.tag = normalizeSlotFallbackWrapperTag(rule.tag, context)
+        resolved.tag = normalizeSlotFallbackWrapperTag(rule.tag)
       }
       if (rule.attrs) {
         resolved.attrs = mergeSlotFallbackWrapperAttrs(resolved.attrs, rule.attrs)
@@ -368,7 +363,7 @@ function resolveSlotFallbackWrapper(
   }
 
   if (info.local?.tag) {
-    resolved.tag = normalizeSlotFallbackWrapperTag(info.local.tag, context)
+    resolved.tag = normalizeSlotFallbackWrapperTag(info.local.tag)
   }
   if (info.local?.staticClass !== undefined) {
     resolved.staticClass = info.local.staticClass

--- a/packages/weapp-vite/docs/packaged/vue-sfc.md
+++ b/packages/weapp-vite/docs/packaged/vue-sfc.md
@@ -254,17 +254,17 @@
 
 如果需要回到旧版 `view` wrapper，可配置 `weapp.vue.template.slotFallbackWrapperStrategy: 'view'`，或显式配置 `slotFallbackWrapper: 'view'`。
 
-`block` 会被编译器拒绝并回退到 `view`。例如全局配置 `slotFallbackWrapper: 'block'` 后，转发 `<slot />` 的场景仍会生成：
+默认策略不会使用 `block`。如果显式配置 `slotFallbackWrapper: 'block'`，编译器会按原样输出：
 
 ```wxml
 <IssueCard>
-  <view slot="header">
+  <block slot="header">
     <slot />
-  </view>
+  </block>
 </IssueCard>
 ```
 
-编译器会输出 warning：`slot fallback wrapper 不支持配置为 block，已回退为 view。`
+注意：`block` 在转发 `<slot />` 的部分 WeChat DevTools 运行时场景中会丢失内容，因此不作为默认值。显式启用时需要自行确认目标运行时和具体插槽内容可用。
 
 你选择的 wrapper 必须能承载实际内容。比如下面的写法会让 `text` 包裹 `view`，这不适合真实运行时：
 

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle.platform.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle.platform.test.ts
@@ -87,6 +87,194 @@ describe('emitVueBundleAssets platform output', () => {
     return dir
   }
 
+  it('registers emitted slot fallback wrapper globally when app json is available', async () => {
+    const configService = {
+      isDev: false,
+      platform: 'weapp',
+      outputExtensions: {
+        wxml: 'wxml',
+        wxss: 'wxss',
+        wxs: 'wxs',
+        json: 'json',
+        js: 'js',
+      },
+      weappViteConfig: {
+        json: {},
+      },
+      relativeOutputPath: (p: string) => p.replace('/project/src/', ''),
+      absoluteSrcRoot: '/project/src',
+    } as unknown as CompilerContext['configService']
+
+    const ctx = {
+      configService,
+      scanService: {
+        independentSubPackageMap: new Map(),
+      },
+    } as CompilerContext
+
+    const filePath = '/project/src/components/Forwarder/index.vue'
+    const compilationCache = new Map([
+      [
+        filePath,
+        {
+          result: {
+            template: '<Child><weapp-slot-wrapper slot="header"><slot /></weapp-slot-wrapper></Child>',
+            config: JSON.stringify({
+              component: true,
+            }),
+            script: 'Component({})',
+            slotFallbackWrapperComponent: {
+              tagName: 'weapp-slot-wrapper',
+              componentBase: '__weapp_vite_slot_wrapper',
+              template: '<slot></slot>',
+              script: 'Component({options:{virtualHost:true,multipleSlots:true}})',
+              config: {
+                component: true,
+              },
+            },
+          },
+          isPage: false,
+        },
+      ],
+    ])
+
+    const emitFile = vi.fn()
+    const bundle: Record<string, any> = {
+      'app.json': {
+        type: 'asset',
+        fileName: 'app.json',
+        source: JSON.stringify({
+          pages: ['pages/index/index'],
+        }),
+      },
+    }
+
+    await emitVueBundleAssets(bundle, {
+      ctx,
+      pluginCtx: { emitFile },
+      compilationCache,
+      reExportResolutionCache: new Map(),
+      classStyleRuntimeWarned: { value: false },
+    })
+
+    const emittedAssets = new Map<string, string>()
+    for (const call of emitFile.mock.calls) {
+      const asset = call[0]
+      emittedAssets.set(asset.fileName, String(asset.source))
+    }
+
+    expect(JSON.parse(bundle['app.json'].source)).toEqual({
+      pages: ['pages/index/index'],
+      usingComponents: {
+        'weapp-slot-wrapper': '/__weapp_vite_slot_wrapper',
+      },
+    })
+    expect(emittedAssets.get('__weapp_vite_slot_wrapper.wxml')).toBe('<slot></slot>')
+    expect(JSON.parse(emittedAssets.get('__weapp_vite_slot_wrapper.json')!)).toEqual({
+      component: true,
+    })
+    expect(emittedAssets.get('__weapp_vite_slot_wrapper.js')).toContain('virtualHost:true')
+
+    const componentJson = JSON.parse(emittedAssets.get('components/Forwarder/index.json')!)
+    expect(componentJson.usingComponents?.['weapp-slot-wrapper']).toBeUndefined()
+  })
+
+  it('registers emitted slot fallback wrapper locally when app json is unavailable', async () => {
+    const configService = {
+      isDev: false,
+      platform: 'weapp',
+      outputExtensions: {
+        wxml: 'wxml',
+        wxss: 'wxss',
+        wxs: 'wxs',
+        json: 'json',
+        js: 'js',
+      },
+      weappViteConfig: {
+        json: {},
+      },
+      relativeOutputPath: (p: string) => p.replace('/project/src/', ''),
+      absoluteSrcRoot: '/project/src',
+    } as unknown as CompilerContext['configService']
+
+    const ctx = {
+      configService,
+      scanService: {
+        independentSubPackageMap: new Map(),
+      },
+    } as CompilerContext
+
+    const compilationCache = new Map([
+      [
+        '/project/src/components/ForwarderA/index.vue',
+        {
+          result: {
+            template: '<Child><weapp-slot-wrapper slot="header"><slot /></weapp-slot-wrapper></Child>',
+            config: JSON.stringify({
+              component: true,
+            }),
+            script: 'Component({})',
+            slotFallbackWrapperComponent: {
+              tagName: 'weapp-slot-wrapper',
+              componentBase: '__weapp_vite_slot_wrapper',
+              template: '<slot></slot>',
+              script: 'Component({options:{virtualHost:true,multipleSlots:true}})',
+              config: {
+                component: true,
+              },
+            },
+          },
+          isPage: false,
+        },
+      ],
+      [
+        '/project/src/components/ForwarderB/index.vue',
+        {
+          result: {
+            template: '<Child><weapp-slot-wrapper slot="header"><slot /></weapp-slot-wrapper></Child>',
+            config: JSON.stringify({
+              component: true,
+            }),
+            script: 'Component({})',
+            slotFallbackWrapperComponent: {
+              tagName: 'weapp-slot-wrapper',
+              componentBase: '__weapp_vite_slot_wrapper',
+              template: '<slot></slot>',
+              script: 'Component({options:{virtualHost:true,multipleSlots:true}})',
+              config: {
+                component: true,
+              },
+            },
+          },
+          isPage: false,
+        },
+      ],
+    ])
+
+    const emitFile = vi.fn()
+    const bundle: Record<string, any> = {}
+
+    await emitVueBundleAssets(bundle, {
+      ctx,
+      pluginCtx: { emitFile },
+      compilationCache,
+      reExportResolutionCache: new Map(),
+      classStyleRuntimeWarned: { value: false },
+    })
+
+    const emittedAssets = new Map<string, string>()
+    for (const call of emitFile.mock.calls) {
+      const asset = call[0]
+      emittedAssets.set(asset.fileName, String(asset.source))
+    }
+
+    const forwarderAJson = JSON.parse(emittedAssets.get('components/ForwarderA/index.json')!)
+    const forwarderBJson = JSON.parse(emittedAssets.get('components/ForwarderB/index.json')!)
+    expect(forwarderAJson.usingComponents?.['weapp-slot-wrapper']).toBe('/__weapp_vite_slot_wrapper')
+    expect(forwarderBJson.usingComponents?.['weapp-slot-wrapper']).toBe('/__weapp_vite_slot_wrapper')
+    expect(emitFile.mock.calls.filter(call => call[0]?.fileName === '__weapp_vite_slot_wrapper.js')).toHaveLength(1)
+  })
+
   it('returns original config/template when direct platform helpers hit fallback branches', () => {
     expect(resolveVueBundlePlatformAssetOptions({
       configService: undefined,

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/index.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/index.ts
@@ -1,6 +1,7 @@
 import type { CompilationCacheEntry, VueBundleState } from './shared'
 import { normalizeFsResolvedId } from '../../../../utils/resolvedId'
 import { hasAppShellTemplate, isAppVueFile, resolveAppShellLayout } from '../appShell'
+import { injectGlobalSlotFallbackWrapperUsingComponent } from '../slotFallbackWrapper'
 import { emitCompiledVueEntryAssets } from './emitCompiledEntry'
 import { emitFallbackPageAssets } from './emitFallbackPage'
 
@@ -68,4 +69,9 @@ export async function emitVueBundleAssets(
   await emitFallbackPageAssets(bundle, state, {
     emittedEntryIds: emitState.emittedEntryIds,
   })
+  injectGlobalSlotFallbackWrapperUsingComponent(
+    bundle,
+    state.ctx,
+    state.ctx.configService.outputExtensions,
+  )
 }

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/assets.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/assets.ts
@@ -6,7 +6,7 @@ import { getClassStyleWxsSource } from 'wevu/compiler'
 import { resolveClassStyleWxsLocationForBase } from '../../classStyle'
 import { emitClassStyleWxsAssetIfMissing, emitSfcJsonAsset, emitSfcStyleIfMissing } from '../../emitAssets'
 import { emitScopedSlotAssets } from '../../scopedSlot'
-import { emitSlotFallbackWrapperComponentAsset, injectSlotFallbackWrapperUsingComponent } from '../../slotFallbackWrapper'
+import { emitSlotFallbackWrapperComponentAsset, injectLocalSlotFallbackWrapperUsingComponentIfNeeded } from '../../slotFallbackWrapper'
 import { resolveBundleOutputExtensions } from '../outputExtensions'
 import { emitPlatformTemplateAsset, preparePlatformConfigAsset, resolveVueBundlePlatformAssetOptions } from '../platform'
 
@@ -210,6 +210,12 @@ export function emitSharedVueEntryAssets(options: {
     defaults: scopedSlotDefaults,
     mergeStrategy: scopedSlotMergeStrategy,
   })
+  injectLocalSlotFallbackWrapperUsingComponentIfNeeded({
+    bundle,
+    result,
+    compilerCtx: ctx,
+    outputExtensions,
+  })
   emitSlotFallbackWrapperComponentAsset({
     ctx: pluginCtx,
     bundle,
@@ -222,7 +228,6 @@ export function emitSharedVueEntryAssets(options: {
       mergeStrategy: scopedSlotMergeStrategy,
     },
   })
-  injectSlotFallbackWrapperUsingComponent(result, relativeBase, ctx)
 
   return {
     classStyleWxs,

--- a/packages/weapp-vite/src/plugins/vue/transform/slotFallbackWrapper.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/slotFallbackWrapper.ts
@@ -1,8 +1,12 @@
 import type { VueTransformResult } from 'wevu/compiler'
 import type { CompilerContext } from '../../../context'
+import {
+  WEVU_SLOT_FALLBACK_VIRTUAL_HOST_BASE,
+  WEVU_SLOT_FALLBACK_VIRTUAL_HOST_GLOBAL_PATH,
+  WEVU_SLOT_FALLBACK_VIRTUAL_HOST_TAG_NAME,
+} from '@weapp-core/constants'
 import { createJsonMerger } from 'wevu/compiler'
 import { resolveJson } from '../../../utils'
-import { toPosixPath } from '../../../utils/path'
 import { resolveBundleOutputExtensions } from './bundle/outputExtensions'
 import { emitSfcJsonAsset, emitSfcTemplateIfMissing } from './emitAssets'
 import { resolveVueTransformJsonPlatformOptions } from './platform'
@@ -10,6 +14,15 @@ import { resolveVueTransformJsonPlatformOptions } from './platform'
 interface Emitter {
   emitFile: (asset: { type: 'asset', fileName: string, source: string }) => void
 }
+
+interface BundleAsset {
+  type: 'asset'
+  fileName?: string
+  source?: string | Uint8Array
+}
+
+const slotFallbackWrapperUsageByBundle = new WeakMap<Record<string, any>, Set<string>>()
+const slotFallbackWrapperScriptByBundle = new WeakMap<Record<string, any>, Map<string, string>>()
 
 function parseJsonSafely(source: string | undefined): Record<string, any> {
   if (!source) {
@@ -24,6 +37,27 @@ function parseJsonSafely(source: string | undefined): Record<string, any> {
   catch {
     return {}
   }
+}
+
+function stringifyJson(json: Record<string, any>) {
+  return JSON.stringify(json, null, 2)
+}
+
+function isAsset(value: any): value is BundleAsset {
+  return value?.type === 'asset'
+}
+
+function getAssetSource(asset: BundleAsset | undefined) {
+  return asset?.source?.toString?.() ?? ''
+}
+
+function upsertSlotFallbackWrapperUsingComponent(json: Record<string, any>) {
+  const usingComponents = json.usingComponents && typeof json.usingComponents === 'object' && !Array.isArray(json.usingComponents)
+    ? { ...json.usingComponents }
+    : {}
+  usingComponents[WEVU_SLOT_FALLBACK_VIRTUAL_HOST_TAG_NAME] = WEVU_SLOT_FALLBACK_VIRTUAL_HOST_GLOBAL_PATH
+  json.usingComponents = usingComponents
+  return json
 }
 
 function normalizeJsonConfigForPlatform(
@@ -52,6 +86,88 @@ function normalizeJsonConfigForPlatform(
   }
 }
 
+function getSlotFallbackWrapperUsage(bundle: Record<string, any>) {
+  let usage = slotFallbackWrapperUsageByBundle.get(bundle)
+  if (!usage) {
+    usage = new Set<string>()
+    slotFallbackWrapperUsageByBundle.set(bundle, usage)
+  }
+  return usage
+}
+
+function markSlotFallbackWrapperUsage(bundle: Record<string, any>, relativeBase: string) {
+  getSlotFallbackWrapperUsage(bundle).add(relativeBase)
+}
+
+function getSlotFallbackWrapperScriptCache(bundle: Record<string, any>) {
+  let cache = slotFallbackWrapperScriptByBundle.get(bundle)
+  if (!cache) {
+    cache = new Map<string, string>()
+    slotFallbackWrapperScriptByBundle.set(bundle, cache)
+  }
+  return cache
+}
+
+function injectSlotFallbackWrapperIntoJsonAsset(
+  bundle: Record<string, any>,
+  jsonFileName: string,
+  compilerCtx?: Pick<CompilerContext, 'configService'>,
+) {
+  const output = bundle[jsonFileName]
+  if (!isAsset(output)) {
+    return false
+  }
+
+  const json = upsertSlotFallbackWrapperUsingComponent(parseJsonSafely(getAssetSource(output)))
+  output.source = stringifyJson(normalizeJsonConfigForPlatform(json, compilerCtx))
+  return true
+}
+
+export function injectGlobalSlotFallbackWrapperUsingComponent(
+  bundle: Record<string, any>,
+  compilerCtx?: Pick<CompilerContext, 'configService'>,
+  outputExtensions?: NonNullable<CompilerContext['configService']>['outputExtensions'],
+) {
+  const { jsonExtension } = resolveBundleOutputExtensions(outputExtensions)
+  const usage = slotFallbackWrapperUsageByBundle.get(bundle)
+  if (!usage?.size) {
+    return false
+  }
+
+  if (injectSlotFallbackWrapperIntoJsonAsset(bundle, `app.${jsonExtension}`, compilerCtx)) {
+    return true
+  }
+
+  for (const relativeBase of usage) {
+    injectSlotFallbackWrapperIntoJsonAsset(bundle, `${relativeBase}.${jsonExtension}`, compilerCtx)
+  }
+  return false
+}
+
+function hasGlobalSlotFallbackWrapperUsingComponentAsset(
+  bundle: Record<string, any>,
+  outputExtensions?: NonNullable<CompilerContext['configService']>['outputExtensions'],
+) {
+  const { jsonExtension } = resolveBundleOutputExtensions(outputExtensions)
+  return isAsset(bundle[`app.${jsonExtension}`])
+}
+
+export function injectLocalSlotFallbackWrapperUsingComponentIfNeeded(options: {
+  bundle: Record<string, any>
+  result: Pick<VueTransformResult, 'config' | 'slotFallbackWrapperComponent'>
+  compilerCtx?: Pick<CompilerContext, 'configService'>
+  outputExtensions?: NonNullable<CompilerContext['configService']>['outputExtensions']
+}) {
+  const component = options.result.slotFallbackWrapperComponent
+  if (!component || hasGlobalSlotFallbackWrapperUsingComponentAsset(options.bundle, options.outputExtensions)) {
+    return false
+  }
+
+  const config = upsertSlotFallbackWrapperUsingComponent(parseJsonSafely(options.result.config))
+  options.result.config = stringifyJson(normalizeJsonConfigForPlatform(config, options.compilerCtx))
+  return true
+}
+
 function emitSlotFallbackWrapperScriptIfMissing(
   ctx: Emitter,
   bundle: Record<string, any>,
@@ -66,28 +182,14 @@ function emitSlotFallbackWrapperScriptIfMissing(
     }
     return
   }
-  if (!existing) {
-    ctx.emitFile({ type: 'asset', fileName, source: script })
-  }
-}
-
-export function injectSlotFallbackWrapperUsingComponent(
-  result: Pick<VueTransformResult, 'config' | 'slotFallbackWrapperComponent'>,
-  relativeBase: string,
-  compilerCtx?: Pick<CompilerContext, 'configService'>,
-) {
-  const component = result.slotFallbackWrapperComponent
-  if (!component) {
+  const cache = getSlotFallbackWrapperScriptCache(bundle)
+  if (cache.get(fileName) === script) {
     return
   }
-
-  const config = parseJsonSafely(result.config)
-  const usingComponents = config.usingComponents && typeof config.usingComponents === 'object' && !Array.isArray(config.usingComponents)
-    ? { ...config.usingComponents }
-    : {}
-  usingComponents[component.tagName] = `/${toPosixPath(`${relativeBase}.${component.componentBase}`)}`
-  config.usingComponents = usingComponents
-  result.config = JSON.stringify(normalizeJsonConfigForPlatform(config, compilerCtx), null, 2)
+  if (!existing) {
+    ctx.emitFile({ type: 'asset', fileName, source: script })
+    cache.set(fileName, script)
+  }
 }
 
 export function emitSlotFallbackWrapperComponentAsset(options: {
@@ -108,7 +210,8 @@ export function emitSlotFallbackWrapperComponentAsset(options: {
   }
 
   const { templateExtension, jsonExtension, scriptExtension } = resolveBundleOutputExtensions(options.outputExtensions)
-  const componentBase = `${options.relativeBase}.${component.componentBase}`
+  const componentBase = WEVU_SLOT_FALLBACK_VIRTUAL_HOST_BASE
+  markSlotFallbackWrapperUsage(options.bundle, options.relativeBase)
   emitSfcTemplateIfMissing(
     options.ctx,
     options.bundle,

--- a/website/config/vue.md
+++ b/website/config/vue.md
@@ -546,9 +546,9 @@ export default defineConfig({
 </IssueCard>
 ```
 
-#### `block`：会被拒绝并回退到 `view` {#slot-wrapper-block}
+#### `block`：显式配置后按原样输出 {#slot-wrapper-block}
 
-不要把 `block` 配成 fallback wrapper：
+默认策略不会把 `block` 作为 fallback wrapper。你可以显式配置 `block`，编译器会按原样输出，但这需要自行承担宿主运行时兼容性风险：
 
 ```ts
 import { defineConfig } from 'weapp-vite/config'
@@ -576,17 +576,17 @@ export default defineConfig({
 </template>
 ```
 
-不会生成 `<block slot="header"><slot /></block>`，而是回退成 `view`：
+会生成 `<block slot="header"><slot /></block>`：
 
 ```wxml
 <IssueCard>
-  <view slot="header">
+  <block slot="header">
     <slot />
-  </view>
+  </block>
 </IssueCard>
 ```
 
-原因是 issue #613 的真实 WeChat DevTools e2e 已验证：`<block slot="header"><slot></slot></block>` 在转发 `<slot />` 的场景会丢失内容。编译器会输出 warning：`slot fallback wrapper 不支持配置为 block，已回退为 view。`
+注意：issue #613 的真实 WeChat DevTools e2e 已验证，`<block slot="header"><slot></slot></block>` 在转发 `<slot />` 的部分场景会丢失内容。因此 `block` 不作为默认值，只建议在你确认目标运行时和具体插槽内容可用时显式启用。
 
 #### wrapper 必须能承载实际内容 {#slot-wrapper-content}
 

--- a/website/public/llms-index.json
+++ b/website/public/llms-index.json
@@ -916,7 +916,7 @@
         "slot-wrapper-：覆盖指定具名插槽 {#slot-wrapper-named}",
         "slot-wrapper-class/style：给生成的 wrapper 加属性 {#slot-wrapper-attrs}",
         "slot-single-root-no-wrapper-：单根真实节点下推 slot {#slot-single-root-no-wrapper-named}",
-        "block：会被拒绝并回退到 view {#slot-wrapper-block}",
+        "block：显式配置后按原样输出 {#slot-wrapper-block}",
         "wrapper 必须能承载实际内容 {#slot-wrapper-content}",
         "weapp.vue.autoImport {#weapp-vue-autoimport}"
       ],

--- a/website/wevu/vue-sfc/template.md
+++ b/website/wevu/vue-sfc/template.md
@@ -345,17 +345,17 @@ export default defineConfig({
 
 ### `block` 和内容承载限制
 
-`block` 会被编译器拒绝并回退到 `view`。例如配置 `slotFallbackWrapper: 'block'` 后，上面的转发 `<slot />` 场景仍会生成：
+默认策略不会使用 `block`。如果显式配置 `slotFallbackWrapper: 'block'`，编译器会按原样输出：
 
 ```wxml
 <IssueCard>
-  <view slot="header">
+  <block slot="header">
     <slot />
-  </view>
+  </block>
 </IssueCard>
 ```
 
-编译器会输出 warning：`slot fallback wrapper 不支持配置为 block，已回退为 view。`
+注意：`block` 在转发 `<slot />` 的部分 WeChat DevTools 运行时场景中会丢失内容，因此不作为默认值。显式启用时需要自行确认目标运行时和具体插槽内容可用。
 
 你选择的 wrapper 还必须能承载实际内容。比如：
 


### PR DESCRIPTION
## 变更说明

- 将内部 slot fallback wrapper 固定输出到根级 `__weapp_vite_slot_wrapper.*`，减少页面/组件产物路径波动。
- 优先在 `app.json` 全局注册 `weapp-slot-wrapper`，无 `app.json` 时保留本地 JSON 兜底注册。
- 允许显式配置 `slot-wrapper="block"`，默认策略仍使用内部 virtualHost wrapper。
- 同步更新 #613 回归断言、Vue SFC 文档和 changeset。

## 验证

- `pnpm vitest run @weapp-core/constants/test/index.test.ts packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts packages/weapp-vite/src/plugins/vue/transform/bundle/shared.test.ts packages/weapp-vite/src/plugins/vue/transform/bundle.platform.test.ts --pool forks`
- `pnpm eslint @weapp-core/constants/src/index.ts @weapp-core/constants/test/index.test.ts packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/elements/tag-slot.ts packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts packages/weapp-vite/src/plugins/vue/transform/slotFallbackWrapper.ts packages/weapp-vite/src/plugins/vue/transform/bundle/index.ts packages/weapp-vite/src/plugins/vue/transform/bundle/shared/assets.ts packages/weapp-vite/src/plugins/vue/transform/bundle.platform.test.ts e2e/ci/github-issues.build.test.ts e2e/ide/github-issues.runtime.props.test.ts`
- `pnpm --filter @weapp-core/constants typecheck`
- `pnpm --filter @wevu/compiler typecheck`
- `pnpm --filter weapp-vite typecheck`
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`
- `node --import tsx scripts/check-catalog-changeset.ts`
- `pnpm vitest run -c e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #613" --pool forks`

Closes #630