### PR TITLE
fix(weapp-vite): 修复 HMR 未处理 @wv-keep-import

### DIFF
--- a/.changeset/fix-wv-keep-import-hmr.md
+++ b/.changeset/fix-wv-keep-import-hmr.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复 Vue SFC 样式在 HMR 重建时可能跳过 `@wv-keep-import` 后处理的问题，确保产物稳定输出为 `@import`。

--- a/e2e-apps/style-import-vue/src/pages/index/index.vue
+++ b/e2e-apps/style-import-vue/src/pages/index/index.vue
@@ -20,6 +20,8 @@ definePageJson({
 
 <style lang="css">
 @import './hello.css';
+/* stylelint-disable-next-line at-rule-no-unknown, scss/at-rule-no-unknown */
+@wv-keep-import './keep-import.css';
 
 .css-inline {
   font-size: 28rpx;

--- a/e2e-apps/style-import-vue/src/pages/index/keep-import.css
+++ b/e2e-apps/style-import-vue/src/pages/index/keep-import.css
@@ -1,0 +1,3 @@
+.keep-imported {
+  color: #0891b2;
+}

--- a/e2e-apps/wevu-runtime-e2e/src/pages/hmr-sfc/index.vue
+++ b/e2e-apps/wevu-runtime-e2e/src/pages/hmr-sfc/index.vue
@@ -22,6 +22,9 @@ export default defineComponent({
 
 <style>
 /* HMR-SFC-STYLE */
+/* stylelint-disable-next-line at-rule-no-unknown, scss/at-rule-no-unknown */
+@wv-keep-import '../hmr/index.wxss';
+
 .hmr-sfc-page {
   padding: 24rpx;
 }

--- a/e2e/ci/__snapshots__/wevu-runtime.platforms.test.ts.alipay.snap
+++ b/e2e/ci/__snapshots__/wevu-runtime.platforms.test.ts.alipay.snap
@@ -166,7 +166,9 @@ exports[`wevu runtime platform outputs > builds and snapshots alipay outputs > w
 `;
 
 exports[`wevu runtime platform outputs > builds and snapshots alipay outputs > wevu-runtime::alipay::pages/hmr-sfc/index.style 1`] = `
-".hmr-sfc-page {
+"@import '../hmr/index.wxss';
+
+.hmr-sfc-page {
   padding: 24rpx;
 }
 .title {

--- a/e2e/ci/__snapshots__/wevu-runtime.platforms.test.ts.tt.snap
+++ b/e2e/ci/__snapshots__/wevu-runtime.platforms.test.ts.tt.snap
@@ -166,7 +166,9 @@ exports[`wevu runtime platform outputs > builds and snapshots tt outputs > wevu-
 `;
 
 exports[`wevu runtime platform outputs > builds and snapshots tt outputs > wevu-runtime::tt::pages/hmr-sfc/index.style 1`] = `
-".hmr-sfc-page {
+"@import '../hmr/index.wxss';
+
+.hmr-sfc-page {
   padding: 24rpx;
 }
 .title {

--- a/e2e/ci/__snapshots__/wevu-runtime.platforms.test.ts.weapp.snap
+++ b/e2e/ci/__snapshots__/wevu-runtime.platforms.test.ts.weapp.snap
@@ -166,7 +166,9 @@ exports[`wevu runtime platform outputs > builds and snapshots weapp outputs > we
 `;
 
 exports[`wevu runtime platform outputs > builds and snapshots weapp outputs > wevu-runtime::weapp::pages/hmr-sfc/index.style 1`] = `
-".hmr-sfc-page {
+"@import '../hmr/index.wxss';
+
+.hmr-sfc-page {
   padding: 24rpx;
 }
 .title {

--- a/e2e/ci/hmr-modify.test.ts
+++ b/e2e/ci/hmr-modify.test.ts
@@ -481,6 +481,13 @@ describe.sequential('HMR modify — component-level file changes (dev watch)', (
  * Vue SFC HMR 源文件路径
  */
 const SFC_SRC_PATH = path.join(APP_ROOT, 'src/pages/hmr-sfc/index.vue')
+const SFC_KEEP_IMPORT_OUTPUT = '@import \'../hmr/index.wxss\';'
+const SFC_KEEP_IMPORT_DIRECTIVE = '@wv-keep-import'
+
+function expectSfcKeepImportResolved(content: string) {
+  expect(content).toContain(SFC_KEEP_IMPORT_OUTPUT)
+  expect(content).not.toContain(SFC_KEEP_IMPORT_DIRECTIVE)
+}
 
 describe.sequential('HMR modify — Vue SFC changes (dev watch)', () => {
   it.each(PLATFORM_LIST)('修改 .vue SFC template 部分 (%s)', async (platform) => {
@@ -564,7 +571,8 @@ describe.sequential('HMR modify — Vue SFC changes (dev watch)', () => {
         ),
         `${platform} app.json generated`,
       )
-      await dev.waitFor(waitForFileContains(distPath, 'hmr-sfc-page'), `${platform} initial SFC style`)
+      const initialStyle = await dev.waitFor(waitForFileContains(distPath, 'hmr-sfc-page'), `${platform} initial SFC style`)
+      expectSfcKeepImportResolved(initialStyle)
 
       await replaceFileByRename(SFC_SRC_PATH, updatedSource)
 
@@ -584,6 +592,7 @@ describe.sequential('HMR modify — Vue SFC changes (dev watch)', () => {
         )
       }
       expect(content).toContain(marker)
+      expectSfcKeepImportResolved(content)
     }
     finally {
       await dev.stop(5_000)

--- a/e2e/ci/hmr-rapid.test.ts
+++ b/e2e/ci/hmr-rapid.test.ts
@@ -17,6 +17,8 @@ const SRC_SCRIPT = path.join(HMR_SRC_DIR, 'index.ts')
  * Vue SFC HMR 源文件路径
  */
 const SFC_SRC_PATH = path.join(APP_ROOT, 'src/pages/hmr-sfc/index.vue')
+const SFC_KEEP_IMPORT_OUTPUT = '@import \'../hmr/index.wxss\';'
+const SFC_KEEP_IMPORT_DIRECTIVE = '@wv-keep-import'
 
 const PLATFORM_LIST = resolvePlatforms()
 const RAPID_HMR_TIMEOUT = 180_000
@@ -33,6 +35,11 @@ async function retryWithSourceTouch<T>(
     await replaceFileByRename(touchFilePath, touchContent)
     return await task()
   }
+}
+
+function expectSfcKeepImportResolved(content: string) {
+  expect(content).toContain(SFC_KEEP_IMPORT_OUTPUT)
+  expect(content).not.toContain(SFC_KEEP_IMPORT_DIRECTIVE)
 }
 
 beforeEach(async () => {
@@ -196,6 +203,59 @@ describe.sequential('HMR rapid modifications (dev watch)', () => {
       }
       expect(content).toContain(secondMarker)
       expect(content).not.toContain(firstMarker)
+    }
+    finally {
+      await dev.stop(5_000)
+      await fs.writeFile(SFC_SRC_PATH, originalSource, 'utf8')
+    }
+  })
+
+  it.each(PLATFORM_LIST)('连续快速修改 .vue SFC style 部分 (%s)', async (platform) => {
+    await fs.remove(DIST_ROOT)
+    const originalSource = await fs.readFile(SFC_SRC_PATH, 'utf8')
+    const ext = PLATFORM_EXT[platform]
+    const distPath = path.join(DIST_ROOT, `pages/hmr-sfc/index.${ext.style}`)
+    const firstMarker = createHmrMarker('RAPID-FIRST-SFC-STYLE', platform)
+    const secondMarker = createHmrMarker('RAPID-SECOND-SFC-STYLE', platform)
+
+    const firstUpdate = originalSource.replace('.marker {', `.marker {\n  --hmr-marker: '${firstMarker}';`)
+    const secondUpdate = originalSource.replace('.marker {', `.marker {\n  --hmr-marker: '${secondMarker}';`)
+    if (firstUpdate === originalSource || secondUpdate === originalSource) {
+      throw new Error('Failed to insert marker into .vue SFC style source.')
+    }
+
+    // @ts-expect-error execa v9 overload resolution
+    const dev = startDevProcess('node', ['--import', 'tsx', CLI_PATH, 'dev', APP_ROOT, '--platform', platform, '--skipNpm'], {
+      env: createDevProcessEnv(),
+      stdio: 'inherit',
+    })
+
+    try {
+      await dev.waitFor(waitForFile(path.join(DIST_ROOT, 'app.json'), 30_000), `${platform} app.json generated`)
+      const initialStyle = await dev.waitFor(waitForFileContains(distPath, 'hmr-sfc-page'), `${platform} initial SFC style`)
+      expectSfcKeepImportResolved(initialStyle)
+
+      await replaceFileByRename(SFC_SRC_PATH, firstUpdate)
+      await replaceFileByRename(SFC_SRC_PATH, secondUpdate)
+
+      let content = ''
+      try {
+        content = await dev.waitFor(
+          waitForFileContains(distPath, secondMarker, RAPID_HMR_TIMEOUT),
+          `${platform} rapid second SFC style marker`,
+        )
+      }
+      catch {
+        await replaceFileByRename(SFC_SRC_PATH, `${secondUpdate}\n`)
+        content = await dev.waitFor(
+          waitForFileContains(distPath, secondMarker, RAPID_HMR_TIMEOUT),
+          `${platform} rapid second SFC style marker (retry)`,
+        )
+      }
+      expect(content).toContain(secondMarker)
+      expect(content).not.toContain(firstMarker)
+      expectSfcKeepImportResolved(content)
+      expect(dev.getOutput()).not.toContain('Build failed')
     }
     finally {
       await dev.stop(5_000)

--- a/e2e/ci/style-import-vue.test.ts
+++ b/e2e/ci/style-import-vue.test.ts
@@ -177,6 +177,8 @@ describe.sequential('vue style @import resolution (e2e)', () => {
         'weapp hello.css hmr output',
       )
       expect(helloWxss).toContain(helloMarker)
+      expect(helloWxss).toContain('@import \'./keep-import.css\';')
+      expect(helloWxss).not.toContain('@wv-keep-import')
 
       await replaceFileByRename(SCSS_IMPORT_PATH, updatedScssImport)
       const scssWxss = await devProcess.waitFor(
@@ -188,6 +190,8 @@ describe.sequential('vue style @import resolution (e2e)', () => {
         'weapp scss import hmr output',
       )
       expect(scssWxss).toContain(scssMarker)
+      expect(scssWxss).toContain('@import \'./keep-import.css\';')
+      expect(scssWxss).not.toContain('@wv-keep-import')
 
       await replaceFileByRename(EXTERNAL_CSS_PATH, updatedExternalCss)
       const externalWxss = await devProcess.waitFor(
@@ -199,6 +203,8 @@ describe.sequential('vue style @import resolution (e2e)', () => {
         'weapp external style src hmr output',
       )
       expect(externalWxss).toContain(externalMarker)
+      expect(externalWxss).toContain('@import \'./keep-import.css\';')
+      expect(externalWxss).not.toContain('@wv-keep-import')
       expect(devProcess.getOutput()).not.toContain('Build failed')
     }
     finally {

--- a/e2e/ci/style-import-vue.test.ts
+++ b/e2e/ci/style-import-vue.test.ts
@@ -89,6 +89,8 @@ describe.sequential('vue style @import resolution (e2e)', () => {
     for (const marker of EXPECTED_MARKERS) {
       expect(wxss).toContain(marker)
     }
+    expect(wxss).toContain('@import \'./keep-import.css\';')
+    expect(wxss).not.toContain('@wv-keep-import')
   })
 
   it('dev build inlines css/scss/src imports into wxss', async () => {
@@ -111,6 +113,8 @@ describe.sequential('vue style @import resolution (e2e)', () => {
       for (const marker of EXPECTED_MARKERS) {
         expect(wxss).toContain(marker)
       }
+      expect(wxss).toContain('@import \'./keep-import.css\';')
+      expect(wxss).not.toContain('@wv-keep-import')
     }
     finally {
       await devProcess.stop(2_000)
@@ -125,10 +129,12 @@ describe.sequential('vue style @import resolution (e2e)', () => {
     const originalScssImport = await fs.readFile(SCSS_IMPORT_PATH, 'utf8')
     const originalExternalCss = await fs.readFile(EXTERNAL_CSS_PATH, 'utf8')
 
+    const pageMarker = 'STYLE-IMPORT-HMR-PAGE'
     const helloMarker = 'STYLE-IMPORT-HMR-HELLO'
     const scssMarker = 'STYLE-IMPORT-HMR-SCSS'
     const externalMarker = 'STYLE-IMPORT-HMR-EXTERNAL'
 
+    const updatedPageSource = injectStyleMarker(originalPageSource, '.css-inline {', pageMarker)
     const updatedHelloCss = injectStyleMarker(originalHelloCss, '.hello-import {', helloMarker)
     const updatedScssImport = injectStyleMarker(originalScssImport, '.scss-imported {', scssMarker)
     const updatedExternalCss = injectStyleMarker(originalExternalCss, '.external-src {', externalMarker)
@@ -147,6 +153,19 @@ describe.sequential('vue style @import resolution (e2e)', () => {
         ),
         'weapp initial style import output',
       )
+
+      await replaceFileByRename(PAGE_SOURCE_PATH, updatedPageSource)
+      const pageWxss = await devProcess.waitFor(
+        waitForFileWithSourceHeartbeat(
+          () => waitForFileContains(WXSS_PATH, [pageMarker], 1_000),
+          PAGE_SOURCE_PATH,
+          updatedPageSource,
+        ),
+        'weapp page style keep-import hmr output',
+      )
+      expect(pageWxss).toContain(pageMarker)
+      expect(pageWxss).toContain('@import \'./keep-import.css\';')
+      expect(pageWxss).not.toContain('@wv-keep-import')
 
       await replaceFileByRename(HELLO_CSS_PATH, updatedHelloCss)
       const helloWxss = await devProcess.waitFor(
@@ -184,6 +203,7 @@ describe.sequential('vue style @import resolution (e2e)', () => {
     }
     finally {
       await devProcess.stop(2_000)
+      await fs.writeFile(PAGE_SOURCE_PATH, originalPageSource, 'utf8')
       await fs.writeFile(HELLO_CSS_PATH, originalHelloCss, 'utf8')
       await fs.writeFile(SCSS_IMPORT_PATH, originalScssImport, 'utf8')
       await fs.writeFile(EXTERNAL_CSS_PATH, originalExternalCss, 'utf8')

--- a/e2e/ide/wevu-runtime.core-hmr.test.ts
+++ b/e2e/ide/wevu-runtime.core-hmr.test.ts
@@ -42,6 +42,9 @@ const RUNTIME_PAGE_JS_DIST = path.join(DIST_ROOT, 'pages/runtime/index.js')
 const HMR_PAGE_BASE_MARKER = '<view class="title">HMR</view>'
 const HMR_SFC_TEMPLATE_BASE_MARKER = 'HMR-SFC'
 const HMR_SFC_SCRIPT_BASE_MARKER = 'HMR-SFC-SCRIPT'
+const HMR_SFC_STYLE_BASE_MARKER = 'hmr-sfc-page'
+const HMR_SFC_KEEP_IMPORT_OUTPUT = '@import \'../hmr/index.wxss\';'
+const HMR_SFC_KEEP_IMPORT_DIRECTIVE = '@wv-keep-import'
 const LAYOUT_PAGE_TEMPLATE_BASE_MARKER = 'LAYOUTS-PAGE-TEMPLATE-BASE'
 const LAYOUT_PAGE_SCRIPT_BASE_MARKER = 'LAYOUTS-PAGE-SCRIPT-BASE'
 
@@ -64,6 +67,11 @@ async function waitForPageWxmlContains(page: any, marker: string, timeoutMs = 20
     await page.waitFor(200)
   }
   throw new Error(`Timed out waiting runtime wxml to contain marker: ${marker}; lastWxml=${lastWxml.slice(0, 800)}`)
+}
+
+function expectSfcKeepImportResolved(content: string) {
+  expect(content).toContain(HMR_SFC_KEEP_IMPORT_OUTPUT)
+  expect(content).not.toContain(HMR_SFC_KEEP_IMPORT_DIRECTIVE)
 }
 
 async function waitForIdeRecompileSettled(delayMs = 1_200) {
@@ -106,7 +114,7 @@ async function waitForInitialHmrDistReady(dev: ReturnType<typeof startDevProcess
       waitForFile(HMR_PAGE_WXSS_DIST, 90_000),
       waitForFileContains(HMR_SFC_WXML_DIST, HMR_SFC_TEMPLATE_BASE_MARKER, 90_000),
       waitForFileContains(HMR_SFC_JS_DIST, HMR_SFC_SCRIPT_BASE_MARKER, 90_000),
-      waitForFile(HMR_SFC_WXSS_DIST, 90_000),
+      waitForFileContains(HMR_SFC_WXSS_DIST, HMR_SFC_STYLE_BASE_MARKER, 90_000),
       waitForFileContains(LAYOUT_PAGE_WXML_DIST, LAYOUT_PAGE_TEMPLATE_BASE_MARKER, 90_000),
       waitForFileContains(LAYOUT_PAGE_JS_DIST, LAYOUT_PAGE_SCRIPT_BASE_MARKER, 90_000),
       waitForFile(LAYOUT_PAGE_WXSS_DIST, 90_000),
@@ -248,6 +256,7 @@ describe.sequential('wevu runtime core hmr matrix (ide)', () => {
 
     try {
       await waitForInitialHmrDistReady(dev)
+      expectSfcKeepImportResolved(await fs.readFile(HMR_SFC_WXSS_DIST, 'utf8'))
       let page = await relaunchIdeRoute('/pages/hmr/index', 'HMR', ctx)
       expect(await waitForPageWxmlContains(page, 'HMR')).toContain('HMR')
 
@@ -323,6 +332,7 @@ describe.sequential('wevu runtime core hmr matrix (ide)', () => {
       await waitForIdeRecompileSettled()
       page = await relaunchIdeRoute('/pages/hmr-sfc/index', sfcTemplateMarker, ctx, { allowCurrentSession: true })
       expect(await waitForPageWxmlContains(page, sfcTemplateMarker)).toContain(sfcTemplateMarker)
+      expectSfcKeepImportResolved(await fs.readFile(HMR_SFC_WXSS_DIST, 'utf8'))
 
       const sfcScriptMarker = createHmrMarker('IDE-CORE-SFC-SCRIPT', 'weapp')
       const updatedSfcScript = updatedSfcTemplate
@@ -340,6 +350,7 @@ describe.sequential('wevu runtime core hmr matrix (ide)', () => {
       page = await relaunchIdeRoute('/pages/hmr-sfc/index', sfcTemplateMarker, ctx, { allowCurrentSession: true })
       expect(await waitForPageWxmlContains(page, sfcScriptMarker)).toContain(sfcScriptMarker)
       expect(await page.data('marker')).toBe(sfcScriptMarker)
+      expectSfcKeepImportResolved(await fs.readFile(HMR_SFC_WXSS_DIST, 'utf8'))
 
       const sfcStyleMarker = createHmrMarker('IDE-CORE-SFC-STYLE', 'weapp')
       const updatedSfcStyle = updatedSfcScript
@@ -354,6 +365,7 @@ describe.sequential('wevu runtime core hmr matrix (ide)', () => {
         'sfc style hmr marker emitted',
       )
       expect(sfcStyleOutput).toContain(sfcStyleMarker)
+      expectSfcKeepImportResolved(sfcStyleOutput)
       await waitForIdeRecompileSettled()
       page = await relaunchIdeRoute('/pages/hmr-sfc/index', sfcTemplateMarker, ctx, { allowCurrentSession: true })
       expect(await page.data('marker')).toBe(sfcScriptMarker)

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/emitCompiledEntry.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/emitCompiledEntry.ts
@@ -83,7 +83,7 @@ export async function emitResolvedCompiledVueEntryAssets(options: {
     })
   }
 
-  const { shouldEmitComponentJson } = emitCompiledEntryBundleAssets({
+  const { shouldEmitComponentJson } = await emitCompiledEntryBundleAssets({
     bundle,
     pluginCtx,
     ctx,

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/emitFallbackPage.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/emitFallbackPage.ts
@@ -77,7 +77,7 @@ export async function emitResolvedFallbackPageEntryAssets(options: {
 
   applyAppShell(result, options.entryFilePath, options.appShell)
 
-  emitFallbackPageBundleAssets({
+  await emitFallbackPageBundleAssets({
     bundle: options.bundle,
     pluginCtx: options.pluginCtx,
     ctx: options.ctx,

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/shared.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/shared.test.ts
@@ -6,6 +6,7 @@ const emitClassStyleWxsAssetIfMissingMock = vi.hoisted(() => vi.fn())
 const emitSfcJsonAssetMock = vi.hoisted(() => vi.fn())
 const emitSfcStyleIfMissingMock = vi.hoisted(() => vi.fn())
 const emitScopedSlotAssetsMock = vi.hoisted(() => vi.fn())
+const processCssWithCacheMock = vi.hoisted(() => vi.fn(async (code: string) => code))
 const resolveClassStyleWxsLocationForBaseMock = vi.hoisted(() => vi.fn(() => ({
   fileName: 'pages/index/__class_style.sjs',
 })))
@@ -48,6 +49,10 @@ vi.mock('../emitAssets', () => ({
   emitClassStyleWxsAssetIfMissing: emitClassStyleWxsAssetIfMissingMock,
   emitSfcJsonAsset: emitSfcJsonAssetMock,
   emitSfcStyleIfMissing: emitSfcStyleIfMissingMock,
+}))
+
+vi.mock('../../../css/shared/preprocessor', () => ({
+  processCssWithCache: processCssWithCacheMock,
 }))
 
 vi.mock('../scopedSlot', () => ({
@@ -118,6 +123,8 @@ describe('emitSharedVueEntryAssets', () => {
     emitSfcJsonAssetMock.mockReset()
     emitSfcStyleIfMissingMock.mockReset()
     emitScopedSlotAssetsMock.mockReset()
+    processCssWithCacheMock.mockReset()
+    processCssWithCacheMock.mockImplementation(async (code: string) => code)
     resolveClassStyleWxsLocationForBaseMock.mockClear()
     getClassStyleWxsSourceMock.mockClear()
     preparePlatformConfigAssetMock.mockReset()
@@ -336,8 +343,8 @@ describe('emitSharedVueEntryAssets', () => {
     })
   })
 
-  it('emits compiled component entry assets with default component json config', () => {
-    const result = emitCompiledEntryBundleAssets({
+  it('emits compiled component entry assets with default component json config', async () => {
+    const result = await emitCompiledEntryBundleAssets({
       bundle: {},
       pluginCtx: { emitFile: vi.fn() },
       ctx: {} as any,
@@ -392,8 +399,8 @@ describe('emitSharedVueEntryAssets', () => {
     })
   })
 
-  it('emits page SFC style assets during asset-only HMR refresh', () => {
-    emitCompiledEntryBundleAssets({
+  it('emits page SFC style assets during asset-only HMR refresh', async () => {
+    await emitCompiledEntryBundleAssets({
       bundle: {},
       pluginCtx: { emitFile: vi.fn() },
       ctx: {
@@ -418,6 +425,7 @@ describe('emitSharedVueEntryAssets', () => {
       isPage: true,
       configService: {
         isDev: true,
+        platform: 'weapp',
       } as any,
       templateExtension: 'wxml',
       jsonExtension: 'json',
@@ -440,10 +448,13 @@ describe('emitSharedVueEntryAssets', () => {
       'wxss',
       undefined,
     )
+    expect(processCssWithCacheMock).toHaveBeenCalledWith('.marker { color: red; }', expect.objectContaining({
+      isDev: true,
+    }))
   })
 
-  it('does not overwrite Vite-processed page SFC style assets during css importer HMR', () => {
-    emitCompiledEntryBundleAssets({
+  it('does not overwrite Vite-processed page SFC style assets during css importer HMR', async () => {
+    await emitCompiledEntryBundleAssets({
       bundle: {},
       pluginCtx: { emitFile: vi.fn() },
       ctx: {
@@ -485,8 +496,8 @@ describe('emitSharedVueEntryAssets', () => {
     expect(emitSfcStyleIfMissingMock).not.toHaveBeenCalled()
   })
 
-  it('emits compiled app entry assets with merged app json config', () => {
-    const result = emitCompiledEntryBundleAssets({
+  it('emits compiled app entry assets with merged app json config', async () => {
+    const result = await emitCompiledEntryBundleAssets({
       bundle: {},
       pluginCtx: { emitFile: vi.fn() },
       ctx: {
@@ -563,8 +574,8 @@ describe('emitSharedVueEntryAssets', () => {
     })
   })
 
-  it('does not overwrite processed app styles during unrelated dev HMR updates', () => {
-    emitCompiledEntryBundleAssets({
+  it('does not overwrite processed app styles during unrelated dev HMR updates', async () => {
+    await emitCompiledEntryBundleAssets({
       bundle: {},
       pluginCtx: { emitFile: vi.fn() },
       ctx: {
@@ -1142,8 +1153,8 @@ describe('emitSharedVueEntryAssets', () => {
     expect(result.result.script).toBe('Page({ loaded: true })')
   })
 
-  it('emits fallback page bundle assets through shared entry and page flows', () => {
-    emitFallbackPageBundleAssets({
+  it('emits fallback page bundle assets through shared entry and page flows', async () => {
+    await emitFallbackPageBundleAssets({
       bundle: {},
       pluginCtx: { emitFile: vi.fn() },
       ctx: {} as any,
@@ -1369,10 +1380,13 @@ describe('emitSharedVueEntryAssets', () => {
     )
   })
 
-  it('emits fallback page style and shared page json asset', () => {
-    emitSharedFallbackPageAssets({
+  it('emits fallback page style and shared page json asset', async () => {
+    await emitSharedFallbackPageAssets({
       bundle: {},
       pluginCtx: { emitFile: vi.fn() },
+      configService: {
+        platform: 'alipay',
+      } as any,
       relativeBase: 'pages/index/index',
       result: {
         style: '.page{}',
@@ -1409,6 +1423,41 @@ describe('emitSharedVueEntryAssets', () => {
         kind: 'page',
         extension: 'json',
       },
+    )
+  })
+
+  it('post-processes fallback page style before emitting', async () => {
+    processCssWithCacheMock.mockResolvedValueOnce('@import \'./keep.css\';\n.page{}')
+
+    await emitSharedFallbackPageAssets({
+      bundle: {},
+      pluginCtx: { emitFile: vi.fn() },
+      configService: {
+        platform: 'weapp',
+      } as any,
+      relativeBase: 'pages/index/index',
+      result: {
+        style: '@wv-keep-import \'./keep.css\';\n.page{}',
+      },
+      outputExtensions: {},
+      platformAssetOptions: {
+        platform: 'weapp',
+        templateExtension: 'wxml',
+      },
+      styleExtension: 'wxss',
+      jsonExtension: 'json',
+    })
+
+    expect(processCssWithCacheMock).toHaveBeenCalledWith(
+      '@wv-keep-import \'./keep.css\';\n.page{}',
+      expect.objectContaining({ platform: 'weapp' }),
+    )
+    expect(emitSfcStyleIfMissingMock).toHaveBeenCalledWith(
+      expect.anything(),
+      {},
+      'pages/index/index',
+      '@import \'./keep.css\';\n.page{}',
+      'wxss',
     )
   })
 })

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/assets.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/assets.ts
@@ -3,6 +3,7 @@ import type { CompilerContext } from '../../../../../context'
 import type { JsonMergeStrategy } from '../../../../../types'
 import type { ClassStyleWxsAsset } from './types'
 import { getClassStyleWxsSource } from 'wevu/compiler'
+import { processCssWithCache } from '../../../../css/shared/preprocessor'
 import { resolveClassStyleWxsLocationForBase } from '../../classStyle'
 import { emitClassStyleWxsAssetIfMissing, emitSfcJsonAsset, emitSfcStyleIfMissing } from '../../emitAssets'
 import { emitScopedSlotAssets } from '../../scopedSlot'
@@ -11,6 +12,16 @@ import { resolveBundleOutputExtensions } from '../outputExtensions'
 import { emitPlatformTemplateAsset, preparePlatformConfigAsset, resolveVueBundlePlatformAssetOptions } from '../platform'
 
 const APP_VUE_LIKE_FILE_RE = /[\\/]app\.(?:vue|jsx|tsx)$/
+
+async function processVueResultStyle(
+  style: string,
+  configService: NonNullable<CompilerContext['configService']>,
+) {
+  if (!configService.platform) {
+    return style
+  }
+  return await processCssWithCache(style, configService)
+}
 
 export function resolveVueBundleAssetContext(
   configService: NonNullable<CompilerContext['configService']>,
@@ -69,9 +80,10 @@ export function emitSharedVueEntryJsonAsset(options: {
   )
 }
 
-export function emitSharedFallbackPageAssets(options: {
+export async function emitSharedFallbackPageAssets(options: {
   bundle: Record<string, any>
   pluginCtx: any
+  configService: NonNullable<CompilerContext['configService']>
   relativeBase: string
   result: Pick<VueTransformResult, 'style' | 'config'>
   outputExtensions: NonNullable<CompilerContext['configService']>['outputExtensions']
@@ -90,6 +102,7 @@ export function emitSharedFallbackPageAssets(options: {
   const {
     bundle,
     pluginCtx,
+    configService,
     relativeBase,
     result,
     outputExtensions,
@@ -101,7 +114,8 @@ export function emitSharedFallbackPageAssets(options: {
   } = options
 
   if (result.style) {
-    emitSfcStyleIfMissing(pluginCtx, bundle, relativeBase, result.style, styleExtension)
+    const style = await processVueResultStyle(result.style, configService)
+    emitSfcStyleIfMissing(pluginCtx, bundle, relativeBase, style, styleExtension)
   }
 
   emitSharedVueEntryJsonAsset({
@@ -266,7 +280,7 @@ export function emitBundleVueEntryAssets(options: {
   }
 }
 
-export function emitFallbackPageBundleAssets(options: {
+export async function emitFallbackPageBundleAssets(options: {
   bundle: Record<string, any>
   pluginCtx: any
   ctx: CompilerContext
@@ -301,9 +315,10 @@ export function emitFallbackPageBundleAssets(options: {
     platformAssetOptions: options.platformAssetOptions,
   })
 
-  emitSharedFallbackPageAssets({
+  await emitSharedFallbackPageAssets({
     bundle: options.bundle,
     pluginCtx: options.pluginCtx,
+    configService: options.configService,
     relativeBase: options.relativeBase,
     result: options.result,
     outputExtensions: options.outputExtensions,
@@ -315,7 +330,7 @@ export function emitFallbackPageBundleAssets(options: {
   })
 }
 
-export function emitCompiledEntryBundleAssets(options: {
+export async function emitCompiledEntryBundleAssets(options: {
   bundle: Record<string, any>
   pluginCtx: any
   ctx: CompilerContext
@@ -376,11 +391,12 @@ export function emitCompiledEntryBundleAssets(options: {
   })
 
   if (shouldEmitSfcStyleAsset) {
+    const style = await processVueResultStyle(sfcStyle, options.configService)
     emitSfcStyleIfMissing(
       options.pluginCtx,
       options.bundle,
       options.relativeBase,
-      sfcStyle,
+      style,
       options.outputExtensions.wxss,
       isAppVue ? { updateExisting: false } : undefined,
     )


### PR DESCRIPTION
## 变更说明

- 修复 Vue SFC 样式 HMR 产物未执行 weapp-vite CSS 后处理，导致 `@wv-keep-import` 保留到最终 wxss 的问题
- 为 style-import-vue HMR 场景补充 `@wv-keep-import` 回归覆盖
- 补充 weapp-vite 与 create-weapp-vite patch changeset

## 验证

- `pnpm exec vitest run src/plugins/vue/transform/bundle/shared.test.ts src/plugins/css.test.ts test/vue/fallback-js-emission.test.ts test/vue/transform-plugin.test.ts`
- `pnpm exec tsc --noEmit -p tsconfig.json`（在 `packages/weapp-vite` 下执行）
- `pnpm --filter weapp-vite build`
- `pnpm run e2e:ci:hmr:style-import`
- `pnpm exec eslint packages/weapp-vite/src/plugins/vue/transform/bundle/emitCompiledEntry.ts packages/weapp-vite/src/plugins/vue/transform/bundle/emitFallbackPage.ts packages/weapp-vite/src/plugins/vue/transform/bundle/shared/assets.ts packages/weapp-vite/src/plugins/vue/transform/bundle/shared.test.ts e2e/ci/style-import-vue.test.ts e2e-apps/style-import-vue/src/pages/index/index.vue`
- `pnpm exec stylelint e2e-apps/style-import-vue/src/pages/index/keep-import.css e2e-apps/style-import-vue/src/pages/index/index.vue`
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`
- `node --import tsx scripts/check-catalog-changeset.ts`
- `node scripts/check-changeset-frontmatter.mjs`

Closes #658