### PR TITLE
fix(wevu): 修复嵌套 scoped slot owner id 同步

### DIFF
--- a/.changeset/fix-issue-642-bug8-scoped-slot-owner.md
+++ b/.changeset/fix-issue-642-bug8-scoped-slot-owner.md
@@ -1,0 +1,6 @@
+---
+"wevu": patch
+"create-weapp-vite": patch
+---
+
+修复嵌套组件透传 scoped slot 时，组件自身的 `__wvOwnerId` 只写入运行时内存而没有同步到小程序视图层，导致子组件收到空的 `__wvSlotOwnerId`、作用域插槽无法在微信开发者工具中稳定渲染的问题。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -477,6 +477,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-642-bug8/index",
+          "pathName": "pages/issue-642-bug8/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-651/index",
           "pathName": "pages/issue-651/index",
           "query": "",

--- a/e2e-apps/github-issues/src/app.vue
+++ b/e2e-apps/github-issues/src/app.vue
@@ -17,6 +17,9 @@ const tabBarList = [
 defineAppJson({
   pages: routes.pages,
   subPackages: routes.subPackages,
+  usingComponents: {
+    'custom-tab-bar': '/custom-tab-bar/index',
+  },
   ...(tabBarList.length >= 2
     ? {
         tabBar: {

--- a/e2e-apps/github-issues/src/components/issue-642-bug8/Cell/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-642-bug8/Cell/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <slot :io="123" />
+</template>

--- a/e2e-apps/github-issues/src/components/issue-642-bug8/Wrap/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-642-bug8/Wrap/index.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { useNativeInstance } from 'wevu'
+import Issue642Bug8Cell from '../Cell/index.vue'
+
+const nativeInstance = useNativeInstance()
+
+function _runE2E() {
+  const child = (nativeInstance as any).selectComponent?.('#issue642-bug8-wrapped-cell') ?? null
+  return {
+    owner: {
+      dataOwnerId: (nativeInstance as any).data?.__wvOwnerId,
+      runtimeOwnerId: (nativeInstance as any).__wevu?.state?.__wvOwnerId,
+    },
+    child: {
+      dataSlotOwnerId: child?.data?.__wvSlotOwnerId,
+      propsSlotOwnerId: child?.properties?.__wvSlotOwnerId,
+      dataSlotScope: child?.data?.__wvSlotScope,
+      propsSlotScope: child?.properties?.__wvSlotScope,
+    },
+  }
+}
+
+defineExpose({
+  _runE2E,
+})
+</script>
+
+<template>
+  <Issue642Bug8Cell id="issue642-bug8-wrapped-cell">
+    <template #default="{ io }">
+      <text
+        data-issue642-bug8-case="wrapped"
+        :data-issue642-bug8-value="io"
+      >
+        {{ io }}
+      </text>
+    </template>
+  </Issue642Bug8Cell>
+</template>

--- a/e2e-apps/github-issues/src/pages/issue-642-bug8/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-642-bug8/index.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { useNativeInstance } from 'wevu'
+import Issue642Bug8Cell from '../../components/issue-642-bug8/Cell/index.vue'
+import Issue642Bug8Wrap from '../../components/issue-642-bug8/Wrap/index.vue'
+
+definePageJson({
+  navigationBarTitleText: 'issue-642-bug8',
+})
+definePageMeta({
+  layout: false,
+})
+
+const nativeInstance = useNativeInstance()
+
+function readChild(selector: string) {
+  return (nativeInstance as any).selectComponent?.(selector) ?? null
+}
+
+function readScopedState(selector: string) {
+  const child = readChild(selector)
+  return {
+    dataSlotOwnerId: child?.data?.__wvSlotOwnerId,
+    propsSlotOwnerId: child?.properties?.__wvSlotOwnerId,
+    dataSlotScope: child?.data?.__wvSlotScope,
+    propsSlotScope: child?.properties?.__wvSlotScope,
+  }
+}
+
+function _runE2E() {
+  const runtime = (nativeInstance as any).__wevu
+  const wrap = readChild('#issue642-bug8-wrap')
+  return {
+    owner: {
+      dataOwnerId: (nativeInstance as any).data?.__wvOwnerId,
+      runtimeOwnerId: runtime?.state?.__wvOwnerId,
+    },
+    direct: readScopedState('#issue642-bug8-direct-cell'),
+    wrap: wrap?._runE2E?.(),
+  }
+}
+
+defineExpose({
+  _runE2E,
+})
+</script>
+
+<template>
+  <view class="issue642-bug8-page">
+    <Issue642Bug8Cell id="issue642-bug8-direct-cell">
+      <template #default="{ io }">
+        <text
+          data-issue642-bug8-case="direct"
+          :data-issue642-bug8-value="io"
+        >
+          {{ io }}
+        </text>
+      </template>
+    </Issue642Bug8Cell>
+
+    <Issue642Bug8Wrap id="issue642-bug8-wrap" />
+  </view>
+</template>
+
+<style scoped>
+.issue642-bug8-page {
+  min-height: 100vh;
+  padding: 24rpx;
+}
+</style>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -10,6 +10,7 @@ const issue564AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_564_AUGMENTED
 const issue615AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_615_AUGMENTED === 'true'
 const issue621AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_621_AUGMENTED === 'true'
 const issue595ScopedBuildEnabled = process.env.WEAPP_GITHUB_ISSUE_595_SCOPED === 'true'
+const issue642ScopedBuildEnabled = process.env.WEAPP_GITHUB_ISSUE_642_SCOPED === 'true'
 const issue651NoExtResolvedId = path.resolve(import.meta.dirname, 'src/issue-fixtures/issue-651/ResolverNoExt/index')
 const issue651WithExtResolvedId = path.resolve(import.meta.dirname, 'src/issue-fixtures/issue-651/ResolverWithExt/index.vue')
 const e2eTargetFile = process.env.WEAPP_VITE_E2E_TARGET_FILE?.replaceAll('\\', '/') ?? ''
@@ -92,6 +93,7 @@ const githubIssuesRouteGroups: Record<string, string[]> = {
     'pages/issue-320/**',
     'pages/issue-373/**',
     'pages/issue-380/**',
+    'custom-tab-bar/**',
     'pages/issue-385/**',
     'pages/issue-398/**',
     'pages/issue-404/**',
@@ -402,5 +404,11 @@ export default defineConfig({
                 outDir: 'dist-issue-595',
               },
             }
-          : {}),
+          : issue642ScopedBuildEnabled
+            ? {
+                build: {
+                  outDir: 'dist-issue-642',
+                },
+              }
+            : {}),
 })

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -75,6 +75,10 @@ const githubIssuesRouteGroups: Record<string, string[]> = {
   'github-issues.runtime.issue642-bug7-performance.test.ts': [
     'pages/issue-642-bug7/**',
   ],
+  'github-issues.runtime.issue642-bug8.test.ts': [
+    'pages/issue-642-bug8/**',
+    'components/issue-642-bug8/**',
+  ],
   'github-issues.runtime.issue581.test.ts': [
     'pages/issue-581/**',
   ],

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -13,6 +13,7 @@ const DIST_ROOT = path.join(APP_ROOT, 'dist')
 const ISSUE_393_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-393')
 const ISSUE_510_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-510')
 const ISSUE_595_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-595')
+const ISSUE_642_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-642')
 const SLOT_FALLBACK_COMPILER_OFF_DIST_ROOT = path.join(APP_ROOT, 'dist-slot-fallback-compiler-off')
 let standardBuildPromise: Promise<void> | null = null
 let distVariant: 'standard' | 'sourcemap' | null = null
@@ -293,7 +294,7 @@ async function runIssue621AugmentedBuild() {
 
 async function runIssue642Build() {
   standardBuildPromise = null
-  await fs.remove(DIST_ROOT)
+  await fs.remove(ISSUE_642_DIST_ROOT)
 
   await runWeappViteBuildWithLogCapture({
     cliPath: CLI_PATH,
@@ -301,9 +302,11 @@ async function runIssue642Build() {
     platform: 'weapp',
     cwd: APP_ROOT,
     label: 'ci:github-issues:issue642',
+    outDir: 'dist-issue-642',
     skipNpm: true,
     env: {
       WEAPP_VITE_E2E_TARGET_FILE: 'e2e/ide/github-issues.runtime.issue642.test.ts',
+      WEAPP_GITHUB_ISSUE_642_SCOPED: 'true',
     },
   })
 
@@ -398,9 +401,12 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(appShellWxml).toContain('issue-563-app-shell')
     expect(appShellWxml).toContain('<slot />')
     expect(appShellWxml).not.toContain('scoped-slots-default')
-    expect(appShellJson).toEqual({
+    expect(appShellJson).toMatchObject({
       component: true,
       styleIsolation: 'apply-shared',
+      usingComponents: {
+        'custom-tab-bar': '/custom-tab-bar/index',
+      },
     })
     expect(pageWxml).toContain('<weapp-app-shell><weapp-layout-default>')
     expect(pageWxml).toContain('</weapp-layout-default></weapp-app-shell>')
@@ -704,13 +710,13 @@ describe.sequential('e2e app: github-issues (build)', () => {
   it('issue #642: keeps slot bridge props available to performance setData pick', async () => {
     await runIssue642Build()
 
-    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-642/index.wxml')
-    const pageJsPath = path.join(DIST_ROOT, 'pages/issue-642/index.js')
-    const scopedSlotWxmlPath = path.join(DIST_ROOT, 'pages/issue-642/index.__scoped-slot-default-0.wxml')
-    const slotProbeWxmlPath = path.join(DIST_ROOT, 'components/issue-642/SlotProbe/index.wxml')
-    const slotProbeJsPath = path.join(DIST_ROOT, 'components/issue-642/SlotProbe/index.js')
-    const scopedProbeWxmlPath = path.join(DIST_ROOT, 'components/issue-642/ScopedSlotProbe/index.wxml')
-    const scopedProbeJsPath = path.join(DIST_ROOT, 'components/issue-642/ScopedSlotProbe/index.js')
+    const pageWxmlPath = path.join(ISSUE_642_DIST_ROOT, 'pages/issue-642/index.wxml')
+    const pageJsPath = path.join(ISSUE_642_DIST_ROOT, 'pages/issue-642/index.js')
+    const scopedSlotWxmlPath = path.join(ISSUE_642_DIST_ROOT, 'pages/issue-642/index.__scoped-slot-default-0.wxml')
+    const slotProbeWxmlPath = path.join(ISSUE_642_DIST_ROOT, 'components/issue-642/SlotProbe/index.wxml')
+    const slotProbeJsPath = path.join(ISSUE_642_DIST_ROOT, 'components/issue-642/SlotProbe/index.js')
+    const scopedProbeWxmlPath = path.join(ISSUE_642_DIST_ROOT, 'components/issue-642/ScopedSlotProbe/index.wxml')
+    const scopedProbeJsPath = path.join(ISSUE_642_DIST_ROOT, 'components/issue-642/ScopedSlotProbe/index.js')
     const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
     const pageJs = await fs.readFile(pageJsPath, 'utf-8')
     const scopedSlotWxml = await fs.readFile(scopedSlotWxmlPath, 'utf-8')

--- a/e2e/ide/github-issues.runtime.issue642-bug8.test.ts
+++ b/e2e/ide/github-issues.runtime.issue642-bug8.test.ts
@@ -1,0 +1,110 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  closeSharedMiniProgram,
+  delay,
+  getSharedMiniProgram,
+  PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT,
+  prepareGithubIssuesBuild,
+  relaunchPage,
+  releaseSharedMiniProgram,
+} from './github-issues.runtime.shared'
+
+async function waitForIssue642Bug8Runtime(page: any, timeoutMs = 8_000) {
+  const startedAt = Date.now()
+  let latest: any
+
+  while (Date.now() - startedAt < timeoutMs) {
+    latest = await page.callMethod('_runE2E')
+    const ownerReady = typeof latest?.owner?.dataOwnerId === 'string'
+      && latest.owner.dataOwnerId.length > 0
+      && latest.owner.runtimeOwnerId === latest.owner.dataOwnerId
+    const directReady = latest?.direct?.dataSlotOwnerId === latest?.owner?.dataOwnerId
+      && latest?.direct?.propsSlotOwnerId === latest?.owner?.dataOwnerId
+    const wrapOwnerReady = typeof latest?.wrap?.owner?.dataOwnerId === 'string'
+      && latest.wrap.owner.dataOwnerId.length > 0
+      && latest.wrap.owner.runtimeOwnerId === latest.wrap.owner.dataOwnerId
+    const wrappedReady = latest?.wrap?.child?.dataSlotOwnerId === latest?.wrap?.owner?.dataOwnerId
+      && latest?.wrap?.child?.propsSlotOwnerId === latest?.wrap?.owner?.dataOwnerId
+
+    if (ownerReady && directReady && wrapOwnerReady && wrappedReady) {
+      return latest
+    }
+
+    await delay(160)
+  }
+
+  return latest
+}
+
+async function readRenderedCase(page: any, name: 'direct' | 'wrapped') {
+  const element = await page.$(`[data-issue642-bug8-case="${name}"]`)
+  return {
+    exists: Boolean(element),
+    text: element ? (await element.text()).trim() : '',
+    value: element ? await element.attribute('data-issue642-bug8-value') : undefined,
+  }
+}
+
+describe.sequential('e2e app: github-issues / issue #642 bug-8', () => {
+  beforeAll(async () => {
+    await prepareGithubIssuesBuild()
+  }, PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT)
+
+  afterAll(async () => {
+    await closeSharedMiniProgram()
+  })
+
+  it('keeps scoped slot owner id when scoped slot component is nested through another component', async (ctx) => {
+    const miniProgram = await getSharedMiniProgram(ctx)
+    try {
+      const issuePage = await relaunchPage(miniProgram, '/pages/issue-642-bug8/index', '123')
+      if (!issuePage) {
+        throw new Error('Failed to launch issue-642-bug8 page')
+      }
+
+      const runtime = await waitForIssue642Bug8Runtime(issuePage)
+      expect(runtime).toMatchObject({
+        owner: {
+          dataOwnerId: expect.any(String),
+          runtimeOwnerId: expect.any(String),
+        },
+        direct: {
+          dataSlotOwnerId: expect.any(String),
+          propsSlotOwnerId: expect.any(String),
+        },
+        wrap: {
+          owner: {
+            dataOwnerId: expect.any(String),
+            runtimeOwnerId: expect.any(String),
+          },
+          child: {
+            dataSlotOwnerId: expect.any(String),
+            propsSlotOwnerId: expect.any(String),
+          },
+        },
+      })
+      expect(runtime.owner.dataOwnerId).not.toBe('')
+      expect(runtime.direct.dataSlotOwnerId).toBe(runtime.owner.dataOwnerId)
+      expect(runtime.direct.propsSlotOwnerId).toBe(runtime.owner.dataOwnerId)
+      expect(runtime.wrap.owner.dataOwnerId).not.toBe('')
+      expect(runtime.wrap.owner.dataOwnerId).not.toBe(runtime.owner.dataOwnerId)
+      expect(runtime.wrap.owner.runtimeOwnerId).toBe(runtime.wrap.owner.dataOwnerId)
+      expect(runtime.wrap.child.dataSlotOwnerId).toBe(runtime.wrap.owner.dataOwnerId)
+      expect(runtime.wrap.child.propsSlotOwnerId).toBe(runtime.wrap.owner.dataOwnerId)
+
+      await expect(readRenderedCase(issuePage, 'direct')).resolves.toEqual({
+        exists: true,
+        text: '123',
+        value: '123',
+      })
+      await expect(readRenderedCase(issuePage, 'wrapped')).resolves.toEqual({
+        exists: true,
+        text: '123',
+        value: '123',
+      })
+    }
+    finally {
+      await releaseSharedMiniProgram(miniProgram)
+    }
+  })
+})

--- a/e2e/ide/github-issues.runtime.shared.ts
+++ b/e2e/ide/github-issues.runtime.shared.ts
@@ -22,6 +22,7 @@ const SLOT_FALLBACK_COMPILER_OFF_ENV = 'WEAPP_GITHUB_SLOT_FALLBACK_COMPILER_OFF'
 const APP_SHELL_FREE_TARGETS = new Set([
   'github-issues.runtime.issue642-bug7-default.test.ts',
   'github-issues.runtime.issue642-bug7-performance.test.ts',
+  'github-issues.runtime.issue642-bug8.test.ts',
 ])
 const SOURCE_PROJECT_COPY_ENTRIES = [
   '.env',
@@ -133,6 +134,7 @@ async function prepareIsolatedProjectRoot() {
       pages: [
         'pages/block-slot/index',
         'pages/issue-642-bug7/index',
+        'pages/issue-642-bug8/index',
       ],
     }, {
       spaces: 2,

--- a/e2e/utils/buildLog.test.ts
+++ b/e2e/utils/buildLog.test.ts
@@ -5,8 +5,14 @@ describe('buildLog', () => {
   it('strips parent pnpm script package metadata before spawning project builds', () => {
     const env = sanitizeBuildCommandEnv({
       FOO: 'bar',
+      NODE_ENV: 'test',
       PNPM_PACKAGE_NAME: 'weapp-vite-monorepo',
       PNPM_SCRIPT_SRC_DIR: '/repo',
+      VITEST: 'true',
+      VITEST_MODE: 'run',
+      VITEST_POOL_ID: 'pool-1',
+      VITEST_WORKER_ID: 'worker-1',
+      WEAPP_VITE_E2E_TARGET_FILE: 'e2e/ide/github-issues.runtime.issue642.test.ts',
       npm_lifecycle_event: 'e2e:ide:full',
       npm_package_json: '/repo/package.json',
       npm_package_name: 'weapp-vite-monorepo',

--- a/e2e/utils/buildLog.ts
+++ b/e2e/utils/buildLog.ts
@@ -26,6 +26,7 @@ interface BuildCommandOptions {
   platform: 'weapp' | 'alipay' | 'tt'
   cwd?: string
   label?: string
+  outDir?: string
   skipNpm?: boolean
   env?: Record<string, string | undefined>
 }
@@ -43,6 +44,12 @@ const BUILD_ENV_STRIP_PREFIXES = [
 const BUILD_ENV_STRIP_KEYS = new Set([
   'PNPM_PACKAGE_NAME',
   'PNPM_SCRIPT_SRC_DIR',
+  'NODE_ENV',
+  'VITEST',
+  'VITEST_MODE',
+  'VITEST_POOL_ID',
+  'VITEST_WORKER_ID',
+  'WEAPP_VITE_E2E_TARGET_FILE',
 ])
 
 function createSkipNpmGuardKey(label: string, projectRoot: string, dependencyMeta: DependencyMeta) {
@@ -180,6 +187,7 @@ export async function runWeappViteBuildWithLogCapture(options: BuildCommandOptio
     platform,
     cwd,
     label = projectRoot,
+    outDir = 'dist',
     skipNpm = false,
     env,
   } = options
@@ -201,7 +209,7 @@ export async function runWeappViteBuildWithLogCapture(options: BuildCommandOptio
     }
   }
 
-  const distRoot = path.resolve(projectRoot, 'dist')
+  const distRoot = path.resolve(projectRoot, outDir)
   const configOverride = await resolveJsFormatConfigOverride({
     configFile,
     jsFormat,

--- a/packages-runtime/wevu/src/runtime/define.ts
+++ b/packages-runtime/wevu/src/runtime/define.ts
@@ -50,6 +50,13 @@ function shouldSeedNativeSlotOwnerId(
     && setData.pick.includes(WEVU_SLOT_OWNER_ID_KEY)
 }
 
+function shouldDeclareNativeSlotOwnerId(
+  setData: DefineComponentOptions<any, any, any, any, any>['setData'],
+) {
+  return Array.isArray(setData?.pick)
+    && setData.pick.includes(WEVU_SLOT_OWNER_ID_KEY)
+}
+
 function hasScopedSlotHostProperties(mpOptions: Record<string, any>) {
   const properties = mpOptions.properties
   return Boolean(
@@ -254,10 +261,13 @@ export function defineComponent(
   const nativeData = typeof data === 'function'
     ? data()
     : data
-  const seededNativeData = shouldSeedNativeSlotOwnerId(mpOptions, resolvedSetData)
+  const shouldDeclareOwnerId = shouldDeclareNativeSlotOwnerId(resolvedSetData)
+  const seededNativeData = shouldDeclareOwnerId
     ? {
         ...(nativeData && typeof nativeData === 'object' ? nativeData : {}),
-        [WEVU_SLOT_OWNER_ID_KEY]: (nativeData as any)?.[WEVU_SLOT_OWNER_ID_KEY] || allocateOwnerId(),
+        [WEVU_SLOT_OWNER_ID_KEY]: shouldSeedNativeSlotOwnerId(mpOptions, resolvedSetData)
+          ? (nativeData as any)?.[WEVU_SLOT_OWNER_ID_KEY] || allocateOwnerId()
+          : (nativeData as any)?.[WEVU_SLOT_OWNER_ID_KEY] || '',
       }
     : nativeData
   const nativeInitialData = resolveNativeInitialData(seededNativeData, computed as ComputedDefinitions, resolvedSetData)

--- a/packages-runtime/wevu/src/runtime/register/component/props.ts
+++ b/packages-runtime/wevu/src/runtime/register/component/props.ts
@@ -61,6 +61,7 @@ export function createPropsSync(options: {
     if (!templateRuntimePropKeys.has(key)) {
       return
     }
+    let nativeDataChanged = false
     const runtimeState = (instance as any).__wevu?.state
     try {
       if (runtimeState && typeof runtimeState === 'object') {
@@ -68,11 +69,20 @@ export function createPropsSync(options: {
       }
       const nativeData = (instance as any).data
       if (nativeData && typeof nativeData === 'object') {
-        setIfChanged(nativeData as Record<string, unknown>, key, value)
+        nativeDataChanged = setIfChanged(nativeData as Record<string, unknown>, key, value)
       }
     }
     catch {
       // 忽略模板运行时字段同步失败，保持 props 主链路可用。
+    }
+    if (!nativeDataChanged || typeof (instance as any).setData !== 'function') {
+      return
+    }
+    try {
+      ;(instance as any).setData({ [key]: value })
+    }
+    catch {
+      // 忽略模板桥接字段 setData 失败，后续响应式调度仍可兜底。
     }
   }
 

--- a/packages-runtime/wevu/src/runtime/register/runtimeInstance.ts
+++ b/packages-runtime/wevu/src/runtime/register/runtimeInstance.ts
@@ -159,6 +159,7 @@ export function mountRuntimeInstance<D extends object, C extends ComputedDefinit
   const ownerId = typeof initialNativeOwnerId === 'string' && initialNativeOwnerId
     ? initialNativeOwnerId
     : allocateOwnerId()
+  const shouldFlushNativeOwnerId = typeof initialNativeOwnerId === 'string' && initialNativeOwnerId !== ownerId
   const suspendWhenHidden = Boolean((runtimeApp as any)?.__wevuSetDataOptions?.suspendWhenHidden)
   const targetLabel = typeof (target as any).route === 'string' && (target as any).route
     ? `page:${(target as any).route}`
@@ -228,6 +229,25 @@ export function mountRuntimeInstance<D extends object, C extends ComputedDefinit
     const propsSource = (target as any)[WEVU_PROPS_KEY] ?? (target as any).properties
     mergeOwnerSnapshotProps(snapshot, propsSource, runtimeRef)
     updateOwnerSnapshot(ownerId, snapshot, runtimeRef.proxy)
+  }
+  const syncNativeOwnerId = () => {
+    if (!shouldFlushNativeOwnerId) {
+      return
+    }
+    const nativeData = (target as any).data
+    try {
+      if (nativeData && typeof nativeData === 'object') {
+        nativeData[WEVU_SLOT_OWNER_ID_KEY] = ownerId
+      }
+    }
+    catch {
+      // 忽略直接写入失败，后续 setData 仍会尝试同步。
+    }
+    const setData = resolveNativeSetData(target)
+    if (!setData) {
+      return
+    }
+    callNativeSetData(target, setData, { [WEVU_SLOT_OWNER_ID_KEY]: ownerId })
   }
   const adapter: AdapterWithSetData = {
     ...(baseAdapter as any),
@@ -366,6 +386,7 @@ export function mountRuntimeInstance<D extends object, C extends ComputedDefinit
   ensureRuntimeProps(target, runtimeState as Record<string, any>)
 
   attachOwnerSnapshot(target, runtimeWithDefaults as any, ownerId)
+  syncNativeOwnerId()
 
   if (watchMap) {
     const stops = registerWatches(runtimeWithDefaults, watchMap, target)

--- a/packages-runtime/wevu/test/runtime-scoped-slots.test.ts
+++ b/packages-runtime/wevu/test/runtime-scoped-slots.test.ts
@@ -195,6 +195,46 @@ describe('runtime: scoped slots', () => {
     expect(inst[WEVU_PUBLIC_RUNTIME_KEY].proxy.__wv_bind_0).toEqual(['io', 1])
   })
 
+  it('predeclares regular component owner id in native initial data without sharing owner ids', () => {
+    defineComponent({
+      computed: {
+        __wv_bind_0() {
+          return { default: true }
+        },
+      },
+      setData: {
+        pick: [WEVU_SLOT_OWNER_ID_KEY, '__wv_bind_0'],
+        strategy: 'patch',
+      },
+    } as any)
+
+    const opts = registeredComponents.pop()!
+    expect(opts).toBeTruthy()
+    expect(opts.data[WEVU_SLOT_OWNER_ID_KEY]).toBe('')
+    expect(opts.data.__wv_bind_0).toEqual({ default: true })
+
+    const first: any = {
+      data: { ...opts.data },
+      setData: vi.fn(),
+    }
+    const second: any = {
+      data: { ...opts.data },
+      setData: vi.fn(),
+    }
+    opts.lifetimes.attached.call(first)
+    opts.lifetimes.attached.call(second)
+
+    expect(first.data[WEVU_SLOT_OWNER_ID_KEY]).toMatch(/^wv\d+$/)
+    expect(second.data[WEVU_SLOT_OWNER_ID_KEY]).toMatch(/^wv\d+$/)
+    expect(first.data[WEVU_SLOT_OWNER_ID_KEY]).not.toBe(second.data[WEVU_SLOT_OWNER_ID_KEY])
+    expect(first.setData).toHaveBeenCalledWith({
+      [WEVU_SLOT_OWNER_ID_KEY]: first.data[WEVU_SLOT_OWNER_ID_KEY],
+    })
+    expect(second.setData).toHaveBeenCalledWith({
+      [WEVU_SLOT_OWNER_ID_KEY]: second.data[WEVU_SLOT_OWNER_ID_KEY],
+    })
+  })
+
   it('seeds page slot owner id and static slot metadata in native initial data', () => {
     defineComponent({
       __wevu_isPage: true,

--- a/packages/weapp-ide-cli/test/automator.test.ts
+++ b/packages/weapp-ide-cli/test/automator.test.ts
@@ -50,6 +50,8 @@ vi.mock('node:fs/promises', () => ({
 }))
 
 describe('automator helpers', () => {
+  const mockProjectPath = path.resolve('/workspace/project')
+
   beforeEach(() => {
     launchMock.mockReset()
     connectMock.mockReset()
@@ -208,14 +210,14 @@ describe('automator helpers', () => {
       })
 
       expect(bootstrapWechatDevtoolsSettingsMock).toHaveBeenCalledWith({
-        projectPath: '/workspace/project',
+        projectPath: mockProjectPath,
         trustProject: false,
       })
       expect(resolveCliPathMock).toHaveBeenCalledTimes(1)
       expect(launchMock).toHaveBeenCalledWith({
         cliPath: '/Applications/wechat-cli',
         port: 19_510,
-        projectPath: '/workspace/project',
+        projectPath: mockProjectPath,
         timeout: 12_345,
         trustProject: false,
       })
@@ -228,13 +230,13 @@ describe('automator helpers', () => {
       })
 
       expect(bootstrapWechatDevtoolsSettingsMock).toHaveBeenCalledWith({
-        projectPath: '/workspace/project',
+        projectPath: mockProjectPath,
         trustProject: false,
       })
       expect(resolveCliPathMock).not.toHaveBeenCalled()
       expect(launchMock).toHaveBeenCalledWith({
         cliPath: '/custom/cli',
-        projectPath: '/workspace/project',
+        projectPath: mockProjectPath,
         timeout: 30_000,
         trustProject: false,
       })
@@ -250,7 +252,7 @@ describe('automator helpers', () => {
       })
 
       expect(bootstrapWechatDevtoolsSettingsMock).toHaveBeenCalledWith({
-        projectPath: '/workspace/project',
+        projectPath: mockProjectPath,
         trustProject: true,
       })
       expect(launchMock).toHaveBeenCalledWith(expect.objectContaining({
@@ -317,7 +319,7 @@ describe('automator helpers', () => {
 
       expect(launchMock).toHaveBeenCalledWith({
         cliPath: '/Applications/wechat-cli',
-        projectPath: '/workspace/project',
+        projectPath: mockProjectPath,
         timeout: 30_000,
         trustProject: true,
       })


### PR DESCRIPTION
## 背景

修复 #642 最新反馈中 `A -> B -> Page` 三层组件使用 scoped slot 时，子组件收到空 `__wvSlotOwnerId` 的问题。复现用例来自 `Airkro/weapp-vite-bug` 的 `bug-8` 场景，并已收敛到 `e2e-apps/github-issues`。

## 根因

普通组件的 `__wvOwnerId` 在运行时挂载时会生成真实 owner id，但小程序初始 `data` 中只有空占位值。此前运行时只更新了内存态和 owner snapshot，没有把新的 owner id 通过原生 `setData` 同步到视图层，导致嵌套子组件的 WXML 表达式仍读取到空值。

## 改动

- 为普通组件预声明 `__wvOwnerId` 占位，避免多个实例共享同一个初始 owner id。
- 在 runtime mount 后将新分配的 `__wvOwnerId` 同步到原生 `setData`，保证 WXML 依赖能更新。
- 将模板运行时 prop 同步到组件 `data/setData`，覆盖 scoped slot host 的 prop 到 data 桥接。
- 新增 #642 bug-8 IDE e2e 覆盖，并补充 wevu 单测和 changeset。

## 验证

- `pnpm vitest run packages-runtime/wevu/test/runtime-scoped-slots.test.ts packages-runtime/wevu/test/runtime-props-sync.test.ts packages-runtime/wevu/test/runtime-component.test.ts packages-runtime/wevu/test/runtime-initial-computed.test.ts packages-runtime/wevu/test/runtime-register-extra.test.ts`
- `pnpm -w exec eslint packages-runtime/wevu/src/runtime/define.ts packages-runtime/wevu/src/runtime/register/component/props.ts packages-runtime/wevu/src/runtime/register/runtimeInstance.ts packages-runtime/wevu/test/runtime-scoped-slots.test.ts e2e/ide/github-issues.runtime.issue642-bug8.test.ts e2e/ide/github-issues.runtime.shared.ts e2e-apps/github-issues/src/components/issue-642-bug8/Wrap/index.vue e2e-apps/github-issues/src/pages/issue-642-bug8/index.vue e2e-apps/github-issues/src/components/issue-642-bug8/Cell/index.vue`
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`
- `node --import tsx scripts/check-catalog-changeset.ts`
- `pnpm --filter wevu typecheck`
- `node --import tsx scripts/check-e2e-ide-shared-launch.ts`
- `pnpm vitest run -c ./e2e/vitest.e2e.devtools.config.ts e2e/ide/github-issues.runtime.issue642-bug8.test.ts`
- `pnpm vitest run -c ./e2e/vitest.e2e.devtools.config.ts e2e/ide/github-issues.runtime.issue642.test.ts e2e/ide/github-issues.runtime.issue642-bug7-default.test.ts e2e/ide/github-issues.runtime.issue642-bug7-performance.test.ts`