### PR TITLE
fix(wevu): 修复 performance 预设下 slot 桥接字段同步

### DIFF
--- a/.changeset/issue-642-slot-bridge-props.md
+++ b/.changeset/issue-642-slot-bridge-props.md
@@ -1,0 +1,6 @@
+---
+"wevu": patch
+"create-weapp-vite": patch
+---
+
+修复 performance 预设下组件 slot 桥接字段没有同步到顶层 data 的问题，避免普通插槽误渲染 fallback、scoped slot 拿不到 owner id。同步发布 create-weapp-vite，保持脚手架模板依赖版本与本次修复一致。

--- a/e2e-apps/github-issues/src/components/issue-642/ScopedSlotProbe/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-642/ScopedSlotProbe/index.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { useNativeInstance } from 'wevu'
+
+const nativeInstance = useNativeInstance()
+
+function _runE2E() {
+  return {
+    dataSlotOwnerId: (nativeInstance as any)?.data?.__wvSlotOwnerId,
+    propsSlotOwnerId: (nativeInstance as any)?.properties?.__wvSlotOwnerId,
+  }
+}
+
+defineExpose({
+  _runE2E,
+})
+</script>
+
+<template>
+  <view class="issue642-scoped-slot-probe">
+    <slot :io="1234" />
+  </view>
+</template>

