### PR TITLE
fix(weapp-vite): 优化 DevTools engine build 接口缺失提示

### DIFF
--- a/.changeset/friendly-devtools-engine-build.md
+++ b/.changeset/friendly-devtools-engine-build.md
@@ -1,0 +1,7 @@
+---
+"weapp-ide-cli": patch
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+优化微信开发者工具缺少 engine build 接口时的错误处理，避免将 DevTools 返回的 HTML 404 原样暴露为构建失败，并在打开 IDE 时跳过不兼容的自动刷新步骤。

--- a/packages/weapp-ide-cli/src/cli/engine.ts
+++ b/packages/weapp-ide-cli/src/cli/engine.ts
@@ -20,6 +20,7 @@ export interface RunWechatIdeEngineBuildByHttpOptions extends WechatDevtoolsHttp
 }
 
 export interface RunWechatIdeEngineBuildOptions extends RunWechatIdeEngineBuildByHttpOptions {
+  fallbackToCli?: boolean
   logPath?: string
 }
 
@@ -33,6 +34,7 @@ const ENGINE_BUILD_ENDPOINT_MISSING_PATTERNS = [
   /Cannot GET \/engine\/build\b/i,
   /Cannot GET \/engine\/buildResult\//i,
 ]
+const ENGINE_BUILD_ENDPOINT_MISSING_MESSAGE = '当前微信开发者工具未提供 engine build 接口，已跳过自动 engine build 刷新。'
 const ENGINE_BUILD_CLI_OPENED_PATTERN = /打开项目成功|project\s+opened|open\s+project\s+success/i
 const COMPACT_WHITESPACE_PATTERN = /\s+/g
 
@@ -85,6 +87,19 @@ function isEngineBuildEndpointMissingError(error: unknown) {
   return ENGINE_BUILD_ENDPOINT_MISSING_PATTERNS.some(pattern => pattern.test(message))
 }
 
