### PR TITLE
fix(weapp-vite): 修复配置重启入口组合扫描

### DIFF
--- a/.changeset/tame-config-restart.md
+++ b/.changeset/tame-config-restart.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复开发模式下配置文件变更触发重启时，入口扫描错误被分包扫描覆盖的问题。现在重启会重新加载应用入口和分包元数据，并保持 `app.vue`、`app.ts` 搭配 `app.json.ts` 等入口配置组合的扫描结果，避免被误报为缺少 `app.json`。

--- a/e2e/ci/issue-649-entry-combos.build.test.ts
+++ b/e2e/ci/issue-649-entry-combos.build.test.ts
@@ -1,0 +1,141 @@
+import { fs } from '@weapp-core/shared/node'
+import path from 'pathe'
+import { afterAll, describe, expect, it } from 'vitest'
+import { runWeappViteBuildWithLogCapture } from '../utils/buildLog'
+
+const CLI_PATH = path.resolve(import.meta.dirname, '../../packages/weapp-vite/bin/weapp-vite.js')
+const CONFIG_MODULE_PATH = path.resolve(import.meta.dirname, '../../packages/weapp-vite/dist/config.mjs')
+const TEMP_ROOT = path.resolve(import.meta.dirname, '../../.tmp')
+const tempRoots: string[] = []
+
+async function writeJson(target: string, value: Record<string, any>) {
+  await fs.ensureDir(path.dirname(target))
+  await fs.writeJson(target, value, { spaces: 2 })
+}
+
+async function writeText(target: string, source: string) {
+  await fs.ensureDir(path.dirname(target))
+  await fs.writeFile(target, source, 'utf8')
+}
+
+async function createBaseProject(label: string) {
+  await fs.ensureDir(TEMP_ROOT)
+  const root = await fs.mkdtemp(path.join(TEMP_ROOT, `${label}-`))
+  tempRoots.push(root)
+
+  await writeJson(path.join(root, 'package.json'), {
+    name: `e2e-${label}`,
+    private: true,
+    type: 'module',
+  })
+  await writeJson(path.join(root, 'project.config.json'), {
+    appid: 'wxb3d842a4a7e3440d',
+    miniprogramRoot: 'dist',
+  })
+  await writeText(
+    path.join(root, 'weapp-vite.config.ts'),
+    [
+      `import { defineConfig } from ${JSON.stringify(CONFIG_MODULE_PATH)}`,
+      '',
+      'export default defineConfig({',
+      '  weapp: {',
+      '    srcRoot: \'src\',',
+      '  },',
+      '})',
+      '',
+    ].join('\n'),
+  )
+  await writeText(path.join(root, 'src/pages/index/index.ts'), 'Page({})\n')
+  await writeText(path.join(root, 'src/pages/index/index.wxml'), '<view>issue 649</view>\n')
+  await writeText(path.join(root, 'src/pkgA/pages/detail/index.ts'), 'Page({})\n')
+  await writeText(path.join(root, 'src/pkgA/pages/detail/index.wxml'), '<view>issue 649 subpackage</view>\n')
+
+  return root
+}
+
+async function createAppVueProject() {
+  const root = await createBaseProject('issue-649-app-vue')
+
+  await writeText(
+    path.join(root, 'src/app.vue'),
+    [
+      '<script setup lang="ts">',
+      'defineAppJson({',
+      '  pages: [\'pages/index/index\'],',
+      '  subPackages: [{ root: \'pkgA\', pages: [\'pages/detail/index\'] }],',
+      '})',
+      '</script>',
+      '',
+      '<template>',
+      '  <slot />',
+      '</template>',
+      '',
+    ].join('\n'),
+  )
+
+  return root
+}
+
+async function createAppTsWithJsonTsProject() {
+  const root = await createBaseProject('issue-649-app-ts-json-ts')
+
+  await writeText(path.join(root, 'src/app.ts'), 'App({})\n')
+  await writeText(
+    path.join(root, 'src/app.json.ts'),
+    [
+      'export default {',
+      '  pages: [\'pages/index/index\'],',
+      '  subPackages: [{ root: \'pkgA\', pages: [\'pages/detail/index\'] }],',
+      '}',
+      '',
+    ].join('\n'),
+  )
+
+  return root
+}
+
+async function buildProject(root: string, label: string) {
+  await runWeappViteBuildWithLogCapture({
+    cliPath: CLI_PATH,
+    projectRoot: root,
+    platform: 'weapp',
+    cwd: root,
+    label,
+    skipNpm: true,
+  })
+}
+
+async function expectAppJson(root: string) {
+  const appJson = await fs.readJson(path.join(root, 'dist/app.json'))
+  expect(appJson.pages).toEqual(['pages/index/index'])
+  expect(appJson.subPackages).toEqual([
+    {
+      root: 'pkgA',
+      pages: ['pages/detail/index'],
+    },
+  ])
+}
+
+afterAll(async () => {
+  await Promise.all(tempRoots.splice(0).map(root => fs.remove(root)))
+})
+
+describe.sequential('issue 649 entry config combinations', () => {
+  it('builds when app.vue provides the app config', async () => {
+    const root = await createAppVueProject()
+
+    await buildProject(root, 'ci:issue-649:app-vue')
+
+    expect(await fs.pathExists(path.join(root, 'dist/app.js'))).toBe(true)
+    await expectAppJson(root)
+  })
+
+  it('builds when app.ts uses app.json.ts as the app config', async () => {
+    const root = await createAppTsWithJsonTsProject()
+
+    await buildProject(root, 'ci:issue-649:app-ts-json-ts')
+
+    expect(await fs.pathExists(path.join(root, 'dist/app.js'))).toBe(true)
+    await expectAppJson(root)
+  })
+})

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
@@ -641,9 +641,34 @@ describe('runtime buildPlugin service', () => {
     expect(sidecarWatcher.close).toHaveBeenCalledTimes(1)
     expect(ctx.configService.load).toHaveBeenCalledWith(ctx.configService.loadOptions)
     expect(ctx.scanService.loadAppEntry).toHaveBeenCalledTimes(1)
+    expect(ctx.scanService.loadSubPackages).toHaveBeenCalledTimes(1)
     expect(buildMock).toHaveBeenCalledTimes(2)
     expect(ctx.watcherService.rollupWatcherMap.get('/')).toBe(restartedWatcher)
     expect(loggerInfoMock).toHaveBeenCalledWith('检测到 Vite 配置变更，正在重启小程序开发构建...')
+  })
+
+  it('keeps the app entry scan error when config restart cannot reload entries', async () => {
+    const watcher = createManualWatcher()
+    buildMock.mockResolvedValueOnce(watcher)
+    const ctx = createMockContext()
+    const appEntryError = new Error('在 /project/src 目录下没有找到 `app.json`、`app.json.ts` 或 `app.vue`')
+    ctx.scanService.loadAppEntry.mockRejectedValueOnce(appEntryError)
+    const service = createBuildService(ctx)
+
+    const firstBuild = service.build({ skipNpm: true })
+    await watcher.subscribed
+    watcher.emit('START')
+    watcher.emit('END')
+    await firstBuild
+
+    service.requestConfigRestart('app')
+    watcher.emit('START')
+    watcher.emit('END')
+
+    await waitForMockCalls(ctx.scanService.loadAppEntry, 1)
+    await flushAsyncTasks()
+    expect(ctx.scanService.loadSubPackages).not.toHaveBeenCalled()
+    expect(buildMock).toHaveBeenCalledTimes(1)
   })
 
   it('narrows snapshot sidecar watcher to sidecar globs and ignores generated roots', async () => {

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.ts
@@ -794,7 +794,8 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
             logger.info('检测到 Vite 配置变更，正在重启小程序开发构建...')
             resetRuntimeStateForConfigRestart()
             await configService.load(configService.loadOptions)
-            await scanService.loadAppEntry().catch(() => {})
+            await scanService.loadAppEntry()
+            scanService.loadSubPackages()
             logger.success('Vite 配置已重新加载，小程序开发构建已重启。')
             await runDev(target)
           }

--- a/packages/weapp-vite/src/runtime/scanPlugin/service.test.ts
+++ b/packages/weapp-vite/src/runtime/scanPlugin/service.test.ts
@@ -268,6 +268,38 @@ describe('scanPlugin service', () => {
     expect(entry.json.subPackages).toEqual([])
   })
 
+  it('uses app.json.ts as config source with app.ts entry', async () => {
+    findJsonEntryMock.mockResolvedValue({ path: '/project/src/app.json.ts' })
+    findJsEntryMock.mockResolvedValue({ path: '/project/src/app.ts' })
+    findVueEntryMock.mockResolvedValue(undefined)
+
+    const ctx = createCtx({
+      jsonService: {
+        read: vi.fn(async () => ({
+          pages: ['pages/index/index'],
+          subpackages: [{ root: 'pkgA', pages: ['pages/a'] }],
+        })),
+      },
+      configService: {
+        absoluteSrcRoot: '/project/src',
+        absolutePluginRoot: undefined,
+        weappViteConfig: {},
+      },
+    })
+
+    const { createScanService } = await import('./service')
+    const service = createScanService(ctx)
+    const entry = await service.loadAppEntry()
+
+    expect(entry.path).toBe('/project/src/app.ts')
+    expect(entry.jsonPath).toBe('/project/src/app.json.ts')
+    expect(entry.json).toEqual({
+      pages: ['pages/index/index'],
+      subPackages: [{ root: 'pkgA', pages: ['pages/a'] }],
+    })
+    expect(ctx.jsonService.read).toHaveBeenCalledWith('/project/src/app.json.ts')
+  })
+
   it('warns app/app config conflicts only once within the same scan context', async () => {
     findJsonEntryMock.mockResolvedValue({ path: '/project/src/app.json' })
     findJsEntryMock.mockResolvedValue({ path: '/project/src/app.ts' })
@@ -577,7 +609,7 @@ describe('scanPlugin service', () => {
     const { createScanService } = await import('./service')
     const service = createScanService(ctx)
 
-    expect(() => service.loadSubPackages()).toThrow('没有找到 `app.json`')
+    expect(() => service.loadSubPackages()).toThrow('没有找到 `app.json`、`app.json.ts` 或 `app.vue`')
   })
 
   it('markDirty resets cached app/plugin states and ignores empty independent roots', async () => {

--- a/packages/weapp-vite/src/runtime/scanPlugin/service/app.ts
+++ b/packages/weapp-vite/src/runtime/scanPlugin/service/app.ts
@@ -260,5 +260,5 @@ export async function loadAppEntry(ctx: MutableCompilerContext, scanState: ScanS
     throw new Error('`app.json` 解析失败，请确保 `app.json` 文件格式正确')
   }
 
-  throw new Error(`在 ${appDirname} 目录下没有找到 \`app.json\` 或 \`app.vue\`，请确保你初始化了小程序项目，或者在 \`vite.config.ts\` / \`weapp-vite.config.ts\` 中设置正确的 \`weapp.srcRoot\` 配置路径`)
+  throw new Error(`在 ${appDirname} 目录下没有找到 \`app.json\`、\`app.json.ts\` 或 \`app.vue\`，请确保你初始化了小程序项目，或者在 \`vite.config.ts\` / \`weapp-vite.config.ts\` 中设置正确的 \`weapp.srcRoot\` 配置路径`)
 }

--- a/packages/weapp-vite/src/runtime/scanPlugin/service/subPackages.ts
+++ b/packages/weapp-vite/src/runtime/scanPlugin/service/subPackages.ts
@@ -68,5 +68,5 @@ export function loadSubPackages(ctx: MutableCompilerContext) {
     return [...subPackageMap.values()]
   }
 
-  throw new Error(`在 ${configService.absoluteSrcRoot} 目录下没有找到 \`app.json\`, 请确保你初始化了小程序项目，或者在 \`vite.config.ts\` / \`weapp-vite.config.ts\` 中设置正确的 \`weapp.srcRoot\` 配置路径`)
+  throw new Error(`在 ${configService.absoluteSrcRoot} 目录下没有找到 \`app.json\`、\`app.json.ts\` 或 \`app.vue\`，请确保你初始化了小程序项目，或者在 \`vite.config.ts\` / \`weapp-vite.config.ts\` 中设置正确的 \`weapp.srcRoot\` 配置路径`)
 }


### PR DESCRIPTION
## 摘要

- 合入 #652 的配置重启入口重扫修复，重启时重新加载 app 入口与分包元数据
- 补充 `app.ts + app.json.ts` 扫描单测，并把入口缺失文案同步到 `app.json` / `app.json.ts` / `app.vue`
- 新增临时项目 e2e build，覆盖 `app.vue` 和 `app.ts + app.json.ts` 两种 issue comment 提到的组合

Closes #649

## 验证

- `pnpm --filter weapp-vite... build`
- `pnpm vitest run packages/weapp-vite/src/runtime/scanPlugin/service.test.ts packages/weapp-vite/src/runtime/buildPlugin/service.test.ts`
- `pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/issue-649-entry-combos.build.test.ts`
- `pnpm --filter weapp-vite typecheck`
- `pnpm --filter weapp-vite lint:src`（通过，存在既有 warning）
- `pnpm exec eslint e2e/ci/issue-649-entry-combos.build.test.ts`
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`
- `node --import tsx scripts/check-catalog-changeset.ts`