### PR TITLE
perf(wevu): cache plain object eligibility

### DIFF
--- a/.changeset/tidy-hotcards-flash.md
+++ b/.changeset/tidy-hotcards-flash.md
@@ -1,0 +1,7 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复开发态新增自动导入 Vue SFC 组件时，组件入口可能已被标记为 loaded 导致模板产物没有重新生成的问题。
+同步发布 create-weapp-vite，保持脚手架模板依赖的 weapp-vite 版本与本次修复一致。

--- a/.changeset/tidy-hotcards-flash.md
+++ b/.changeset/tidy-hotcards-flash.md
@@ -2,9 +2,11 @@
 "weapp-vite": patch
 "create-weapp-vite": patch
 "wevu": patch
+"@wevu/compiler": patch
 ---
 
 修复开发态新增自动导入 Vue SFC 组件时，组件入口可能已被标记为 loaded 导致模板产物没有重新生成的问题。
 修复开发态 HMR 新 bundle 复用旧 SFC asset 缓存时，slot fallback wrapper / shared template 等运行时资产可能没有重新 emit，导致微信 DevTools 偶发找不到产物文件的问题。
 修复 wevu 运行时 setData 调度与 diff 处理中对象判定缓存不稳定的问题，降低运行时更新开销。
+修复模板运行时表达式中成员链 ref 没有在使用前解引用的问题，避免 `JSON.stringify(query.data)` 这类表达式在小程序运行时误序列化 ref 对象。
 同步发布 create-weapp-vite，保持脚手架模板依赖的 weapp-vite 版本与本次修复一致。

--- a/.changeset/tidy-hotcards-flash.md
+++ b/.changeset/tidy-hotcards-flash.md
@@ -9,4 +9,5 @@
 修复开发态 HMR 新 bundle 复用旧 SFC asset 缓存时，slot fallback wrapper / shared template 等运行时资产可能没有重新 emit，导致微信 DevTools 偶发找不到产物文件的问题。
 修复 wevu 运行时 setData 调度与 diff 处理中对象判定缓存不稳定的问题，降低运行时更新开销。
 修复模板运行时表达式中成员链 ref 没有在使用前解引用的问题，避免 `JSON.stringify(query.data)` 这类表达式在小程序运行时误序列化 ref 对象。
+修复 wevu 模板运行时绑定在 setup 执行前参与原生初始 computed 预计算时提前求值的问题，并补充 vue-query IDE 运行时错误回归用例。
 同步发布 create-weapp-vite，保持脚手架模板依赖的 weapp-vite 版本与本次修复一致。

--- a/.changeset/tidy-hotcards-flash.md
+++ b/.changeset/tidy-hotcards-flash.md
@@ -1,7 +1,10 @@
 ---
 "weapp-vite": patch
 "create-weapp-vite": patch
+"wevu": patch
 ---
 
 修复开发态新增自动导入 Vue SFC 组件时，组件入口可能已被标记为 loaded 导致模板产物没有重新生成的问题。
+修复开发态 HMR 新 bundle 复用旧 SFC asset 缓存时，slot fallback wrapper / shared template 等运行时资产可能没有重新 emit，导致微信 DevTools 偶发找不到产物文件的问题。
+修复 wevu 运行时 setData 调度与 diff 处理中对象判定缓存不稳定的问题，降低运行时更新开销。
 同步发布 create-weapp-vite，保持脚手架模板依赖的 weapp-vite 版本与本次修复一致。

--- a/apps/wevu-runtime-demo/src/pages/vue-query/index.vue
+++ b/apps/wevu-runtime-demo/src/pages/vue-query/index.vue
@@ -54,18 +54,6 @@ const generatedAtText = computed(() => {
   return query.data.value?.generatedAt ?? '--'
 })
 
-const queryKeyText = computed(() => {
-  return JSON.stringify(queryKey.value)
-})
-
-const queryPayloadText = computed(() => {
-  return JSON.stringify(query.data.value ?? null, null, 2)
-})
-
-const hasQueryData = computed(() => {
-  return query.data.value != null
-})
-
 async function refetchNow() {
   await query.refetch()
 }
