### PR TITLE
fix(weapp-vite): 修复无 props 组件无法读取 slots

### DIFF
--- a/.changeset/fix-issue-674-vue-slots.md
+++ b/.changeset/fix-issue-674-vue-slots.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复无业务 props 的 Vue SFC 组件在 `setup` 中调用 `useSlots()` 或 `defineSlots()` 时无法读取父级传入插槽的问题。编译收尾阶段现在会在脚本使用 slot 元数据时为组件同步注入 `vueSlots` 等内部属性，确保默认插槽和具名插槽的存在性检测可用。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -491,6 +491,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-674/index",
+          "pathName": "pages/issue-674/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-528/index",
           "pathName": "pages/issue-528/index",
           "query": "",

--- a/e2e-apps/github-issues/src/components/issue-674/SlotProbe/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-674/SlotProbe/index.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { computed } from 'wevu'
+
+const slots = defineSlots<{
+  default?: () => any
+  header?: () => any
+}>()
+const slotKeys = computed(() => Object.keys(slots).sort().join(',') || 'none')
+</script>
+
+<template>
+  <view class="issue674-slot-probe">
+    <text :data-issue674-slot-keys="slotKeys">
+      {{ slotKeys }}
+    </text>
+    <slot />
+    <slot name="header" />
+  </view>
+</template>

--- a/e2e-apps/github-issues/src/pages/issue-674/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-674/index.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import Issue674SlotProbe from '../../components/issue-674/SlotProbe/index.vue'
+
+definePageJson({
+  navigationBarTitleText: 'issue-674',
+})
+definePageMeta({
+  layout: false,
+})
+</script>
+
+<template>
+  <view class="issue674-page">
+    <Issue674SlotProbe>
+      <template #header>
+        <text class="issue674-page__header">issue-674 header slot</text>
+      </template>
+      <text class="issue674-page__default">issue-674 default slot</text>
+    </Issue674SlotProbe>
+  </view>
+</template>
+
+<style scoped>
+.issue674-page {
+  min-height: 100vh;
+  padding: 24rpx;
+}
+</style>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -80,6 +80,10 @@ const githubIssuesRouteGroups: Record<string, string[]> = {
     'pages/issue-642-bug8/**',
     'components/issue-642-bug8/**',
   ],
+  'github-issues.runtime.issue674.test.ts': [
+    'pages/issue-674/**',
+    'components/issue-674/**',
+  ],
   'github-issues.runtime.issue581.test.ts': [
     'pages/issue-581/**',
   ],

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -747,6 +747,28 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expectSetDataPickKeys(scopedProbeJs, ['vueSlots', '__wvSlotOwnerId', '__wvSlotScope'])
   })
 
