### PR TITLE
fix(web-apis): 支持 FormData multipart 上传

### DIFF
--- a/.changeset/formdata-multipart-upload.md
+++ b/.changeset/formdata-multipart-upload.md
@@ -1,0 +1,5 @@
+---
+"@wevu/web-apis": patch
+---
+
+修复 fetch 通过小程序 request 桥发送 FormData 时不支持 multipart body 的问题，支持 Blob/File 文件字段上传并保留文件名与内容类型。

--- a/e2e-apps/github-issues/src/pages/issue-448/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-448/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'wevu'
+import { onLoad, ref } from 'wevu'
 
 definePageJson({
   navigationBarTitleText: 'issue-448',
@@ -33,13 +33,172 @@ const jsonResponse = Response.json({ ok: true })
 const jsonResponseContentType = jsonResponse.headers.get('content-type')
 const errorResponse = Response.error()
 const microtaskState = ref('pending')
+const baseUrl = ref('')
+const formDataUploadStatus = ref('idle')
+const formDataUploadPayload = ref('')
 
 queueMicrotask(() => {
   microtaskState.value = 'flushed'
 })
 
+interface DownloadFileSuccessResult {
+  statusCode?: number
+  tempFilePath: string
+}
+
+interface MultipartUploadFileResult {
+  contentType: string
+  filename: string
+  name: string
+  sha256: string
+  size: number
+}
+
+interface MultipartUploadPayload {
+  expectedSha256: string
+  files: MultipartUploadFileResult[]
+  path: string
+}
+
+interface Issue448WxApi {
+  downloadFile: (options: {
+    fail?: (error: unknown) => void
+    success?: (result: DownloadFileSuccessResult) => void
+    url: string
+  }) => void
+  getFileSystemManager: () => {
+    readFile: (options: {
+      encoding?: 'binary'
+      fail?: (error: unknown) => void
+      filePath: string
+      success?: (result: { data: string | ArrayBuffer }) => void
+    }) => void
+  }
+}
+
+const wxApi = (globalThis as unknown as { wx: Issue448WxApi }).wx
+
+function resolveBaseUrl(query: Record<string, unknown> | undefined) {
+  return typeof query?.baseUrl === 'string' ? decodeURIComponent(query.baseUrl) : ''
+}
+
+function downloadFile(url: string) {
+  return new Promise<DownloadFileSuccessResult>((resolve, reject) => {
+    wxApi.downloadFile({
+      fail: reject,
+      success: resolve,
+      url,
+    })
+  })
+}
+
+function readDownloadedFile(filePath: string) {
+  return new Promise<ArrayBuffer>((resolve, reject) => {
+    wxApi.getFileSystemManager().readFile({
+      encoding: 'binary',
+      fail: reject,
+      filePath,
+      success(result) {
+        if (typeof result.data === 'string') {
+          const bytes = new Uint8Array(result.data.length)
+          for (let index = 0; index < result.data.length; index++) {
+            bytes[index] = result.data.charCodeAt(index) & 0xFF
+          }
+          resolve(bytes.buffer)
+          return
+        }
+        resolve(result.data)
+      },
+    })
+  })
+}
+
+function assertUploadPayload(payload: MultipartUploadPayload, expectedNames: string[]) {
+  if (payload.path !== '/issue-448/upload') {
+    throw new Error(`unexpected upload path: ${payload.path}`)
+  }
+
+  for (const expectedName of expectedNames) {
+    const file = payload.files.find(item => item.name === expectedName)
+    if (!file) {
+      throw new Error(`missing upload file: ${expectedName}`)
+    }
+    if (file.sha256 !== payload.expectedSha256) {
+      throw new Error(`unexpected ${expectedName} sha256: ${file.sha256}, size: ${file.size}`)
+    }
+    if (file.size <= 0) {
+      throw new Error(`unexpected ${expectedName} size: ${file.size}`)
+    }
+  }
+}
+
+async function uploadDownloadedFileAsFormData() {
+  if (!baseUrl.value) {
+    throw new Error('missing issue-448 baseUrl')
+  }
+
+  formDataUploadStatus.value = 'running'
+  const download = await downloadFile(`${baseUrl.value}/issue-448/download.bin`)
+  if (download.statusCode && download.statusCode !== 200) {
+    throw new Error(`downloadFile failed with status ${download.statusCode}`)
+  }
+
+  const buffer = await readDownloadedFile(download.tempFilePath)
+  const blobFormData = new FormData()
+  blobFormData.append('blob-file', new Blob([buffer], { type: 'application/octet-stream' }), 'downloaded-blob.bin')
+  const blobResponse = await fetch(`${baseUrl.value}/issue-448/upload`, {
+    body: blobFormData,
+    method: 'POST',
+  })
+  const blobPayload = await blobResponse.json() as MultipartUploadPayload
+  assertUploadPayload(blobPayload, ['blob-file'])
+
+  const fileFormData = new FormData()
+  fileFormData.append('file-file', new File([buffer], 'downloaded-file.bin', { type: 'application/octet-stream' }))
+  const fileResponse = await fetch(`${baseUrl.value}/issue-448/upload`, {
+    body: fileFormData,
+    method: 'POST',
+  })
+  const filePayload = await fileResponse.json() as MultipartUploadPayload
+  assertUploadPayload(filePayload, ['file-file'])
+
+  const payload = {
+    blob: blobPayload.files.find(item => item.name === 'blob-file'),
+    expectedSha256: blobPayload.expectedSha256,
+    file: filePayload.files.find(item => item.name === 'file-file'),
+  }
+  formDataUploadPayload.value = JSON.stringify(payload)
+  formDataUploadStatus.value = 'passed'
+  return payload
+}
+
+async function _runFormDataUploadE2E() {
+  try {
+    const payload = await uploadDownloadedFileAsFormData()
+    return {
+      ok: true,
+      payload,
+      status: formDataUploadStatus.value,
+    }
+  }
+  catch (error) {
+    formDataUploadStatus.value = 'failed'
+    formDataUploadPayload.value = error instanceof Error ? error.message : String(error)
+    return {
+      error: formDataUploadPayload.value,
+      ok: false,
+      status: formDataUploadStatus.value,
+    }
+  }
+}
+
+onLoad((query) => {
+  baseUrl.value = resolveBaseUrl(query)
+})
+
 function _runE2E() {
   return {
+    baseUrl: baseUrl.value,
     encoded,
     decoded,
     duration,
@@ -54,6 +213,8 @@ function _runE2E() {
     jsonResponseContentType,
     errorResponseStatus: errorResponse.status,
     errorResponseType: errorResponse.type,
+    formDataUploadPayload: formDataUploadPayload.value,
+    formDataUploadStatus: formDataUploadStatus.value,
     microtaskState: microtaskState.value,
   }
 }
@@ -74,6 +235,8 @@ function _runE2E() {
     <text class="issue448-line">cookies = {{ cookieCount }}</text>
     <text class="issue448-line">json = {{ jsonResponseContentType }}</text>
     <text class="issue448-line">error = {{ errorResponseStatus }}:{{ errorResponseType }}</text>
+    <text class="issue448-line">upload = {{ formDataUploadStatus }}</text>
+    <text class="issue448-line">uploadPayload = {{ formDataUploadPayload }}</text>
     <text class="issue448-line">microtask = {{ microtaskState }}</text>
   </view>
 </template>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -28,6 +28,9 @@ const githubIssuesRouteGroups: Record<string, string[]> = {
     'pages/issue-338/**',
     'pages/issue-448/**',
   ],
+  'github-issues.runtime.issue448-formdata-upload.test.ts': [
+    'pages/issue-448/**',
+  ],
   'github-issues.runtime.import-meta.test.ts': [
     'pages/issue-431/**',
   ],

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -831,6 +831,12 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageJs).toContain('Response.json(')
     expect(pageJs).toContain('Response.error()')
     expect(pageJs).toContain('function _runE2E() {')
+    expect(pageJs).toContain('function _runFormDataUploadE2E()')
+    expect(pageJs).toContain('globalThis.wx')
+    expect(pageJs).toContain('.downloadFile({')
+    expect(pageJs).toContain('new Blob([')
+    expect(pageJs).toContain('new File([')
+    expect(pageJs).toContain('FormData')
   })
 
   it('issue #457: keeps injected web runtime code readable in production output', async () => {

--- a/e2e/ide/github-issues.runtime.issue448-formdata-upload.test.ts
+++ b/e2e/ide/github-issues.runtime.issue448-formdata-upload.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { startRequestClientsRealServer } from '../utils/requestClientsRealServer'
+import {
+  closeSharedMiniProgram,
+  getSharedMiniProgram,
+  PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT,
+  prepareGithubIssuesBuild,
+  relaunchPage,
+  releaseSharedMiniProgram,
+} from './github-issues.runtime.shared'
+
+const LOCAL_SERVER_INFRA_ERROR_PATTERNS = [
+  /listen EPERM/i,
+  /operation not permitted/i,
+  /EACCES/i,
+]
+
+let baseUrl = ''
+let serverHandle: Awaited<ReturnType<typeof startRequestClientsRealServer>> | null = null
+let sharedInfraUnavailableMessage = ''
+
+function isLocalServerInfraError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error)
+  return LOCAL_SERVER_INFRA_ERROR_PATTERNS.some(pattern => pattern.test(message))
+}
+
+function withBaseUrl(route: string) {
+  return `${route}?baseUrl=${encodeURIComponent(baseUrl)}`
+}
+
+describe.sequential('github-issues runtime issue #448 FormData upload', () => {
+  beforeAll(async () => {
+    try {
+      serverHandle = await startRequestClientsRealServer()
+      baseUrl = serverHandle.baseUrl
+    }
+    catch (error) {
+      if (isLocalServerInfraError(error)) {
+        sharedInfraUnavailableMessage = '本地测试服务基础设施不可用，跳过 issue-448 FormData 上传 IDE 自动化用例。'
+        return
+      }
+      throw error
+    }
+
+    await prepareGithubIssuesBuild()
+  }, PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT)
+
+  afterAll(async () => {
+    await closeSharedMiniProgram()
+    if (serverHandle) {
+      await serverHandle.stop()
+    }
+  })
+
+  it('uploads wx.downloadFile data as Blob and File FormData bodies in real DevTools', async (ctx) => {
+    if (sharedInfraUnavailableMessage) {
+      ctx.skip(sharedInfraUnavailableMessage)
+    }
+
+    const miniProgram = await getSharedMiniProgram(ctx)
+    try {
+      const page = await relaunchPage(
+        miniProgram,
+        withBaseUrl('/pages/issue-448/index'),
+        'issue448-page',
+        30_000,
+      )
+      if (!page) {
+        throw new Error('Failed to launch issue-448 page')
+      }
+
+      const result = await page.callMethod('_runFormDataUploadE2E')
+      const runtime = await page.callMethod('_runE2E')
+
+      expect(result?.ok, JSON.stringify({ result, requestCounts: serverHandle?.requestCounts })).toBe(true)
+      expect(result?.status).toBe('passed')
+      expect(result?.payload?.blob).toMatchObject({
+        contentType: 'application/octet-stream',
+        filename: 'downloaded-blob.bin',
+        name: 'blob-file',
+      })
+      expect(result?.payload?.file).toMatchObject({
+        contentType: 'application/octet-stream',
+        filename: 'downloaded-file.bin',
+        name: 'file-file',
+      })
+      expect(result?.payload?.blob?.sha256).toBe(result?.payload?.expectedSha256)
+      expect(result?.payload?.file?.sha256).toBe(result?.payload?.expectedSha256)
+      expect(result?.payload?.blob?.size).toBeGreaterThan(0)
+      expect(result?.payload?.file?.size).toBe(result?.payload?.blob?.size)
+      expect(runtime.formDataUploadStatus).toBe('passed')
+      expect(runtime.formDataUploadPayload).toContain('downloaded-blob.bin')
+      expect(runtime.formDataUploadPayload).toContain('downloaded-file.bin')
+      expect(serverHandle?.requestCounts.formDataUpload).toBe(2)
+    }
+    finally {
+      await releaseSharedMiniProgram(miniProgram)
+    }
+  })
+})

--- a/e2e/utils/requestClientsRealServer.ts
+++ b/e2e/utils/requestClientsRealServer.ts
@@ -1,5 +1,7 @@
 import type { IncomingHttpHeaders, ServerResponse } from 'node:http'
 import type { AddressInfo } from 'node:net'
+import { Buffer } from 'node:buffer'
+import { createHash } from 'node:crypto'
 import { createServer } from 'node:http'
 import { Readable } from 'node:stream'
 import { Hono } from 'hono'
@@ -7,10 +9,24 @@ import { Server as SocketIOServer } from 'socket.io'
 import { WebSocketServer } from 'ws'
 
 const REALTIME_RANDOM_PUSH_INTERVAL_MS = 5_000
+const FORM_DATA_BINARY_FIXTURE = Buffer.from([
+  0x00,
+  0x01,
+  0x02,
+  0x03,
+  ...Buffer.from('issue-448-formdata-upload'),
+  0xF0,
+  0x9F,
+  0x94,
+  0xA5,
+  0xFF,
+])
+const FORM_DATA_BINARY_FIXTURE_SHA256 = createHash('sha256').update(FORM_DATA_BINARY_FIXTURE).digest('hex')
 
 export interface RequestClientsRealServerState {
   axios: number
   fetch: number
+  formDataUpload: number
   graphql: number
   socketIo: number
   vueQuery: number
@@ -41,11 +57,68 @@ function createRequestCounts(): RequestClientsRealServerState {
   return {
     axios: 0,
     fetch: 0,
+    formDataUpload: 0,
     graphql: 0,
     socketIo: 0,
     vueQuery: 0,
     websocket: 0,
   }
+}
+
+function parseMultipartBoundary(contentType: string | null) {
+  const match = contentType?.match(/(?:^|;\s*)boundary=([^;]+)/i)
+  return match?.[1]?.replace(/^"|"$/g, '') ?? ''
+}
+
+async function readRequestBuffer(request: Request) {
+  const buffer = await request.arrayBuffer()
+  return Buffer.from(buffer)
+}
+
+function parseMultipartParts(body: Buffer, boundary: string) {
+  const rawBody = body.toString('binary')
+  const delimiter = `--${boundary}`
+  const parts: Array<{
+    content: Buffer
+    headers: Record<string, string>
+    name: string
+    filename: string | null
+  }> = []
+
+  for (const rawPart of rawBody.split(delimiter)) {
+    if (!rawPart || rawPart === '--\r\n' || rawPart === '--') {
+      continue
+    }
+
+    const normalized = rawPart.replace(/^\r\n/, '').replace(/\r\n$/, '').replace(/--$/, '')
+    const headerEnd = normalized.indexOf('\r\n\r\n')
+    if (headerEnd < 0) {
+      continue
+    }
+
+    const headerBlock = normalized.slice(0, headerEnd)
+    const contentBinary = normalized.slice(headerEnd + 4)
+    const headers: Record<string, string> = {}
+    for (const line of headerBlock.split('\r\n')) {
+      const separatorIndex = line.indexOf(':')
+      if (separatorIndex < 0) {
+        continue
+      }
+      headers[line.slice(0, separatorIndex).trim().toLowerCase()] = line.slice(separatorIndex + 1).trim()
+    }
+
+    const disposition = headers['content-disposition'] ?? ''
+    const name = disposition.match(/(?:^|;\s*)name="([^"]*)"/)?.[1] ?? ''
+    const filename = disposition.match(/(?:^|;\s*)filename="([^"]*)"/)?.[1] ?? null
+    parts.push({
+      content: Buffer.from(contentBinary, 'binary'),
+      filename,
+      headers,
+      name,
+    })
+  }
+
+  return parts
 }
 
 function createNodeRequest(url: string, method: string, headers: IncomingHttpHeaders, req: NodeJS.ReadableStream) {
@@ -96,6 +169,41 @@ export async function startRequestClientsRealServer(
       path: '/fetch',
       requestCount: requestCounts.fetch,
       transport: 'fetch',
+    })
+  })
+
+  app.get('/issue-448/download.bin', (_c) => {
+    return new Response(FORM_DATA_BINARY_FIXTURE, {
+      headers: {
+        'content-type': 'application/octet-stream',
+        'x-issue-448-sha256': FORM_DATA_BINARY_FIXTURE_SHA256,
+      },
+    })
+  })
+
+  app.post('/issue-448/upload', async (c) => {
+    requestCounts.formDataUpload += 1
+    const contentType = c.req.header('content-type') ?? ''
+    const boundary = parseMultipartBoundary(contentType)
+    const body = await readRequestBuffer(c.req.raw)
+    const parts = boundary ? parseMultipartParts(body, boundary) : []
+    const files = parts
+      .filter(part => part.filename)
+      .map(part => ({
+        contentType: part.headers['content-type'] ?? '',
+        filename: part.filename,
+        name: part.name,
+        sha256: createHash('sha256').update(part.content).digest('hex'),
+        size: part.content.byteLength,
+      }))
+
+    return c.json({
+      contentType,
+      expectedSha256: FORM_DATA_BINARY_FIXTURE_SHA256,
+      files,
+      method: c.req.method,
+      path: '/issue-448/upload',
+      requestCount: requestCounts.formDataUpload,
     })
   })
 

