### PR TITLE
fix(wevu): 修复 performance slot 桥接字段首轮同步

### DIFF
--- a/.changeset/issue-642-slot-runtime-pick.md
+++ b/.changeset/issue-642-slot-runtime-pick.md
@@ -1,0 +1,7 @@
+---
+"wevu": patch
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复 performance 预设下极简 slot 场景仍可能误渲染 fallback 的问题。组件初始同步时会把 `vueSlots`、`__wvSlotOwnerId` 与 `__wvSlotScope` 同步到原生顶层 data，并且自动 `setData.pick` 会稳定保留这些 slot 桥接字段，避免普通插槽和作用域插槽在首轮渲染中读取到默认空值。

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -89,6 +89,14 @@ function createObjectPropertyPattern(property: string, value: string) {
   return new RegExp(`${escapeRegex(JSON.stringify(property))}\\s*:\\s*${escapeRegex(JSON.stringify(value))}`)
 }
 
+function expectSetDataPickKeys(code: string, keys: string[]) {
+  const match = code.match(/setData\s*:\s*\{\s*pick\s*:\s*\[([\s\S]*?)\]/)
+  expect(match?.[1]).toBeTruthy()
+  for (const key of keys) {
+    expect(match![1]).toContain(JSON.stringify(key))
+  }
+}
+
 function createSerializedJsonEntryPattern(key: string, value: string) {
   return new RegExp(escapeRegex(`\\"${key}\\":\\"${value}\\"`))
 }
@@ -671,10 +679,12 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(slotProbeWxml).toContain(`<block wx:if="{{vueSlots&&vueSlots.header}}">`)
     expect(slotProbeWxml).toContain(`<block wx:if="{{vueSlots&&vueSlots.default}}">`)
     expect(slotProbeJs).toContain('"vueSlots"')
+    expectSetDataPickKeys(slotProbeJs, ['vueSlots', '__wvSlotOwnerId', '__wvSlotScope'])
     expect(scopedProbeWxml).toContain('<scoped-slots-default wx:if="{{__wvSlotOwnerId}}"')
     expect(scopedProbeWxml).toContain(`__wvSlotProps="{{['io',1234]}}"`)
     expect(scopedProbeJs).toContain('"__wvSlotOwnerId"')
     expect(scopedProbeJs).toContain('"__wvSlotScope"')
+    expectSetDataPickKeys(scopedProbeJs, ['vueSlots', '__wvSlotOwnerId', '__wvSlotScope'])
   })
 
   it('issue #424: avoids duplicated output for imported src/assets images', async () => {

--- a/e2e/ide/github-issues.runtime.issue642.test.ts
+++ b/e2e/ide/github-issues.runtime.issue642.test.ts
@@ -37,6 +37,10 @@ describe.sequential('e2e app: github-issues / issue #642', () => {
             default: true,
             header: true,
           },
+          propertyVueSlots: {
+            default: true,
+            header: true,
+          },
           hasDefault: true,
           hasHeader: true,
         },
@@ -49,6 +53,7 @@ describe.sequential('e2e app: github-issues / issue #642', () => {
           dataSlotOwnerId: expect.any(String),
         },
       })
+      expect(initialRuntime.provided.dataVueSlots).toEqual(initialRuntime.provided.propertyVueSlots)
       expect(initialRuntime.scoped.propsSlotOwnerId).not.toBe('')
       expect(initialRuntime.scoped.dataSlotOwnerId).toBe(initialRuntime.scoped.propsSlotOwnerId)
 
@@ -74,6 +79,10 @@ describe.sequential('e2e app: github-issues / issue #642', () => {
             default: true,
             header: true,
           },
+          propertyVueSlots: {
+            default: true,
+            header: true,
+          },
           hasDefault: true,
           hasHeader: true,
         },
@@ -82,6 +91,7 @@ describe.sequential('e2e app: github-issues / issue #642', () => {
           propsSlotOwnerId: initialRuntime.scoped.propsSlotOwnerId,
         },
       })
