### PR TITLE
feat(miniprogram-automator): 支持并发 automator 会话

### DIFF
--- a/.changeset/fast-automator-sessions.md
+++ b/.changeset/fast-automator-sessions.md
@@ -1,0 +1,8 @@
+---
+"@weapp-vite/miniprogram-automator": minor
+"@weapp-vite/devtools-runtime": minor
+"weapp-ide-cli": minor
+"@weapp-vite/mcp": minor
+---
+
+支持按端口或 sessionId 区分多个 DevTools automator 会话，并为自动启动流程增加并发安全的端口租约，避免多个自动化任务同时启动时争抢同一个 websocket 端口。

--- a/e2e/ide/automator-concurrent-sessions.runtime.test.ts
+++ b/e2e/ide/automator-concurrent-sessions.runtime.test.ts
@@ -1,0 +1,149 @@
+import { fs } from '@weapp-core/shared/node'
+import path from 'pathe'
+import { afterAll } from 'vitest'
+import { launchAutomator } from '../utils/automator'
+import { runWeappViteBuildWithLogCapture } from '../utils/buildLog'
+
+const AUTOMATOR_LAUNCH_MODE_ENV = 'WEAPP_VITE_E2E_AUTOMATOR_LAUNCH_MODE'
+const CLI_PATH = path.resolve(import.meta.dirname, '../../packages/weapp-vite/bin/weapp-vite.js')
+const BASE_APP_ROOT = path.resolve(import.meta.dirname, '../../e2e-apps/base')
+const NATIVE_APP_ROOT = path.resolve(import.meta.dirname, '../../e2e-apps/app-lifecycle-native')
+const INDEX_ROUTE = '/pages/index/index'
+const LEADING_SLASH_RE = /^\/+/
+const HOOK_TIMEOUT = 180_000
+
+interface AutomatorSessionMetadata {
+  port: number
+  projectPath: string
+  wsEndpoint: string
+}
+
+function normalizeRoutePath(routePath: string) {
+  return routePath.replace(LEADING_SLASH_RE, '')
+}
+
+function readSessionMetadata(miniProgram: any) {
+  return Reflect.get(miniProgram as object, '__WEAPP_VITE_SESSION_METADATA') as AutomatorSessionMetadata | undefined
+}
+
+function delay(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForCurrentPage(miniProgram: any, expectedPath: string, timeoutMs = 20_000) {
+  const normalizedExpectedPath = normalizeRoutePath(expectedPath)
+  const start = Date.now()
+
+  while (Date.now() - start <= timeoutMs) {
+    try {
+      const page = await miniProgram.currentPage()
+      if (normalizeRoutePath(String(page?.path ?? '')) === normalizedExpectedPath) {
+        return page
+      }
+    }
+    catch {
+    }
+    await delay(250)
+  }
+
+  return null
+}
+
+async function readPageWxml(page: any) {
+  const element = await page.$('page')
+  if (!element) {
+    throw new Error('Failed to find page element')
+  }
+  return await element.wxml()
+}
+
+async function runBuild(projectRoot: string, label: string) {
+  await fs.remove(path.join(projectRoot, 'dist'))
+  await runWeappViteBuildWithLogCapture({
+    cliPath: CLI_PATH,
+    projectRoot,
+    platform: 'weapp',
+    skipNpm: true,
+    label,
+  })
+}
+
+async function launchProjectAutomator(projectPath: string) {
+  return await launchAutomator({
+    projectPath,
+    skipWarmup: true,
+    timeout: 120_000,
+  })
+}
+
+async function closeMiniProgram(miniProgram: any) {
+  if (!miniProgram) {
+    return
+  }
+  await miniProgram.close().catch(() => {})
+}
+
+describe.sequential('automator concurrent sessions', () => {
+  const miniPrograms: any[] = []
+  let previousLaunchMode: string | undefined
+
+  beforeAll(async () => {
+    previousLaunchMode = process.env[AUTOMATOR_LAUNCH_MODE_ENV]
+    process.env[AUTOMATOR_LAUNCH_MODE_ENV] = 'direct'
+    await Promise.all([
+      runBuild(BASE_APP_ROOT, 'ide:automator-concurrent-sessions:base'),
+      runBuild(NATIVE_APP_ROOT, 'ide:automator-concurrent-sessions:native'),
+    ])
+    const sessions = await Promise.all([
+      launchProjectAutomator(BASE_APP_ROOT),
+      launchProjectAutomator(NATIVE_APP_ROOT),
+    ])
+    miniPrograms.push(...sessions)
+  }, HOOK_TIMEOUT)
+
+  afterAll(async () => {
+    if (previousLaunchMode === undefined) {
+      delete process.env[AUTOMATOR_LAUNCH_MODE_ENV]
+    }
+    else {
+      process.env[AUTOMATOR_LAUNCH_MODE_ENV] = previousLaunchMode
+    }
+
+    await Promise.all(miniPrograms.map(closeMiniProgram))
+  }, HOOK_TIMEOUT)
+
+  it('launches one independent automator connection per project', async () => {
+    const [baseMiniProgram, nativeMiniProgram] = miniPrograms
+
+    const baseMetadata = readSessionMetadata(baseMiniProgram)
+    const nativeMetadata = readSessionMetadata(nativeMiniProgram)
+
+    expect(baseMetadata?.projectPath).toBe(BASE_APP_ROOT)
+    expect(nativeMetadata?.projectPath).toBe(NATIVE_APP_ROOT)
+    expect(baseMetadata?.wsEndpoint).toMatch(/^ws:\/\/127\.0\.0\.1:\d+$/)
+    expect(nativeMetadata?.wsEndpoint).toMatch(/^ws:\/\/127\.0\.0\.1:\d+$/)
+    expect(baseMetadata?.port).not.toBe(nativeMetadata?.port)
+    expect(baseMetadata?.wsEndpoint).not.toBe(nativeMetadata?.wsEndpoint)
+
+    const [basePage, nativePage] = await Promise.all([
+      waitForCurrentPage(baseMiniProgram, INDEX_ROUTE),
+      waitForCurrentPage(nativeMiniProgram, INDEX_ROUTE),
+    ])
+
+    expect(basePage).toBeTruthy()
+    expect(nativePage).toBeTruthy()
+    if (!basePage || !nativePage) {
+      throw new Error('Failed to resolve concurrent session pages')
+    }
+
+    const [baseWxml, nativeWxml] = await Promise.all([
+      readPageWxml(basePage),
+      readPageWxml(nativePage),
+    ])
+
+    expect(baseWxml).toContain('Status: ready')
+    expect(baseWxml).toContain('Target: index snapshot')
+    expect(nativeWxml).toContain('App lifecycle native')
+    expect(nativeWxml).toContain('E2E Result')
+  })
+})

--- a/packages/devtools-runtime/src/index.ts
+++ b/packages/devtools-runtime/src/index.ts
@@ -41,6 +41,11 @@ function normalizeError(hooks: DevtoolsRuntimeHooks, error: unknown) {
   return normalized instanceof Error ? normalized : new Error(String(normalized))
 }
 
+export function resolveSharedMiniProgramSessionKey(options: Pick<DevtoolsRuntimeSessionOptions, 'port' | 'projectPath' | 'sessionId'>) {
+  const sessionSuffix = options.sessionId || (options.port ? `port:${options.port}` : 'default')
+  return `${options.projectPath}#${sessionSuffix}`
+}
+
 /**
  * @description 获取指定项目的共享 automator 会话；若不存在则自动创建。
  */
@@ -48,7 +53,8 @@ export async function acquireSharedMiniProgram(
   hooks: DevtoolsRuntimeHooks,
   options: DevtoolsRuntimeSessionOptions,
 ): Promise<AutomatorMiniProgram> {
-  const existing = sharedMiniProgramSessions.get(options.projectPath)
+  const sessionKey = resolveSharedMiniProgramSessionKey(options)
+  const existing = sharedMiniProgramSessions.get(sessionKey)
   if (existing) {
     existing.refs += 1
     return await existing.session
@@ -59,13 +65,13 @@ export async function acquireSharedMiniProgram(
     refs: 1,
     session,
   }
-  sharedMiniProgramSessions.set(options.projectPath, entry)
+  sharedMiniProgramSessions.set(sessionKey, entry)
 
   try {
     return await session
   }
   catch (error) {
-    sharedMiniProgramSessions.delete(options.projectPath)
+    sharedMiniProgramSessions.delete(sessionKey)
     throw normalizeError(hooks, error)
   }
 }
@@ -73,8 +79,12 @@ export async function acquireSharedMiniProgram(
 /**
  * @description 释放指定项目的共享会话引用；会话对象会继续缓存，直到显式关闭或重置。
  */
-export function releaseSharedMiniProgram(projectPath: string) {
-  const entry = sharedMiniProgramSessions.get(projectPath)
+export function releaseSharedMiniProgram(projectPath: string, sessionIdOrPort?: string | number) {
+  const entry = sharedMiniProgramSessions.get(resolveSharedMiniProgramSessionKey({
+    projectPath,
+    ...(typeof sessionIdOrPort === 'number' ? { port: sessionIdOrPort } : {}),
+    ...(typeof sessionIdOrPort === 'string' ? { sessionId: sessionIdOrPort } : {}),
+  }))
   if (!entry) {
     return
   }
@@ -84,12 +94,17 @@ export function releaseSharedMiniProgram(projectPath: string) {
 /**
  * @description 关闭并移除指定项目的共享 automator 会话。
  */
-export async function closeSharedMiniProgram(projectPath: string) {
-  const entry = sharedMiniProgramSessions.get(projectPath)
+export async function closeSharedMiniProgram(projectPath: string, sessionIdOrPort?: string | number) {
+  const sessionKey = resolveSharedMiniProgramSessionKey({
+    projectPath,
+    ...(typeof sessionIdOrPort === 'number' ? { port: sessionIdOrPort } : {}),
+    ...(typeof sessionIdOrPort === 'string' ? { sessionId: sessionIdOrPort } : {}),
+  })
+  const entry = sharedMiniProgramSessions.get(sessionKey)
   if (!entry) {
     return
   }
-  sharedMiniProgramSessions.delete(projectPath)
+  sharedMiniProgramSessions.delete(sessionKey)
   const miniProgram = await entry.session.catch(() => null)
   miniProgram?.disconnect()
 }
@@ -120,11 +135,11 @@ export async function withMiniProgram<T>(
       return await runner(miniProgram)
     }
     catch (error) {
-      await closeSharedMiniProgram(options.projectPath)
+      await closeSharedMiniProgram(options.projectPath, options.sessionId || options.port)
       throw normalizeError(hooks, error)
     }
     finally {
-      releaseSharedMiniProgram(options.projectPath)
+      releaseSharedMiniProgram(options.projectPath, options.sessionId || options.port)
     }
   }
 

--- a/packages/devtools-runtime/src/mcp.ts
+++ b/packages/devtools-runtime/src/mcp.ts
@@ -11,8 +11,10 @@ export type AutomatorElement = InstanceType<typeof Element> & {
 export interface DevtoolsRuntimeSessionOptions {
   miniProgram?: AutomatorMiniProgram
   preferOpenedSession?: boolean
+  port?: number
   projectPath: string
   sharedSession?: boolean
+  sessionId?: string
   timeout?: number
 }
 
@@ -24,7 +26,9 @@ export interface DevtoolsRuntimeHooks {
 export interface DevtoolsConnectionInput {
   projectPath: string
   timeout?: number
+  port?: number
   preferOpenedSession?: boolean
+  sessionId?: string
 }
 
 export interface DevtoolsElementSnapshot {

--- a/packages/devtools-runtime/test/session.test.ts
+++ b/packages/devtools-runtime/test/session.test.ts
@@ -24,6 +24,10 @@ beforeEach(async () => {
   await Promise.all([
     closeSharedMiniProgram('/project-a'),
     closeSharedMiniProgram('/project-b'),
+    closeSharedMiniProgram('/project-a', 'worker-a'),
+    closeSharedMiniProgram('/project-a', 'worker-b'),
+    closeSharedMiniProgram('/project-a', 19_510),
+    closeSharedMiniProgram('/project-a', 19_511),
   ])
 })
 
@@ -48,6 +52,52 @@ describe('devtools runtime shared sessions', () => {
     await closeSharedMiniProgram('/project-a')
     expect(miniProgram.disconnect).toHaveBeenCalledTimes(1)
     expect(getSharedMiniProgramSessionCount()).toBe(0)
+  })
+
+  it('separates shared sessions by explicit session id', async () => {
+    const miniProgramA = createMiniProgram()
+    const miniProgramB = createMiniProgram()
+    const hooks = {
+      connectMiniProgram: vi.fn()
+        .mockResolvedValueOnce(miniProgramA)
+        .mockResolvedValueOnce(miniProgramB),
+    }
+
+    const first = await acquireSharedMiniProgram(hooks, {
+      projectPath: '/project-a',
+      sessionId: 'worker-a',
+    })
+    const second = await acquireSharedMiniProgram(hooks, {
+      projectPath: '/project-a',
+      sessionId: 'worker-b',
+    })
+
+    expect(first).toBe(miniProgramA)
+    expect(second).toBe(miniProgramB)
+    expect(hooks.connectMiniProgram).toHaveBeenCalledTimes(2)
+    expect(getSharedMiniProgramSessionCount()).toBe(2)
+  })
+
+  it('separates shared sessions by explicit port', async () => {
+    const miniProgramA = createMiniProgram()
+    const miniProgramB = createMiniProgram()
+    const hooks = {
+      connectMiniProgram: vi.fn()
+        .mockResolvedValueOnce(miniProgramA)
+        .mockResolvedValueOnce(miniProgramB),
+    }
+
+    await acquireSharedMiniProgram(hooks, {
+      port: 19_510,
+      projectPath: '/project-a',
+    })
+    await acquireSharedMiniProgram(hooks, {
+      port: 19_511,
+      projectPath: '/project-a',
+    })
+
+    expect(hooks.connectMiniProgram).toHaveBeenCalledTimes(2)
+    expect(getSharedMiniProgramSessionCount()).toBe(2)
   })
 
   it('normalizes shared session connection errors', async () => {

--- a/packages/mcp/src/server/runtime/rest.ts
+++ b/packages/mcp/src/server/runtime/rest.ts
@@ -16,7 +16,9 @@ export const DEFAULT_RUNTIME_REST_ENDPOINT = '/api/weapp/devtools'
 const connectionSchema = z.object({
   projectPath: z.string().trim().min(1),
   timeout: z.number().int().positive().optional(),
+  port: z.number().int().positive().optional(),
   preferOpenedSession: z.boolean().optional(),
+  sessionId: z.string().trim().min(1).optional(),
 })
 
 const routeBodySchema = connectionSchema.extend({
@@ -124,7 +126,9 @@ function readConnectionFromQuery(url: URL): RuntimeConnectionInput {
   return connectionSchema.parse(compactObject({
     projectPath: url.searchParams.get('projectPath') ?? undefined,
     timeout: readNumberParam(url.searchParams.get('timeout')),
+    port: readNumberParam(url.searchParams.get('port')),
     preferOpenedSession: readBooleanParam(url.searchParams.get('preferOpenedSession')),
+    sessionId: url.searchParams.get('sessionId') ?? undefined,
   }))
 }
 

--- a/packages/mcp/src/server/runtime/shared.ts
+++ b/packages/mcp/src/server/runtime/shared.ts
@@ -8,6 +8,7 @@ import {
   releaseSharedMiniProgram,
   resolveDevtoolsProjectPath,
   resolveDevtoolsWorkspacePath,
+  resolveSharedMiniProgramSessionKey,
   toDevtoolsSerializableValue,
 } from '@weapp-vite/devtools-runtime'
 import { z } from 'zod'
@@ -48,7 +49,9 @@ export interface MiniProgramLike {
 export interface RuntimeConnectionInput {
   projectPath: string
   timeout?: number
+  port?: number
   preferOpenedSession?: boolean
+  sessionId?: string
 }
 
 export interface RuntimeToolOptions {
@@ -73,13 +76,17 @@ interface AttachedSession {
 export const connectionSchema = z.object({
   projectPath: z.string().trim().min(1).describe('小程序项目路径；支持 workspaceRoot 相对路径'),
   timeout: z.number().int().positive().optional(),
+  port: z.number().int().positive().optional(),
   preferOpenedSession: z.boolean().optional(),
+  sessionId: z.string().trim().min(1).optional(),
 })
 
 export const connectionInputSchema = {
   projectPath: z.string().trim().min(1).describe('小程序项目路径；支持 workspaceRoot 相对路径'),
   timeout: z.number().int().positive().optional(),
+  port: z.number().int().positive().optional(),
   preferOpenedSession: z.boolean().optional(),
+  sessionId: z.string().trim().min(1).optional(),
 }
 
 export class RuntimeSessionManager {
@@ -94,8 +101,9 @@ export class RuntimeSessionManager {
 
   async close(input: RuntimeConnectionInput) {
     const projectPath = this.resolveProjectPath(input.projectPath)
-    this.detach(projectPath)
-    await closeSharedMiniProgram(projectPath)
+    const sessionKey = this.resolveSessionKey(projectPath, input)
+    this.detach(sessionKey)
+    await closeSharedMiniProgram(projectPath, input.sessionId || input.port)
   }
 
   clearLogs() {
@@ -120,24 +128,27 @@ export class RuntimeSessionManager {
   ): Promise<T> {
     const projectPath = this.resolveProjectPath(input.projectPath)
     const miniProgram = await acquireSharedMiniProgram(this.runtimeHooks, {
+      port: input.port,
       projectPath,
+      sessionId: input.sessionId,
       timeout: input.timeout,
       preferOpenedSession: input.preferOpenedSession,
       sharedSession: true,
     })
 
-    this.attach(projectPath, miniProgram)
+    const sessionKey = this.resolveSessionKey(projectPath, input)
+    this.attach(sessionKey, miniProgram)
 
     try {
       return await runner(miniProgram)
     }
     catch (error) {
-      this.detach(projectPath)
-      await closeSharedMiniProgram(projectPath)
+      this.detach(sessionKey)
+      await closeSharedMiniProgram(projectPath, input.sessionId || input.port)
       throw error
     }
     finally {
-      releaseSharedMiniProgram(projectPath)
+      releaseSharedMiniProgram(projectPath, input.sessionId || input.port)
     }
   }
 
@@ -154,13 +165,21 @@ export class RuntimeSessionManager {
     })
   }
 
-  private attach(projectPath: string, miniProgram: MiniProgramLike) {
-    const existing = this.attachedSessions.get(projectPath)
+  private resolveSessionKey(projectPath: string, input: Pick<RuntimeConnectionInput, 'port' | 'sessionId'>) {
+    return resolveSharedMiniProgramSessionKey({
+      port: input.port,
+      projectPath,
+      sessionId: input.sessionId,
+    })
+  }
+
+  private attach(sessionKey: string, miniProgram: MiniProgramLike) {
+    const existing = this.attachedSessions.get(sessionKey)
     if (existing?.miniProgram === miniProgram) {
       return
     }
 
-    this.detach(projectPath)
+    this.detach(sessionKey)
 
     const onConsole = (payload: unknown) => {
       this.pushLog(normalizeConsoleEvent(payload))
@@ -171,7 +190,7 @@ export class RuntimeSessionManager {
 
     miniProgram.on('console', onConsole)
     miniProgram.on('exception', onException)
-    this.attachedSessions.set(projectPath, {
+    this.attachedSessions.set(sessionKey, {
       miniProgram,
       onConsole,
       onException,

--- a/packages/miniprogram-automator/src/Launcher.ts
+++ b/packages/miniprogram-automator/src/Launcher.ts
@@ -8,21 +8,27 @@ import path from 'node:path'
 import process from 'node:process'
 import Connection from './Connection'
 import { launchHeadlessAutomator } from './headless'
-import { endWith, extendDeep, getPort, isEmpty, isRelative, isWindows, sleep, toStr, waitUntil } from './internal/compat'
+import { endWith, extendDeep, isEmpty, isRelative, isWindows, sleep, toStr, waitUntil } from './internal/compat'
+import { acquireAutomatorPortLease } from './launcher/portLease'
 import MiniProgram from './MiniProgram'
 import { normalizePlatform } from './platform'
 import SwanLauncher from './SwanLauncher'
 
-const DEFAULT_PORT = 9420
 const DEFAULT_TIMEOUT = 30000
+const AUTOMATOR_LAUNCH_RETRIES = 3
 const DEFAULT_RUNTIME_PROVIDER_ENV = 'WEAPP_VITE_AUTOMATOR_RUNTIME_PROVIDER'
 const LEGACY_RUNTIME_PROVIDER_ENV = 'WEAPP_VITE_E2E_RUNTIME_PROVIDER'
 const EXTENSION_CONTEXT_INVALIDATED_RE = /Extension context invalidated/i
+const RETRYABLE_LAUNCH_PORT_RE = /Wait timed out after \d+ ms|Failed connecting to ws:\/\/127\.0\.0\.1:\d+|Failed connecting to devtools websocket endpoint/i
 const WINDOWS_BATCH_CLI_RE = /\.(?:bat|cmd)$/i
 let localhostListenPatched = false
 
 function isExtensionContextInvalidatedError(error: unknown) {
   return error instanceof Error && EXTENSION_CONTEXT_INVALIDATED_RE.test(error.message)
+}
+
+function isRetryableAutomatorPortLaunchError(error: unknown) {
+  return error instanceof Error && RETRYABLE_LAUNCH_PORT_RE.test(error.message)
 }
 
 function patchNetListenToLoopback() {
@@ -134,129 +140,154 @@ export default class Launcher {
       })
     }
     patchNetListenToLoopback()
-    const { cliPath = await this.resolveCliPath(), timeout = DEFAULT_TIMEOUT, projectConfig = {}, ticket = '', cwd = '', account = '', trustProject = false } = options
-    let { args = [], projectPath } = options
-    const port = await getPort(options.port || DEFAULT_PORT)
-    if (options.port && options.port !== port) {
-      throw new Error(`Port ${options.port} is in use, please specify another port`)
+    if (options.port) {
+      return await this.launchWechatDevtools(options)
     }
-    if (!cliPath) {
-      throw new Error('Wechat web devTools not found, please specify cliPath option')
-    }
-    if (isWindows && endWith(cliPath, '.exe')) {
-      throw new Error('cliPath is not correct, it\'s usually named as \'cli\' or \'cli.bat\'')
-    }
-    if (!projectPath) {
-      throw new Error('projectPath is not provided')
-    }
-    if (isRelative(projectPath)) {
-      projectPath = path.resolve(projectPath)
-    }
-    const projectExists = await import('node:fs/promises').then(fs => fs.access(projectPath).then(() => true).catch(() => false))
-    if (!projectExists) {
-      throw new Error(`Project path ${projectPath} doesn't exist`)
-    }
-    if (!isEmpty(projectConfig)) {
-      await this.extendProjectConfig(projectConfig, projectPath)
-    }
-    let processError: unknown = null
-    let processExitCode: number | null = null
-    let processSignal: NodeJS.Signals | null = null
-    args = [
-      ...args,
-      'auto',
-      '--project',
-      projectPath,
-      '--auto-port',
-      toStr(port),
-    ]
-    if (account) {
-      args.push('--auto-account', account)
-    }
-    else if (ticket) {
-      args.push('--ticket', ticket)
-    }
-    if (trustProject) {
-      args.push('--trust-project')
-    }
-    try {
-      const spawnTarget = shouldUseWindowsCommandShell(cliPath)
-        ? resolveWindowsBatchSpawn(cliPath, args)
-        : { file: cliPath, args }
-      const child = spawn(spawnTarget.file, spawnTarget.args, {
-        stdio: 'ignore',
-        cwd: cwd || undefined,
-        ...(shouldUseWindowsCommandShell(cliPath)
-          ? {
-              windowsHide: true,
-              windowsVerbatimArguments: true,
-            }
-          : {}),
-      })
-      child.on('error', (error) => {
-        processError = error
-      })
-      child.on('exit', (code, signal) => {
-        processExitCode = code
-        processSignal = signal
-        if (code !== 0 || signal) {
-          processError = new Error(`DevTools cli exited unexpectedly with code ${code ?? 'null'}${signal ? ` and signal ${signal}` : ''}`)
-        }
-      })
-      child.unref()
-    }
-    catch (error) {
-      processError = error
-    }
-    let miniProgram: MiniProgram | null = null
-    let lastConnectError: unknown = null
-    await waitUntil(async () => {
+
+    let lastError: unknown = null
+    for (let attempt = 1; attempt <= AUTOMATOR_LAUNCH_RETRIES; attempt += 1) {
       try {
-        if (processError) {
-          return true
-        }
-        const candidate = await this.connectTool({
-          wsEndpoint: `ws://127.0.0.1:${port}`,
-        })
-        try {
-          await candidate.checkVersion()
-        }
-        catch (error) {
-          candidate.disconnect()
-          lastConnectError = error
-          if (isExtensionContextInvalidatedError(error)) {
-            return false
-          }
-          throw error
-        }
-        miniProgram = candidate
-        return true
+        return await this.launchWechatDevtools(options)
       }
       catch (error) {
-        lastConnectError = error
-        return false
+        lastError = error
+        if (!isRetryableAutomatorPortLaunchError(error) || attempt === AUTOMATOR_LAUNCH_RETRIES) {
+          throw error
+        }
       }
-    }, timeout, 1000)
-    if (!miniProgram) {
-      if (processError) {
-        throw new Error('Failed to launch wechat web devTools, please make sure cliPath is correctly specified')
-      }
-      if (lastConnectError) {
-        throw lastConnectError
-      }
-      if (processExitCode !== null || processSignal) {
-        throw new Error('Failed to launch wechat web devTools, please make sure http port is open')
-      }
-      throw new Error('Failed connecting to devtools websocket endpoint')
     }
-    const resolvedMiniProgram = miniProgram as MiniProgram
-    Reflect.set(resolvedMiniProgram, '__WEAPP_VITE_SESSION_METADATA', {
-      port,
-      projectPath,
-      wsEndpoint: `ws://127.0.0.1:${port}`,
-    } satisfies ILauncherSessionMetadata)
-    await sleep(5000)
-    return resolvedMiniProgram
+
+    throw lastError instanceof Error ? lastError : new Error(String(lastError))
+  }
+
+  private async launchWechatDevtools(options: ILaunchOptions): Promise<any> {
+    const { cliPath = await this.resolveCliPath(), timeout = DEFAULT_TIMEOUT, projectConfig = {}, ticket = '', cwd = '', account = '', trustProject = false } = options
+    let { args = [], projectPath } = options
+    const portLease = await acquireAutomatorPortLease(options.port)
+    try {
+      const port = portLease.port
+      if (!cliPath) {
+        throw new Error('Wechat web devTools not found, please specify cliPath option')
+      }
+      if (isWindows && endWith(cliPath, '.exe')) {
+        throw new Error('cliPath is not correct, it\'s usually named as \'cli\' or \'cli.bat\'')
+      }
+      if (!projectPath) {
+        throw new Error('projectPath is not provided')
+      }
+      const resolvedProjectPath = isRelative(projectPath) ? path.resolve(projectPath) : projectPath
+      if (isRelative(projectPath)) {
+        projectPath = resolvedProjectPath
+      }
+      const projectExists = await import('node:fs/promises').then(fs => fs.access(resolvedProjectPath).then(() => true).catch(() => false))
+      if (!projectExists) {
+        throw new Error(`Project path ${resolvedProjectPath} doesn't exist`)
+      }
+      if (!isEmpty(projectConfig)) {
+        await this.extendProjectConfig(projectConfig, resolvedProjectPath)
+      }
+      let processError: unknown = null
+      let processExitCode: number | null = null
+      let processSignal: NodeJS.Signals | null = null
+      args = [
+        ...args,
+        'auto',
+        '--project',
+        resolvedProjectPath,
+        '--auto-port',
+        toStr(port),
+      ]
+      if (account) {
+        args.push('--auto-account', account)
+      }
+      else if (ticket) {
+        args.push('--ticket', ticket)
+      }
+      if (trustProject) {
+        args.push('--trust-project')
+      }
+      try {
+        const spawnTarget = shouldUseWindowsCommandShell(cliPath)
+          ? resolveWindowsBatchSpawn(cliPath, args)
+          : { file: cliPath, args }
+        const child = spawn(spawnTarget.file, spawnTarget.args, {
+          stdio: 'ignore',
+          cwd: cwd || undefined,
+          ...(shouldUseWindowsCommandShell(cliPath)
+            ? {
+                windowsHide: true,
+                windowsVerbatimArguments: true,
+              }
+            : {}),
+        })
+        child.on('error', (error) => {
+          processError = error
+        })
+        child.on('exit', (code, signal) => {
+          processExitCode = code
+          processSignal = signal
+          if (code !== 0 || signal) {
+            processError = new Error(`DevTools cli exited unexpectedly with code ${code ?? 'null'}${signal ? ` and signal ${signal}` : ''}`)
+          }
+        })
+        child.unref()
+      }
+      catch (error) {
+        processError = error
+      }
+      let miniProgram: MiniProgram | null = null
+      let lastConnectError: unknown = null
+      await waitUntil(async () => {
+        try {
+          if (processError) {
+            return true
+          }
+          const candidate = await this.connectTool({
+            wsEndpoint: `ws://127.0.0.1:${port}`,
+          })
+          try {
+            await candidate.checkVersion()
+          }
+          catch (error) {
+            candidate.disconnect()
+            lastConnectError = error
+            if (isExtensionContextInvalidatedError(error)) {
+              return false
+            }
+            throw error
+          }
+          miniProgram = candidate
+          return true
+        }
+        catch (error) {
+          lastConnectError = error
+          return false
+        }
+      }, timeout, 1000)
+      if (!miniProgram) {
+        if (processError) {
+          throw new Error('Failed to launch wechat web devTools, please make sure cliPath is correctly specified')
+        }
+        if (lastConnectError) {
+          throw lastConnectError
+        }
+        if (processExitCode !== null || processSignal) {
+          throw new Error('Failed to launch wechat web devTools, please make sure http port is open')
+        }
+        throw new Error('Failed connecting to devtools websocket endpoint')
+      }
+      const resolvedMiniProgram = miniProgram as MiniProgram
+      Reflect.set(resolvedMiniProgram, '__WEAPP_VITE_SESSION_METADATA', {
+        port,
+        projectPath: resolvedProjectPath,
+        wsEndpoint: `ws://127.0.0.1:${port}`,
+      } satisfies ILauncherSessionMetadata)
+      await sleep(5000)
+      return resolvedMiniProgram
+    }
+    finally {
+      await portLease.release()
+    }
   }
 
   async connect(options: IConnectOptions) {

--- a/packages/miniprogram-automator/src/launcher.test.ts
+++ b/packages/miniprogram-automator/src/launcher.test.ts
@@ -9,6 +9,10 @@ const accessMock = vi.hoisted(() => vi.fn(async () => undefined))
 const readFileMock = vi.hoisted(() => vi.fn(async () => '{}'))
 const writeFileMock = vi.hoisted(() => vi.fn(async () => undefined))
 const getPortMock = vi.hoisted(() => vi.fn(async (value: number) => value))
+const acquirePortLeaseMock = vi.hoisted(() => vi.fn(async (port?: number) => ({
+  port: port ?? 9420,
+  release: vi.fn(async () => {}),
+})))
 const waitUntilMock = vi.hoisted(() => vi.fn(async (condition: () => unknown | Promise<unknown>, timeout = 0) => {
   const startTime = Date.now()
   while (true) {
@@ -46,6 +50,10 @@ vi.mock('./Connection', () => ({
   },
 }))
 
+vi.mock('./launcher/portLease', () => ({
+  acquireAutomatorPortLease: acquirePortLeaseMock,
+}))
+
 vi.mock('./SwanLauncher', () => ({
   default: swanLauncherMock,
 }))
@@ -69,6 +77,10 @@ async function loadLauncherModule(isWindows = false) {
 describe('Launcher', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    acquirePortLeaseMock.mockImplementation(async (port?: number) => ({
+      port: port ?? 9420,
+      release: vi.fn(async () => {}),
+    }))
     process.env.ComSpec = 'C:\\Windows\\System32\\cmd.exe'
   })
 
@@ -92,7 +104,7 @@ describe('Launcher', () => {
 
   it('rejects occupied custom ports before spawning', async () => {
     const { default: Launcher } = await loadLauncherModule()
-    getPortMock.mockResolvedValueOnce(10000)
+    acquirePortLeaseMock.mockRejectedValueOnce(new Error('Port 9420 is in use, please specify another port'))
     const launcher = new Launcher()
 
     await expect(launcher.launch({
@@ -100,6 +112,31 @@ describe('Launcher', () => {
       port: 9420,
       projectPath: '/tmp/project',
     })).rejects.toThrow('Port 9420 is in use')
+  })
+
+  it('retries automatic launch on websocket port conflicts with a new lease', async () => {
+    const { default: Launcher } = await loadLauncherModule()
+    const child = new EventEmitter() as EventEmitter & { unref: () => void }
+    child.unref = vi.fn()
+    spawnMock.mockReturnValue(child)
+    acquirePortLeaseMock
+      .mockResolvedValueOnce({ port: 9420, release: vi.fn(async () => {}) })
+      .mockResolvedValueOnce({ port: 9421, release: vi.fn(async () => {}) })
+    const launcher = new Launcher()
+    const rawWaitUntil = waitUntilMock.getMockImplementation()!
+    waitUntilMock
+      .mockRejectedValueOnce(new Error('Wait timed out after 1 ms'))
+      .mockImplementationOnce(rawWaitUntil)
+    vi.spyOn(launcher as any, 'connectTool').mockResolvedValueOnce({ checkVersion: vi.fn(async () => {}) })
+
+    await launcher.launch({
+      cliPath: '/Applications/wechatwebdevtools.app/Contents/MacOS/cli',
+      projectPath: '/tmp/project',
+      timeout: 1,
+    })
+
+    expect(acquirePortLeaseMock).toHaveBeenCalledTimes(2)
+    expect(spawnMock.mock.calls[1]?.[1]).toContain('9421')
   })
 
   it('spawns the cli and connects to the computed endpoint', async () => {

--- a/packages/miniprogram-automator/src/launcher/portLease.test.ts
+++ b/packages/miniprogram-automator/src/launcher/portLease.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @file 自动化端口租约测试。
+ */
+import fs from 'node:fs/promises'
+import { afterEach, describe, expect, it } from 'vitest'
+import { acquireAutomatorPortLease } from './portLease'
+
+const activeLeases: Array<{ release: () => Promise<void> }> = []
+
+afterEach(async () => {
+  await Promise.all(activeLeases.splice(0).map(lease => lease.release()))
+})
+
+describe('automator port lease', () => {
+  it('allocates different ports for concurrent default launches', async () => {
+    const leases = await Promise.all([
+      acquireAutomatorPortLease(),
+      acquireAutomatorPortLease(),
+    ])
+    activeLeases.push(...leases)
+
+    expect(leases[0].port).not.toBe(leases[1].port)
+  })
+
+  it('rejects an explicitly leased port', async () => {
+    const lease = await acquireAutomatorPortLease(29_420)
+    activeLeases.push(lease)
+
+    await expect(acquireAutomatorPortLease(29_420)).rejects.toThrow('Port 29420 is in use')
+  })
+
+  it('removes lock files after release', async () => {
+    const lease = await acquireAutomatorPortLease()
+    expect(lease.path).toBeTruthy()
+
+    await lease.release()
+
+    await expect(fs.access(lease.path!)).rejects.toThrow()
+  })
+})

--- a/packages/miniprogram-automator/src/launcher/portLease.ts
+++ b/packages/miniprogram-automator/src/launcher/portLease.ts
@@ -1,0 +1,142 @@
+/**
+ * @file DevTools 自动化端口租约。
+ */
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { getPort } from '../internal/compat'
+
+const DEFAULT_PORT = 9420
+const PORT_RANGE_SIZE = 200
+const PORT_LEASE_DIR = path.join(os.tmpdir(), 'weapp-vite-automator-port-leases')
+
+export interface AutomatorPortLease {
+  path?: string
+  port: number
+  release: () => Promise<void>
+}
+
+export function createCandidatePorts(preferredPort = DEFAULT_PORT) {
+  return Array.from({ length: PORT_RANGE_SIZE }, (_, index) => preferredPort + index)
+}
+
+function isPathExistsError(error: unknown) {
+  return error && typeof error === 'object' && 'code' in error && error.code === 'EEXIST'
+}
+
+function isProcessAlive(pid: number) {
+  try {
+    process.kill(pid, 0)
+    return true
+  }
+  catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ESRCH') {
+      return false
+    }
+    return true
+  }
+}
+
+async function removePortLock(leasePath: string) {
+  await fs.rm(leasePath, { force: true }).catch(() => {})
+}
+
+async function removeStalePortLock(leasePath: string) {
+  try {
+    const raw = await fs.readFile(leasePath, 'utf8')
+    const payload = JSON.parse(raw) as { pid?: unknown }
+    if (typeof payload.pid === 'number' && isProcessAlive(payload.pid)) {
+      return false
+    }
+  }
+  catch {
+  }
+  await removePortLock(leasePath)
+  return true
+}
+
+async function writePortLock(port: number, leasePath: string) {
+  const handle = await fs.open(leasePath, 'wx')
+  await handle.writeFile(JSON.stringify({
+    pid: process.pid,
+    port,
+    updatedAt: new Date().toISOString(),
+  }))
+  await handle.close()
+}
+
+async function createPortLock(port: number) {
+  await fs.mkdir(PORT_LEASE_DIR, { recursive: true })
+  const leasePath = path.join(PORT_LEASE_DIR, `${port}.lock`)
+  try {
+    await writePortLock(port, leasePath)
+  }
+  catch (error) {
+    if (!isPathExistsError(error) || !(await removeStalePortLock(leasePath))) {
+      throw error
+    }
+    await writePortLock(port, leasePath)
+  }
+  return leasePath
+}
+
+function createLease(port: number, leasePath?: string): AutomatorPortLease {
+  let released = false
+  return {
+    path: leasePath,
+    port,
+    release: async () => {
+      if (released) {
+        return
+      }
+      released = true
+      if (leasePath) {
+        await removePortLock(leasePath)
+      }
+    },
+  }
+}
+
+/**
+ * @description 选择并短暂租约一个自动化端口，避免并发启动选择到同一端口。
+ */
+export async function acquireAutomatorPortLease(preferredPort?: number): Promise<AutomatorPortLease> {
+  if (preferredPort) {
+    const port = await getPort(preferredPort, '127.0.0.1')
+    if (port !== preferredPort) {
+      throw new Error(`Port ${preferredPort} is in use, please specify another port`)
+    }
+    let leasePath: string
+    try {
+      leasePath = await createPortLock(port)
+    }
+    catch (error) {
+      if (isPathExistsError(error)) {
+        throw new Error(`Port ${preferredPort} is in use, please specify another port`)
+      }
+      throw error
+    }
+    return createLease(port, leasePath)
+  }
+
+  for (const candidate of createCandidatePorts()) {
+    const port = await getPort(candidate, '127.0.0.1')
+    if (port !== candidate) {
+      continue
+    }
+    try {
+      const leasePath = await createPortLock(port)
+      return createLease(port, leasePath)
+    }
+    catch (error) {
+      if (isPathExistsError(error)) {
+        continue
+      }
+      throw error
+    }
+  }
+
+  const fallbackPort = await getPort(0, '127.0.0.1')
+  return createLease(fallbackPort)
+}

--- a/packages/weapp-ide-cli/src/cli/automator-argv.ts
+++ b/packages/weapp-ide-cli/src/cli/automator-argv.ts
@@ -3,6 +3,8 @@ import process from 'node:process'
 export interface ParsedAutomatorArgs {
   projectPath: string
   timeout?: number
+  port?: number
+  sessionId?: string
   json: boolean
   positionals: string[]
 }
@@ -20,6 +22,8 @@ function takesValue(optionName: string) {
     || optionName === '--project'
     || optionName === '-t'
     || optionName === '--timeout'
+    || optionName === '--port'
+    || optionName === '--session-id'
     || optionName === '-o'
     || optionName === '--output'
     || optionName === '--page'
@@ -42,6 +46,8 @@ export function parseAutomatorArgs(argv: readonly string[]): ParsedAutomatorArgs
   const positionals: string[] = []
   let projectPath = process.cwd()
   let timeout: number | undefined
+  let port: number | undefined
+  let sessionId: string | undefined
   let json = false
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -81,6 +87,34 @@ export function parseAutomatorArgs(argv: readonly string[]): ParsedAutomatorArgs
       continue
     }
 
+    if (token === '--port') {
+      const value = argv[index + 1]
+      if (typeof value === 'string') {
+        port = parsePositiveInt(value)
+        index += 1
+      }
+      continue
+    }
+
+    if (token.startsWith('--port=')) {
+      port = parsePositiveInt(token.slice('--port='.length))
+      continue
+    }
+
+    if (token === '--session-id') {
+      const value = argv[index + 1]
+      if (typeof value === 'string' && !value.startsWith('-')) {
+        sessionId = value.trim() || undefined
+        index += 1
+      }
+      continue
+    }
+
+    if (token.startsWith('--session-id=')) {
+      sessionId = token.slice('--session-id='.length).trim() || undefined
+      continue
+    }
+
     if (token === '--json') {
       json = true
       continue
@@ -102,7 +136,9 @@ export function parseAutomatorArgs(argv: readonly string[]): ParsedAutomatorArgs
 
   return {
     projectPath,
-    timeout,
+    ...(timeout ? { timeout } : {}),
+    ...(port ? { port } : {}),
+    ...(sessionId ? { sessionId } : {}),
     json,
     positionals,
   }

--- a/packages/weapp-ide-cli/src/cli/automator.ts
+++ b/packages/weapp-ide-cli/src/cli/automator.ts
@@ -11,12 +11,16 @@ export interface AutomatorOptions {
   projectPath: string
   timeout?: number
   cliPath?: string
+  port?: number
+  sessionId?: string
   trustProject?: boolean
   preferOpenedSession?: boolean
 }
 
 interface PersistedAutomatorSession {
+  port?: number
   projectPath: string
+  sessionId?: string
   updatedAt: string
   wsEndpoint: string
 }
@@ -74,31 +78,55 @@ function extractErrorText(error: unknown): string {
     .join('\n')
 }
 
-function resolveAutomatorSessionFilePath(projectPath: string) {
+function normalizeAutomatorSessionId(sessionId: string | undefined, port: number | undefined) {
+  if (sessionId?.trim()) {
+    return sessionId.trim()
+  }
+  return port ? `port-${port}` : 'default'
+}
+
+function resolveAutomatorSessionFilePath(projectPath: string, sessionId?: string, port?: number) {
   const normalizedProjectPath = path.resolve(projectPath)
-  const encodedProjectPath = Buffer.from(normalizedProjectPath).toString('base64url')
+  const normalizedSessionId = normalizeAutomatorSessionId(sessionId, port)
+  const sessionKey = normalizedSessionId === 'default'
+    ? normalizedProjectPath
+    : `${normalizedProjectPath}#${normalizedSessionId}`
+  const encodedProjectPath = Buffer.from(sessionKey).toString('base64url')
   return path.join(AUTOMATOR_SESSION_DIR, `${encodedProjectPath}.json`)
 }
 
-async function persistAutomatorSession(projectPath: string, wsEndpoint: string) {
-  const filePath = resolveAutomatorSessionFilePath(projectPath)
+async function persistAutomatorSession(options: {
+  port?: number
+  projectPath: string
+  sessionId?: string
+  wsEndpoint: string
+}) {
+  const filePath = resolveAutomatorSessionFilePath(options.projectPath, options.sessionId, options.port)
   const payload: PersistedAutomatorSession = {
-    projectPath: path.resolve(projectPath),
+    ...(options.port ? { port: options.port } : {}),
+    projectPath: path.resolve(options.projectPath),
+    ...(options.sessionId ? { sessionId: options.sessionId } : {}),
     updatedAt: new Date().toISOString(),
-    wsEndpoint,
+    wsEndpoint: options.wsEndpoint,
   }
 
   await fs.mkdir(path.dirname(filePath), { recursive: true })
   await fs.writeFile(filePath, JSON.stringify(payload, null, 2), 'utf8')
 }
 
-async function readPersistedAutomatorSession(projectPath: string) {
-  const filePath = resolveAutomatorSessionFilePath(projectPath)
+async function readPersistedAutomatorSession(projectPath: string, sessionId?: string, port?: number) {
+  const filePath = resolveAutomatorSessionFilePath(projectPath, sessionId, port)
 
   try {
     const raw = await fs.readFile(filePath, 'utf8')
     const payload = JSON.parse(raw) as Partial<PersistedAutomatorSession>
     if (payload.projectPath !== path.resolve(projectPath) || typeof payload.wsEndpoint !== 'string' || !payload.wsEndpoint.trim()) {
+      return null
+    }
+    if (sessionId && payload.sessionId !== sessionId) {
+      return null
+    }
+    if (port && payload.port !== port) {
       return null
     }
     return payload as PersistedAutomatorSession
@@ -108,8 +136,8 @@ async function readPersistedAutomatorSession(projectPath: string) {
   }
 }
 
-async function removePersistedAutomatorSession(projectPath: string) {
-  const filePath = resolveAutomatorSessionFilePath(projectPath)
+async function removePersistedAutomatorSession(projectPath: string, sessionId?: string, port?: number) {
+  const filePath = resolveAutomatorSessionFilePath(projectPath, sessionId, port)
 
   try {
     await fs.rm(filePath, { force: true })
@@ -239,7 +267,7 @@ export function formatAutomatorLoginError(error: unknown): string {
  * @description 基于当前配置解析 CLI 路径，并通过现代化 automator 入口启动会话。
  */
 export async function launchAutomator(options: AutomatorOptions) {
-  const { cliPath, projectPath, timeout = 30_000 } = options
+  const { cliPath, port, projectPath, sessionId, timeout = 30_000 } = options
   const resolvedCliPath = cliPath ?? (await resolveCliPath()).cliPath ?? undefined
   const config = await readCustomConfig()
   const resolvedTrustProject = options.trustProject ?? config.autoTrustProject ?? false
@@ -262,13 +290,19 @@ export async function launchAutomator(options: AutomatorOptions) {
     try {
       const miniProgram = await launcher.launch({
         cliPath: resolvedCliPath,
+        ...(port ? { port } : {}),
         projectPath,
         timeout,
         trustProject: resolvedTrustProject,
       })
-      const sessionMetadata = Reflect.get(miniProgram as object, '__WEAPP_VITE_SESSION_METADATA') as { wsEndpoint?: string } | undefined
+      const sessionMetadata = Reflect.get(miniProgram as object, '__WEAPP_VITE_SESSION_METADATA') as { port?: number, wsEndpoint?: string } | undefined
       if (typeof sessionMetadata?.wsEndpoint === 'string' && sessionMetadata.wsEndpoint) {
-        await persistAutomatorSession(projectPath, sessionMetadata.wsEndpoint)
+        await persistAutomatorSession({
+          port: sessionMetadata.port ?? port,
+          projectPath,
+          sessionId,
+          wsEndpoint: sessionMetadata.wsEndpoint,
+        })
       }
       return miniProgram
     }
@@ -287,17 +321,17 @@ export async function launchAutomator(options: AutomatorOptions) {
  * @description 连接当前项目已打开的开发者工具自动化会话，不触发新的 IDE 拉起。
  */
 export async function connectOpenedAutomator(options: AutomatorOptions) {
-  const { projectPath } = options
+  const { port, projectPath, sessionId } = options
   const launcher = new Launcher()
-  const persistedSession = await readPersistedAutomatorSession(projectPath)
-  const wsEndpoint = persistedSession?.wsEndpoint ?? DEFAULT_WECHAT_DEVTOOLS_WS_ENDPOINT
+  const persistedSession = await readPersistedAutomatorSession(projectPath, sessionId, port)
+  const wsEndpoint = persistedSession?.wsEndpoint ?? (port ? `ws://127.0.0.1:${port}` : DEFAULT_WECHAT_DEVTOOLS_WS_ENDPOINT)
 
   try {
     return await launcher.connect({ wsEndpoint })
   }
   catch (error) {
     if (persistedSession) {
-      await removePersistedAutomatorSession(projectPath)
+      await removePersistedAutomatorSession(projectPath, sessionId, port)
     }
     throw error
   }

--- a/packages/weapp-ide-cli/src/cli/commands.ts
+++ b/packages/weapp-ide-cli/src/cli/commands.ts
@@ -411,7 +411,13 @@ export async function takeScreenshot(options: ScreenshotOptions): Promise<Screen
       throw error
     }
 
-    await closeSharedMiniProgram(options.projectPath)
+    const sessionIdOrPort = options.sessionId || options.port
+    if (sessionIdOrPort) {
+      await closeSharedMiniProgram(options.projectPath, sessionIdOrPort)
+    }
+    else {
+      await closeSharedMiniProgram(options.projectPath)
+    }
     logger.warn(i18nText(
       '当前共享 DevTools 会话截图超时，正在改用全新自动化会话重试一次...',
       'The current shared DevTools session timed out while capturing screenshot. Retrying once with a fresh automation session...',

--- a/packages/weapp-ide-cli/src/cli/compare.ts
+++ b/packages/weapp-ide-cli/src/cli/compare.ts
@@ -180,6 +180,8 @@ export function parseCompareArgs(argv: string[]): CompareOptions {
   return {
     projectPath: parsed.projectPath,
     timeout: parsed.timeout,
+    ...(parsed.port ? { port: parsed.port } : {}),
+    ...(parsed.sessionId ? { sessionId: parsed.sessionId } : {}),
     page: readOptionValue(argv, '--page'),
     fullPage: argv.includes('--full-page'),
     baselinePath,

--- a/packages/weapp-ide-cli/src/cli/screenshot.ts
+++ b/packages/weapp-ide-cli/src/cli/screenshot.ts
@@ -82,6 +82,8 @@ export function parseScreenshotArgs(argv: string[]): ScreenshotOptions {
   return {
     projectPath: parsed.projectPath,
     ...(parsed.timeout ? { timeout: parsed.timeout } : {}),
+    ...(parsed.port ? { port: parsed.port } : {}),
+    ...(parsed.sessionId ? { sessionId: parsed.sessionId } : {}),
     ...(outputPath ? { outputPath } : {}),
     ...(page ? { page } : {}),
     ...(fullPage ? { fullPage: true } : {}),

--- a/packages/weapp-ide-cli/src/cli/wechat-commands.ts
+++ b/packages/weapp-ide-cli/src/cli/wechat-commands.ts
@@ -89,8 +89,10 @@ export interface ResetWechatIdeFileUtilsOptions {
 }
 
 export interface WechatIdeAutomatorSessionOptions {
+  port?: number
   preferOpenedSession?: boolean
   projectPath: string
+  sessionId?: string
   sharedSession?: boolean
   timeout?: number
 }
@@ -372,8 +374,10 @@ export async function resetWechatIdeFileUtils(options: ResetWechatIdeFileUtilsOp
 
 function createAutomatorSessionOptions(options: WechatIdeAutomatorSessionOptions) {
   return {
+    ...(options.port ? { port: options.port } : {}),
     preferOpenedSession: options.preferOpenedSession ?? true,
     projectPath: path.resolve(options.projectPath),
+    ...(options.sessionId ? { sessionId: options.sessionId } : {}),
     sharedSession: options.sharedSession ?? true,
     timeout: options.timeout,
   }

--- a/packages/weapp-ide-cli/src/mcp/server.ts
+++ b/packages/weapp-ide-cli/src/mcp/server.ts
@@ -14,8 +14,10 @@ interface ToolRegistrar {
 export interface WeappIdeMcpRuntimeHooks {
   withMiniProgram: <T>(options: {
     preferOpenedSession?: boolean
+    port?: number
     projectPath: string
     sharedSession?: boolean
+    sessionId?: string
     timeout?: number
   }, runner: (miniProgram: MiniProgramLike) => Promise<T>) => Promise<T>
 }
@@ -32,7 +34,9 @@ export interface WeappIdeMcpServerHandle {
 interface ConnectionInput {
   projectPath: string
   timeout?: number
+  port?: number
   preferOpenedSession?: boolean
+  sessionId?: string
 }
 
 function createResolvedProjectPath(workspaceRoot: string | undefined, projectPath: string) {
@@ -55,7 +59,9 @@ async function withConnectedMiniProgram(
 ) {
   return await runtimeHooks.withMiniProgram({
     preferOpenedSession: input.preferOpenedSession,
+    port: input.port,
     projectPath: createResolvedProjectPath(workspaceRoot, input.projectPath),
+    sessionId: input.sessionId,
     sharedSession: true,
     timeout: input.timeout,
   }, runner)
@@ -77,7 +83,9 @@ function defineConnectionSchema() {
   return {
     projectPath: z.string().trim().min(1).describe('小程序项目路径，支持 workspaceRoot 相对路径'),
     timeout: z.number().int().positive().optional(),
+    port: z.number().int().positive().optional(),
     preferOpenedSession: z.boolean().optional(),
+    sessionId: z.string().trim().min(1).optional(),
   }
 }
 

--- a/packages/weapp-ide-cli/test/automator-argv.test.ts
+++ b/packages/weapp-ide-cli/test/automator-argv.test.ts
@@ -39,6 +39,24 @@ describe('automator argv helpers', () => {
     expect(parsed.positionals).toEqual([])
   })
 
+  it('parses explicit automator session options', () => {
+    const parsed = parseAutomatorArgs([
+      '--project',
+      '/tmp/project',
+      '--port',
+      '19510',
+      '--session-id=worker-a',
+    ])
+
+    expect(parsed).toEqual({
+      projectPath: '/tmp/project',
+      port: 19510,
+      sessionId: 'worker-a',
+      json: false,
+      positionals: [],
+    })
+  })
+
   it('reads option values from both forms', () => {
     expect(readOptionValue(['--output', 'a.json'], '--output')).toBe('a.json')
     expect(readOptionValue(['--output=b.json'], '--output')).toBe('b.json')

--- a/packages/weapp-ide-cli/test/automator.test.ts
+++ b/packages/weapp-ide-cli/test/automator.test.ts
@@ -198,6 +198,8 @@ describe('automator helpers', () => {
       await launchAutomator({
         projectPath: '/workspace/project',
         timeout: 12_345,
+        port: 19_510,
+        sessionId: 'worker-a',
       })
 
       expect(bootstrapWechatDevtoolsSettingsMock).toHaveBeenCalledWith({
@@ -207,6 +209,7 @@ describe('automator helpers', () => {
       expect(resolveCliPathMock).toHaveBeenCalledTimes(1)
       expect(launchMock).toHaveBeenCalledWith({
         cliPath: '/Applications/wechat-cli',
+        port: 19_510,
         projectPath: '/workspace/project',
         timeout: 12_345,
         trustProject: false,
@@ -317,6 +320,28 @@ describe('automator helpers', () => {
       expect(writeFileMock).toHaveBeenCalledTimes(1)
       expect(String(writeFileMock.mock.calls[0]?.[1])).toContain('"wsEndpoint": "ws://127.0.0.1:9420"')
     })
+
+    it('persists explicit session metadata separately', async () => {
+      launchMock.mockResolvedValueOnce({
+        connected: true,
+        __WEAPP_VITE_SESSION_METADATA: {
+          port: 19_510,
+          wsEndpoint: 'ws://127.0.0.1:19510',
+        },
+      })
+
+      await launchAutomator({
+        port: 19_510,
+        projectPath: '/workspace/project',
+        sessionId: 'worker-a',
+      })
+
+      expect(launchMock).toHaveBeenCalledWith(expect.objectContaining({
+        port: 19_510,
+      }))
+      expect(String(writeFileMock.mock.calls[0]?.[1])).toContain('"port": 19510')
+      expect(String(writeFileMock.mock.calls[0]?.[1])).toContain('"sessionId": "worker-a"')
+    })
   })
 
   describe('connectOpenedAutomator', () => {
@@ -336,6 +361,37 @@ describe('automator helpers', () => {
         wsEndpoint: 'ws://127.0.0.1:19510',
       })
       expect(rmMock).not.toHaveBeenCalled()
+    })
+
+    it('uses explicit port endpoint when no persisted session exists', async () => {
+      await connectOpenedAutomator({
+        port: 19_510,
+        projectPath: '/workspace/project',
+      })
+
+      expect(connectMock).toHaveBeenCalledWith({
+        wsEndpoint: 'ws://127.0.0.1:19510',
+      })
+    })
+
+    it('matches persisted endpoint by session id and port', async () => {
+      readFileMock.mockResolvedValueOnce(JSON.stringify({
+        port: 19_510,
+        projectPath: path.resolve('/workspace/project'),
+        sessionId: 'worker-a',
+        updatedAt: '2026-04-06T00:00:00.000Z',
+        wsEndpoint: 'ws://127.0.0.1:19510',
+      }))
+
+      await connectOpenedAutomator({
+        port: 19_510,
+        projectPath: '/workspace/project',
+        sessionId: 'worker-a',
+      })
+
+      expect(connectMock).toHaveBeenCalledWith({
+        wsEndpoint: 'ws://127.0.0.1:19510',
+      })
     })
 
     it('removes stale persisted endpoint when connect fails', async () => {


### PR DESCRIPTION
## 变更说明

- 为 miniprogram-automator 增加跨进程端口 lease，默认启动时在端口池中自动避让，减少多个 automator 同时启动时抢占同一端口的问题。
- 为 devtools-runtime / weapp-ide-cli / MCP 增加 port 与 sessionId 透传能力，让同一项目可以按 sessionId 或端口维护多个独立共享会话。
- CLI 增加 --port 与 --session-id，默认会话文件保持兼容；显式会话使用 projectPath + sessionId/port 区分。
- 新增真实 WeChat DevTools E2E：并发启动两个不同 e2e-app，各自对应一个 direct automator 会话，断言端口/wsEndpoint 独立且页面可读。
- 增加中文 changeset，覆盖本次用户可见行为变化。

## 验证

- pnpm --filter weapp-vite... build
- pnpm run check:e2e-ide-shared-launch
- pnpm run check:create-weapp-vite-changeset
- pnpm run check:catalog-changeset
- pnpm run check:publishable-workspace-changeset
- pnpm --dir packages/miniprogram-automator test
- pnpm --dir packages/devtools-runtime test
- pnpm --dir packages/weapp-ide-cli test
- pnpm --dir packages/mcp test
- pnpm --dir packages/miniprogram-automator typecheck
- pnpm --dir packages/devtools-runtime typecheck
- pnpm --dir packages/weapp-ide-cli typecheck
- pnpm --dir packages/mcp typecheck
- pnpm --dir packages/mcp test:types
- pnpm --dir packages/miniprogram-automator build
- pnpm --dir packages/devtools-runtime build
- pnpm --dir packages/weapp-ide-cli build
- pnpm --dir packages/miniprogram-automator lint
- pnpm --dir packages/devtools-runtime lint
- pnpm --dir packages/mcp lint
- pnpm eslint packages/weapp-ide-cli/src/cli/automator-argv.ts packages/weapp-ide-cli/src/cli/automator.ts packages/weapp-ide-cli/src/cli/commands.ts packages/weapp-ide-cli/src/cli/compare.ts packages/weapp-ide-cli/src/cli/screenshot.ts packages/weapp-ide-cli/src/cli/wechat-commands.ts packages/weapp-ide-cli/src/mcp/server.ts packages/weapp-ide-cli/test/automator-argv.test.ts packages/weapp-ide-cli/test/automator.test.ts
- pnpm eslint e2e/ide/automator-concurrent-sessions.runtime.test.ts
- pnpm vitest run -c e2e/vitest.e2e.devtools.config.ts e2e/ide/automator-concurrent-sessions.runtime.test.ts --typecheck.enabled false

## 备注

- 真实 DevTools E2E 使用 e2e-apps/base 与 e2e-apps/app-lifecycle-native，两个 app 均已存在真实 AppID 和 index 条件页，无需新增页面或同步 project.private.config.json。
- Launcher.ts 与 weapp-ide-cli 的 automator CLI 文件仍超过 300 行。本次已将端口 lease 独立拆出，剩余启动与错误处理流程暂时保留在原文件，避免把 mock 和异常链路拆得过碎。