### PR TITLE
fix(weapp-vite): 修复 custom resolver SFC 入口识别

### DIFF
--- a/.changeset/fix-issue-651-custom-resolver.md
+++ b/.changeset/fix-issue-651-custom-resolver.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复 custom resolver 返回 Vue SFC 组件时的入口识别问题。现在 `resolvedId` 即使省略 `.vue` 后缀，也会按真实 SFC 入口解析并注入 Vue slot 元数据，同时保持组件样式参与构建输出。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -470,6 +470,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-651/index",
+          "pathName": "pages/issue-651/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-528/index",
           "pathName": "pages/issue-528/index",
           "query": "",

--- a/e2e-apps/github-issues/src/issue-fixtures/issue-651/ResolverNoExt/index.vue
+++ b/e2e-apps/github-issues/src/issue-fixtures/issue-651/ResolverNoExt/index.vue
@@ -1,0 +1,11 @@
+<template>
+  <view class="issue651-no-ext">
+    <slot />
+  </view>
+</template>
+
+<style>
+.issue651-no-ext {
+  padding: 12rpx;
+}
+</style>

--- a/e2e-apps/github-issues/src/issue-fixtures/issue-651/ResolverWithExt/index.vue
+++ b/e2e-apps/github-issues/src/issue-fixtures/issue-651/ResolverWithExt/index.vue
@@ -1,0 +1,12 @@
+<template>
+  <view class="issue651-with-ext">
+    issue-651 resolver with ext style
+  </view>
+</template>
+
+<style>
+.issue651-with-ext {
+  margin-top: 10rpx;
+  color: #22543d;
+}
+</style>

--- a/e2e-apps/github-issues/src/pages/issue-651/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-651/index.vue
@@ -1,0 +1,8 @@
+<template>
+  <view class="issue651-page">
+    <Issue651ResolverNoExt>
+      <text class="issue651-page__slot">issue-651 resolver no ext slot</text>
+    </Issue651ResolverNoExt>
+    <Issue651ResolverWithExt />
+  </view>
+</template>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import process from 'node:process'
 import { defineConfig } from 'weapp-vite'
 
@@ -9,6 +10,8 @@ const issue564AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_564_AUGMENTED
 const issue615AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_615_AUGMENTED === 'true'
 const issue621AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_621_AUGMENTED === 'true'
 const issue595ScopedBuildEnabled = process.env.WEAPP_GITHUB_ISSUE_595_SCOPED === 'true'
+const issue651NoExtResolvedId = path.resolve(import.meta.dirname, 'src/issue-fixtures/issue-651/ResolverNoExt/index')
+const issue651WithExtResolvedId = path.resolve(import.meta.dirname, 'src/issue-fixtures/issue-651/ResolverWithExt/index.vue')
 const e2eTargetFile = process.env.WEAPP_VITE_E2E_TARGET_FILE?.replaceAll('\\', '/') ?? ''
 const slotFallbackCompilerOffEnabled = process.env.WEAPP_GITHUB_SLOT_FALLBACK_COMPILER_OFF === 'true'
   || e2eTargetFile.endsWith('github-issues.runtime.slot-fallback-compiler-off.test.ts')
@@ -303,6 +306,24 @@ export default defineConfig({
         {
           components: {
             Issue520ResolverSlotCard: '/components/issue-520/ResolverSlotCard/index',
+          },
+        },
+        {
+          resolve(componentName) {
+            if (componentName === 'Issue651ResolverNoExt') {
+              return {
+                name: componentName,
+                from: '/issue-fixtures/issue-651/ResolverNoExt/index',
+                resolvedId: issue651NoExtResolvedId,
+              }
+            }
+            if (componentName === 'Issue651ResolverWithExt') {
+              return {
+                name: componentName,
+                from: '/issue-fixtures/issue-651/ResolverWithExt/index',
+                resolvedId: issue651WithExtResolvedId,
+              }
+            }
           },
         },
       ],

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -464,6 +464,31 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageWxml).toContain('issue-520 resolver slot default')
   })
 
