### PR TITLE
feat(web-apis): 补齐 Web API 辅助方法

### DIFF
--- a/.changeset/web-api-helper-methods.md
+++ b/.changeset/web-api-helper-methods.md
@@ -1,0 +1,5 @@
+---
+"@wevu/web-apis": patch
+---
+
+补齐 Web Runtime 兼容层中的低成本 Web API 辅助能力：`URL.parse()`、`URL.canParse()`、`URLSearchParams.size`、`URLSearchParams.sort()`、`Headers.getSetCookie()`、`Response.json()` 与 `Response.error()` 现在可以通过 polyfill 和全局安装链路稳定使用。

--- a/e2e-apps/github-issues/src/pages/issue-448/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-448/index.vue
@@ -19,6 +19,19 @@ const customEventType = new CustomEvent('payload', {
     ok: true,
   },
 }).type
+const parsedUrl = URL.parse('/next?b=2&a=1', 'https://issue-448.invalid/base/')
+const canParseUrl = URL.canParse('/next', 'https://issue-448.invalid')
+const searchParams = new URLSearchParams('b=2&a=1&a=0')
+const searchParamsSize = searchParams.size
+searchParams.sort()
+const sortedParams = searchParams.toString()
+const headers = new Headers()
+headers.append('Set-Cookie', 'session=issue-448')
+headers.append('Set-Cookie', 'theme=dark')
+const cookieCount = headers.getSetCookie().length
+const jsonResponse = Response.json({ ok: true })
+const jsonResponseContentType = jsonResponse.headers.get('content-type')
+const errorResponse = Response.error()
 const microtaskState = ref('pending')
 
 queueMicrotask(() => {
@@ -33,6 +46,14 @@ function _runE2E() {
     randomBytes,
     eventType,
     customEventType,
+    parsedUrl: parsedUrl?.href,
+    canParseUrl,
+    searchParamsSize,
+    sortedParams,
+    cookieCount,
+    jsonResponseContentType,
+    errorResponseStatus: errorResponse.status,
+    errorResponseType: errorResponse.type,
     microtaskState: microtaskState.value,
   }
 }
@@ -47,6 +68,12 @@ function _runE2E() {
     <text class="issue448-line">random = {{ randomBytes }}</text>
     <text class="issue448-line">event = {{ eventType }}</text>
     <text class="issue448-line">custom = {{ customEventType }}</text>
+    <text class="issue448-line">url = {{ parsedUrl?.href }}</text>
+    <text class="issue448-line">canParse = {{ canParseUrl }}</text>
+    <text class="issue448-line">params = {{ sortedParams }}</text>
+    <text class="issue448-line">cookies = {{ cookieCount }}</text>
+    <text class="issue448-line">json = {{ jsonResponseContentType }}</text>
+    <text class="issue448-line">error = {{ errorResponseStatus }}:{{ errorResponseType }}</text>
     <text class="issue448-line">microtask = {{ microtaskState }}</text>
   </view>
 </template>

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -766,6 +766,12 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageJs).toContain('installWebRuntimeGlobals({ targets: [')
     expect(pageJs).toContain('"queueMicrotask"')
     expect(pageJs).toContain('const encoded = btoa("AB");')
+    expect(pageJs).toContain('URL.parse(')
+    expect(pageJs).toContain('URL.canParse(')
+    expect(pageJs).toContain('searchParams.sort()')
+    expect(pageJs).toContain('headers.getSetCookie()')
+    expect(pageJs).toContain('Response.json(')
+    expect(pageJs).toContain('Response.error()')
     expect(pageJs).toContain('function _runE2E() {')
   })
 