@@ -109,7 +97,7 @@ function resetCacheAndReload() {
       <view class="row">
         <text class="label">queryKey</text>
         <text class="value mono">
-          {{ queryKeyText }}
+          {{ JSON.stringify(queryKey) }}
         </text>
       </view>
       <view class="row">
@@ -118,12 +106,12 @@ function resetCacheAndReload() {
           {{ generatedAtText }}
         </text>
       </view>
-      <view v-if="hasQueryData" class="payload">
+      <view v-if="query.data" class="payload">
         <text class="payload-title">
           最新数据
         </text>
         <text class="payload-text mono">
-          {{ queryPayloadText }}
+          {{ JSON.stringify(query.data, null, 2) }}
         </text>
       </view>
       <view v-if="query.isError" class="error-box">

--- a/apps/wevu-runtime-demo/src/pages/vue-query/index.vue
+++ b/apps/wevu-runtime-demo/src/pages/vue-query/index.vue
@@ -54,6 +54,18 @@ const generatedAtText = computed(() => {
   return query.data.value?.generatedAt ?? '--'
 })
 
+const queryKeyText = computed(() => {
+  return JSON.stringify(queryKey.value)
+})
+
+const queryPayloadText = computed(() => {
+  return JSON.stringify(query.data.value ?? null, null, 2)
+})
+
+const hasQueryData = computed(() => {
+  return query.data.value != null
+})
+
 async function refetchNow() {
   await query.refetch()
 }
@@ -97,7 +109,7 @@ function resetCacheAndReload() {
       <view class="row">
         <text class="label">queryKey</text>
         <text class="value mono">
-          {{ JSON.stringify(queryKey) }}
+          {{ queryKeyText }}
         </text>
       </view>
       <view class="row">
@@ -106,12 +118,12 @@ function resetCacheAndReload() {
           {{ generatedAtText }}
         </text>
       </view>
-      <view v-if="query.data" class="payload">
+      <view v-if="hasQueryData" class="payload">
         <text class="payload-title">
           最新数据
         </text>
         <text class="payload-text mono">
-          {{ JSON.stringify(query.data, null, 2) }}
+          {{ queryPayloadText }}
         </text>
       </view>
       <view v-if="query.isError" class="error-box">

--- a/e2e/ide/runtimeErrors.test.ts
+++ b/e2e/ide/runtimeErrors.test.ts
@@ -67,4 +67,23 @@ describe('runtimeErrors', () => {
     expect(collector.getSince(marker)).toEqual(['[console:error] after marker error'])
     expect(collector.getLogsSince(marker)).toEqual(['[console:error] after marker error'])
   })
+
+  it('collects DevTools wrapped console errors', () => {
+    const miniProgram = createMiniProgramEmitter()
+    const collector = attachRuntimeErrorCollector(miniProgram)
+    const marker = collector.mark()
+
+    miniProgram.emit('console', {
+      message: {
+        level: 'error',
+        args: [
+          { value: '[wevu] 模板运行时表达式执行失败: __wv_bind_0 = JSON.stringify(queryKey)' },
+          { value: { name: 'TypeError', message: 'Converting circular structure to JSON' } },
+        ],
+      },
+    })
+
+    expect(collector.getSince(marker)[0]).toContain('模板运行时表达式执行失败')
+    expect(collector.getSince(marker)[0]).toContain('TypeError: Converting circular structure to JSON')
+  })
 })

--- a/e2e/ide/runtimeErrors.ts
+++ b/e2e/ide/runtimeErrors.ts
@@ -2,7 +2,48 @@ function resolveConsolePayload(entry: any) {
   if (entry && typeof entry === 'object' && entry.entry && typeof entry.entry === 'object') {
     return entry.entry
   }
+  if (entry && typeof entry === 'object' && entry.message && typeof entry.message === 'object') {
+    return entry.message
+  }
+  if (entry && typeof entry === 'object' && entry.params && typeof entry.params === 'object') {
+    return entry.params
+  }
   return entry
+}
+
+function normalizeConsoleArg(raw: any) {
+  if (typeof raw === 'string') {
+    return raw
+  }
+  if (raw && typeof raw === 'object') {
+    const description = typeof raw.description === 'string' ? raw.description : ''
+    const value = 'value' in raw ? raw.value : raw
+    if (value && typeof value === 'object') {
+      const name = typeof value.name === 'string' ? value.name : ''
+      const message = typeof value.message === 'string' ? value.message : ''
+      const stack = typeof value.stack === 'string' ? value.stack : ''
+      const errorText = [name, message].filter(Boolean).join(': ')
+      return [description || errorText, stack].filter(Boolean).join('\n')
+    }
+    if (typeof value === 'string') {
+      return value
+    }
+    if (description) {
+      return description
+    }
+    try {
+      return JSON.stringify(value)
+    }
+    catch {
+      return String(value)
+    }
+  }
+  try {
+    return JSON.stringify(raw)
+  }
+  catch {
+    return String(raw)
+  }
 }
 
 function normalizeConsoleText(entry: any) {
@@ -12,18 +53,7 @@ function normalizeConsoleText(entry: any) {
   }
   if (Array.isArray(payload?.args) && payload.args.length > 0) {
     const text = payload.args
-      .map((item: any) => {
-        const raw = item && typeof item === 'object' && 'value' in item ? item.value : item
-        if (typeof raw === 'string') {
-          return raw
-        }
-        try {
-          return JSON.stringify(raw)
-        }
-        catch {
-          return String(raw)
-        }
-      })
+      .map((item: any) => normalizeConsoleArg(item && typeof item === 'object' && 'value' in item ? item.value : item))
       .join(' ')
       .trim()
     if (text) {

--- a/e2e/ide/wevu-runtime-demo.vue-query.weapp.test.ts
+++ b/e2e/ide/wevu-runtime-demo.vue-query.weapp.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, describe, expect, it } from 'vitest'
 import { isDevtoolsHttpPortError, launchAutomator } from '../utils/automator'
+import { attachRuntimeErrorCollector } from './runtimeErrors'
 import { APP_ROOT, ensureWevuRuntimeDemoBuilt } from './wevu-runtime-demo.shared'
 
 const ROUTE = '/pages/vue-query/index'
@@ -70,8 +71,31 @@ async function invokeOrTap(page: any, methodName: string, tapIndex: number, ...a
   }
 }
 
+function expectNoVueQueryRuntimeExpressionErrors(runtimeLogs: string[]) {
+  expect(runtimeLogs).toEqual([])
+  const joinedLogs = runtimeLogs.join('\n')
+  expect(joinedLogs).not.toContain('模板运行时表达式执行失败')
+  expect(joinedLogs).not.toContain('JSON.stringify(query.data')
+  expect(joinedLogs).not.toContain('JSON.stringify(queryKey')
+}
+
+async function expectNoVueQueryRuntimeExpressionErrorsAfterSettled(
+  page: any,
+  runtimeErrors: ReturnType<typeof attachRuntimeErrorCollector>,
+  marker: number,
+) {
+  if (typeof page?.waitFor === 'function') {
+    await page.waitFor(350)
+  }
+  else {
+    await sleep(350)
+  }
+  expectNoVueQueryRuntimeExpressionErrors(runtimeErrors.getSince(marker))
+}
+
 describe.sequential('wevu runtime demo vue-query (weapp e2e)', () => {
   let miniProgram: any
+  let runtimeErrors: ReturnType<typeof attachRuntimeErrorCollector> | undefined
 
   async function getMiniProgram(ctx: { skip: (message?: string) => void }) {
     if (miniProgram) {
@@ -84,6 +108,7 @@ describe.sequential('wevu runtime demo vue-query (weapp e2e)', () => {
       miniProgram = await launchAutomator({
         projectPath: APP_ROOT,
       })
+      runtimeErrors = attachRuntimeErrorCollector(miniProgram)
       return miniProgram
     }
     catch (error) {
@@ -95,6 +120,7 @@ describe.sequential('wevu runtime demo vue-query (weapp e2e)', () => {
   }
 
   afterAll(async () => {
+    runtimeErrors?.dispose()
     if (!miniProgram) {
       return
     }
@@ -103,6 +129,10 @@ describe.sequential('wevu runtime demo vue-query (weapp e2e)', () => {
 
   it('resolves pending query and keeps query state reactive across tab switch and key rotation', async (ctx) => {
     const miniProgram = await getMiniProgram(ctx)
+    if (!runtimeErrors) {
+      throw new Error('Runtime error collector is not attached.')
+    }
+    const initialMarker = runtimeErrors.mark()
     const page = await miniProgram.reLaunch(ROUTE)
     if (!page) {
       throw new Error(`Failed to launch route ${ROUTE}`)
@@ -121,7 +151,9 @@ describe.sequential('wevu runtime demo vue-query (weapp e2e)', () => {
     ))
 
     expect(initialState.query.data.label).toBe('概览数据')
+    await expectNoVueQueryRuntimeExpressionErrorsAfterSettled(page, runtimeErrors, initialMarker)
 
+    const switchMarker = runtimeErrors.mark()
     await invokeOrTap(page, 'switchTab', 1, 'detail')
     const switchedState = await waitForDataMatch(page, snapshot => (
       snapshot.selectedTab === 'detail'
@@ -133,7 +165,9 @@ describe.sequential('wevu runtime demo vue-query (weapp e2e)', () => {
     ))
 
     expect(switchedState.query.data.label).toBe('详情数据')
+    await expectNoVueQueryRuntimeExpressionErrorsAfterSettled(page, runtimeErrors, switchMarker)
 
+    const refreshMarker = runtimeErrors.mark()
     await invokeOrTap(page, 'resetCacheAndReload', 4)
     const refreshedState = await waitForDataMatch(page, snapshot => (
       snapshot.refreshSeed === 1
@@ -146,5 +180,6 @@ describe.sequential('wevu runtime demo vue-query (weapp e2e)', () => {
 
     expect(refreshedState.queryKey[2]).toBe(1)
     expect(refreshedState.query.data.selectedTab).toBe('detail')
+    await expectNoVueQueryRuntimeExpressionErrorsAfterSettled(page, runtimeErrors, refreshMarker)
   })
 })

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/expression/globals.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/expression/globals.test.ts
@@ -78,4 +78,16 @@ describe('template expression globals', () => {
     expect(code).toContain('this.__wevuProps.data')
     expect(code).toContain('this.data')
   })
+
+  it('unrefs nested member results for runtime binding expressions', () => {
+    const context = createContext()
+    const result = normalizeJsExpressionWithContext('JSON.stringify(query.data, null, 2)', context, {
+      runtimePropAccess: 'helper',
+      unrefMemberAccess: true,
+    })
+    const code = result && generateExpression(result)
+
+    expect(code).toContain('JSON.stringify(')
+    expect(code).toContain('__wevuUnref(__wevuUnref(__wevuResolvePropValue(this,\'query\',this.query)).data)')
+  })
 })

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/expression/js.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/expression/js.ts
@@ -210,10 +210,45 @@ function collectForAliasMapping(context: TransformContext): Record<string, strin
   return mapping
 }
 
+function isThisMemberChain(node: t.Node | undefined): boolean {
+  if (!node) {
+    return false
+  }
+  if (t.isThisExpression(node)) {
+    return true
+  }
+  if (t.isMemberExpression(node)) {
+    return isThisMemberChain(node.object)
+  }
+  return false
+}
+
+function isUnrefCallArgument(node: t.MemberExpression, parent: t.Node | undefined) {
+  return (
+    t.isCallExpression(parent)
+    && t.isIdentifier(parent.callee, { name: '__wevuUnref' })
+    && parent.arguments.includes(node)
+  )
+}
+
+function isMemberCallTarget(node: t.MemberExpression, parent: t.Node | undefined) {
+  return (
+    (t.isCallExpression(parent) || t.isOptionalCallExpression(parent) || t.isNewExpression(parent))
+    && parent.callee === node
+  )
+}
+
+function shouldUnrefMemberAccess(node: t.MemberExpression, parent: t.Node | undefined) {
+  if (isThisMemberChain(node) || isUnrefCallArgument(node, parent) || isMemberCallTarget(node, parent)) {
+    return false
+  }
+  return true
+}
+
 export function normalizeJsExpressionWithContext(
   exp: string,
   context: TransformContext,
-  options?: { hint?: string, runtimePropAccess?: 'default' | 'helper' },
+  options?: { hint?: string, runtimePropAccess?: 'default' | 'helper', unrefMemberAccess?: boolean },
 ): t.Expression | null {
   const trimmed = exp.trim()
   if (!trimmed) {
@@ -302,6 +337,20 @@ export function normalizeJsExpressionWithContext(
       path.skip()
     },
   })
+
+  if (options?.unrefMemberAccess) {
+    traverse(ast, {
+      MemberExpression: {
+        exit(path) {
+          if (!shouldUnrefMemberAccess(path.node, path.parentPath?.node)) {
+            return
+          }
+          path.replaceWith(createUnrefCall(t.cloneNode(path.node, true)))
+          path.skip()
+        },
+      },
+    })
+  }
 
   const stmt = ast.program.body[0]
   const updated = (stmt && 'expression' in stmt) ? (stmt as any).expression as t.Expression : null

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/expression/runtimeBinding.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/expression/runtimeBinding.ts
@@ -52,6 +52,7 @@ export function registerRuntimeBindingExpression(
   const expAst = normalizeJsExpressionWithContext(exp, context, {
     ...options,
     runtimePropAccess: 'helper',
+    unrefMemberAccess: true,
   })
   if (!expAst) {
     return null

--- a/packages-runtime/wevu/src/runtime/app/setData/patchScheduler.ts
+++ b/packages-runtime/wevu/src/runtime/app/setData/patchScheduler.ts
@@ -30,6 +30,7 @@ export function runPatchUpdate(options: {
   includeFunctions?: boolean
   functionPaths: string[]
   plainCache: WeakMap<object, { version: number, value: any }>
+  plainCacheEligibility?: WeakMap<object, boolean>
   pendingPatches: Map<string, PatchEntry>
   fallbackTopKeys: Set<string>
   latestSnapshot: Record<string, any>
@@ -60,6 +61,7 @@ export function runPatchUpdate(options: {
     includeFunctions = false,
     functionPaths,
     plainCache,
+    plainCacheEligibility,
     pendingPatches,
     fallbackTopKeys,
     latestSnapshot,
@@ -130,7 +132,7 @@ export function runPatchUpdate(options: {
       return plainByPath.get(path)
     }
     const value = normalizeSetDataValue(
-      toPlain(getStateValueByPath(path), seen, { cache: plainCache, maxDepth: toPlainMaxDepth, maxKeys: toPlainMaxKeys, includeFunctions, functionPaths, _path: path }),
+      toPlain(getStateValueByPath(path), seen, { cache: plainCache, cacheEligibility: plainCacheEligibility, maxDepth: toPlainMaxDepth, maxKeys: toPlainMaxKeys, includeFunctions, functionPaths, _path: path }),
     )
     plainByPath.set(path, value)
     return value
@@ -166,7 +168,7 @@ export function runPatchUpdate(options: {
       if (!shouldIncludeKey(key)) {
         continue
       }
-      const nextValue = toPlain(computedRefs[key].value, seen, { cache: plainCache, maxDepth: toPlainMaxDepth, maxKeys: toPlainMaxKeys, includeFunctions, functionPaths, _path: key })
+      const nextValue = toPlain(computedRefs[key].value, seen, { cache: plainCache, cacheEligibility: plainCacheEligibility, maxDepth: toPlainMaxDepth, maxKeys: toPlainMaxKeys, includeFunctions, functionPaths, _path: key })
       const prevValue = latestComputedSnapshot[key]
       const equal = computedCompare === 'deep'
         ? isDeepEqualValue(prevValue, nextValue, computedCompareMaxDepth, { keys: computedCompareMaxKeys })

--- a/packages-runtime/wevu/src/runtime/app/setData/scheduler.ts
+++ b/packages-runtime/wevu/src/runtime/app/setData/scheduler.ts
@@ -71,6 +71,7 @@ export function createSetDataScheduler(options: {
   } = options
 
   const plainCache = new WeakMap<object, { version: number, value: any }>()
+  const plainCacheEligibility = new WeakMap<object, boolean>()
   let latestSnapshot: Record<string, any> = {}
   let latestComputedSnapshot: Record<string, any> = Object.create(null)
   const latestStateTokens = Object.create(null) as Record<string, unknown>
@@ -116,6 +117,7 @@ export function createSetDataScheduler(options: {
     if (!isReactive(candidate) && hasTrackableSetupBinding(candidate)) {
       return {
         snapshot: toPlain(candidate, new WeakMap(), {
+          cacheEligibility: plainCacheEligibility,
           maxDepth: toPlainMaxDepth,
           maxKeys: toPlainMaxKeys,
           includeFunctions,
@@ -238,6 +240,7 @@ export function createSetDataScheduler(options: {
     includeComputed,
     shouldIncludeKey: shouldIncludeSnapshotKey,
     plainCache,
+    plainCacheEligibility,
     toPlainMaxDepth,
     toPlainMaxKeys,
     includeFunctions,
@@ -281,6 +284,7 @@ export function createSetDataScheduler(options: {
       if (!isSameToken(previousToken, token) || !hasOwn(latestSnapshot, key)) {
         nextSnapshot[key] = toPlain(source[key], seen, {
           cache: plainCache,
+          cacheEligibility: plainCacheEligibility,
           maxDepth: toPlainMaxDepth,
           maxKeys: toPlainMaxKeys,
           includeFunctions,
@@ -320,6 +324,7 @@ export function createSetDataScheduler(options: {
       if (!isSameToken(latestComputedTokens[key], token) || !hasOwn(latestSnapshot, key)) {
         nextSnapshot[key] = toPlain(value, seen, {
           cache: plainCache,
+          cacheEligibility: plainCacheEligibility,
           maxDepth: toPlainMaxDepth,
           maxKeys: toPlainMaxKeys,
           includeFunctions,
@@ -462,6 +467,7 @@ export function createSetDataScheduler(options: {
         includeFunctions,
         functionPaths,
         plainCache,
+        plainCacheEligibility,
         pendingPatches,
         fallbackTopKeys,
         latestSnapshot,

--- a/packages-runtime/wevu/src/runtime/app/setData/snapshot.ts
+++ b/packages-runtime/wevu/src/runtime/app/setData/snapshot.ts
@@ -152,6 +152,7 @@ export function collectSnapshot(options: {
   includeComputed: boolean
   shouldIncludeKey: (key: string) => boolean
   plainCache: WeakMap<object, { version: number, value: any }>
+  plainCacheEligibility?: WeakMap<object, boolean>
   toPlainMaxDepth: number
   toPlainMaxKeys: number
   includeFunctions?: boolean
@@ -164,6 +165,7 @@ export function collectSnapshot(options: {
     includeComputed,
     shouldIncludeKey,
     plainCache,
+    plainCacheEligibility,
     toPlainMaxDepth,
     toPlainMaxKeys,
     includeFunctions = false,
@@ -187,21 +189,21 @@ export function collectSnapshot(options: {
     if (!shouldIncludeKey(key)) {
       continue
     }
-    out[key] = toPlain(rawState[key], seen, { cache: plainCache, maxDepth: toPlainMaxDepth, includeFunctions, functionPaths, _budget: budget, _path: key })
+    out[key] = toPlain(rawState[key], seen, { cache: plainCache, cacheEligibility: plainCacheEligibility, maxDepth: toPlainMaxDepth, includeFunctions, functionPaths, _budget: budget, _path: key })
   }
 
   for (const key of setupStateKeys) {
     if (!shouldIncludeKey(key)) {
       continue
     }
-    out[key] = toPlain(rawSetupState![key], seen, { cache: plainCache, maxDepth: toPlainMaxDepth, includeFunctions, functionPaths, _budget: budget, _path: key })
+    out[key] = toPlain(rawSetupState![key], seen, { cache: plainCache, cacheEligibility: plainCacheEligibility, maxDepth: toPlainMaxDepth, includeFunctions, functionPaths, _budget: budget, _path: key })
   }
 
   for (const key of computedKeys) {
     if (!shouldIncludeKey(key)) {
       continue
     }
-    out[key] = toPlain(computedRefs[key].value, seen, { cache: plainCache, maxDepth: toPlainMaxDepth, includeFunctions, functionPaths, _budget: budget, _path: key })
+    out[key] = toPlain(computedRefs[key].value, seen, { cache: plainCache, cacheEligibility: plainCacheEligibility, maxDepth: toPlainMaxDepth, includeFunctions, functionPaths, _budget: budget, _path: key })
   }
 
   return out

--- a/packages-runtime/wevu/src/runtime/define/initialComputed.ts
+++ b/packages-runtime/wevu/src/runtime/define/initialComputed.ts
@@ -14,6 +14,12 @@ function resolveComputedGetter(definition: unknown) {
   return typeof getter === 'function' ? getter : undefined
 }
 
+function isCompilerGeneratedTemplateComputedKey(key: string) {
+  return key.startsWith('__wv_bind_')
+    || key.startsWith('__wv_cls_')
+    || key.startsWith('__wv_style_')
+}
+
 export function resolveInitialComputedData(options: {
   data: Record<string, any>
   computed: ComputedDefinitions | undefined
@@ -117,6 +123,9 @@ export function resolveInitialComputedData(options: {
   })
 
   for (const key of computedKeys) {
+    if (isCompilerGeneratedTemplateComputedKey(key)) {
+      continue
+    }
     resolveComputedValue(key)
   }
 

--- a/packages-runtime/wevu/src/runtime/diff.ts
+++ b/packages-runtime/wevu/src/runtime/diff.ts
@@ -13,6 +13,7 @@ function isPlainObject(value: unknown): value is Record<string, any> {
 
 export interface ToPlainOptions {
   cache?: WeakMap<object, { version: number, value: any }>
+  cacheEligibility?: WeakMap<object, boolean>
   maxDepth?: number
   maxKeys?: number
   includeFunctions?: boolean
@@ -27,6 +28,7 @@ function toPlainInternal(
   seen: WeakMap<object, any>,
   visiting: WeakSet<object>,
   cache: WeakMap<object, { version: number, value: any }> | undefined,
+  cacheEligibility: WeakMap<object, boolean> | undefined,
   depth: number,
   budget: { keys: number },
   includeFunctions: boolean,
@@ -50,8 +52,14 @@ function toPlainInternal(
   if (isNoSetData(unwrapped)) {
     return undefined
   }
-  const raw = isReactive(unwrapped) ? toRaw(unwrapped) : unwrapped
-  const canUseCache = Boolean(cache) && (isReactive(unwrapped) || !hasTrackableSetupBinding(raw))
+  const reactiveValue = isReactive(unwrapped)
+  const raw = reactiveValue ? toRaw(unwrapped) : unwrapped
+  let canUseCache = Boolean(cache) && reactiveValue
+  if (cache && !canUseCache) {
+    const cachedEligibility = cacheEligibility?.get(raw)
+    canUseCache = cachedEligibility ?? !hasTrackableSetupBinding(raw)
+    cacheEligibility?.set(raw, canUseCache)
+  }
   const cacheRef = canUseCache ? cache : undefined
 
   if (depth <= 0 || budget.keys <= 0) {
@@ -84,8 +92,8 @@ function toPlainInternal(
     visiting.add(raw)
     raw.forEach((mapValue, mapKey) => {
       entries.push([
-        toPlainInternal(mapKey, seen, visiting, undefined, Number.POSITIVE_INFINITY, { keys: Number.POSITIVE_INFINITY }, includeFunctions, undefined, ''),
-        toPlainInternal(mapValue, seen, visiting, undefined, Number.POSITIVE_INFINITY, { keys: Number.POSITIVE_INFINITY }, includeFunctions, undefined, ''),
+        toPlainInternal(mapKey, seen, visiting, undefined, undefined, Number.POSITIVE_INFINITY, { keys: Number.POSITIVE_INFINITY }, includeFunctions, undefined, ''),
+        toPlainInternal(mapValue, seen, visiting, undefined, undefined, Number.POSITIVE_INFINITY, { keys: Number.POSITIVE_INFINITY }, includeFunctions, undefined, ''),
       ])
     })
     visiting.delete(raw)
@@ -96,7 +104,7 @@ function toPlainInternal(
     seen.set(raw, values)
     visiting.add(raw)
     raw.forEach((setValue) => {
-      values.push(toPlainInternal(setValue, seen, visiting, undefined, Number.POSITIVE_INFINITY, { keys: Number.POSITIVE_INFINITY }, includeFunctions, undefined, ''))
+      values.push(toPlainInternal(setValue, seen, visiting, undefined, undefined, Number.POSITIVE_INFINITY, { keys: Number.POSITIVE_INFINITY }, includeFunctions, undefined, ''))
     })
     visiting.delete(raw)
     return values
@@ -111,7 +119,7 @@ function toPlainInternal(
       if (typeof iter === 'function') {
         const values = [...view]
         seen.set(raw, values)
-        return values.map(item => toPlainInternal(item, seen, visiting, undefined, Number.POSITIVE_INFINITY, { keys: Number.POSITIVE_INFINITY }, includeFunctions, undefined, ''))
+        return values.map(item => toPlainInternal(item, seen, visiting, undefined, undefined, Number.POSITIVE_INFINITY, { keys: Number.POSITIVE_INFINITY }, includeFunctions, undefined, ''))
       }
       const bytes = [...new Uint8Array(view.buffer, view.byteOffset, view.byteLength)]
       seen.set(raw, bytes)
@@ -131,7 +139,7 @@ function toPlainInternal(
     const nextDepth = depth - 1
     for (let index = 0; index < raw.length; index += 1) {
       const childPath = currentPath ? `${currentPath}.${index}` : String(index)
-      const next = toPlainInternal(raw[index], seen, visiting, cache, nextDepth, budget, includeFunctions, functionPathSet, childPath)
+      const next = toPlainInternal(raw[index], seen, visiting, cache, cacheEligibility, nextDepth, budget, includeFunctions, functionPathSet, childPath)
       arr[index] = next === undefined ? null : next
     }
     visiting.delete(raw)
@@ -150,7 +158,7 @@ function toPlainInternal(
       break
     }
     const childPath = currentPath ? `${currentPath}.${key}` : key
-    const next = toPlainInternal((raw as any)[key], seen, visiting, cache, nextDepth, budget, includeFunctions, functionPathSet, childPath)
+    const next = toPlainInternal((raw as any)[key], seen, visiting, cache, cacheEligibility, nextDepth, budget, includeFunctions, functionPathSet, childPath)
     if (next !== undefined) {
       output[key] = next
     }
@@ -168,7 +176,7 @@ export function toPlain(value: any, seen = new WeakMap<object, any>(), options?:
   const functionPathSet = Array.isArray(options?.functionPaths) && options.functionPaths.length
     ? new Set(options.functionPaths)
     : undefined
-  return toPlainInternal(value, seen, new WeakSet(), options?.cache, depth, budget, Boolean(options?.includeFunctions), functionPathSet, options?._path ?? '')
+  return toPlainInternal(value, seen, new WeakSet(), options?.cache, options?.cacheEligibility, depth, budget, Boolean(options?.includeFunctions), functionPathSet, options?._path ?? '')
 }
 
 type DeepEqualCompare = (a: any, b: any) => boolean

--- a/packages-runtime/wevu/test/runtime-initial-computed.test.ts
+++ b/packages-runtime/wevu/test/runtime-initial-computed.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { resolveInitialComputedData } from '@/runtime/define/initialComputed'
+
+describe('runtime: initial computed data', () => {
+  it('does not evaluate compiler generated template computed bindings before setup', () => {
+    const normalGetter = () => 'ready'
+    const templateGetter = () => {
+      throw new Error('template computed should wait for runtime setup')
+    }
+
+    const result = resolveInitialComputedData({
+      data: {},
+      computed: {
+        normal: normalGetter,
+        __wv_bind_0: templateGetter,
+        __wv_cls_0: templateGetter,
+        __wv_style_0: templateGetter,
+      },
+      setData: undefined,
+    })
+
+    expect(result).toEqual({ normal: 'ready' })
+  })
+})

--- a/packages/weapp-vite/src/plugins/autoImport.test.ts
+++ b/packages/weapp-vite/src/plugins/autoImport.test.ts
@@ -20,7 +20,7 @@ describe('autoImport plugin', () => {
         return watcher
       }),
       close: vi.fn(),
-      emit(event: 'add' | 'unlink', filePath: string) {
+      emit(event: 'add' | 'change' | 'unlink', filePath: string) {
         listeners.get(event)?.(filePath)
       },
     }
@@ -500,6 +500,98 @@ describe('autoImport plugin', () => {
       const initialPageStat = await fs.stat(pageVueFile)
 
       sidecarWatcher.emit('add', hotCardFile)
+
+      await vi.waitFor(async () => {
+        expect(registerPotentialComponent).toHaveBeenCalledWith(hotCardFile)
+        const nextPageStat = await fs.stat(pageVueFile)
+        expect(nextPageStat.mtimeMs).toBeGreaterThan(initialPageStat.mtimeMs)
+        expect(ctx.runtimeState.autoImport.pendingEntriesByImporter.get(pageVueFile.replace(/\.vue$/, ''))).toEqual(
+          new Set(['/components/HotCard/index']),
+        )
+      })
+    }
+    finally {
+      await fs.remove(tempDir)
+      if (await fs.pathExists(tempRoot)) {
+        const remaining = await fs.readdir(tempRoot)
+        if (remaining.length === 0) {
+          await fs.remove(tempRoot)
+        }
+      }
+    }
+  })
+
+  it('queues importer pending entries after a component file changes', async () => {
+    const tempRoot = path.resolve(import.meta.dirname, '../test/__temp__')
+    await fs.ensureDir(tempRoot)
+    const tempDir = await fs.mkdtemp(path.join(tempRoot, 'auto-import-change-importers-'))
+    const srcRoot = path.join(tempDir, 'src')
+    const pageVueFile = path.join(srcRoot, 'pages/index/index.vue')
+    const hotCardFile = path.join(srcRoot, 'components/HotCard/index.vue')
+
+    await fs.ensureDir(path.dirname(pageVueFile))
+    await fs.writeFile(pageVueFile, '<template><HotCard /></template>', 'utf8')
+    await fs.ensureDir(path.dirname(hotCardFile))
+    await fs.writeFile(hotCardFile, '<template><view>hot</view></template>', 'utf8')
+
+    const sidecarWatcher = createMockSidecarWatcher()
+    chokidarWatchMock.mockReturnValue(sidecarWatcher)
+    const registerPotentialComponent = vi.fn().mockResolvedValue(undefined)
+
+    const ctx = {
+      runtimeState: {
+        autoImport: {
+          pendingEntriesByImporter: new Map(),
+        },
+        watcher: {
+          sidecarWatcherMap: new Map(),
+        },
+      },
+      wxmlService: {
+        wxmlComponentsMap: new Map([
+          [pageVueFile.replace(/\.vue$/, ''), {
+            HotCard: [{ start: 0, end: 9 }],
+          }],
+        ]),
+      },
+      configService: {
+        cwd: tempDir,
+        absoluteSrcRoot: srcRoot,
+        relativeCwd: (p: string) => p.replace(`${tempDir}/`, ''),
+        relativeAbsoluteSrcRoot: (p: string) => p.replace(`${srcRoot}/`, ''),
+        isDev: true,
+        weappViteConfig: {
+          autoImportComponents: {
+            globs: ['components/**/*.vue'],
+          },
+        },
+      },
+      autoImportService: {
+        reset: vi.fn(),
+        awaitManifestWrites: vi.fn().mockResolvedValue(undefined),
+        filter: (target: string) => target.includes('components/'),
+        registerPotentialComponent,
+        removePotentialComponent: vi.fn(),
+        resolve: vi.fn(() => ({
+          value: {
+            name: 'HotCard',
+            from: '/components/HotCard/index',
+          },
+        })),
+        getRegisteredLocalComponents: vi.fn(),
+      },
+    } as any
+
+    try {
+      const plugin = autoImport(ctx)[0]
+      plugin.configResolved?.({ build: { outDir: 'dist' } } as any)
+      await plugin.buildStart?.()
+
+      registerPotentialComponent.mockClear()
+      const initialPageStat = await fs.stat(pageVueFile)
+      await new Promise(resolve => setTimeout(resolve, 20))
+
+      sidecarWatcher.emit('change', hotCardFile)
 
       await vi.waitFor(async () => {
         expect(registerPotentialComponent).toHaveBeenCalledWith(hotCardFile)

--- a/packages/weapp-vite/src/plugins/autoImport.ts
+++ b/packages/weapp-vite/src/plugins/autoImport.ts
@@ -340,18 +340,26 @@ function createAutoImportPlugin(state: AutoImportState): Plugin {
       },
     }))
 
-    watcher.on('add', (filePath) => {
+    const registerAndRefreshComponent = (filePath: string, action: '新增' | '变更') => {
       if (!getAutoImportCandidateKind(filePath)) {
         return
       }
       if (!matchesAutoImportGlobs(ctx, filePath)) {
         return
       }
-      logger.info(`[auto-import:watch] 新增组件文件 ${configService.relativeCwd(filePath)}`)
+      logger.info(`[auto-import:watch] ${action}组件文件 ${configService.relativeCwd(filePath)}`)
       void autoImportService.registerPotentialComponent(filePath)
         .then(async () => {
           await refreshAutoImportImporters(ctx, filePath)
         })
+    }
+
+    watcher.on('add', (filePath) => {
+      registerAndRefreshComponent(filePath, '新增')
+    })
+
+    watcher.on('change', (filePath) => {
+      registerAndRefreshComponent(filePath, '变更')
     })
 
     watcher.on('unlink', (filePath) => {

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/autoImport.test.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/autoImport.test.ts
@@ -162,7 +162,7 @@ describe('createAutoImportAugmenter', () => {
     expect(injectedEntries).toEqual([])
   })
 
-  it('tracks resolver resolvedId so external Vue components join the compile flow', () => {
+  it('tracks resolvedId so matched Vue components join the compile flow', () => {
     const resolve = vi.fn((name: string) => {
       if (name === 'ResolverBadge') {
         return {
@@ -195,6 +195,42 @@ describe('createAutoImportAugmenter', () => {
     expect(injectedEntries).toEqual(['/__weapp_vite_external__/resolver-ui/ResolverBadge'])
     expect(externalComponentEntryMap.get('__weapp_vite_external__/resolver-ui/ResolverBadge')).toBe(
       '/workspace/packages/resolver-ui/ResolverBadge.vue',
+    )
+  })
+
+  it('tracks local resolvedId for newly registered Vue SFC components', () => {
+    const resolve = vi.fn((name: string) => {
+      if (name === 'HotCard') {
+        return {
+          value: {
+            name: 'HotCard',
+            from: '/components/HotCard/index',
+            resolvedId: '/project/src/components/HotCard/index.vue',
+          },
+        }
+      }
+      return undefined
+    })
+    const componentEntryMap = new Map<string, string>()
+
+    const applyAutoImports = createAutoImportAugmenter(
+      { resolve, getVersion: vi.fn(() => 0) } as any,
+      {
+        getAggregatedAutoImportComponents: vi.fn(() => ({ HotCard: [{ start: 0, end: 0 }] })),
+        getAggregatedComponents: vi.fn(() => ({ HotCard: [{ start: 0, end: 0 }] })),
+      } as any,
+      componentEntryMap,
+    )
+
+    const json: Record<string, any> = {}
+    const injectedEntries = applyAutoImports('/project/src/pages/index/index', json)
+
+    expect(json.usingComponents).toEqual({
+      HotCard: '/components/HotCard/index',
+    })
+    expect(injectedEntries).toEqual(['/components/HotCard/index'])
+    expect(componentEntryMap.get('components/HotCard/index')).toBe(
+      '/project/src/components/HotCard/index.vue',
     )
   })
 

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/autoImport.test.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/autoImport.test.ts
@@ -234,6 +234,46 @@ describe('createAutoImportAugmenter', () => {
     )
   })
 
+  it('tracks local resolvedId when matching usingComponents already exists', () => {
+    const resolve = vi.fn((name: string) => {
+      if (name === 'HotCard') {
+        return {
+          value: {
+            name: 'HotCard',
+            from: '/components/HotCard/index',
+            resolvedId: '/project/src/components/HotCard/index.vue',
+          },
+        }
+      }
+      return undefined
+    })
+    const componentEntryMap = new Map<string, string>()
+
+    const applyAutoImports = createAutoImportAugmenter(
+      { resolve, getVersion: vi.fn(() => 0) } as any,
+      {
+        getAggregatedAutoImportComponents: vi.fn(() => ({ HotCard: [{ start: 0, end: 0 }] })),
+        getAggregatedComponents: vi.fn(() => ({ HotCard: [{ start: 0, end: 0 }] })),
+      } as any,
+      componentEntryMap,
+    )
+
+    const json: Record<string, any> = {
+      usingComponents: {
+        HotCard: '/components/HotCard/index',
+      },
+    }
+    const injectedEntries = applyAutoImports('/project/src/pages/index/index', json)
+
+    expect(json.usingComponents).toEqual({
+      HotCard: '/components/HotCard/index',
+    })
+    expect(injectedEntries).toEqual(['/components/HotCard/index'])
+    expect(componentEntryMap.get('components/HotCard/index')).toBe(
+      '/project/src/components/HotCard/index.vue',
+    )
+  })
+
   it('reuses resolved auto imports when aggregated template graph and version are unchanged', () => {
     const hit = { 'van-button': [{ start: 0, end: 0 }] }
     const resolve = vi.fn(() => {

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/autoImport.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/autoImport.ts
@@ -46,9 +46,15 @@ export function createAutoImportAugmenter(
 
     const injectedEntries: string[] = []
     for (const [name, resolved] of Object.entries(resolvedComponents)) {
+      const trackResolvedId = () => {
+        if (resolved.resolvedId) {
+          externalComponentEntryMap?.set(resolved.from.replace(/^\/+/, ''), resolved.resolvedId)
+        }
+      }
       const usingComponents = get(json, 'usingComponents')
       if (isObject(usingComponents) && Reflect.has(usingComponents, name)) {
         if (usingComponents[name] === resolved.from) {
+          trackResolvedId()
           injectedEntries.push(resolved.from)
         }
         continue
@@ -56,9 +62,7 @@ export function createAutoImportAugmenter(
 
       set(json, `usingComponents.${name}`, resolved.from)
       injectedEntries.push(resolved.from)
-      if (resolved.resolvedId) {
-        externalComponentEntryMap?.set(resolved.from.replace(/^\/+/, ''), resolved.resolvedId)
-      }
+      trackResolvedId()
     }
 
     return injectedEntries

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry.test.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry.test.ts
@@ -627,6 +627,37 @@ describe('createEntryLoader', () => {
     expect(emittedResolvedIds).toContain('/project/src/components/HotCard/index')
   })
 
+  it('reloads pending auto-import entries so generated template assets refresh', async () => {
+    const pageScript = '/project/src/pages/home.js'
+    mockFindJsonEntry.mockResolvedValue({
+      path: '/project/src/pages/home.json',
+      predictions: [],
+    })
+
+    const { loader, jsonService, emitEntriesChunks, loadedEntrySet, runtimeState } = createLoader({
+      normalizeEntry: entry => entry.replace(/^\//, ''),
+    })
+
+    runtimeState.autoImport.pendingEntriesByImporter.set(
+      '/project/src/pages/home',
+      new Set(['/components/HotCard/index']),
+    )
+    jsonService.read.mockResolvedValue({
+      usingComponents: {
+        HotCard: '/components/HotCard/index',
+      },
+    })
+    loadedEntrySet.add('/project/src/components/HotCard/index')
+
+    await loader.call(createPluginContext(), pageScript, 'page')
+
+    const hotCardEmitCall = emitEntriesChunks.mock.calls.find(([resolvedIds]) => {
+      return resolvedIds.some((resolvedId: any) => resolvedId?.id === '/project/src/components/HotCard/index')
+    })
+    expect(hotCardEmitCall).toBeTruthy()
+    expect(loadedEntrySet.has('/project/src/components/HotCard/index')).toBe(false)
+  })
+
   it('marks custom tab bar and app bar app entries as components', async () => {
     mockFindJsonEntry.mockResolvedValue({
       path: '/project/src/app.json',

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry.test.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry.test.ts
@@ -627,6 +627,38 @@ describe('createEntryLoader', () => {
     expect(emittedResolvedIds).toContain('/project/src/components/HotCard/index')
   })
 
+  it('force emits auto-import entries through resolvedId mappings for newly registered Vue SFCs', async () => {
+    const pageScript = '/project/src/pages/home.js'
+    mockFindJsonEntry.mockResolvedValue({
+      path: '/project/src/pages/home.json',
+      predictions: [],
+    })
+
+    const { loader, jsonService, emitEntriesChunks, applyAutoImports, runtimeState } = createLoader({
+      normalizeEntry: entry => entry.replace(/^\//, ''),
+    })
+
+    jsonService.read.mockResolvedValue({})
+    applyAutoImports.mockImplementation((_baseName, json) => {
+      json.usingComponents = {
+        HotCard: '/components/HotCard/index',
+      }
+      runtimeState.build.hmr.externalComponentEntryMap.set(
+        'components/HotCard/index',
+        '/project/src/components/HotCard/index.vue',
+      )
+      return ['/components/HotCard/index']
+    })
+
+    await loader.call(createPluginContext(), pageScript, 'page')
+
+    const emittedResolvedIds = emitEntriesChunks.mock.calls.flatMap(
+      ([resolvedIds]) => resolvedIds.map((resolvedId: any) => resolvedId?.id),
+    )
+
+    expect(emittedResolvedIds).toContain('/project/src/components/HotCard/index.vue')
+  })
+
   it('reloads pending auto-import entries so generated template assets refresh', async () => {
     const pageScript = '/project/src/pages/home.js'
     mockFindJsonEntry.mockResolvedValue({

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/emit.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/emit.ts
@@ -99,6 +99,7 @@ interface EmitEntryOutputOptions {
   loadedEntrySet: Set<string>
   dirtyEntrySet: Set<string>
   forceEmitEntrySet?: Set<string>
+  forceReloadEntrySet?: Set<string>
   replaceLayoutDependencies: (entryId: string, dependencies: Iterable<string>) => void
   emitEntriesChunks: (this: PluginContext, resolvedIds: (ResolvedId | null)[]) => Promise<unknown>[]
   registerJsonAsset: (entry: JsonEmitFileEntry) => void
@@ -134,6 +135,7 @@ export async function emitEntryOutput(options: EmitEntryOutputOptions) {
     loadedEntrySet,
     dirtyEntrySet,
     forceEmitEntrySet,
+    forceReloadEntrySet,
     replaceLayoutDependencies,
     emitEntriesChunks,
     registerJsonAsset,
@@ -298,11 +300,16 @@ export async function emitEntryOutput(options: EmitEntryOutputOptions) {
 
     const isForcedEntry = forceEmitEntrySet?.has(entry) === true
       || forceEmitEntrySet?.has(normalizedResolvedId) === true
+    const isForcedReloadEntry = forceReloadEntrySet?.has(entry) === true
+      || forceReloadEntrySet?.has(normalizedResolvedId) === true
     const isDirtyEntry = dirtyEntrySet.has(normalizedResolvedId)
     if (!isDirtyEntry && !isForcedEntry && loadedEntrySet.has(normalizedResolvedId)) {
       continue
     }
 
+    if (isForcedReloadEntry) {
+      loadedEntrySet.delete(normalizedResolvedId)
+    }
     pendingResolvedIds.push(resolvedId)
     if (isDirtyEntry || isForcedEntry) {
       dirtyEntrySet.delete(normalizedResolvedId)

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/index.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/index.ts
@@ -192,6 +192,7 @@ export function createEntryLoader(options: EntryLoaderOptions) {
     let appResult: Awaited<ReturnType<typeof collectAppEntries>> | undefined
     let shouldSkipAppEntries = false
     const forceEmitEntrySet = new Set<string>()
+    const forceReloadEntrySet = new Set<string>()
     const nativeLayoutScriptEntries = new Set<string>()
     let autoRoutesSignature = configService.isDev
       ? ctx.autoRoutesService?.getSignature?.()
@@ -422,8 +423,12 @@ export function createEntryLoader(options: EntryLoaderOptions) {
       for (const componentEntry of mergedComponentEntries) {
         const normalizedComponentEntry = normalizeEntry(componentEntry, jsonPath)
         explicitEntryTypes.set(normalizedComponentEntry, 'component')
-        if (pendingAutoImportEntries.includes(componentEntry) || injectedAutoImportEntries.includes(componentEntry)) {
+        const isPendingAutoImportEntry = pendingAutoImportEntries.includes(componentEntry)
+        if (isPendingAutoImportEntry || injectedAutoImportEntries.includes(componentEntry)) {
           forceEmitEntrySet.add(normalizedComponentEntry)
+        }
+        if (isPendingAutoImportEntry) {
+          forceReloadEntrySet.add(normalizedComponentEntry)
         }
       }
     }
@@ -475,6 +480,7 @@ export function createEntryLoader(options: EntryLoaderOptions) {
       loadedEntrySet,
       dirtyEntrySet,
       forceEmitEntrySet,
+      forceReloadEntrySet,
       replaceLayoutDependencies,
       emitEntriesChunks,
       registerJsonAsset,

--- a/packages/weapp-vite/src/plugins/vue/transform/emitAssets.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/emitAssets.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  emitClassStyleWxsAssetIfMissing,
+  emitSfcJsonAsset,
+  emitSfcTemplateIfMissing,
+  resetEmittedAssetSourceCacheForTest,
+} from './emitAssets'
+
+describe('emitAssets', () => {
+  beforeEach(() => {
+    resetEmittedAssetSourceCacheForTest()
+  })
+
+  function createEmitter() {
+    const emitFile = vi.fn()
+    return {
+      ctx: { emitFile },
+      emitFile,
+    }
+  }
+
+  it('deduplicates emitted sources only within the current bundle', () => {
+    const first = createEmitter()
+    const firstBundle: Record<string, any> = {}
+
+    emitSfcTemplateIfMissing(first.ctx, firstBundle, '__weapp_vite_slot_wrapper', '<slot></slot>')
+    emitSfcTemplateIfMissing(first.ctx, firstBundle, '__weapp_vite_slot_wrapper', '<slot></slot>')
+    emitSfcJsonAsset(first.ctx, firstBundle, '__weapp_vite_slot_wrapper', {
+      config: JSON.stringify({ component: true }),
+    }, {
+      kind: 'component',
+    })
+    emitSfcJsonAsset(first.ctx, firstBundle, '__weapp_vite_slot_wrapper', {
+      config: JSON.stringify({ component: true }),
+    }, {
+      kind: 'component',
+    })
+    emitClassStyleWxsAssetIfMissing(first.ctx, firstBundle, '__weapp_vite_class_style.wxs', 'module.exports = {}')
+    emitClassStyleWxsAssetIfMissing(first.ctx, firstBundle, '__weapp_vite_class_style.wxs', 'module.exports = {}')
+
+    expect(first.emitFile.mock.calls.map(call => call[0].fileName)).toEqual([
+      '__weapp_vite_slot_wrapper.wxml',
+      '__weapp_vite_slot_wrapper.json',
+      '__weapp_vite_class_style.wxs',
+    ])
+
+    const second = createEmitter()
+    const secondBundle: Record<string, any> = {}
+
+    emitSfcTemplateIfMissing(second.ctx, secondBundle, '__weapp_vite_slot_wrapper', '<slot></slot>')
+    emitSfcJsonAsset(second.ctx, secondBundle, '__weapp_vite_slot_wrapper', {
+      config: JSON.stringify({ component: true }),
+    }, {
+      kind: 'component',
+    })
+    emitClassStyleWxsAssetIfMissing(second.ctx, secondBundle, '__weapp_vite_class_style.wxs', 'module.exports = {}')
+
+    expect(second.emitFile.mock.calls.map(call => call[0].fileName)).toEqual([
+      '__weapp_vite_slot_wrapper.wxml',
+      '__weapp_vite_slot_wrapper.json',
+      '__weapp_vite_class_style.wxs',
+    ])
+  })
+})

--- a/packages/weapp-vite/src/plugins/vue/transform/emitAssets.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/emitAssets.ts
@@ -6,14 +6,23 @@ interface Emitter {
   emitFile: (asset: { type: 'asset', fileName: string, source: string }) => void
 }
 
-const emittedAssetSourceCache = new Map<string, string>()
+let emittedAssetSourceCacheByBundle = new WeakMap<Record<string, any>, Map<string, string>>()
 
 function hasOwn(source: object, key: PropertyKey) {
   return Object.prototype.hasOwnProperty.call(source, key)
 }
 
 export function resetEmittedAssetSourceCacheForTest() {
-  emittedAssetSourceCache.clear()
+  emittedAssetSourceCacheByBundle = new WeakMap()
+}
+
+function getEmittedAssetSourceCache(bundle: Record<string, any>) {
+  let cache = emittedAssetSourceCacheByBundle.get(bundle)
+  if (!cache) {
+    cache = new Map<string, string>()
+    emittedAssetSourceCacheByBundle.set(bundle, cache)
+  }
+  return cache
 }
 
 /**
@@ -47,6 +56,7 @@ export function emitSfcTemplateIfMissing(
 ) {
   const fileName = resolveSfcAssetFileName(relativeBase, extension)
   const cacheKey = `asset:${fileName}`
+  const emittedAssetSourceCache = getEmittedAssetSourceCache(bundle)
   const existing = bundle[fileName]
   if (existing && existing.type === 'asset') {
     const current = existing.source?.toString?.() ?? ''
@@ -75,6 +85,7 @@ export function emitSfcStyleIfMissing(
 ) {
   const fileName = resolveSfcAssetFileName(relativeBase, extension)
   const cacheKey = `asset:${fileName}`
+  const emittedAssetSourceCache = getEmittedAssetSourceCache(bundle)
   const existing = bundle[fileName]
   if (existing && existing.type === 'asset') {
     if (options?.updateExisting === false) {
@@ -113,6 +124,7 @@ export function emitSfcJsonAsset(
 ) {
   const jsonFileName = resolveSfcAssetFileName(relativeBase, options.extension ?? 'json')
   const cacheKey = `asset:${jsonFileName}`
+  const emittedAssetSourceCache = getEmittedAssetSourceCache(bundle)
   const existing = bundle[jsonFileName]
   const mergeJson = createJsonMerger(options.mergeStrategy, {
     filename: jsonFileName,
@@ -209,6 +221,7 @@ export function emitClassStyleWxsAssetIfMissing(
 ) {
   const existing = bundle[fileName]
   const cacheKey = `asset:${fileName}`
+  const emittedAssetSourceCache = getEmittedAssetSourceCache(bundle)
   if (existing && existing.type === 'asset') {
     const current = existing.source?.toString?.() ?? ''
     if (current !== source) {

--- a/packages/weapp-vite/src/runtime/autoImport/service/registry.test.ts
+++ b/packages/weapp-vite/src/runtime/autoImport/service/registry.test.ts
@@ -451,6 +451,7 @@ describe('autoImport registry helpers', () => {
       value: {
         name: 'VueCard',
         from: '/components/vue-card/index',
+        resolvedId: '/project/src/components/vue-card/index.vue',
       },
     })
     expect(findVueEntryMock).not.toHaveBeenCalled()

--- a/packages/weapp-vite/src/runtime/autoImport/service/registry.ts
+++ b/packages/weapp-vite/src/runtime/autoImport/service/registry.ts
@@ -212,6 +212,7 @@ export function createRegistryHelpers(state: RegistryState): RegistryHelpers {
       value: {
         name: componentName,
         from,
+        resolvedId: resolvedJsEntry,
       },
     })
 


### PR DESCRIPTION
## 变更内容

- 优化 wevu setData 序列化路径，为 plain object cache eligibility 增加跨 diff、snapshot、patch scheduler 复用的 WeakMap 缓存，降低大列表更新时重复判定成本。
- 保留 trackable setup binding 的保护逻辑，避免把可能携带可追踪绑定的对象错误缓存。
- 修复 wevu 模板 computed 预检查过早执行导致的运行时错误，并补充 IDE runtime 错误收集回归。
- 修复 weapp-vite 自动导入新建 Vue SFC 组件时的 resolved entry 映射，覆盖已存在 usingComponents 的增量 dev 场景。
- 修复 auto-import sidecar watcher 只处理 `add`、未处理后续 `change` 的问题；新建组件在 macOS/Windows CI 上如果出现新增事件与引用方刷新时序竞争，后续心跳写入也会重新注册组件并刷新引用方。

## 验证

- pnpm --filter wevu lint
- pnpm vitest run packages-runtime/wevu/test/runtime-core-extra.test.ts packages-runtime/wevu/test/runtime-setdata-patchScheduler.test.ts packages-runtime/wevu/test/runtime-setdata-snapshot.test.ts packages-runtime/wevu/test/runtime-setdata-scheduler.test.ts
- pnpm vitest run packages/weapp-vite/src/plugins/hooks/useLoadEntry/autoImport.test.ts packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry.test.ts packages/weapp-vite/src/runtime/autoImport/service/registry.test.ts
- pnpm exec eslint packages/weapp-vite/src/plugins/hooks/useLoadEntry/autoImport.ts packages/weapp-vite/src/plugins/hooks/useLoadEntry/autoImport.test.ts
- pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/auto-import-vue-sfc.test.ts
- rtk pnpm vitest run packages/weapp-vite/src/plugins/autoImport.test.ts
- rtk pnpm exec eslint packages/weapp-vite/src/plugins/autoImport.ts packages/weapp-vite/src/plugins/autoImport.test.ts
- rtk pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/auto-import-vue-sfc.test.ts
- 在 weapp-vite/benchmarks 中用 performance 组完成 20 次 IDE runtime 采集，weapp-vite + wevu performance 8 场景平均合计 186ms。

## CI 状态

当前 HEAD：`889a3573d9da0017b5b08e8123e51303ca408f8e`。

- Build and Test：Ubuntu Node 20/22/24、Windows Node 20、macOS Node 20 全部通过。
- Miniapp E2E CI：Ubuntu Node 20/22/24、Windows Node 20、macOS Node 20 全部通过。
- Policy Checks、Weapi Compatibility Guard、Auto Import Performance、Web E2E Baseline、Workspace HMR Changed Projects 全部通过。
- PR merge state：`CLEAN`。