--- a/e2e-apps/github-issues/src/pages/issue-642/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-642/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, useNativeInstance } from 'wevu'
+import Issue642ScopedSlotProbe from '../../components/issue-642/ScopedSlotProbe/index.vue'
 import Issue642SlotProbe from '../../components/issue-642/SlotProbe/index.vue'
 
 definePageJson({
@@ -23,6 +24,7 @@ function _runE2E() {
     base: base.value,
     provided: readProbe('#issue642-provided'),
     empty: readProbe('#issue642-empty'),
+    scoped: readProbe('#issue642-scoped'),
   }
 }
 
@@ -907,6 +909,20 @@ defineExpose({
         issue-642 provided default
       </text>
     </Issue642SlotProbe>
+    <Issue642ScopedSlotProbe
+      id="issue642-scoped"
+      class="issue642-scoped"
+    >
+      <template #default="{ io }">
+        <text
+          class="issue642-scoped-provided"
+          data-issue642-slot-state="scoped-provided"
+          :data-issue642-scoped-value="io"
+        >
+          {{ io }}
+        </text>
+      </template>
+    </Issue642ScopedSlotProbe>
   </view>
 </template>
 

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -61,6 +61,10 @@ const githubIssuesRouteGroups: Record<string, string[]> = {
   'github-issues.runtime.issue627.test.ts': [
     'pages/issue-627-native/**',
   ],
+  'github-issues.runtime.issue642.test.ts': [
+    'pages/issue-642/**',
+    'components/issue-642/**',
+  ],
   'github-issues.runtime.issue581.test.ts': [
     'pages/issue-581/**',
   ],

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -275,6 +275,25 @@ async function runIssue621AugmentedBuild() {
   distVariant = null
 }
 
+async function runIssue642Build() {
+  standardBuildPromise = null
+  await fs.remove(DIST_ROOT)
+
+  await runWeappViteBuildWithLogCapture({
+    cliPath: CLI_PATH,
+    projectRoot: APP_ROOT,
+    platform: 'weapp',
+    cwd: APP_ROOT,
+    label: 'ci:github-issues:issue642',
+    skipNpm: true,
+    env: {
+      WEAPP_VITE_E2E_TARGET_FILE: 'e2e/ide/github-issues.runtime.issue642.test.ts',
+    },
+  })
+
+  distVariant = null
+}
+
 interface AppJsonWithSubPackages {
   pages?: string[]
   subPackages?: Array<{ root?: string, pages?: string[] }>
@@ -623,6 +642,37 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageJs).not.toContain('ReferenceError')
     expect(pageJs).not.toContain('ctx.explicitCount.value.value')
     expect(pageJs).not.toContain('ctx.nestedState.count.value.value')
+  })
+
+  it('issue #642: keeps slot bridge props available to performance setData pick', async () => {
+    await runIssue642Build()
+
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-642/index.wxml')
+    const scopedSlotWxmlPath = path.join(DIST_ROOT, 'pages/issue-642/index.__scoped-slot-default-0.wxml')
+    const slotProbeWxmlPath = path.join(DIST_ROOT, 'components/issue-642/SlotProbe/index.wxml')
+    const slotProbeJsPath = path.join(DIST_ROOT, 'components/issue-642/SlotProbe/index.js')
+    const scopedProbeWxmlPath = path.join(DIST_ROOT, 'components/issue-642/ScopedSlotProbe/index.wxml')
+    const scopedProbeJsPath = path.join(DIST_ROOT, 'components/issue-642/ScopedSlotProbe/index.js')
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+    const scopedSlotWxml = await fs.readFile(scopedSlotWxmlPath, 'utf-8')
+    const slotProbeWxml = await fs.readFile(slotProbeWxmlPath, 'utf-8')
+    const slotProbeJs = await fs.readFile(slotProbeJsPath, 'utf-8')
+    const scopedProbeWxml = await fs.readFile(scopedProbeWxmlPath, 'utf-8')
+    const scopedProbeJs = await fs.readFile(scopedProbeJsPath, 'utf-8')
+
+    expect(pageWxml).toContain('Issue642SlotProbe')
+    expect(pageWxml).toContain('vue-slots="{{__wv_bind_')
+    expect(pageWxml).toContain('generic:scoped-slots-default=')
+    expect(scopedSlotWxml).toContain('data-issue642-slot-state="scoped-provided"')
+    expect(scopedSlotWxml).toContain('data-issue642-scoped-value="{{__wvSlotPropsData.io}}"')
+    expect(scopedSlotWxml).toContain('{{__wvSlotPropsData.io}}')
+    expect(slotProbeWxml).toContain(`<block wx:if="{{vueSlots&&vueSlots.header}}">`)
+    expect(slotProbeWxml).toContain(`<block wx:if="{{vueSlots&&vueSlots.default}}">`)
+    expect(slotProbeJs).toContain('"vueSlots"')
+    expect(scopedProbeWxml).toContain('<scoped-slots-default wx:if="{{__wvSlotOwnerId}}"')
+    expect(scopedProbeWxml).toContain(`__wvSlotProps="{{['io',1234]}}"`)
+    expect(scopedProbeJs).toContain('"__wvSlotOwnerId"')
+    expect(scopedProbeJs).toContain('"__wvSlotScope"')
   })
 
   it('issue #424: avoids duplicated output for imported src/assets images', async () => {

--- a/e2e/ide/github-issues.runtime.issue642.test.ts
+++ b/e2e/ide/github-issues.runtime.issue642.test.ts
@@ -44,13 +44,21 @@ describe.sequential('e2e app: github-issues / issue #642', () => {
           hasDefault: false,
           hasHeader: false,
         },
+        scoped: {
+          propsSlotOwnerId: expect.any(String),
+          dataSlotOwnerId: expect.any(String),
+        },
       })
+      expect(initialRuntime.scoped.propsSlotOwnerId).not.toBe('')
+      expect(initialRuntime.scoped.dataSlotOwnerId).toBe(initialRuntime.scoped.propsSlotOwnerId)
 
       const initialWxml = await readPageWxml(issuePage)
       expect(countToken(initialWxml, 'data-issue642-slot-state="provided-header"')).toBe(1)
       expect(countToken(initialWxml, 'data-issue642-slot-state="provided-default"')).toBe(1)
       expect(countToken(initialWxml, 'data-issue642-slot-state="fallback-header"')).toBe(1)
       expect(countToken(initialWxml, 'data-issue642-slot-state="fallback-default"')).toBe(1)
+      expect(countToken(initialWxml, 'data-issue642-slot-state="scoped-provided"')).toBe(1)
+      expect(initialWxml).toContain('data-issue642-scoped-value="1234"')
 
       const action = await issuePage.$('[data-issue642-action="bump"]')
       if (!action) {
@@ -69,6 +77,10 @@ describe.sequential('e2e app: github-issues / issue #642', () => {
           hasDefault: true,
           hasHeader: true,
         },
+        scoped: {
+          dataSlotOwnerId: initialRuntime.scoped.dataSlotOwnerId,
+          propsSlotOwnerId: initialRuntime.scoped.propsSlotOwnerId,
+        },
       })
 
       const updatedWxml = await readPageWxml(issuePage)
@@ -76,6 +88,8 @@ describe.sequential('e2e app: github-issues / issue #642', () => {
       expect(countToken(updatedWxml, 'data-issue642-slot-state="provided-default"')).toBe(1)
       expect(countToken(updatedWxml, 'data-issue642-slot-state="fallback-header"')).toBe(1)
       expect(countToken(updatedWxml, 'data-issue642-slot-state="fallback-default"')).toBe(1)
+      expect(countToken(updatedWxml, 'data-issue642-slot-state="scoped-provided"')).toBe(1)
+      expect(updatedWxml).toContain('data-issue642-scoped-value="1234"')
     }
     finally {
       await releaseSharedMiniProgram(miniProgram)

--- a/e2e/scripts/e2e-suite-manifest.ts
+++ b/e2e/scripts/e2e-suite-manifest.ts
@@ -18,6 +18,7 @@ const IDE_GITHUB_ISSUES_PATTERNS = [
   'ide/github-issues.runtime.issue558.test.ts',
   'ide/github-issues.runtime.issue615.test.ts',
   'ide/github-issues.runtime.issue627.test.ts',
+  'ide/github-issues.runtime.issue642.test.ts',
   'ide/github-issues.runtime.issue553-555.test.ts',
   'ide/github-issues.runtime.lifecycle.test.ts',
   'ide/github-issues.runtime.props.test.ts',

--- a/e2e/scripts/suiteRunner.test.ts
+++ b/e2e/scripts/suiteRunner.test.ts
@@ -255,10 +255,11 @@ describe('suiteRunner', () => {
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue289.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue558.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue615.test.ts')
+    expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue642.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.lifecycle.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.slot-fallback-compiler-off.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.slot-fallback.test.ts')
-    expect(ideGithubIssuesTasks.length).toBe(11)
+    expect(ideGithubIssuesTasks.length).toBe(13)
     expect(ideGithubIssuesTasks.every(task => task.env?.WEAPP_VITE_E2E_AUTOMATOR_LAUNCH_MODE === 'direct')).toBe(true)
   })
 

--- a/packages-runtime/wevu/src/runtime/register/component/props.ts
+++ b/packages-runtime/wevu/src/runtime/register/component/props.ts
@@ -5,6 +5,9 @@ import {
   WEVU_PROP_KEYS_KEY,
   WEVU_PROPS_DERIVED_KEYS_KEY,
   WEVU_PROPS_KEY,
+  WEVU_SLOT_NAMES_PROP,
+  WEVU_SLOT_OWNER_ID_PROP,
+  WEVU_SLOT_SCOPE_KEY,
 } from '@weapp-core/constants'
 import { hasOwn } from '../../../utils'
 import { refreshOwnerSnapshotFromInstance } from '../snapshot'
@@ -26,6 +29,11 @@ export function createPropsSync(options: {
   const aliasKeySet = new Set(aliasEntries.map(([alias]) => alias))
   const directPropsDerivedKeys = [...propsDerivedKeySet]
     .filter(key => propKeySet.has(key) && !aliasKeySet.has(key))
+  const templateRuntimePropKeys = new Set([
+    WEVU_SLOT_NAMES_PROP,
+    WEVU_SLOT_OWNER_ID_PROP,
+    WEVU_SLOT_SCOPE_KEY,
+  ])
   const syncedAliases = new WeakMap<InternalRuntimeState, Set<string>>()
 
   const isInternalAttrKey = (key: string) => key.startsWith('__wv_')
@@ -47,6 +55,22 @@ export function createPropsSync(options: {
     }
     target[key] = value
     return true
+  }
+
+  const syncTemplateRuntimeProp = (instance: InternalRuntimeState, key: string, value: unknown) => {
+    if (!templateRuntimePropKeys.has(key)) {
+      return
+    }
+    const runtimeState = (instance as any).__wevu?.state
+    if (!runtimeState || typeof runtimeState !== 'object') {
+      return
+    }
+    try {
+      setIfChanged(runtimeState as Record<string, unknown>, key, value)
+    }
+    catch {
+      // 忽略模板运行时字段同步失败，保持 props 主链路可用。
+    }
   }
 
   const syncSetupStatePropsAliases = (instance: InternalRuntimeState, propsProxy: Record<string, unknown>) => {
@@ -207,6 +231,7 @@ export function createPropsSync(options: {
         catch {
           // 忽略异常
         }
+        syncTemplateRuntimeProp(instance, k, nextValue)
       }
       if (pendingPropValues) {
         for (const [k, v] of Object.entries(pendingPropValues)) {
@@ -217,6 +242,7 @@ export function createPropsSync(options: {
             catch {
               // 忽略异常
             }
+            syncTemplateRuntimeProp(instance, k, v)
           }
         }
       }
@@ -251,6 +277,7 @@ export function createPropsSync(options: {
       catch {
         // 忽略 query props 同步失败，保持页面生命周期主链路可用。
       }
+      syncTemplateRuntimeProp(instance, key, values[key])
     }
     if (!changed) {
       return
@@ -272,6 +299,7 @@ export function createPropsSync(options: {
     catch {
       // 忽略异常
     }
+    syncTemplateRuntimeProp(instance, key, value)
     const pendingPropValues = ((instance as any)[WEVU_PENDING_PROP_VALUES_KEY] ??= Object.create(null)) as Record<string, unknown>
     pendingPropValues[key] = value
     syncPropsDerivedKeys(instance, propsProxy as Record<string, unknown>)

--- a/packages-runtime/wevu/test/runtime-props-sync.test.ts
+++ b/packages-runtime/wevu/test/runtime-props-sync.test.ts
@@ -1,4 +1,11 @@
-import { WEVU_PROPS_ALIASES_KEY, WEVU_PROPS_DERIVED_KEYS_KEY, WEVU_PUBLIC_RUNTIME_KEY } from '@weapp-core/constants'
+import {
+  WEVU_PROPS_ALIASES_KEY,
+  WEVU_PROPS_DERIVED_KEYS_KEY,
+  WEVU_PUBLIC_RUNTIME_KEY,
+  WEVU_SLOT_NAMES_PROP,
+  WEVU_SLOT_OWNER_ID_PROP,
+  WEVU_SLOT_SCOPE_KEY,
+} from '@weapp-core/constants'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick } from '@/index'
 import { resolvePropValue } from '@/runtime'
@@ -546,6 +553,90 @@ describe('runtime: props sync', () => {
     const payloads = inst.setData.mock.calls.map(([payload]: any[]) => payload ?? {})
     expect(payloads.some((payload: any) => Object.hasOwn(payload, 'title'))).toBe(false)
     expect(observerFeedbackCount).toBe(0)
+  })
+
+  it('mirrors compiled slot metadata prop to top-level data for fallback guards', async () => {
+    defineComponent({
+      props: {
+        title: { type: String, default: '' },
+      } as any,
+      setup(props) {
+        return { props }
+      },
+      setData: {
+        pick: [WEVU_SLOT_NAMES_PROP],
+        strategy: 'patch',
+      },
+    })
+
+    const opts = registeredComponents[0]
+    const nextSlots = { default: true, header: true }
+    const inst: any = {
+      setData: vi.fn(),
+      triggerEvent: vi.fn(),
+      properties: {
+        title: 'initial',
+        [WEVU_SLOT_NAMES_PROP]: null,
+      },
+    }
+    opts.lifetimes.created.call(inst)
+    opts.lifetimes.attached.call(inst)
+    await nextTick()
+    inst.setData.mockClear()
+
+    inst.properties[WEVU_SLOT_NAMES_PROP] = nextSlots
+    opts.observers[WEVU_SLOT_NAMES_PROP].call(inst, nextSlots, null)
+    await nextTick()
+
+    expect(inst[WEVU_PUBLIC_RUNTIME_KEY].proxy.props[WEVU_SLOT_NAMES_PROP]).toBe(nextSlots)
+    expect(inst[WEVU_PUBLIC_RUNTIME_KEY].proxy[WEVU_SLOT_NAMES_PROP]).toEqual(nextSlots)
+    expect(inst.setData).toHaveBeenCalledWith({ [WEVU_SLOT_NAMES_PROP]: nextSlots })
+  })
+
+  it('mirrors scoped slot owner metadata props to top-level data for compiled outlets', async () => {
+    defineComponent({
+      props: {
+        title: { type: String, default: '' },
+      } as any,
+      setup(props) {
+        return { props }
+      },
+      setData: {
+        pick: [WEVU_SLOT_OWNER_ID_PROP, WEVU_SLOT_SCOPE_KEY],
+        strategy: 'patch',
+      },
+    })
+
+    const opts = registeredComponents[0]
+    const nextScope = ['io', 1234]
+    const inst: any = {
+      setData: vi.fn(),
+      triggerEvent: vi.fn(),
+      properties: {
+        title: 'initial',
+        [WEVU_SLOT_OWNER_ID_PROP]: '',
+        [WEVU_SLOT_SCOPE_KEY]: null,
+      },
+    }
+    opts.lifetimes.created.call(inst)
+    opts.lifetimes.attached.call(inst)
+    await nextTick()
+    inst.setData.mockClear()
+
+    inst.properties[WEVU_SLOT_OWNER_ID_PROP] = 'wv-owner-1'
+    opts.observers[WEVU_SLOT_OWNER_ID_PROP].call(inst, 'wv-owner-1', '')
+    inst.properties[WEVU_SLOT_SCOPE_KEY] = nextScope
+    opts.observers[WEVU_SLOT_SCOPE_KEY].call(inst, nextScope, null)
+    await nextTick()
+
+    expect(inst[WEVU_PUBLIC_RUNTIME_KEY].proxy.props[WEVU_SLOT_OWNER_ID_PROP]).toBe('wv-owner-1')
+    expect(inst[WEVU_PUBLIC_RUNTIME_KEY].proxy[WEVU_SLOT_OWNER_ID_PROP]).toBe('wv-owner-1')
+    expect(inst[WEVU_PUBLIC_RUNTIME_KEY].proxy.props[WEVU_SLOT_SCOPE_KEY]).toBe(nextScope)
+    expect(inst[WEVU_PUBLIC_RUNTIME_KEY].proxy[WEVU_SLOT_SCOPE_KEY]).toEqual(nextScope)
+    expect(inst.setData).toHaveBeenCalledWith({
+      [WEVU_SLOT_OWNER_ID_PROP]: 'wv-owner-1',
+      [WEVU_SLOT_SCOPE_KEY]: nextScope,
+    })
   })
 
   it('keeps alias-derived setup keys visible to template setData output', async () => {


### PR DESCRIPTION
## 变更说明

- 修复 wevu 组件 props 同步时未将编译器 slot 桥接字段同步到顶层 data 的问题，覆盖 `vueSlots`、`__wvSlotOwnerId` 与 `__wvSlotScope`。
- 为 issue #642 增加普通 slot 与 scoped slot 两类回归用例，包含第二条评论中的 `slot :io` 场景。
- 补充 changeset，发布 `wevu` 并联动 `create-weapp-vite`。

## 验证

- `pnpm vitest run packages-runtime/wevu/test/runtime-props-sync.test.ts`
- `pnpm --filter wevu typecheck`
- `pnpm exec eslint packages-runtime/wevu/src/runtime/register/component/props.ts packages-runtime/wevu/test/runtime-props-sync.test.ts e2e/ci/github-issues.build.test.ts e2e/ide/github-issues.runtime.issue642.test.ts e2e-apps/github-issues/src/pages/issue-642/index.vue e2e-apps/github-issues/src/components/issue-642/ScopedSlotProbe/index.vue e2e-apps/github-issues/weapp-vite.config.ts`
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`
- `node --import tsx scripts/check-catalog-changeset.ts`
- `WEAPP_VITE_E2E_TARGET_FILE=ci/github-issues.build.test.ts pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts -t "issue #642"`
- `WEAPP_VITE_E2E_TARGET_FILE=ide/github-issues.runtime.issue642.test.ts pnpm vitest run -c ./e2e/vitest.e2e.devtools.config.ts`

DevTools runtime E2E 中 `/pages/issue-642/index` ready 文本等待触发 fallback，但页面返回成功，runtime stats 为 0 warn / 0 error / 0 exception，最终断言通过。

Fixes #642