+function createEngineBuildEndpointMissingError() {
+  return createEngineBuildError(
+    ENGINE_BUILD_ENDPOINT_MISSING_MESSAGE,
+    'WECHAT_DEVTOOLS_ENGINE_BUILD_ENDPOINT_MISSING',
+  )
+}
+
+export function isWechatIdeEngineBuildEndpointMissingError(error: unknown) {
+  return error instanceof Error
+    && 'code' in error
+    && error.code === 'WECHAT_DEVTOOLS_ENGINE_BUILD_ENDPOINT_MISSING'
+}
+
 function compactOutput(value: string | undefined) {
   return typeof value === 'string'
     ? value.replace(COMPACT_WHITESPACE_PATTERN, ' ').trim()
@@ -105,6 +120,10 @@ async function runWechatIdeEngineBuildByCli(projectPath: string, options: RunWec
   const stderr = typeof result.stderr === 'string' ? result.stderr : ''
   const output = [stdout, stderr].filter(Boolean).join('\n')
   await writeEngineBuildLog(options.logPath, output)
+
+  if (isEngineBuildEndpointMissingError(output)) {
+    throw createEngineBuildEndpointMissingError()
+  }
 
   if ((result.exitCode ?? 1) === 0) {
     if (stdout) {
@@ -197,6 +216,9 @@ export async function runWechatIdeEngineBuild(
   }
   catch (error) {
     if (isEngineBuildEndpointMissingError(error)) {
+      if (options.fallbackToCli === false) {
+        throw createEngineBuildEndpointMissingError()
+      }
       return await runWechatIdeEngineBuildByCli(projectPath, options)
     }
     logs.push(error instanceof Error ? error.message : String(error))

--- a/packages/weapp-ide-cli/test/engine.test.ts
+++ b/packages/weapp-ide-cli/test/engine.test.ts
@@ -144,6 +144,40 @@ describe('runWechatIdeEngineBuildByHttp', () => {
     )
   })
 
+  it('can skip official cli fallback when http engine build endpoint is unavailable', async () => {
+    startWechatIdeEngineBuildByHttpMock.mockRejectedValueOnce(new Error('Cannot GET /engine/build'))
+    const { runWechatIdeEngineBuild } = await import('../src/cli/engine')
+
+    await expect(runWechatIdeEngineBuild('/workspace/demo-app', {
+      fallbackToCli: false,
+    })).rejects.toMatchObject({
+      code: 'WECHAT_DEVTOOLS_ENGINE_BUILD_ENDPOINT_MISSING',
+      message: '当前微信开发者工具未提供 engine build 接口，已跳过自动 engine build 刷新。',
+    })
+
+    expect(execaMock).not.toHaveBeenCalled()
+  })
+
+  it('normalizes endpoint-missing errors returned by official cli fallback', async () => {
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
+    const stderrWriteSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+    startWechatIdeEngineBuildByHttpMock.mockRejectedValueOnce(new Error('Cannot GET /engine/build'))
+    execaMock.mockResolvedValueOnce({
+      exitCode: 1,
+      stderr: '[error] Fail to buil project:<!DOCTYPE html><pre>Cannot GET /engine/build</pre> - initialize',
+      stdout: '',
+    })
+    const { runWechatIdeEngineBuild } = await import('../src/cli/engine')
+
+    await expect(runWechatIdeEngineBuild('/workspace/demo-app')).rejects.toMatchObject({
+      code: 'WECHAT_DEVTOOLS_ENGINE_BUILD_ENDPOINT_MISSING',
+      message: '当前微信开发者工具未提供 engine build 接口，已跳过自动 engine build 刷新。',
+    })
+
+    expect(stdoutWriteSpy).not.toHaveBeenCalled()
+    expect(stderrWriteSpy).not.toHaveBeenCalled()
+  })
+
   it('accepts cli engine build when devtools opens project but exits non-zero', async () => {
     vi.spyOn(process.stderr, 'write').mockReturnValue(true)
     startWechatIdeEngineBuildByHttpMock.mockRejectedValueOnce(new Error('Cannot GET /engine/build'))

--- a/packages/weapp-vite/src/cli/openIde.test.ts
+++ b/packages/weapp-vite/src/cli/openIde.test.ts
@@ -4,6 +4,7 @@ const parseMock = vi.hoisted(() => vi.fn())
 const closeWechatIdeProjectMock = vi.hoisted(() => vi.fn())
 const isAutomatorLoginErrorMock = vi.hoisted(() => vi.fn())
 const formatAutomatorLoginErrorMock = vi.hoisted(() => vi.fn())
+const isWechatIdeEngineBuildEndpointMissingErrorMock = vi.hoisted(() => vi.fn())
 const isWechatIdeLoginRequiredErrorMock = vi.hoisted(() => vi.fn())
 const promptWechatIdeLoginRetryMock = vi.hoisted(() => vi.fn())
 const promptRetryKeypressMock = vi.hoisted(() => vi.fn())
@@ -39,6 +40,7 @@ vi.mock('weapp-ide-cli', () => ({
   parse: parseMock,
   getConfig: getConfigMock,
   isAutomatorLoginError: isAutomatorLoginErrorMock,
+  isWechatIdeEngineBuildEndpointMissingError: isWechatIdeEngineBuildEndpointMissingErrorMock,
   isWechatIdeLoginRequiredError: isWechatIdeLoginRequiredErrorMock,
   launchAutomator: launchAutomatorMock,
   openWechatIdeProjectByHttp: openWechatIdeProjectByHttpMock,
@@ -74,6 +76,7 @@ describe('openIde', () => {
     closeWechatIdeProjectMock.mockReset()
     isAutomatorLoginErrorMock.mockReset()
     formatAutomatorLoginErrorMock.mockReset()
+    isWechatIdeEngineBuildEndpointMissingErrorMock.mockReset()
     isWechatIdeLoginRequiredErrorMock.mockReset()
     promptWechatIdeLoginRetryMock.mockReset()
     promptRetryKeypressMock.mockReset()
@@ -104,6 +107,7 @@ describe('openIde', () => {
     resetWechatIdeFileUtilsByHttpMock.mockResolvedValue(undefined)
     runWechatIdeEngineBuildMock.mockResolvedValue(undefined)
     isAutomatorLoginErrorMock.mockReturnValue(false)
+    isWechatIdeEngineBuildEndpointMissingErrorMock.mockReturnValue(false)
     isWechatIdeLoginRequiredErrorMock.mockReturnValue(false)
     formatAutomatorLoginErrorMock.mockReturnValue('微信开发者工具返回登录错误：\n- code: 10\n- message: 需要重新登录')
     getConfigMock.mockResolvedValue({
@@ -178,9 +182,29 @@ describe('openIde', () => {
     expect(openWechatIdeProjectByHttpMock).toHaveBeenCalledWith('dist/dev/mp-weixin')
     expect(resetWechatIdeFileUtilsByHttpMock).toHaveBeenCalledWith('dist/dev/mp-weixin')
     expect(runWechatIdeEngineBuildMock).toHaveBeenCalledWith('dist/dev/mp-weixin', {
+      fallbackToCli: false,
       logPath: undefined,
     })
     expect(miniProgramDisconnectMock).toHaveBeenCalledTimes(1)
+    expect(parseMock).not.toHaveBeenCalled()
+  })
+
+  it('skips engine build refresh when devtools endpoint is missing', async () => {
+    const endpointMissingError = Object.assign(new Error('当前微信开发者工具未提供 engine build 接口，已跳过自动 engine build 刷新。'), {
+      code: 'WECHAT_DEVTOOLS_ENGINE_BUILD_ENDPOINT_MISSING',
+    })
+    runWechatIdeEngineBuildMock.mockRejectedValueOnce(endpointMissingError)
+    isWechatIdeEngineBuildEndpointMissingErrorMock.mockImplementation(error => error === endpointMissingError)
+    const { openIde } = await import('./openIde')
+
+    await openIde('weapp', 'dist/dev/mp-weixin')
+
+    expect(runWechatIdeEngineBuildMock).toHaveBeenCalledWith('dist/dev/mp-weixin', {
+      fallbackToCli: false,
+      logPath: undefined,
+    })
+    expect(loggerMock.warn).toHaveBeenCalledWith('当前微信开发者工具不支持自动 engine build 刷新，已跳过该步骤；如模拟器显示旧状态，可在开发者工具内手动编译。')
+    expect(loggerMock.warn).not.toHaveBeenCalledWith('刷新微信开发者工具项目索引失败，已保留当前打开状态；如模拟器仍显示旧状态，可手动刷新一次。')
     expect(parseMock).not.toHaveBeenCalled()
   })
 
@@ -204,6 +228,7 @@ describe('openIde', () => {
     expect(openWechatIdeProjectByHttpMock).toHaveBeenCalledWith('dist/dev/mp-weixin')
     expect(resetWechatIdeFileUtilsByHttpMock).toHaveBeenCalledWith('dist/dev/mp-weixin')
     expect(runWechatIdeEngineBuildMock).toHaveBeenCalledWith('dist/dev/mp-weixin', {
+      fallbackToCli: false,
       logPath: undefined,
     })
     expect(parseMock).not.toHaveBeenCalled()
@@ -234,6 +259,7 @@ describe('openIde', () => {
     expect(openWechatIdeProjectByHttpMock).toHaveBeenCalledWith('dist/dev/mp-weixin')
     expect(resetWechatIdeFileUtilsByHttpMock).toHaveBeenCalledWith('dist/dev/mp-weixin')
     expect(runWechatIdeEngineBuildMock).toHaveBeenCalledWith('dist/dev/mp-weixin', {
+      fallbackToCli: false,
       logPath: undefined,
     })
   })
@@ -262,6 +288,7 @@ describe('openIde', () => {
     expect(openWechatIdeProjectByHttpMock).toHaveBeenCalledWith('dist/dev/mp-weixin')
     expect(resetWechatIdeFileUtilsByHttpMock).toHaveBeenCalledWith('dist/dev/mp-weixin')
     expect(runWechatIdeEngineBuildMock).toHaveBeenCalledWith('dist/dev/mp-weixin', {
+      fallbackToCli: false,
       logPath: undefined,
     })
   })
@@ -282,6 +309,7 @@ describe('openIde', () => {
     expect(openWechatIdeProjectByHttpMock).toHaveBeenCalledWith('dist/dev/mp-weixin')
     expect(resetWechatIdeFileUtilsByHttpMock).toHaveBeenCalledWith('dist/dev/mp-weixin')
     expect(runWechatIdeEngineBuildMock).toHaveBeenCalledWith('dist/dev/mp-weixin', {
+      fallbackToCli: false,
       logPath: undefined,
     })
     expect(launchAutomatorMock).not.toHaveBeenCalled()

--- a/packages/weapp-vite/src/cli/openIde/execute.test.ts
+++ b/packages/weapp-vite/src/cli/openIde/execute.test.ts
@@ -5,6 +5,7 @@ const clearWechatIdeCacheMock = vi.hoisted(() => vi.fn())
 const compileWechatIdeByAutomatorMock = vi.hoisted(() => vi.fn())
 const closeWechatIdeProjectMock = vi.hoisted(() => vi.fn())
 const parseMock = vi.hoisted(() => vi.fn())
+const isWechatIdeEngineBuildEndpointMissingErrorMock = vi.hoisted(() => vi.fn())
 const isWechatIdeLoginRequiredErrorMock = vi.hoisted(() => vi.fn())
 const openWechatIdeProjectByHttpMock = vi.hoisted(() => vi.fn())
 const promptWechatIdeLoginRetryMock = vi.hoisted(() => vi.fn())
@@ -24,6 +25,7 @@ vi.mock('weapp-ide-cli', () => ({
   clearWechatIdeCache: clearWechatIdeCacheMock,
   compileWechatIdeByAutomator: compileWechatIdeByAutomatorMock,
   closeWechatIdeProject: closeWechatIdeProjectMock,
+  isWechatIdeEngineBuildEndpointMissingError: isWechatIdeEngineBuildEndpointMissingErrorMock,
   isWechatIdeLoginRequiredError: isWechatIdeLoginRequiredErrorMock,
   openWechatIdeProjectByHttp: openWechatIdeProjectByHttpMock,
   parse: parseMock,
@@ -46,6 +48,7 @@ describe('executeWechatIdeCliCommand', () => {
     compileWechatIdeByAutomatorMock.mockReset()
     closeWechatIdeProjectMock.mockReset()
     parseMock.mockReset()
+    isWechatIdeEngineBuildEndpointMissingErrorMock.mockReset()
     isWechatIdeLoginRequiredErrorMock.mockReset()
     openWechatIdeProjectByHttpMock.mockReset()
     promptWechatIdeLoginRetryMock.mockReset()
@@ -62,6 +65,7 @@ describe('executeWechatIdeCliCommand', () => {
     compileWechatIdeByAutomatorMock.mockResolvedValue(undefined)
     closeWechatIdeProjectMock.mockResolvedValue(undefined)
     parseMock.mockResolvedValue(undefined)
+    isWechatIdeEngineBuildEndpointMissingErrorMock.mockReturnValue(false)
     isWechatIdeLoginRequiredErrorMock.mockReturnValue(false)
     openWechatIdeProjectByHttpMock.mockResolvedValue('OK')
     resetWechatIdeFileUtilsByHttpMock.mockResolvedValue('OK')
@@ -184,8 +188,24 @@ describe('executeWechatIdeCliCommand', () => {
     })
 
     expect(runWechatIdeEngineBuildMock).toHaveBeenCalledWith('/project/dist', {
+      fallbackToCli: false,
       logPath: undefined,
     })
+    expect(parseMock).not.toHaveBeenCalled()
+  })
+
+  it('throws engine endpoint missing errors without falling back to parse', async () => {
+    const endpointMissingError = Object.assign(new Error('当前微信开发者工具未提供 engine build 接口，已跳过自动 engine build 刷新。'), {
+      code: 'WECHAT_DEVTOOLS_ENGINE_BUILD_ENDPOINT_MISSING',
+    })
+    runWechatIdeEngineBuildMock.mockRejectedValueOnce(endpointMissingError)
+    isWechatIdeEngineBuildEndpointMissingErrorMock.mockReturnValue(true)
+    const { executeWechatIdeCliCommand } = await import('./execute')
+
+    await expect(executeWechatIdeCliCommand(['engine', 'build'], {
+      projectPath: '/project/dist',
+    })).rejects.toBe(endpointMissingError)
+
     expect(parseMock).not.toHaveBeenCalled()
   })
 

--- a/packages/weapp-vite/src/cli/openIde/execute.ts
+++ b/packages/weapp-vite/src/cli/openIde/execute.ts
@@ -3,6 +3,7 @@ import {
   clearWechatIdeCacheByAutomator,
   closeWechatIdeProject,
   compileWechatIdeByAutomator,
+  isWechatIdeEngineBuildEndpointMissingError,
   isWechatIdeLoginRequiredError,
   openWechatIdeProjectByHttp,
   parse,
@@ -18,6 +19,7 @@ import logger from '../../logger'
 export interface ExecuteWechatIdeCliCommandOptions {
   automatorMode?: 'prefer' | 'require'
   cancelLevel?: 'info' | 'warn'
+  engineBuildFallbackToCli?: boolean
   httpMode?: 'prefer' | 'require' | 'skip'
   onNonLoginError?: (error: unknown) => void
   onRetry?: () => void
@@ -70,7 +72,11 @@ async function tryExecuteWechatIdeCliCommandByAutomator(argv: readonly string[],
   return false
 }
 
-async function tryExecuteWechatIdeCliCommandByHttp(argv: readonly string[], projectPath?: string) {
+async function tryExecuteWechatIdeCliCommandByHttp(
+  argv: readonly string[],
+  projectPath?: string,
+  engineBuildFallbackToCli = false,
+) {
   const command = argv[0]
   if (!command) {
     return false
@@ -101,6 +107,7 @@ async function tryExecuteWechatIdeCliCommandByHttp(argv: readonly string[], proj
     }
 
     await runWechatIdeEngineBuild(engineProjectPath, {
+      fallbackToCli: engineBuildFallbackToCli,
       logPath: readArgOption(argv, '--logPath', '-l'),
     })
     return true
@@ -150,6 +157,7 @@ export async function executeWechatIdeCliCommand(
   const {
     automatorMode = 'prefer',
     cancelLevel = 'warn',
+    engineBuildFallbackToCli = false,
     httpMode = 'prefer',
     onNonLoginError,
     onRetry,
@@ -159,13 +167,13 @@ export async function executeWechatIdeCliCommand(
   await runWithSuspendedSharedInput(async () => {
     if (httpMode !== 'skip') {
       try {
-        const handledByHttp = await tryExecuteWechatIdeCliCommandByHttp(argv, projectPath)
+        const handledByHttp = await tryExecuteWechatIdeCliCommandByHttp(argv, projectPath, engineBuildFallbackToCli)
         if (handledByHttp) {
           return
         }
       }
       catch (error) {
-        if (httpMode === 'require') {
+        if (httpMode === 'require' || isWechatIdeEngineBuildEndpointMissingError(error)) {
           throw error
         }
       }

--- a/packages/weapp-vite/src/cli/openIde/index.ts
+++ b/packages/weapp-vite/src/cli/openIde/index.ts
@@ -5,6 +5,7 @@ import {
   bootstrapWechatDevtoolsSettings,
   formatAutomatorLoginError,
   isAutomatorLoginError,
+  isWechatIdeEngineBuildEndpointMissingError,
 } from 'weapp-ide-cli'
 import { createCompilerContext } from '../../createContext'
 import logger, { colors } from '../../logger'
@@ -122,11 +123,19 @@ async function stabilizeOpenedWechatIdeProject(projectPath: string, servicePortE
       onNonLoginError: error => logger.error(error),
       projectPath,
     })
-    await executeWechatIdeCliCommand(['engine', 'build', projectPath], {
-      httpMode: 'prefer',
-      onNonLoginError: error => logger.error(error),
-      projectPath,
-    })
+    try {
+      await executeWechatIdeCliCommand(['engine', 'build', projectPath], {
+        httpMode: 'prefer',
+        onNonLoginError: error => logger.error(error),
+        projectPath,
+      })
+    }
+    catch (error) {
+      if (!isWechatIdeEngineBuildEndpointMissingError(error)) {
+        throw error
+      }
+      logger.warn('当前微信开发者工具不支持自动 engine build 刷新，已跳过该步骤；如模拟器显示旧状态，可在开发者工具内手动编译。')
+    }
     try {
       await executeWechatIdeCliCommand(['compile'], {
         automatorMode: 'require',


### PR DESCRIPTION
## 变更说明

- 将微信开发者工具 `/engine/build` / `/engine/buildResult/` 缺失归类为结构化错误，避免 HTML 404 原样透出。
- `weapp-vite` 打开 IDE 后刷新项目索引时禁用 engine build 的官方 CLI fallback，遇到不兼容 DevTools 时跳过该步骤并输出明确提示。
- 补充 `weapp-ide-cli` 与 `openIde` 相关单元测试，并添加 changeset。

## 验证

- `pnpm vitest run packages/weapp-ide-cli/test/engine.test.ts`
- `pnpm vitest run packages/weapp-vite/src/cli/openIde/execute.test.ts packages/weapp-vite/src/cli/openIde.test.ts`
- `pnpm --filter weapp-ide-cli typecheck`
- `pnpm --filter weapp-ide-cli build`
- `pnpm --filter weapp-vite typecheck`
- `pnpm exec eslint packages/weapp-ide-cli/src/cli/engine.ts packages/weapp-ide-cli/test/engine.test.ts packages/weapp-vite/src/cli/openIde/execute.ts packages/weapp-vite/src/cli/openIde/index.ts packages/weapp-vite/src/cli/openIde/execute.test.ts packages/weapp-vite/src/cli/openIde.test.ts`
- `pnpm run check:create-weapp-vite-changeset`
- `pnpm run check:changeset:frontmatter`
- `pnpm --filter weapp-vite build`

Closes #653
Related #635