### PR TITLE
fix(weapp-vite): 修复 dev 配置变更重启入口扫描

### DIFF
--- a/.changeset/tame-config-restart.md
+++ b/.changeset/tame-config-restart.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复开发模式下配置文件变更触发重启时，入口扫描错误被分包扫描覆盖的问题。现在重启会重新加载应用入口和分包元数据，避免使用 `app.vue` 作为应用配置来源的 wevu 模板被误报为缺少 `app.json`。

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
@@ -641,9 +641,34 @@ describe('runtime buildPlugin service', () => {
     expect(sidecarWatcher.close).toHaveBeenCalledTimes(1)
     expect(ctx.configService.load).toHaveBeenCalledWith(ctx.configService.loadOptions)
     expect(ctx.scanService.loadAppEntry).toHaveBeenCalledTimes(1)
+    expect(ctx.scanService.loadSubPackages).toHaveBeenCalledTimes(1)
     expect(buildMock).toHaveBeenCalledTimes(2)
     expect(ctx.watcherService.rollupWatcherMap.get('/')).toBe(restartedWatcher)
     expect(loggerInfoMock).toHaveBeenCalledWith('检测到 Vite 配置变更，正在重启小程序开发构建...')
+  })
+
+  it('keeps the app entry scan error when config restart cannot reload entries', async () => {
+    const watcher = createManualWatcher()
+    buildMock.mockResolvedValueOnce(watcher)
+    const ctx = createMockContext()
+    const appEntryError = new Error('在 /project/src 目录下没有找到 `app.json` 或 `app.vue`')
+    ctx.scanService.loadAppEntry.mockRejectedValueOnce(appEntryError)
+    const service = createBuildService(ctx)
+
+    const firstBuild = service.build({ skipNpm: true })
+    await watcher.subscribed
+    watcher.emit('START')
+    watcher.emit('END')
+    await firstBuild
+
+    service.requestConfigRestart('app')
+    watcher.emit('START')
+    watcher.emit('END')
+
+    await waitForMockCalls(ctx.scanService.loadAppEntry, 1)
+    await flushAsyncTasks()
+    expect(ctx.scanService.loadSubPackages).not.toHaveBeenCalled()
+    expect(buildMock).toHaveBeenCalledTimes(1)
   })
 
   it('narrows snapshot sidecar watcher to sidecar globs and ignores generated roots', async () => {

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.ts
@@ -794,7 +794,8 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
             logger.info('检测到 Vite 配置变更，正在重启小程序开发构建...')
             resetRuntimeStateForConfigRestart()
             await configService.load(configService.loadOptions)
-            await scanService.loadAppEntry().catch(() => {})
+            await scanService.loadAppEntry()
+            scanService.loadSubPackages()
             logger.success('Vite 配置已重新加载，小程序开发构建已重启。')
             await runDev(target)
           }


### PR DESCRIPTION
## 摘要

- 修复 dev 模式配置文件变更触发重启时吞掉应用入口扫描错误的问题
- 重启时重新加载 app 入口与分包元数据，避免 wevu 模板使用 app.vue 配置时被误报缺少 app.json
- 补充配置重启单测与 weapp-vite / create-weapp-vite changeset

Closes #649

## 验证

- pnpm vitest run packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
- pnpm --filter weapp-vite build
- pnpm --filter weapp-vite-wevu-template build
- pnpm --filter weapp-vite typecheck
- pnpm --filter weapp-vite lint:src（通过，存在既有 warning）
- node --import tsx scripts/check-create-weapp-vite-changeset.ts
- node --import tsx scripts/check-catalog-changeset.ts