+      expect(updatedRuntime.provided.dataVueSlots).toEqual(updatedRuntime.provided.propertyVueSlots)
 
       const updatedWxml = await readPageWxml(issuePage)
       expect(countToken(updatedWxml, 'data-issue642-slot-state="provided-header"')).toBe(1)

--- a/packages-runtime/wevu/src/runtime/register/component/props.ts
+++ b/packages-runtime/wevu/src/runtime/register/component/props.ts
@@ -62,11 +62,14 @@ export function createPropsSync(options: {
       return
     }
     const runtimeState = (instance as any).__wevu?.state
-    if (!runtimeState || typeof runtimeState !== 'object') {
-      return
-    }
     try {
-      setIfChanged(runtimeState as Record<string, unknown>, key, value)
+      if (runtimeState && typeof runtimeState === 'object') {
+        setIfChanged(runtimeState as Record<string, unknown>, key, value)
+      }
+      const nativeData = (instance as any).data
+      if (nativeData && typeof nativeData === 'object') {
+        setIfChanged(nativeData as Record<string, unknown>, key, value)
+      }
     }
     catch {
       // 忽略模板运行时字段同步失败，保持 props 主链路可用。

--- a/packages-runtime/wevu/test/runtime-props-sync.test.ts
+++ b/packages-runtime/wevu/test/runtime-props-sync.test.ts
@@ -593,6 +593,44 @@ describe('runtime: props sync', () => {
     expect(inst.setData).toHaveBeenCalledWith({ [WEVU_SLOT_NAMES_PROP]: nextSlots })
   })
 
+  it('mirrors initially provided slot metadata before the first performance snapshot flush', async () => {
+    defineComponent({
+      props: {
+        title: { type: String, default: '' },
+      } as any,
+      setup(props) {
+        return { props }
+      },
+      setData: {
+        pick: [WEVU_SLOT_NAMES_PROP],
+        strategy: 'patch',
+      },
+    })
+
+    const opts = registeredComponents[0]
+    const initialSlots = { default: true }
+    const inst: any = {
+      data: {
+        [WEVU_SLOT_NAMES_PROP]: null,
+      },
+      setData: vi.fn(),
+      triggerEvent: vi.fn(),
+      properties: {
+        title: 'initial',
+        [WEVU_SLOT_NAMES_PROP]: initialSlots,
+      },
+    }
+
+    opts.lifetimes.created.call(inst)
+    opts.lifetimes.attached.call(inst)
+    await nextTick()
+
+    expect(inst.data[WEVU_SLOT_NAMES_PROP]).toBe(initialSlots)
+    expect(inst[WEVU_PUBLIC_RUNTIME_KEY].proxy.props[WEVU_SLOT_NAMES_PROP]).toBe(initialSlots)
+    expect(inst[WEVU_PUBLIC_RUNTIME_KEY].proxy[WEVU_SLOT_NAMES_PROP]).toEqual(initialSlots)
+    expect(inst.setData).toHaveBeenCalledWith({ [WEVU_SLOT_NAMES_PROP]: initialSlots })
+  })
+
   it('mirrors scoped slot owner metadata props to top-level data for compiled outlets', async () => {
     defineComponent({
       props: {
@@ -636,6 +674,50 @@ describe('runtime: props sync', () => {
     expect(inst.setData).toHaveBeenCalledWith({
       [WEVU_SLOT_OWNER_ID_PROP]: 'wv-owner-1',
       [WEVU_SLOT_SCOPE_KEY]: nextScope,
+    })
+  })
+
+  it('mirrors initially provided scoped slot owner metadata before the first performance snapshot flush', async () => {
+    defineComponent({
+      props: {
+        title: { type: String, default: '' },
+      } as any,
+      setup(props) {
+        return { props }
+      },
+      setData: {
+        pick: [WEVU_SLOT_OWNER_ID_PROP, WEVU_SLOT_SCOPE_KEY],
+        strategy: 'patch',
+      },
+    })
+
+    const opts = registeredComponents[0]
+    const initialScope = ['io', 1234]
+    const inst: any = {
+      data: {
+        [WEVU_SLOT_OWNER_ID_PROP]: '',
+        [WEVU_SLOT_SCOPE_KEY]: null,
+      },
+      setData: vi.fn(),
+      triggerEvent: vi.fn(),
+      properties: {
+        title: 'initial',
+        [WEVU_SLOT_OWNER_ID_PROP]: 'wv-owner-1',
+        [WEVU_SLOT_SCOPE_KEY]: initialScope,
+      },
+    }
+
+    opts.lifetimes.created.call(inst)
+    opts.lifetimes.attached.call(inst)
+    await nextTick()
+
+    expect(inst.data[WEVU_SLOT_OWNER_ID_PROP]).toBe('wv-owner-1')
+    expect(inst.data[WEVU_SLOT_SCOPE_KEY]).toBe(initialScope)
+    expect(inst[WEVU_PUBLIC_RUNTIME_KEY].proxy.props[WEVU_SLOT_OWNER_ID_PROP]).toBe('wv-owner-1')
+    expect(inst[WEVU_PUBLIC_RUNTIME_KEY].proxy.props[WEVU_SLOT_SCOPE_KEY]).toBe(initialScope)
+    expect(inst.setData).toHaveBeenCalledWith({
+      [WEVU_SLOT_OWNER_ID_PROP]: 'wv-owner-1',
+      [WEVU_SLOT_SCOPE_KEY]: initialScope,
     })
   })
 

--- a/packages/weapp-vite/src/plugins/vue/transform/injectSetDataPick.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/injectSetDataPick.test.ts
@@ -1,3 +1,4 @@
+import { WEVU_SLOT_NAMES_PROP, WEVU_SLOT_OWNER_ID_PROP, WEVU_SLOT_SCOPE_KEY } from '@weapp-core/constants'
 import { describe, expect, it } from 'vitest'
 import { getWxmlDirectivePrefix } from '../../../platform'
 import { collectSetDataPickKeysFromTemplate, injectScopedSlotHostPropertiesInJs, injectSetDataPickInJs, mayNeedInjectSetDataPickInJs } from './injectSetDataPick'
@@ -35,6 +36,24 @@ createWevuComponent(__wevuOptions)
     expect(injected.code).toContain('pick')
     expect(injected.code).toContain('"count"')
     expect(injected.code).toContain('"total"')
+  })
+
+  it('keeps slot bridge keys in injected setData.pick', () => {
+    const source = `
+import { defineComponent } from 'wevu'
+defineComponent({
+  setup() {
+    return {}
+  },
+})
+    `.trim()
+
+    const injected = injectSetDataPickInJs(source, ['count'])
+    expect(injected.transformed).toBe(true)
+    expect(injected.code).toContain('"count"')
+    expect(injected.code).toContain(`"${WEVU_SLOT_NAMES_PROP}"`)
+    expect(injected.code).toContain(`"${WEVU_SLOT_OWNER_ID_PROP}"`)
+    expect(injected.code).toContain(`"${WEVU_SLOT_SCOPE_KEY}"`)
   })
 
   it('detects whether js may need setData.pick injection', () => {
@@ -79,7 +98,10 @@ defineComponent({
     const injected = injectSetDataPickInJs(source, ['count'])
     expect(injected.transformed).toBe(true)
     expect(injected.code).toContain('setData: {')
-    expect(injected.code).toContain('pick: ["count"]')
+    expect(injected.code).toContain('"count"')
+    expect(injected.code).toContain(`"${WEVU_SLOT_NAMES_PROP}"`)
+    expect(injected.code).toContain(`"${WEVU_SLOT_OWNER_ID_PROP}"`)
+    expect(injected.code).toContain(`"${WEVU_SLOT_SCOPE_KEY}"`)
     expect(injected.code).toContain('...setDataOption')
   })
 

--- a/packages/weapp-vite/src/plugins/vue/transform/injectSetDataPick.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/injectSetDataPick.ts
@@ -4,6 +4,7 @@ import type { AstEngineName } from '../../../ast'
 import type { WeappViteConfig } from '../../../types'
 import type { EncodedSourceMapLike } from '../../../utils/sourcemap'
 import {
+  WEVU_SLOT_NAMES_PROP,
   WEVU_SLOT_OWNER_ID_PROP,
   WEVU_SLOT_SCOPE_KEY,
 } from '@weapp-core/constants'
@@ -111,6 +112,19 @@ function createPickArrayExpression(keys: string[]): t.ArrayExpression {
     type: 'ArrayExpression',
     elements: keys.map(key => ({ type: 'StringLiteral', value: key })),
   }
+}
+
+function mergeStableKeys(keys: string[], stableKeys: string[]): string[] {
+  const merged: string[] = []
+  const seen = new Set<string>()
+  for (const key of [...keys, ...stableKeys]) {
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    merged.push(key)
+  }
+  return merged
 }
 
 function mergePickArrayExpression(
@@ -366,13 +380,18 @@ export function injectSetDataPickInJs(
   source: string,
   pickKeys: string[],
 ): { code: string, transformed: boolean, map?: EncodedSourceMapLike | null } {
-  if (!pickKeys.length) {
+  const mergedPickKeys = mergeStableKeys(pickKeys, [
+    WEVU_SLOT_NAMES_PROP,
+    WEVU_SLOT_OWNER_ID_PROP,
+    WEVU_SLOT_SCOPE_KEY,
+  ])
+  if (!mergedPickKeys.length) {
     return { code: source, transformed: false }
   }
 
   return transformTargetWevuOptionsInJs(
     source,
-    optionsObject => injectPickIntoOptionsObject(optionsObject, pickKeys),
+    optionsObject => injectPickIntoOptionsObject(optionsObject, mergedPickKeys),
   )
 }
 


### PR DESCRIPTION
## 变更说明

- 修复 performance 预设下 slot 桥接字段只同步到 runtime state、没有同步到原生顶层 data 的问题，避免初始 snapshot 继续保留 `vueSlots = null` 或空 `__wvSlotOwnerId`。
- 自动 `setData.pick` 注入时稳定保留 `vueSlots`、`__wvSlotOwnerId` 与 `__wvSlotScope`，覆盖普通 slot fallback 和 scoped slot owner 两类场景。
- 补充 issue #642 对应的 runtime 单测、构建产物断言和 changeset。

## 验证

- `pnpm vitest run packages-runtime/wevu/test/runtime-props-sync.test.ts packages/weapp-vite/src/plugins/vue/transform/injectSetDataPick.test.ts`
- `pnpm --filter wevu typecheck`
- `pnpm --filter weapp-vite typecheck`
- `pnpm exec eslint packages-runtime/wevu/src/runtime/register/component/props.ts packages-runtime/wevu/test/runtime-props-sync.test.ts packages/weapp-vite/src/plugins/vue/transform/injectSetDataPick.ts packages/weapp-vite/src/plugins/vue/transform/injectSetDataPick.test.ts e2e/ci/github-issues.build.test.ts`
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`
- `node --import tsx scripts/check-catalog-changeset.ts`
- `pnpm build:pkgs`
- `WEAPP_VITE_E2E_TARGET_FILE=ci/github-issues.build.test.ts pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts -t "issue #642"`
- `WEAPP_VITE_E2E_TARGET_FILE=ide/github-issues.runtime.issue642.test.ts pnpm vitest run -c ./e2e/vitest.e2e.devtools.config.ts`

DevTools runtime E2E 中 `/pages/issue-642/index` ready 文本等待触发 fallback，但页面返回成功，runtime stats 为 0 warn / 0 error / 0 exception，最终断言通过。

Fixes #642