+  it('issue #651: resolves custom resolver SFC entries without relying on .vue suffix in resolvedId', async () => {
+    await runBuild()
+
+    const pageJsonPath = path.join(DIST_ROOT, 'pages/issue-651/index.json')
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-651/index.wxml')
+    const noExtComponentWxmlPath = path.join(DIST_ROOT, 'issue-fixtures/issue-651/ResolverNoExt/index.wxml')
+    const noExtComponentWxssPath = path.join(DIST_ROOT, 'issue-fixtures/issue-651/ResolverNoExt/index.wxss')
+    const withExtComponentWxssPath = path.join(DIST_ROOT, 'issue-fixtures/issue-651/ResolverWithExt/index.wxss')
+    const pageJson = await fs.readJson(pageJsonPath) as { usingComponents?: Record<string, string> }
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+    const noExtComponentWxml = await fs.readFile(noExtComponentWxmlPath, 'utf-8')
+    const noExtComponentWxss = await fs.readFile(noExtComponentWxssPath, 'utf-8')
+    const withExtComponentWxss = await fs.readFile(withExtComponentWxssPath, 'utf-8')
+
+    expect(pageJson.usingComponents).toMatchObject({
+      Issue651ResolverNoExt: '/issue-fixtures/issue-651/ResolverNoExt/index',
+      Issue651ResolverWithExt: '/issue-fixtures/issue-651/ResolverWithExt/index',
+    })
+    expect(pageWxml).toContain('Issue651ResolverNoExt vue-slots="{{__wv_bind_0}}"')
+    expect(pageWxml).toContain('Issue651ResolverWithExt')
+    expect(noExtComponentWxml).toContain('<slot />')
+    expect(noExtComponentWxss).toContain('.issue651-no-ext')
+    expect(withExtComponentWxss).toContain('.issue651-with-ext')
+  })
+
   it('issue #528: compiles slot fallback content to conditional wxml branches', async () => {
     await runBuild()
 

--- a/packages/weapp-vite/src/plugins/vue/transform/compileOptions.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/compileOptions.test.ts
@@ -16,6 +16,7 @@ const resolveClassStyleWxsLocationForBaseMock = vi.hoisted(() => vi.fn(() => ({
   src: '/virtual/__class_style__.wxs',
 })))
 const createUsingComponentPathResolverMock = vi.hoisted(() => vi.fn(() => 'resolved/path'))
+const resolveEntryPathMock = vi.hoisted(() => vi.fn(async () => undefined as string | undefined))
 const resolveWevuDefaultsWithPresetMock = vi.hoisted(() => vi.fn(() => ({
   preset: 'default',
 })))
@@ -35,6 +36,13 @@ vi.mock('./classStyle', () => ({
   resolveClassStyleWxsLocationForBase: resolveClassStyleWxsLocationForBaseMock,
 }))
 
+vi.mock('../../../utils/entryResolve', () => ({
+  createCachedEntryResolveOptions: vi.fn((_configService: any, options?: any) => ({
+    kind: options?.kind,
+  })),
+  resolveEntryPath: resolveEntryPathMock,
+}))
+
 vi.mock('./usingComponentResolver', () => ({
   createUsingComponentPathResolver: createUsingComponentPathResolverMock,
 }))
@@ -47,6 +55,8 @@ vi.mock('./wevuPreset', () => ({
 describe('resolveVueTemplatePlatformOptions', () => {
   beforeEach(() => {
     isWevuMinifyEnabledMock.mockClear()
+    resolveEntryPathMock.mockReset()
+    resolveEntryPathMock.mockResolvedValue(undefined)
   })
 
   it('resolves template platform and wxs runtime support', () => {
@@ -365,6 +375,52 @@ describe('resolveVueTemplatePlatformOptions', () => {
     expect(await options.autoImportTags.resolveUsingComponent('Issue520ResolverSlotCard')).toEqual({
       name: 'Issue520ResolverSlotCard',
       from: '/components/issue-520/ResolverSlotCard/index.vue',
+      sourceType: 'wevu-sfc',
+    })
+  })
+
+  it('marks resolver auto-imports with extensionless resolvedId when entry resolution finds a vue sfc', async () => {
+    const resolvedVueEntry = '/workspace/packages/ui/ResolverCard/index.vue'
+    resolveEntryPathMock.mockImplementation(async (value: string) => {
+      return value === '/workspace/packages/ui/ResolverCard/index'
+        ? resolvedVueEntry
+        : undefined
+    })
+    const autoImportResolve = vi.fn(() => ({
+      kind: 'resolver',
+      value: {
+        name: 'ResolverCard',
+        from: '/issue-fixtures/issue-651/ResolverCard/index',
+        resolvedId: '/workspace/packages/ui/ResolverCard/index',
+      },
+    }))
+    const options = createCompileVueFileOptions(
+      {
+        autoImportService: {
+          resolve: autoImportResolve,
+        },
+      } as any,
+      {} as any,
+      '/project/src/pages/issue-651/index.vue',
+      true,
+      false,
+      {
+        platform: 'weapp',
+        outputExtensions: {},
+        absoluteSrcRoot: '/project/src',
+        weappViteConfig: {},
+        relativeOutputPath: () => undefined,
+      } as any,
+      {
+        reExportResolutionCache: new Map(),
+        classStyleRuntimeWarned: { value: false },
+      },
+    )
+
+    await expect(options.autoImportTags.resolveUsingComponent('ResolverCard')).resolves.toEqual({
+      name: 'ResolverCard',
+      from: '/issue-fixtures/issue-651/ResolverCard/index',
+      resolvedId: resolvedVueEntry,
       sourceType: 'wevu-sfc',
     })
   })

--- a/packages/weapp-vite/src/plugins/vue/transform/compileOptions.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/compileOptions.ts
@@ -6,6 +6,7 @@ import path from 'pathe'
 import { getMiniProgramTemplatePlatform } from 'wevu/compiler'
 import logger from '../../../logger'
 import { createCachedEntryResolveOptions, resolveEntryPath } from '../../../utils/entryResolve'
+import { isSkippableResolvedId, normalizeFsResolvedId } from '../../../utils/resolvedId'
 import { createSfcResolveSrcOptions } from '../../utils/vueSfc'
 import { resolveClassStyleWxsLocationForBase } from './classStyle'
 import { createUsingComponentPathResolver } from './usingComponentResolver'
@@ -20,6 +21,10 @@ interface CompileOptionsContext {
 }
 
 type AutoImportComponentSourceType = 'wevu-sfc' | 'native'
+
+function hasVueExtension(id: string | undefined) {
+  return Boolean(id?.endsWith('.vue'))
+}
 
 export function getCompileVueFileOptionsCacheKey(vuePath: string, isPage: boolean, isApp: boolean) {
   return `${vuePath}::${isPage ? 'page' : 'component'}::${isApp ? 'app' : 'entry'}`
@@ -107,10 +112,62 @@ function buildCompileVueFileOptions(
   const wevuMinify = isWevuMinifyEnabled(configService.weappViteConfig, configService.isDev)
   const jsonKind = isApp ? 'app' : isPage ? 'page' : 'component'
 
+  async function resolvePotentialVueSfcEntryId(candidate: string | undefined) {
+    const trimmed = candidate?.trim()
+    if (!trimmed) {
+      return undefined
+    }
+
+    const entryResolveOptions = createCachedEntryResolveOptions(configService, { kind: 'default' })
+    const localCandidate = path.isAbsolute(trimmed)
+      ? trimmed
+      : trimmed.startsWith('.')
+        ? path.resolve(path.dirname(vuePath), trimmed)
+        : !trimmed.includes(':') && !trimmed.startsWith('@')
+            ? path.resolve(configService.absoluteSrcRoot, trimmed)
+            : undefined
+
+    if (localCandidate) {
+      const normalized = normalizeFsResolvedId(localCandidate)
+      if (hasVueExtension(normalized)) {
+        return normalized
+      }
+      const resolvedEntry = !normalized || isSkippableResolvedId(normalized)
+        ? undefined
+        : await resolveEntryPath(normalized, entryResolveOptions)
+      if (hasVueExtension(resolvedEntry)) {
+        return resolvedEntry
+      }
+    }
+
+    const resolveCandidates = path.extname(trimmed)
+      ? [trimmed]
+      : [trimmed, `${trimmed}.vue`, `${trimmed}/index.vue`]
+
+    for (const resolveCandidate of resolveCandidates) {
+      const resolved = await pluginCtx.resolve?.(resolveCandidate, vuePath)
+      const normalized = resolved?.id ? normalizeFsResolvedId(resolved.id) : undefined
+      if (!normalized || isSkippableResolvedId(normalized)) {
+        continue
+      }
+      if (hasVueExtension(normalized)) {
+        return normalized
+      }
+      if (path.isAbsolute(normalized)) {
+        const resolvedEntry = await resolveEntryPath(normalized, entryResolveOptions)
+        if (hasVueExtension(resolvedEntry)) {
+          return resolvedEntry
+        }
+      }
+    }
+
+    return undefined
+  }
+
   async function resolveAutoImportComponentSourceType(match: NonNullable<ReturnType<NonNullable<CompilerContext['autoImportService']>['resolve']>>) {
     if (match.kind === 'local') {
       const resolvedId = match.entry.templatePath
-      const sourceType: AutoImportComponentSourceType = resolvedId?.endsWith('.vue') ? 'wevu-sfc' : 'native'
+      const sourceType: AutoImportComponentSourceType = hasVueExtension(resolvedId) ? 'wevu-sfc' : 'native'
       return {
         resolvedId,
         sourceType,
@@ -119,10 +176,11 @@ function buildCompileVueFileOptions(
 
     const explicitSourceType = (match.value as { sourceType?: AutoImportComponentSourceType }).sourceType
     const explicitResolvedId = (match.value as { resolvedId?: string }).resolvedId
-    if (explicitSourceType || explicitResolvedId?.endsWith('.vue') || match.value.from.endsWith('.vue')) {
+    const resolvedExplicitVueId = await resolvePotentialVueSfcEntryId(explicitResolvedId)
+    if (explicitSourceType || resolvedExplicitVueId || hasVueExtension(explicitResolvedId) || hasVueExtension(match.value.from)) {
       return {
-        resolvedId: explicitResolvedId,
-        sourceType: explicitSourceType ?? (explicitResolvedId?.endsWith('.vue') || match.value.from.endsWith('.vue') ? 'wevu-sfc' : 'native'),
+        resolvedId: resolvedExplicitVueId ?? explicitResolvedId,
+        sourceType: explicitSourceType ?? (resolvedExplicitVueId || hasVueExtension(explicitResolvedId) || hasVueExtension(match.value.from) ? 'wevu-sfc' : 'native'),
       }
     }
 
@@ -147,7 +205,7 @@ function buildCompileVueFileOptions(
     )
     return {
       resolvedId,
-      sourceType: resolvedId?.endsWith('.vue') ? 'wevu-sfc' as const : 'native' as const,
+      sourceType: hasVueExtension(resolvedId) ? 'wevu-sfc' as const : 'native' as const,
     }
   }
 


### PR DESCRIPTION
## Summary

修复 custom resolver 返回 Vue SFC 组件时依赖 `.vue` 后缀判断的问题。`resolvedId` 省略后缀时会先解析真实入口，再按 SFC 注入 Vue slot 元数据；带 `.vue` 的 resolver 组件样式也通过 github-issues 回归覆盖。

## Changes

- 让 auto import resolver 的 `resolvedId` 通过入口解析识别真实 `.vue` 文件
- 新增 issue #651 的 github-issues 页面和 resolver fixture
- 补充单测、e2e 断言和 changeset

## Testing

- `vitest run packages/weapp-vite/src/plugins/vue/transform/compileOptions.test.ts`
- `pnpm --filter weapp-vite typecheck`
- `eslint packages/weapp-vite/src/plugins/vue/transform/compileOptions.ts packages/weapp-vite/src/plugins/vue/transform/compileOptions.test.ts e2e/ci/github-issues.build.test.ts e2e-apps/github-issues/weapp-vite.config.ts e2e-apps/github-issues/src/pages/issue-651/index.vue e2e-apps/github-issues/src/issue-fixtures/issue-651/ResolverNoExt/index.vue e2e-apps/github-issues/src/issue-fixtures/issue-651/ResolverWithExt/index.vue`
- `pnpm --filter weapp-vite build`
- `vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #651"`

Closes #651