+  it('issue #674: injects vueSlots into slot-aware components without declared props', async () => {
+    await runBuild()
+
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-674/index.wxml')
+    const slotProbeWxmlPath = path.join(DIST_ROOT, 'components/issue-674/SlotProbe/index.wxml')
+    const slotProbeJsPath = path.join(DIST_ROOT, 'components/issue-674/SlotProbe/index.js')
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+    const slotProbeWxml = await fs.readFile(slotProbeWxmlPath, 'utf-8')
+    const slotProbeJs = await fs.readFile(slotProbeJsPath, 'utf-8')
+
+    expect(pageWxml).toContain('Issue674SlotProbe')
+    expect(pageWxml).toContain('vue-slots=')
+    expect(pageWxml).toContain('header:true')
+    expect(pageWxml).toContain('default:true')
+    expect(slotProbeWxml).toContain('<slot />')
+    expect(slotProbeWxml).toContain('<slot name="header" />')
+    expect(slotProbeWxml).not.toContain('vueSlots&&vueSlots')
+    expect(slotProbeJs).toContain('"vueSlots"')
+    expect(slotProbeJs).toContain('"__wvSlotOwnerId"')
+    expect(slotProbeJs).toContain('"__wvSlotScope"')
+  })
+
   it('issue #424: avoids duplicated output for imported src/assets images', async () => {
     await runBuild()
 

--- a/packages-runtime/wevu/test/runtime-vue-compat.test.ts
+++ b/packages-runtime/wevu/test/runtime-vue-compat.test.ts
@@ -1,6 +1,6 @@
-import { WEVU_PUBLIC_RUNTIME_KEY } from '@weapp-core/constants'
+import { WEVU_PUBLIC_RUNTIME_KEY, WEVU_SLOT_NAMES_PROP } from '@weapp-core/constants'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, mergeModels, useAttrs, useBindModel, useChangeModel, useDisposables, useIntersectionObserver, useModel, useNativeInstance, useNativePageRouter, useNativeRouter, usePageScrollThrottle, useSlots, useUpdatePerformanceListener } from '@/index'
+import { createWevuComponent, defineComponent, mergeModels, useAttrs, useBindModel, useChangeModel, useDisposables, useIntersectionObserver, useModel, useNativeInstance, useNativePageRouter, useNativeRouter, usePageScrollThrottle, useSlots, useUpdatePerformanceListener } from '@/index'
 
 const registeredComponents: Record<string, any>[] = []
 
@@ -72,6 +72,35 @@ describe('runtime: vue compat helpers', () => {
     inst.properties.extra = 'beta'
     opts.observers['**'].call(inst)
     expect(inst[WEVU_PUBLIC_RUNTIME_KEY]?.state?.attrs).toMatchObject({ extra: 'beta' })
+  })
+
+  it('useSlots reads compiled slot metadata in components without user props', () => {
+    createWevuComponent({
+      properties: {
+        [WEVU_SLOT_NAMES_PROP]: { type: null, value: null },
+      },
+      setup() {
+        const slots = useSlots()
+        return { slots }
+      },
+    } as any)
+
+    const opts = registeredComponents[0]
+    expect(opts.properties[WEVU_SLOT_NAMES_PROP]).toBeTruthy()
+
+    const inst: any = {
+      setData() {},
+      triggerEvent: vi.fn(),
+      properties: {
+        [WEVU_SLOT_NAMES_PROP]: { default: true, header: true },
+      },
+    }
+    opts.lifetimes.created.call(inst)
+    opts.lifetimes.attached.call(inst)
+
+    expect(Object.keys(inst[WEVU_PUBLIC_RUNTIME_KEY]?.state?.slots)).toEqual(['default', 'header'])
+    expect(typeof inst[WEVU_PUBLIC_RUNTIME_KEY]?.state?.slots.default).toBe('function')
+    expect('header' in inst[WEVU_PUBLIC_RUNTIME_KEY]?.state?.slots).toBe(true)
   })
 
   it('useAttrs filters compiler internal template binding keys', () => {

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/shared.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/shared.test.ts
@@ -29,6 +29,7 @@ const injectScopedSlotHostPropertiesInJsMock = vi.hoisted(() => vi.fn((code: str
   transformed: false,
   code,
 })))
+const mayNeedScopedSlotHostPropertiesForSetupSlotsInJsMock = vi.hoisted(() => vi.fn(() => false))
 const isAutoSetDataPickEnabledMock = vi.hoisted(() => vi.fn(() => false))
 const mayNeedInjectSetDataPickInJsMock = vi.hoisted(() => vi.fn(() => true))
 const pruneScopedSlotOwnerAutoSetDataPickKeysMock = vi.hoisted(() => vi.fn((keys: string[]) => keys.filter(key => !key.startsWith('__wv_bind_'))))
@@ -80,6 +81,7 @@ vi.mock('../injectSetDataPick', () => ({
   injectSetDataPickInJs: injectSetDataPickInJsMock,
   isAutoSetDataPickEnabled: isAutoSetDataPickEnabledMock,
   mayNeedInjectSetDataPickInJs: mayNeedInjectSetDataPickInJsMock,
+  mayNeedScopedSlotHostPropertiesForSetupSlotsInJs: mayNeedScopedSlotHostPropertiesForSetupSlotsInJsMock,
   pruneScopedSlotOwnerAutoSetDataPickKeys: pruneScopedSlotOwnerAutoSetDataPickKeysMock,
   shouldUseScopedSlotOwnerOnlySetDataPick: shouldUseScopedSlotOwnerOnlySetDataPickMock,
 }))
@@ -165,6 +167,8 @@ describe('emitSharedVueEntryAssets', () => {
       transformed: false,
       code,
     }))
+    mayNeedScopedSlotHostPropertiesForSetupSlotsInJsMock.mockReset()
+    mayNeedScopedSlotHostPropertiesForSetupSlotsInJsMock.mockReturnValue(false)
     isAutoSetDataPickEnabledMock.mockReset()
     isAutoSetDataPickEnabledMock.mockReturnValue(false)
     mayNeedInjectSetDataPickInJsMock.mockReset()
@@ -821,6 +825,33 @@ describe('emitSharedVueEntryAssets', () => {
     })
 
     expect(injectScopedSlotHostPropertiesInJsMock).toHaveBeenCalledWith('Component({ setup() { return {} } })')
+    expect(result.script).toContain('vueSlots')
+  })
+
+  it('injects slot host properties when setup uses slots without template vueSlots fallback', async () => {
+    mayNeedScopedSlotHostPropertiesForSetupSlotsInJsMock.mockReturnValue(true)
+    injectScopedSlotHostPropertiesInJsMock.mockReturnValue({
+      transformed: true,
+      code: 'Component({ properties: { vueSlots: { type: null, value: null } } })',
+    })
+
+    const result = await finalizeCompiledVueLikeResult({
+      result: {
+        template: '<view><slot /></view>',
+        script: 'import { useSlots } from "wevu/internal-runtime"; Component({ setup() { return { slots: useSlots() } } })',
+      } as any,
+      filename: '/project/src/components/SlotProbe/index.vue',
+      pluginCtx: { emitFile: vi.fn() },
+      configService: {
+        isDev: true,
+        weappViteConfig: {},
+      } as any,
+      isPage: false,
+      isApp: false,
+    })
+
+    expect(mayNeedScopedSlotHostPropertiesForSetupSlotsInJsMock).toHaveBeenCalledWith(expect.stringContaining('useSlots'))
+    expect(injectScopedSlotHostPropertiesInJsMock).toHaveBeenCalledWith(expect.stringContaining('useSlots'))
     expect(result.script).toContain('vueSlots')
   })
 

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/compile.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/compile.ts
@@ -8,7 +8,7 @@ import { normalizeFsResolvedId } from '../../../../../utils/resolvedId'
 import { addResolvedPageLayoutWatchFiles } from '../../../../utils/pageLayout'
 import { createCompileVueFileOptions } from '../../compileOptions'
 import { injectWevuPageFeaturesInJsWithViteResolver } from '../../injectPageFeatures'