--- a/e2e/ide/github-issues.runtime.web-runtime.test.ts
+++ b/e2e/ide/github-issues.runtime.web-runtime.test.ts
@@ -133,13 +133,21 @@ describe.sequential.skip('github-issues runtime web runtime globals', () => {
       expect(runtime.decoded).toBe('AB')
       expect(runtime.eventType).toBe('tick')
       expect(runtime.customEventType).toBe('payload')
+      expect(runtime.parsedUrl).toBe('https://issue-448.invalid/next?b=2&a=1')
+      expect(runtime.canParseUrl).toBe(true)
+      expect(runtime.searchParamsSize).toBe(3)
+      expect(runtime.sortedParams).toBe('a=1&a=0&b=2')
+      expect(runtime.cookieCount).toBe(2)
+      expect(runtime.jsonResponseContentType).toBe('application/json')
+      expect(runtime.errorResponseStatus).toBe(0)
+      expect(runtime.errorResponseType).toBe('error')
       expect(runtime.microtaskState).toBe('flushed')
       expect(runtime.duration).toBeGreaterThanOrEqual(0)
       expectRandomBytesPayload(runtime.randomBytes)
 
       expect(pageWxml).toContain('class="issue448-page"')
       expect(pageWxml).toContain('class="issue448-title"')
-      expect(pageWxml.match(/class="issue448-line"/g)?.length).toBe(7)
+      expect(pageWxml.match(/class="issue448-line"/g)?.length).toBe(13)
     }
     finally {
       await releaseSharedMiniProgram(miniProgram)

--- a/packages-runtime/web-apis/src/http.ts
+++ b/packages-runtime/web-apis/src/http.ts
@@ -10,6 +10,7 @@ import {
 
 type HeaderTuple = readonly [string, string]
 type HeaderRecord = Record<string, string>
+const SET_COOKIE_HEADER_NAME = 'set-cookie'
 
 function isIterableHeaders(input: unknown): input is Iterable<HeaderTuple> {
   return Boolean(input) && typeof (input as Iterable<HeaderTuple>)[Symbol.iterator] === 'function'
@@ -20,7 +21,7 @@ function isHeaderObject(input: unknown): input is Record<string, unknown> {
 }
 
 export class HeadersPolyfill {
-  private readonly store = new Map<string, { key: string, value: string }>()
+  private readonly store = new Map<string, { key: string, values: string[] }>()
 
   constructor(init?: unknown) {
     if (!init) {
@@ -49,8 +50,21 @@ export class HeadersPolyfill {
   }
 
   append(key: string, value: string) {
-    const current = this.get(key)
-    this.set(key, current ? `${current}, ${value}` : value)
+    const normalized = normalizeHeaderName(key)
+    if (!normalized) {
+      return
+    }
+
+    const item = this.store.get(normalized)
+    if (item) {
+      item.values.push(String(value))
+      return
+    }
+
+    this.store.set(normalized, {
+      key,
+      values: [String(value)],
+    })
   }
 
   set(key: string, value: string) {
@@ -60,12 +74,16 @@ export class HeadersPolyfill {
     }
     this.store.set(normalized, {
       key,
-      value: String(value),
+      values: [String(value)],
     })
   }
 
   get(key: string) {
-    return this.store.get(normalizeHeaderName(key))?.value ?? null
+    return this.store.get(normalizeHeaderName(key))?.values.join(', ') ?? null
+  }
+
+  getSetCookie() {
+    return this.store.get(SET_COOKIE_HEADER_NAME)?.values.slice() ?? []
   }
 
   has(key: string) {
@@ -77,13 +95,13 @@ export class HeadersPolyfill {
   }
 
   forEach(callback: (value: string, key: string) => void) {
-    for (const { key, value } of this.store.values()) {
-      callback(value, key)
+    for (const { key, values } of this.store.values()) {
+      callback(values.join(', '), key)
     }
   }
 
   entries() {
-    return Array.from(this.store.values(), item => [item.key, item.value] as [string, string])[Symbol.iterator]()
+    return Array.from(this.store.values(), item => [item.key, item.values.join(', ')] as [string, string])[Symbol.iterator]()
   }
 
   keys() {
@@ -91,7 +109,7 @@ export class HeadersPolyfill {
   }
 
   values() {
-    return Array.from(this.store.values(), item => item.value)[Symbol.iterator]()
+    return Array.from(this.store.values(), item => item.values.join(', '))[Symbol.iterator]()
   }
 
   [Symbol.iterator]() {
@@ -206,7 +224,7 @@ export class ResponsePolyfill {
   readonly ok: boolean
   readonly url: string
   readonly redirected = false
-  readonly type: ResponseType = 'basic'
+  readonly type: ResponseType
   readonly [Symbol.toStringTag] = 'Response'
 
   constructor(body?: RequestBodyLike, init: Record<string, any> = {}) {
@@ -217,6 +235,31 @@ export class ResponsePolyfill {
     this.ok = this.status >= 200 && this.status < 300
     this.headers = new HeadersPolyfill(init.headers)
     this.url = init.url ?? ''
+    this.type = init.type ?? 'basic'
+  }
+
+  static error() {
+    return new ResponsePolyfill(null, {
+      status: 0,
+      type: 'error',
+    })
+  }
+
+  static json(data: unknown, init: Record<string, any> = {}) {
+    const body = JSON.stringify(data)
+    if (body === undefined) {
+      throw new TypeError('Failed to execute \'json\' on \'Response\': data is not JSON serializable')
+    }
+
+    const headers = new HeadersPolyfill(init.headers)
+    if (!headers.has('content-type')) {
+      headers.set('content-type', 'application/json')
+    }
+
+    return new ResponsePolyfill(body, {
+      ...init,
+      headers,
+    })
   }
 
   get body(): ReadableStream<Uint8Array> | null {

--- a/packages-runtime/web-apis/src/index.ts
+++ b/packages-runtime/web-apis/src/index.ts
@@ -125,6 +125,137 @@ function assignHostGlobal(host: Record<string, any>, key: string, value: unknown
   }
 }
 
+function defineHostGlobal(host: Record<string, any>, key: string, descriptor: PropertyDescriptor) {
+  try {
+    Object.defineProperty(host, key, {
+      configurable: true,
+      ...descriptor,
+    })
+    return true
+  }
+  catch {
+    return false
+  }
+}
+
+function createUrlParser(URLConstructor: typeof URLPolyfill) {
+  return function parse(input: string | URLPolyfill, base?: string | URLPolyfill) {
+    try {
+      return new URLConstructor(input, base)
+    }
+    catch {
+      return null
+    }
+  }
+}
+
+function createUrlCanParser(URLConstructor: typeof URLPolyfill) {
+  return function canParse(input: string | URLPolyfill, base?: string | URLPolyfill) {
+    try {
+      Reflect.construct(URLConstructor, base === undefined ? [input] : [input, base])
+      return true
+    }
+    catch {
+      return false
+    }
+  }
+}
+
+function patchUrlConstructor(host: Record<string, any>) {
+  const URLConstructor = host.URL
+  if (typeof URLConstructor !== 'function' || isPlaceholderRequestGlobal(URLConstructor)) {
+    return false
+  }
+
+  let patched = true
+  if (typeof URLConstructor.parse !== 'function') {
+    patched = assignHostGlobal(URLConstructor, 'parse', createUrlParser(URLConstructor)) && patched
+  }
+  if (typeof URLConstructor.canParse !== 'function') {
+    patched = assignHostGlobal(URLConstructor, 'canParse', createUrlCanParser(URLConstructor)) && patched
+  }
+  return patched
+}
+
+function compareUrlSearchParamKeys(leftKey: string, rightKey: string) {
+  if (leftKey < rightKey) {
+    return -1
+  }
+  if (leftKey > rightKey) {
+    return 1
+  }
+  return 0
+}
+
+function sortUrlSearchParams(this: URLSearchParams) {
+  const entries = Array.from(this.entries()).sort(([leftKey], [rightKey]) => compareUrlSearchParamKeys(leftKey, rightKey))
+  const keys = [...new Set(entries.map(([key]) => key))]
+  for (const key of keys) {
+    this.delete(key)
+  }
+  for (const [key, value] of entries) {
+    this.append(key, value)
+  }
+}
+
+function patchUrlSearchParamsConstructor(host: Record<string, any>) {
+  const URLSearchParamsConstructor = host.URLSearchParams
+  const prototype = URLSearchParamsConstructor?.prototype as Record<string, any> | undefined
+  if (typeof URLSearchParamsConstructor !== 'function' || isPlaceholderRequestGlobal(URLSearchParamsConstructor) || !prototype) {
+    return false
+  }
+
+  let patched = true
+  if (!('size' in prototype)) {
+    patched = defineHostGlobal(prototype, 'size', {
+      get(this: URLSearchParams) {
+        let size = 0
+        this.forEach(() => {
+          size += 1
+        })
+        return size
+      },
+    }) && patched
+  }
+  if (typeof prototype.sort !== 'function') {
+    patched = assignHostGlobal(prototype, 'sort', sortUrlSearchParams) && patched
+  }
+  return patched
+}
+
+function patchHeadersConstructor(host: Record<string, any>) {
+  const HeadersConstructor = host.Headers
+  const prototype = HeadersConstructor?.prototype as Record<string, any> | undefined
+  if (typeof HeadersConstructor !== 'function' || isPlaceholderRequestGlobal(HeadersConstructor) || !prototype) {
+    return false
+  }
+
+  if (typeof prototype.getSetCookie === 'function') {
+    return true
+  }
+
+  return assignHostGlobal(prototype, 'getSetCookie', function getSetCookie(this: Headers) {
+    const value = this.get('set-cookie')
+    return value == null ? [] : [value]
+  })
+}
+
+function patchResponseConstructor(host: Record<string, any>) {
+  const ResponseConstructor = host.Response
+  if (typeof ResponseConstructor !== 'function' || isPlaceholderRequestGlobal(ResponseConstructor)) {
+    return false
+  }
+
+  let patched = true
+  if (typeof ResponseConstructor.json !== 'function') {
+    patched = assignHostGlobal(ResponseConstructor, 'json', ResponsePolyfill.json) && patched
+  }
+  if (typeof ResponseConstructor.error !== 'function') {
+    patched = assignHostGlobal(ResponseConstructor, 'error', ResponsePolyfill.error) && patched
+  }
+  return patched
+}
+
 function installSingleTarget(host: Record<string, any>, target: WeappInjectWebRuntimeGlobalsTarget) {
   if (target === 'fetch') {
     if (typeof host.fetch !== 'function' || isPlaceholderRequestGlobal(host.fetch)) {
@@ -134,7 +265,7 @@ function installSingleTarget(host: Record<string, any>, target: WeappInjectWebRu
   }
 
   if (target === 'Headers') {
-    if (typeof host.Headers !== 'function' || isPlaceholderRequestGlobal(host.Headers)) {
+    if (typeof host.Headers !== 'function' || isPlaceholderRequestGlobal(host.Headers) || !patchHeadersConstructor(host)) {
       assignHostGlobal(host, 'Headers', HeadersPolyfill)
     }
     return
@@ -148,7 +279,7 @@ function installSingleTarget(host: Record<string, any>, target: WeappInjectWebRu
   }
 
   if (target === 'Response') {
-    if (typeof host.Response !== 'function' || isPlaceholderRequestGlobal(host.Response)) {
+    if (typeof host.Response !== 'function' || isPlaceholderRequestGlobal(host.Response) || !patchResponseConstructor(host)) {
       assignHostGlobal(host, 'Response', ResponsePolyfill)
     }
     return
@@ -244,10 +375,10 @@ function installSingleTarget(host: Record<string, any>, target: WeappInjectWebRu
 }
 
 function installUrlGlobals(host: Record<string, any>) {
-  if (!hasUsableConstructor(host.URL, ['https://request-globals.invalid'])) {
+  if (!hasUsableConstructor(host.URL, ['https://request-globals.invalid']) || !patchUrlConstructor(host)) {
     assignHostGlobal(host, 'URL', URLPolyfill)
   }
-  if (!hasUsableConstructor(host.URLSearchParams, ['client=graphql-request'])) {
+  if (!hasUsableConstructor(host.URLSearchParams, ['client=graphql-request']) || !patchUrlSearchParamsConstructor(host)) {
     assignHostGlobal(host, 'URLSearchParams', URLSearchParamsPolyfill)
   }
   if (!hasUsableConstructor(host.Blob)) {

--- a/packages-runtime/web-apis/src/url.ts
+++ b/packages-runtime/web-apis/src/url.ts
@@ -174,9 +174,26 @@ export class URLSearchParamsPolyfill {
     return this.entriesStore.some(([entryKey]) => entryKey === String(key))
   }
 
+  get size() {
+    return this.entriesStore.length
+  }
+
   set(key: string, value: string) {
     this.delete(key)
     this.append(key, value)
+  }
+
+  sort() {
+    this.entriesStore.sort(([leftKey], [rightKey]) => {
+      if (leftKey < rightKey) {
+        return -1
+      }
+      if (leftKey > rightKey) {
+        return 1
+      }
+      return 0
+    })
+    this.onChange?.()
   }
 
   forEach(callback: (value: string, key: string) => void) {
@@ -219,6 +236,19 @@ export class URLPolyfill {
   protocol = ''
   username = ''
   readonly searchParams: URLSearchParamsPolyfill
+
+  static canParse(input: string | URLPolyfill, base?: string | URLPolyfill) {
+    return URLPolyfill.parse(input, base) !== null
+  }
+
+  static parse(input: string | URLPolyfill, base?: string | URLPolyfill) {
+    try {
+      return new URLPolyfill(input, base)
+    }
+    catch {
+      return null
+    }
+  }
 
   constructor(input: string | URLPolyfill, base?: string | URLPolyfill) {
     const inputString = typeof input === 'string' ? input : input.toString()

--- a/packages-runtime/web-apis/test-d/index.test-d.ts
+++ b/packages-runtime/web-apis/test-d/index.test-d.ts
@@ -11,14 +11,17 @@ import type {
 } from '@wevu/web-apis/fetch'
 import {
   getMiniProgramNetworkDefaults,
+  HeadersPolyfill,
   installRequestGlobals,
   installWebRuntimeGlobals,
   RequestPolyfill,
   resetMiniProgramNetworkDefaults,
+  ResponsePolyfill,
   setMiniProgramNetworkDefaults,
   TextDecoderPolyfill,
   TextEncoderPolyfill,
   URLPolyfill,
+  URLSearchParamsPolyfill,
 } from '@wevu/web-apis'
 import { expectError, expectType } from 'tsd'
 
@@ -47,6 +50,13 @@ expectType<void>(installWebRuntimeGlobals())
 expectType<void>(installRequestGlobals(options))
 expectType<void>(installRequestGlobals())
 expectType<RequestPolyfill>(new RequestPolyfill(new URLPolyfill('https://request-globals.invalid')))
+expectType<URLPolyfill | null>(URLPolyfill.parse('/path', 'https://request-globals.invalid'))
+expectType<boolean>(URLPolyfill.canParse('/path', 'https://request-globals.invalid'))
+expectType<number>(new URLSearchParamsPolyfill('b=2&a=1').size)
+expectType<void>(new URLSearchParamsPolyfill('b=2&a=1').sort())
+expectType<string[]>(new HeadersPolyfill([['Set-Cookie', 'a=1']]).getSetCookie())
+expectType<ResponsePolyfill>(ResponsePolyfill.json({ ok: true }))
+expectType<ResponsePolyfill>(ResponsePolyfill.error())
 expectType<Uint8Array>(new TextEncoderPolyfill().encode('ok'))
 expectType<string>(new TextDecoderPolyfill().decode(new Uint8Array([111, 107])))
 

--- a/packages-runtime/web-apis/test/runtime.test.ts
+++ b/packages-runtime/web-apis/test/runtime.test.ts
@@ -529,6 +529,41 @@ describe('request globals runtime', () => {
     expect(searchParams.toString()).toBe('variables=%7B%22ok%22%3Atrue%7D')
   })
 
+  it('provides low-cost URL and URLSearchParams modern helpers', async () => {
+    const { URLPolyfill, URLSearchParamsPolyfill } = await import('../src/url')
+
+    const parsed = URLPolyfill.parse('/graphql?b=2&a=1', 'https://request-globals.invalid/base/')
+    const params = new URLSearchParamsPolyfill('b=2&a=1&a=0')
+    params.sort()
+
+    expect(parsed?.href).toBe('https://request-globals.invalid/graphql?b=2&a=1')
+    expect(URLPolyfill.parse('/graphql')).toBeNull()
+    expect(URLPolyfill.canParse('/graphql', 'https://request-globals.invalid')).toBe(true)
+    expect(URLPolyfill.canParse('/graphql')).toBe(false)
+    expect(params.size).toBe(3)
+    expect(params.toString()).toBe('a=1&a=0&b=2')
+  })
+
+  it('provides Headers.getSetCookie and static Response helpers', async () => {
+    const { HeadersPolyfill, ResponsePolyfill } = await import('../src')
+
+    const headers = new HeadersPolyfill()
+    headers.append('Set-Cookie', 'session=issue-448')
+    headers.append('Set-Cookie', 'theme=dark')
+
+    const jsonResponse = ResponsePolyfill.json({ ok: true })
+    const errorResponse = ResponsePolyfill.error()
+
+    expect(headers.get('set-cookie')).toBe('session=issue-448, theme=dark')
+    expect(headers.getSetCookie()).toEqual(['session=issue-448', 'theme=dark'])
+    expect(jsonResponse.status).toBe(200)
+    expect(jsonResponse.headers.get('content-type')).toBe('application/json')
+    expect(await jsonResponse.json()).toEqual({ ok: true })
+    expect(errorResponse.status).toBe(0)
+    expect(errorResponse.ok).toBe(false)
+    expect(errorResponse.type).toBe('error')
+  })
+
   it('keeps directly imported web-apis polyfills interoperable', async () => {
     wpiRequestMock.mockImplementation((options: Record<string, any>) => {
       options.success?.({
@@ -627,6 +662,67 @@ describe('request globals runtime', () => {
     expect(event.type).toBe('tick')
     expect(customEvent.detail).toEqual({ ok: true })
     expect(customEvent.defaultPrevented).toBe(true)
+  })
+
+  it('patches incomplete host constructors before local bindings use newer helpers', async () => {
+    class HostURL extends URL {}
+    class HostURLSearchParams extends URLSearchParams {}
+    class HostHeaders {
+      private readonly headers = new Map<string, string>()
+
+      append(key: string, value: string) {
+        const normalizedKey = key.toLowerCase()
+        const current = this.headers.get(normalizedKey)
+        this.headers.set(normalizedKey, current ? `${current}, ${value}` : value)
+      }
+
+      get(key: string) {
+        return this.headers.get(key.toLowerCase()) ?? null
+      }
+    }
+
+    class HostResponse {
+      readonly headers: HostHeaders
+      readonly status: number
+
+      constructor(_body?: unknown, init: Record<string, any> = {}) {
+        this.headers = init.headers ?? new HostHeaders()
+        this.status = init.status ?? 200
+      }
+    }
+
+    ;(HostURL as Record<string, any>).parse = undefined
+    ;(HostURL as Record<string, any>).canParse = undefined
+    ;(HostURLSearchParams.prototype as Record<string, any>).sort = undefined
+    ;(HostHeaders.prototype as Record<string, any>).getSetCookie = undefined
+    ;(HostResponse as Record<string, any>).json = undefined
+    ;(HostResponse as Record<string, any>).error = undefined
+
+    setGlobalValue('URL', HostURL)
+    setGlobalValue('URLSearchParams', HostURLSearchParams)
+    setGlobalValue('Headers', HostHeaders)
+    setGlobalValue('Response', HostResponse)
+
+    const { installWebRuntimeGlobals } = await import('../src')
+    installWebRuntimeGlobals({
+      targets: ['fetch', 'Headers', 'Response'],
+    })
+
+    const params = new globalThis.URLSearchParams('b=2&a=1&a=0')
+    params.sort()
+    const headers = new globalThis.Headers()
+    headers.append('Set-Cookie', 'session=issue-448')
+    const jsonResponse = globalThis.Response.json({ ok: true })
+    const errorResponse = globalThis.Response.error()
+
+    expect((globalThis.URL as any).parse('/next', 'https://issue-448.invalid')?.href).toBe('https://issue-448.invalid/next')
+    expect((globalThis.URL as any).canParse('/next', 'https://issue-448.invalid')).toBe(true)
+    expect(params.size).toBe(3)
+    expect(params.toString()).toBe('a=1&a=0&b=2')
+    expect((headers as any).getSetCookie()).toEqual(['session=issue-448'])
+    expect(await jsonResponse.json()).toEqual({ ok: true })
+    expect(errorResponse.status).toBe(0)
+    expect(errorResponse.type).toBe('error')
   })
 
   it('falls back to additional mini-program host getRandomValues implementations', async () => {


### PR DESCRIPTION
## 背景

关联 #448 中补充项：`URL.parse()`、`URL.canParse()`、`URLSearchParams.size`、`URLSearchParams.sort()`、`Headers.getSetCookie()`、`Response.json()` 与 `Response.error()`。

## 改动

- 为 `@wevu/web-apis` 补齐上述低成本 Web API 辅助能力。
- 安装 Web Runtime 全局对象时，优先 patch 已存在但缺少辅助方法的宿主构造器，patch 失败才替换为 polyfill。
- 扩展 issue #448 的 `github-issues` 构建页、构建断言和 IDE runtime 断言。
- 补充 `@wevu/web-apis` 单测、类型契约测试和 patch changeset。

## Changeset

- 已补 `@wevu/web-apis` patch changeset。
- 本次未修改 `weapp-vite` 或模板发布行为，不需要 `create-weapp-vite` 联动 changeset。

## 验证

- `pnpm --filter @wevu/web-apis typecheck`
- `pnpm --filter @wevu/web-apis test`
- `pnpm --filter @wevu/web-apis test:types`
- `pnpm eslint packages-runtime/web-apis/src/index.ts packages-runtime/web-apis/src/http.ts packages-runtime/web-apis/src/url.ts packages-runtime/web-apis/test/runtime.test.ts packages-runtime/web-apis/test-d/index.test-d.ts e2e-apps/github-issues/src/pages/issue-448/index.vue e2e/ci/github-issues.build.test.ts e2e/ide/github-issues.runtime.web-runtime.test.ts`
- `pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #448"`
- `pnpm check:publishable-workspace-changeset`
- `pnpm check:create-weapp-vite-changeset`