--- a/packages-runtime/web-apis/src/fetch.ts
+++ b/packages-runtime/web-apis/src/fetch.ts
@@ -8,8 +8,10 @@ import type { URLPolyfill } from './url'
 import { wpi } from '@wevu/api'
 import { isUrlInstance, isUrlSearchParamsInstance } from './constructors'
 import { HeadersPolyfill, ResponsePolyfill } from './http'
+import { encodeMultipartFormData } from './multipart'
 import { resolveRequestMiniProgramOptions } from './networkDefaults'
 import { cloneArrayBuffer, cloneArrayBufferView, normalizeHeaderName } from './shared'
+import { FormDataPolyfill } from './web'
 
 export type { RequestGlobalsMiniProgramOptions } from './networkDefaults'
 
@@ -150,6 +152,17 @@ function isRequestLikeInput(input: unknown): input is RequestLikeInput {
   return isObject(input) && typeof input.url === 'string'
 }
 
+function isFormDataInstance(value: unknown): value is FormData {
+  return Boolean(
+    value
+    && typeof value === 'object'
+    && (
+      (typeof FormData !== 'undefined' && value instanceof FormData)
+      || value instanceof FormDataPolyfill
+    ),
+  )
+}
+
 async function extractRequestBodyFromInput(input: RequestLikeInput | undefined) {
   if (!input || typeof input.clone !== 'function') {
     return undefined
@@ -195,8 +208,12 @@ async function normalizeRequestBody(body: unknown, headers: HeaderMap) {
     }
     return body.arrayBuffer()
   }
-  if (typeof FormData !== 'undefined' && body instanceof FormData) {
-    throw new TypeError('Failed to execute fetch: FormData body is not supported in request globals fetch')
+  if (isFormDataInstance(body)) {
+    const payload = await encodeMultipartFormData(body)
+    if (!hasHeader(headers, 'content-type')) {
+      headers['content-type'] = payload.contentType
+    }
+    return payload.body
   }
   return String(body)
 }

--- a/packages-runtime/web-apis/src/multipart.ts
+++ b/packages-runtime/web-apis/src/multipart.ts
@@ -1,0 +1,85 @@
+import { encodeText } from './shared'
+
+export interface MultipartFormDataPayload {
+  body: ArrayBuffer
+  contentType: string
+}
+
+type MultipartFormDataEntryValue = Blob | File | string | {
+  readonly name?: string
+  readonly size?: number
+  readonly type?: string
+  arrayBuffer: () => Promise<ArrayBuffer>
+}
+type FormDataLike = Iterable<[string, MultipartFormDataEntryValue]>
+
+const CRLF = '\r\n'
+
+function createMultipartBoundary() {
+  return `----weapp-vite-formdata-${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`
+}
+
+function escapeMultipartName(value: string) {
+  return String(value).replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('\r', '%0D').replaceAll('\n', '%0A')
+}
+
+function concatArrayBuffers(buffers: ArrayBuffer[]) {
+  const totalLength = buffers.reduce((sum, buffer) => sum + buffer.byteLength, 0)
+  const merged = new Uint8Array(totalLength)
+  let offset = 0
+  for (const buffer of buffers) {
+    merged.set(new Uint8Array(buffer), offset)
+    offset += buffer.byteLength
+  }
+  return merged.buffer
+}
+
+function isBlobFormDataValue(value: MultipartFormDataEntryValue): value is Exclude<MultipartFormDataEntryValue, string> {
+  return typeof value !== 'string' && typeof value?.arrayBuffer === 'function'
+}
+
+function getMultipartFilename(value: Exclude<MultipartFormDataEntryValue, string>) {
+  const name = (value as { name?: unknown }).name
+  return typeof name === 'string' && name.length > 0 ? name : 'blob'
+}
+
+async function createMultipartPart(name: string, value: MultipartFormDataEntryValue) {
+  if (!isBlobFormDataValue(value)) {
+    return [
+      encodeText(`Content-Disposition: form-data; name="${escapeMultipartName(name)}"${CRLF}${CRLF}`),
+      encodeText(String(value)),
+      encodeText(CRLF),
+    ]
+  }
+
+  const filename = getMultipartFilename(value)
+  const headers = [
+    `Content-Disposition: form-data; name="${escapeMultipartName(name)}"; filename="${escapeMultipartName(filename)}"`,
+    `Content-Type: ${value.type || 'application/octet-stream'}`,
+    '',
+    '',
+  ].join(CRLF)
+
+  return [
+    encodeText(headers),
+    await value.arrayBuffer(),
+    encodeText(CRLF),
+  ]
+}
+
+export async function encodeMultipartFormData(formData: FormDataLike): Promise<MultipartFormDataPayload> {
+  const boundary = createMultipartBoundary()
+  const buffers: ArrayBuffer[] = []
+
+  for (const [name, value] of formData) {
+    buffers.push(encodeText(`--${boundary}${CRLF}`))
+    buffers.push(...await createMultipartPart(name, value))
+  }
+
+  buffers.push(encodeText(`--${boundary}--${CRLF}`))
+
+  return {
+    body: concatArrayBuffers(buffers),
+    contentType: `multipart/form-data; boundary=${boundary}`,
+  }
+}

--- a/packages-runtime/web-apis/src/web.ts
+++ b/packages-runtime/web-apis/src/web.ts
@@ -153,6 +153,10 @@ export class FormDataPolyfill {
   set(name: string, value: BlobLikePart, filename?: string): void
   set(name: string, value: BlobLikePart | string, filename?: string) {
     this.delete(name)
+    if (typeof value === 'string') {
+      this.append(name, value)
+      return
+    }
     this.append(name, value, filename)
   }
 

--- a/packages-runtime/web-apis/test/runtime.test.ts
+++ b/packages-runtime/web-apis/test/runtime.test.ts
@@ -408,6 +408,51 @@ describe('request globals runtime', () => {
     expect(await blobFile.text()).toBe('blob text')
   })
 
+  it('serializes FormData Blob and File values into multipart fetch bodies', async () => {
+    let requestOptions: Record<string, any> | undefined
+    wpiRequestMock.mockImplementation((options: Record<string, any>) => {
+      requestOptions = options
+      options.success?.({
+        data: '{"ok":true}',
+        statusCode: 200,
+        header: {
+          'content-type': 'application/json',
+        },
+      })
+      return {
+        abort: vi.fn(),
+      }
+    })
+
+    const { installRequestGlobals } = await import('../src')
+    installRequestGlobals({
+      targets: ['fetch'],
+    })
+
+    const formData = new globalThis.FormData()
+    formData.append('message', 'hello')
+    formData.append('blob-file', new globalThis.Blob(['blob payload'], { type: 'text/plain' }), 'blob.txt')
+    formData.append('file-file', new globalThis.File(['file payload'], 'file.txt', { type: 'text/plain' }))
+
+    const response = await globalThis.fetch('https://request-globals.invalid/upload', {
+      body: formData,
+      method: 'POST',
+    })
+
+    expect(await response.json()).toEqual({ ok: true })
+    expect(requestOptions?.header['content-type']).toMatch(/^multipart\/form-data; boundary=----weapp-vite-formdata-/)
+    expect(requestOptions?.data).toBeInstanceOf(ArrayBuffer)
+
+    const multipartBody = new TextDecoder().decode(requestOptions?.data)
+    expect(multipartBody).toContain('name="message"')
+    expect(multipartBody).toContain('hello')
+    expect(multipartBody).toContain('name="blob-file"; filename="blob.txt"')
+    expect(multipartBody).toContain('Content-Type: text/plain')
+    expect(multipartBody).toContain('blob payload')
+    expect(multipartBody).toContain('name="file-file"; filename="file.txt"')
+    expect(multipartBody).toContain('file payload')
+  })
+
   it('installs request globals onto additional mini-program host globals discovered from shared platform registry', async () => {
     ;(globalThis as Record<string, any>).swan = {}
 


### PR DESCRIPTION
## 摘要

- 为 `@wevu/web-apis` 的 fetch 增加 FormData multipart 序列化，支持 Blob/File 字段上传并保留 filename 与 content-type。
- 在 `e2e-apps/github-issues` 的 issue #448 页面补充 `wx.downloadFile -> Blob/File -> FormData -> fetch` 真实验收链路。
- 新增 IDE runtime 用例，通过本地服务端校验上传文件的 sha256、size、filename 与 content-type。

## 验证

- `pnpm --filter @wevu/web-apis typecheck`
- `pnpm --filter @wevu/web-apis test`
- `pnpm eslint e2e-apps/github-issues/src/pages/issue-448/index.vue e2e-apps/github-issues/weapp-vite.config.ts e2e/ci/github-issues.build.test.ts e2e/ide/github-issues.runtime.issue448-formdata-upload.test.ts e2e/utils/requestClientsRealServer.ts packages-runtime/web-apis/src/fetch.ts packages-runtime/web-apis/src/multipart.ts packages-runtime/web-apis/src/web.ts packages-runtime/web-apis/test/runtime.test.ts`
- `pnpm --filter @wevu/web-apis build`
- `pnpm --filter weapp-vite build`
- `pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts`
- `node --import tsx scripts/check-e2e-ide-shared-launch.ts`
- `pnpm vitest run -c ./e2e/vitest.e2e.devtools.config.ts e2e/ide/github-issues.runtime.issue448-formdata-upload.test.ts`

## 说明

`e2e/utils/requestClientsRealServer.ts` 超过 300 行。本次保留 issue #448 的下载与 multipart 上传端点在现有共享真实服务中，避免为单个验收链路再引入独立服务启动、端口管理和 IDE 清理逻辑；运行时 multipart 编码本身已拆到 `packages-runtime/web-apis/src/multipart.ts`。

Closes #448