-import { collectSetDataPickKeysFromTemplate, injectScopedSlotHostPropertiesInJs, injectScopedSlotOwnerSetDataPickInJs, injectSetDataPickInJs, isAutoSetDataPickEnabled, mayNeedInjectSetDataPickInJs, pruneScopedSlotOwnerAutoSetDataPickKeys, shouldUseScopedSlotOwnerOnlySetDataPick } from '../../injectSetDataPick'
+import { collectSetDataPickKeysFromTemplate, injectScopedSlotHostPropertiesInJs, injectScopedSlotOwnerSetDataPickInJs, injectSetDataPickInJs, isAutoSetDataPickEnabled, mayNeedInjectSetDataPickInJs, mayNeedScopedSlotHostPropertiesForSetupSlotsInJs, pruneScopedSlotOwnerAutoSetDataPickKeys, shouldUseScopedSlotOwnerOnlySetDataPick } from '../../injectSetDataPick'
 import { applyPageLayoutPlan, resolvePageLayoutPlan } from '../../pageLayout'
 import { resolveTransformAutoRoutesSource } from '../../plugin/shared'
 import { isWevuMinifyEnabled } from '../../wevuPreset'
@@ -119,7 +119,8 @@ export async function finalizeCompiledVueLikeResult(options: {
   }
 
   const hasScopedSlotHostGenerics = Boolean(result.componentGenerics && Object.keys(result.componentGenerics).length > 0)
-  if (!isPage && !isApp && result.script && (hasScopedSlotHostGenerics || result.template?.includes(WEVU_SLOT_OWNER_ID_PROP) || result.template?.includes('vueSlots'))) {
+  const needsSetupSlotHostProperties = result.script && mayNeedScopedSlotHostPropertiesForSetupSlotsInJs(result.script)
+  if (!isPage && !isApp && result.script && (hasScopedSlotHostGenerics || result.template?.includes(WEVU_SLOT_OWNER_ID_PROP) || result.template?.includes('vueSlots') || needsSetupSlotHostProperties)) {
     const injectedProps = injectScopedSlotHostPropertiesInJs(result.script)
     if (injectedProps.transformed) {
       result.script = injectedProps.code

--- a/packages/weapp-vite/src/plugins/vue/transform/injectSetDataPick.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/injectSetDataPick.test.ts
@@ -1,7 +1,7 @@
 import { WEVU_SLOT_NAMES_PROP, WEVU_SLOT_OWNER_ID_KEY, WEVU_SLOT_OWNER_ID_PROP, WEVU_SLOT_SCOPE_KEY } from '@weapp-core/constants'
 import { describe, expect, it } from 'vitest'
 import { getWxmlDirectivePrefix } from '../../../platform'
-import { collectSetDataPickKeysFromTemplate, injectScopedSlotHostPropertiesInJs, injectScopedSlotOwnerSetDataPickInJs, injectSetDataPickInJs, mayNeedInjectSetDataPickInJs, pruneScopedSlotOwnerAutoSetDataPickKeys, shouldUseScopedSlotOwnerOnlySetDataPick } from './injectSetDataPick'
+import { collectSetDataPickKeysFromTemplate, injectScopedSlotHostPropertiesInJs, injectScopedSlotOwnerSetDataPickInJs, injectSetDataPickInJs, mayNeedInjectSetDataPickInJs, mayNeedScopedSlotHostPropertiesForSetupSlotsInJs, pruneScopedSlotOwnerAutoSetDataPickKeys, shouldUseScopedSlotOwnerOnlySetDataPick } from './injectSetDataPick'
 
 const DEFAULT_WXML_DIRECTIVE_PREFIX = getWxmlDirectivePrefix()
 
@@ -125,6 +125,28 @@ defineComponent({
     expect(mayNeedInjectSetDataPickInJs('createWevuComponent(options)')).toBe(true)
     expect(mayNeedInjectSetDataPickInJs('defineComponent({})')).toBe(true)
     expect(mayNeedInjectSetDataPickInJs('Page({})')).toBe(false)
+  })
+
+  it('detects setup useSlots calls that need slot host properties', () => {
+    expect(mayNeedScopedSlotHostPropertiesForSetupSlotsInJs(`
+import { useSlots } from 'wevu/internal-runtime'
+const slots = useSlots()
+    `.trim())).toBe(true)
+
+    expect(mayNeedScopedSlotHostPropertiesForSetupSlotsInJs(`
+import { useSlots as useSetupSlots } from 'wevu'
+const slots = useSetupSlots()
+    `.trim())).toBe(true)
+
+    expect(mayNeedScopedSlotHostPropertiesForSetupSlotsInJs(`
+import { useSlots } from 'wevu'
+const slots = {}
+    `.trim())).toBe(false)
+
+    expect(mayNeedScopedSlotHostPropertiesForSetupSlotsInJs(`
+const useSlots = () => ({})
+const slots = useSlots()
+    `.trim())).toBe(false)
   })
 
   it('merges with existing setData.pick array', () => {

--- a/packages/weapp-vite/src/plugins/vue/transform/injectSetDataPick.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/injectSetDataPick.ts
@@ -44,6 +44,54 @@ export function mayNeedInjectSetDataPickInJs(source: string): boolean {
     || source.includes('.so(')
 }
 
+/**
+ * 判断脚本 setup 阶段是否会读取编译期 slot 名元数据。
+ */
+export function mayNeedScopedSlotHostPropertiesForSetupSlotsInJs(source: string): boolean {
+  if (!source.includes('useSlots')) {
+    return false
+  }
+
+  const ast = parseJsLike(source)
+  const useSlotsLocals = new Set<string>()
+  traverse(ast, {
+    ImportDeclaration(path) {
+      const sourceValue = path.node.source.value
+      if (sourceValue !== 'wevu' && sourceValue !== 'vue' && sourceValue !== 'wevu/internal-runtime') {
+        return
+      }
+      for (const specifier of path.node.specifiers) {
+        if (
+          specifier.type === 'ImportSpecifier'
+          && specifier.imported.type === 'Identifier'
+          && specifier.imported.name === 'useSlots'
+          && specifier.local.type === 'Identifier'
+        ) {
+          useSlotsLocals.add(specifier.local.name)
+        }
+      }
+    },
+  })
+
+  if (!useSlotsLocals.size) {
+    return false
+  }
+
+  let hasSetupSlotsCall = false
+  traverse(ast, {
+    CallExpression(path) {
+      if (
+        path.node.callee.type === 'Identifier'
+        && useSlotsLocals.has(path.node.callee.name)
+      ) {
+        hasSetupSlotsCall = true
+      }
+    },
+  })
+
+  return hasSetupSlotsCall
+}
+
 function getObjectPropertyByKey(objectExpression: t.ObjectExpression, key: string): t.ObjectProperty | undefined {
   for (const member of objectExpression.properties) {
     if (member.type !== 'ObjectProperty') {

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin.astEngine.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin.astEngine.test.ts
@@ -6,6 +6,7 @@ const collectSetDataPickKeysFromTemplateMock = vi.hoisted(() => vi.fn())
 const injectSetDataPickInJsMock = vi.hoisted(() => vi.fn())
 const isAutoSetDataPickEnabledMock = vi.hoisted(() => vi.fn())
 const mayNeedInjectSetDataPickInJsMock = vi.hoisted(() => vi.fn(() => true))
+const mayNeedScopedSlotHostPropertiesForSetupSlotsInJsMock = vi.hoisted(() => vi.fn(() => false))
 const pruneScopedSlotOwnerAutoSetDataPickKeysMock = vi.hoisted(() => vi.fn((keys: string[]) => keys))
 const shouldUseScopedSlotOwnerOnlySetDataPickMock = vi.hoisted(() => vi.fn(() => false))
 const createCompileVueFileOptionsMock = vi.hoisted(() => vi.fn(() => ({ mock: true })))
@@ -38,6 +39,7 @@ vi.mock('./injectSetDataPick', () => ({
   injectSetDataPickInJs: injectSetDataPickInJsMock,
   isAutoSetDataPickEnabled: isAutoSetDataPickEnabledMock,
   mayNeedInjectSetDataPickInJs: mayNeedInjectSetDataPickInJsMock,
+  mayNeedScopedSlotHostPropertiesForSetupSlotsInJs: mayNeedScopedSlotHostPropertiesForSetupSlotsInJsMock,
   pruneScopedSlotOwnerAutoSetDataPickKeys: pruneScopedSlotOwnerAutoSetDataPickKeysMock,
   shouldUseScopedSlotOwnerOnlySetDataPick: shouldUseScopedSlotOwnerOnlySetDataPickMock,
 }))
@@ -131,6 +133,8 @@ describe('createVueTransformPlugin ast engine smoke', () => {
     })
     mayNeedInjectSetDataPickInJsMock.mockReset()
     mayNeedInjectSetDataPickInJsMock.mockReturnValue(true)
+    mayNeedScopedSlotHostPropertiesForSetupSlotsInJsMock.mockReset()
+    mayNeedScopedSlotHostPropertiesForSetupSlotsInJsMock.mockReturnValue(false)
     pruneScopedSlotOwnerAutoSetDataPickKeysMock.mockReset()
     pruneScopedSlotOwnerAutoSetDataPickKeysMock.mockImplementation((keys: string[]) => keys)
     shouldUseScopedSlotOwnerOnlySetDataPickMock.mockReset()

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/shared.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/shared.test.ts
@@ -26,6 +26,7 @@ const injectScopedSlotHostPropertiesInJsMock = vi.hoisted(() => vi.fn((code: str
   code,
   map: null,
 })))
+const mayNeedScopedSlotHostPropertiesForSetupSlotsInJsMock = vi.hoisted(() => vi.fn(() => false))
 const isAutoSetDataPickEnabledMock = vi.hoisted(() => vi.fn(() => false))
 const mayNeedInjectSetDataPickInJsMock = vi.hoisted(() => vi.fn(() => true))
 const pruneScopedSlotOwnerAutoSetDataPickKeysMock = vi.hoisted(() => vi.fn((keys: string[]) => keys.filter(key => !key.startsWith('__wv_bind_'))))
@@ -66,6 +67,7 @@ vi.mock('../injectSetDataPick', () => ({
   injectSetDataPickInJs: injectSetDataPickInJsMock,
   isAutoSetDataPickEnabled: isAutoSetDataPickEnabledMock,
   mayNeedInjectSetDataPickInJs: mayNeedInjectSetDataPickInJsMock,
+  mayNeedScopedSlotHostPropertiesForSetupSlotsInJs: mayNeedScopedSlotHostPropertiesForSetupSlotsInJsMock,
   pruneScopedSlotOwnerAutoSetDataPickKeys: pruneScopedSlotOwnerAutoSetDataPickKeysMock,
   shouldUseScopedSlotOwnerOnlySetDataPick: shouldUseScopedSlotOwnerOnlySetDataPickMock,
 }))
@@ -139,6 +141,8 @@ describe('vue transform plugin shared helpers', () => {
       code,
       map: null,
     }))
+    mayNeedScopedSlotHostPropertiesForSetupSlotsInJsMock.mockReset()
+    mayNeedScopedSlotHostPropertiesForSetupSlotsInJsMock.mockReturnValue(false)
     isAutoSetDataPickEnabledMock.mockReset()
     isAutoSetDataPickEnabledMock.mockReturnValue(false)
     mayNeedInjectSetDataPickInJsMock.mockReset()
@@ -806,6 +810,34 @@ describe('vue transform plugin shared helpers', () => {
     })
 
     expect(injectScopedSlotHostPropertiesInJsMock).toHaveBeenCalledWith('Component({ setup() { return {} } })')
+    expect(result.script).toContain('vueSlots')
+  })
+
+  it('injects slot host properties when setup uses slots without template vueSlots fallback', async () => {
+    mayNeedScopedSlotHostPropertiesForSetupSlotsInJsMock.mockReturnValue(true)
+    injectScopedSlotHostPropertiesInJsMock.mockReturnValue({
+      transformed: true,
+      code: 'Component({ properties: { vueSlots: { type: null, value: null } } })',
+      map: null,
+    })
+
+    const result = await finalizeTransformEntryScript({
+      result: {
+        template: '<view><slot /></view>',
+        script: 'import { useSlots } from "wevu/internal-runtime"; Component({ setup() { return { slots: useSlots() } } })',
+      } as any,
+      filename: '/project/src/components/SlotProbe/index.vue',
+      pluginCtx: {},
+      configService: {
+        isDev: true,
+        weappViteConfig: {},
+      } as any,
+      isPage: false,
+      isApp: false,
+    })
+
+    expect(mayNeedScopedSlotHostPropertiesForSetupSlotsInJsMock).toHaveBeenCalledWith(expect.stringContaining('useSlots'))
+    expect(injectScopedSlotHostPropertiesInJsMock).toHaveBeenCalledWith(expect.stringContaining('useSlots'))
     expect(result.script).toContain('vueSlots')
   })
 

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/shared/compile.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/shared/compile.ts
@@ -11,7 +11,7 @@ import { composeSourceMaps, normalizeEncodedSourceMapLike } from '../../../../..
 import { collectOnPageScrollPerformanceWarnings } from '../../../../performance/onPageScrollDiagnostics'
 import { hasAppShellTemplate, resolveAppShellLayout } from '../../appShell'
 import { injectWevuPageFeaturesInJsWithViteResolver } from '../../injectPageFeatures'
-import { collectSetDataPickKeysFromTemplate, injectScopedSlotHostPropertiesInJs, injectScopedSlotOwnerSetDataPickInJs, injectSetDataPickInJs, isAutoSetDataPickEnabled, mayNeedInjectSetDataPickInJs, pruneScopedSlotOwnerAutoSetDataPickKeys, shouldUseScopedSlotOwnerOnlySetDataPick } from '../../injectSetDataPick'
+import { collectSetDataPickKeysFromTemplate, injectScopedSlotHostPropertiesInJs, injectScopedSlotOwnerSetDataPickInJs, injectSetDataPickInJs, isAutoSetDataPickEnabled, mayNeedInjectSetDataPickInJs, mayNeedScopedSlotHostPropertiesForSetupSlotsInJs, pruneScopedSlotOwnerAutoSetDataPickKeys, shouldUseScopedSlotOwnerOnlySetDataPick } from '../../injectSetDataPick'
 import { registerVueTemplateToken, resolveVueOutputBase } from '../../shared'
 import { buildWeappVueStyleRequests } from '../../styleRequest'
 import { isWevuMinifyEnabled } from '../../wevuPreset'
@@ -109,7 +109,8 @@ export async function finalizeTransformEntryScript(options: {
   }
 
   const hasScopedSlotHostGenerics = Boolean(result.componentGenerics && Object.keys(result.componentGenerics).length > 0)
-  if (!isPage && !isApp && result.script && (hasScopedSlotHostGenerics || result.template?.includes(WEVU_SLOT_OWNER_ID_PROP) || result.template?.includes('vueSlots'))) {
+  const needsSetupSlotHostProperties = result.script && mayNeedScopedSlotHostPropertiesForSetupSlotsInJs(result.script)
+  if (!isPage && !isApp && result.script && (hasScopedSlotHostGenerics || result.template?.includes(WEVU_SLOT_OWNER_ID_PROP) || result.template?.includes('vueSlots') || needsSetupSlotHostProperties)) {
     const injectedProps = injectScopedSlotHostPropertiesInJs(result.script)
     if (injectedProps.transformed) {
       result.script = injectedProps.code


### PR DESCRIPTION
## 变更说明

Fixes #674

- 在编译收尾阶段检测脚本中实际调用的 `useSlots()`，即使模板没有 `vueSlots` fallback 表达式，也为普通组件注入 `vueSlots`、`__wvSlotOwnerId`、`__wvSlotScope` 等内部 slot host properties。
- 新增 issue #674 的 github-issues 复现页面，覆盖无业务 props 的组件通过 `defineSlots()` 检测默认插槽和具名插槽。
- 补充 transform、runtime compat 和 build-only e2e 断言，并添加 `weapp-vite` / `create-weapp-vite` patch changeset。

## 验证

- `pnpm exec vitest run packages/weapp-vite/src/plugins/vue/transform/injectSetDataPick.test.ts packages/weapp-vite/src/plugins/vue/transform/plugin/shared.test.ts packages/weapp-vite/src/plugins/vue/transform/bundle/shared.test.ts packages-runtime/wevu/test/runtime-vue-compat.test.ts`
- `pnpm exec vitest run -c e2e/vitest.e2e.ci.build-only.config.ts e2e/ci/github-issues.build.test.ts -t "issue #674"`
- `pnpm exec eslint packages/weapp-vite/src/plugins/vue/transform/injectSetDataPick.ts packages/weapp-vite/src/plugins/vue/transform/injectSetDataPick.test.ts packages/weapp-vite/src/plugins/vue/transform/bundle/shared/compile.ts packages/weapp-vite/src/plugins/vue/transform/bundle/shared.test.ts packages/weapp-vite/src/plugins/vue/transform/plugin/shared/compile.ts packages/weapp-vite/src/plugins/vue/transform/plugin/shared.test.ts packages/weapp-vite/src/plugins/vue/transform/plugin.astEngine.test.ts packages-runtime/wevu/test/runtime-vue-compat.test.ts e2e/ci/github-issues.build.test.ts e2e-apps/github-issues/weapp-vite.config.ts e2e-apps/github-issues/src/components/issue-674/SlotProbe/index.vue e2e-apps/github-issues/src/pages/issue-674/index.vue`
- `pnpm run check:create-weapp-vite-changeset`
- `pnpm run check:publishable-workspace-changeset`
- `git diff --check`

## 已知说明

- 已尝试 package-scoped typecheck，但当前分支存在与本次改动无关的既有错误：`packages/weapp-vite/src/runtime/npmPlugin/builder/packageBuilder.ts` 中 `TransformOptions` 类型缺少 `tsconfig`，以及 `packages-runtime/wevu/src/runtime/define/initialComputed.ts` 中函数类型不兼容。