### PR TITLE
fix(weapp-vite): 收敛默认 auto HMR 共享 chunk 扇出

### DIFF
--- a/.changeset/scoped-tdesign-template-hmr.md
+++ b/.changeset/scoped-tdesign-template-hmr.md
@@ -1,0 +1,6 @@
+---
+"create-weapp-vite": patch
+"weapp-vite": patch
+---
+
+优化默认 `auto` 模式下的 HMR 入口收敛逻辑。直接编辑页面或组件入口时，不再因为稳定公共 chunk 的 importer 很多而扩散成大量入口重新构建；普通旁路模板、样式、JSON 更新也不再强制 full shared chunk refresh，同时保留依赖驱动、layout、配置类和旁路拓扑变化的跨入口刷新能力。

--- a/docs/reports/2026-06-14-tdesign-template-hmr-report.md
+++ b/docs/reports/2026-06-14-tdesign-template-hmr-report.md
@@ -1,0 +1,124 @@
+# 2026-06-14 TDesign Wevu 模板 HMR 报告
+
+## 结论
+
+本次先针对两个较重的 wevu + TDesign 模板建立守卫测试，并优化 weapp-vite 默认 `auto` 模式下的 HMR 入口收敛逻辑。调整后，保存 Vue SFC 模板时的 HMR 影响面已从多入口扇出收敛到单入口更新，不需要在模板里配置 `sharedChunks: 'off'`。
+
+第二轮继续收窄 sidecar snapshot build：只有无法定位到单入口的旁路拓扑变化才强制 full shared chunk refresh；普通 `.wxml`、`.wxss`、`.json` 窄入口更新保持默认 `auto` 逻辑。retail 模板的 `app-style` 采样从前序约 `25855.4ms` 降到 `17574.1ms`，主要收益来自减少 sidecar 更新时不必要的 shared chunk 图刷新。
+
+CI 已有 `Workspace HMR Changed Projects` 和 `Workspace HMR Nightly Full` 两个任务生成 `.tmp/workspace-hmr/**` 报告 artifact；本地可通过 `pnpm audit:hmr:*` 生成同格式报告。
+
+## 本次验证命令
+
+```bash
+pnpm vitest run packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts packages/weapp-vite/src/runtime/buildPlugin/service.test.ts packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts scripts/workspace-hmr/baseline.test.ts packages/weapp-vite/src/plugins/core.test.ts packages/weapp-vite/src/plugins/core/helpers/graph.test.ts
+```
+
+结果：6 个测试文件通过，159 个测试用例通过。
+
+```bash
+pnpm vitest run --pool forks -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/hmr-shared-chunks-auto.test.ts
+```
+
+结果：1 个测试文件通过，2 个测试用例通过。
+
+```bash
+pnpm vitest run --pool forks -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/e2e-app-tailwind-memory-guard.test.ts
+```
+
+结果：1 个测试文件通过，3 个测试用例通过。GC 后 heap 增长分别为 `29.1 MiB`、`27.8 MiB`、`53.1 MiB`，均低于 `180.0 MiB` 阈值。
+
+```bash
+WORKSPACE_HMR_MODE=smoke \
+WORKSPACE_HMR_SCOPE=templates \
+WORKSPACE_HMR_FILTER=weapp-vite-wevu-tailwindcss-tdesign \
+WORKSPACE_HMR_REPORT_DIR=.tmp/workspace-hmr-tdesign-auto \
+WORKSPACE_HMR_FAIL_ON_ERROR=1 \
+WORKSPACE_HMR_MAX_STARTUP_MS=60000 \
+pnpm exec tsx ./scripts/audit-workspace-hmr.ts
+```
+
+结果文件：
+
+- `.tmp/workspace-hmr-tdesign-auto/report.md`
+- `.tmp/workspace-hmr-tdesign-auto/report.json`
+- `.tmp/workspace-hmr-tdesign-auto/thresholds.md`
+
+```bash
+WORKSPACE_HMR_MODE=changed-project \
+WORKSPACE_HMR_SCOPE=workspace \
+WORKSPACE_HMR_FAIL_ON_ERROR=1 \
+WORKSPACE_HMR_STARTUP_TIMEOUT_MS=180000 \
+WORKSPACE_HMR_TIMEOUT_MS=60000 \
+WORKSPACE_HMR_MAX_STARTUP_MS=180000 \
+WORKSPACE_HMR_MAX_SCENARIO_MS=1000 \
+WORKSPACE_HMR_MAX_P95_MS=1000 \
+WORKSPACE_HMR_MAX_REGRESSION_MS=12000 \
+WORKSPACE_HMR_MAX_PENDING_COUNT=16 \
+WORKSPACE_HMR_MAX_EMITTED_COUNT=16 \
+WORKSPACE_HMR_MAX_PENDING_DELTA=8 \
+WORKSPACE_HMR_MAX_EMITTED_DELTA=8 \
+WORKSPACE_HMR_REPORT_DIR=.tmp/workspace-hmr-ci-final \
+pnpm exec tsx ./scripts/audit-workspace-hmr.ts
+```
+
+结果：changed-project fallback smoke 通过。
+
+## Smoke 结果
+
+| project | scenario | total | observed | build | write | pending/emitted | impact |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| `templates/weapp-vite-wevu-tailwindcss-tdesign-retail-template` | `vue-template` | 1962.8ms | 2289.4ms | 860.8ms | 1089.2ms | 1 / 1 | `pages/category/index.wxml` |
+| `templates/weapp-vite-wevu-tailwindcss-tdesign-template` | `vue-template` | 516.0ms | 1012.5ms | 313.6ms | 187.5ms | 1 / 1 | `pages/index/index.wxml` |
+
+Threshold 结果：
+
+- measured scenarios: 2/2
+- scenario P95: 1962.8ms
+- threshold issues: 0
+
+## 对比基线
+
+优化前采样中，retail 模板 `vue-page-script` 曾出现 `pending/emitted = 75 / 75`，总耗时约 19817.6ms，pending 原因包含 `shared-chunk(common.js,wevu-ref.js+)+74:direct`。
+
+当前 smoke 报告中两个模板均为 `pending/emitted = 1 / 1`，说明默认 `auto` 模式下，页面级 Vue SFC 模板更新不再因为稳定公共 chunk importer 扇出而触发大量入口重建。
+
+## 剩余瓶颈
+
+retail 模板首轮启动仍偏慢：
+
+- startup: 29080.9ms
+
+前序详细 benchmark 采样到 retail 模板仍存在非 shared chunk 扇出瓶颈：
+
+| scenario | total |
+| --- | ---: |
+| `vue-app-json-macro` | 10022.4ms |
+| `vue-page-json-macro` | 1673.4ms |
+| `vue-page-template` | 3387.5ms |
+| `vue-page-script` | 3946.0ms |
+| `app-style` | 25855.4ms |
+| `json-sitemap` | 2003.7ms |
+
+第二轮 sidecar 优化后，retail 模板局部采样结果：
+
+| scenario | total | build-core | transform | write | pending/emitted |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `vue-app-json-macro` | 6691.8ms | 674.1ms | 5.2ms | 6004.6ms | 1 / 1 |
+| `vue-page-json-macro` | 1623.5ms | 504.9ms | 5.4ms | 1108.1ms | 2 / 2 |
+| `vue-page-template` | 3771.3ms | 543.6ms | 1067.2ms | 3203.2ms | 1 / 3 |
+| `vue-page-script` | 3193.4ms | 665.0ms | 605.5ms | 2514.8ms | 1 / 1 |
+| `app-style` | 17574.1ms | 5939.1ms | 6.2ms | 11615.1ms | 2 / 2 |
+
+其中 `app-style` 仍然是全局样式、Tailwind `@source` 扫描和写盘链路成本，不能通过关闭 shared chunk 或手写产物规避。当前优化只收敛 weapp-vite 自身不必要的 shared refresh，剩余瓶颈需要继续拆解 Tailwind 生成和 Rolldown write 阶段。
+
+## 守卫覆盖
+
+- `packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts`：锁定默认 `auto` 模式下，即使稳定 vendor shared chunk 有 75 个 importer，直接入口更新也只重建当前 dirty 入口。
+- `packages/weapp-vite/src/runtime/buildPlugin/service.test.ts`：锁定窄 sidecar snapshot build 不再强制 full shared chunk refresh，同时保留拓扑变化的 full fallback。
+- `scripts/workspace-hmr/baseline.test.ts`：锁定模板 HMR 扇出超过优化预算时会快速报错，避免 `75 / 75` 这类结果静默通过。
+- `scripts/workspace-hmr/templates-baseline.json`：更新 `templates/weapp-vite-lib-template` 的 `native-script` 稳定 impact 基线，并将该场景增量 impact 预算设为 0，避免 changed-project smoke 因旧基线误报，也避免新增写盘文件静默通过。
+
+## 后续建议
+
+下一步建议继续拆分 retail 模板的 Tailwind 全局样式生成、Rolldown write 阶段和首轮启动阶段。当前默认 `auto` 模式下，页面 Vue SFC 保存和窄 sidecar 更新的共享 chunk 扇出已经收敛，但全局样式写盘仍然是主要耗时来源。

--- a/e2e/ci/hmr-shared-chunks-auto.test.ts
+++ b/e2e/ci/hmr-shared-chunks-auto.test.ts
@@ -104,7 +104,7 @@ afterEach(async () => {
 })
 
 describe.sequential('hmr sharedChunks auto diagnostics (dev watch)', () => {
-  it('expands direct page edits through non-source shared chunks without emitAll', async () => {
+  it('keeps direct page edits scoped across stable shared chunks', async () => {
     await fs.remove(DIST_ROOT)
     const originalConfig = await fs.readFile(CONFIG_PATH, 'utf8')
     const originalSource = await fs.readFile(PAGE_HMR_SOURCE_PATH, 'utf8')
@@ -140,18 +140,17 @@ describe.sequential('hmr sharedChunks auto diagnostics (dev watch)', () => {
           profile.file === PAGE_HMR_SOURCE_PATH
           && (profile.event === 'create' || profile.event === 'update')
           && typeof profile.pendingCount === 'number'
-          && profile.pendingCount > 1
+          && profile.pendingCount === 1
           && typeof profile.emittedCount === 'number'
-          && profile.emittedCount === profile.pendingCount
+          && profile.emittedCount === 1
           && (profile.dirtyReasonSummary ?? []).includes('entry-direct:1'),
         ),
         'direct page edit shared-chunk auto hmr profile',
       )
       expect(sample.dirtyCount).toBe(1)
-      expect(sample.pendingCount).toBeGreaterThan(1)
-      expect(sample.pendingReasonSummary?.some(reason =>
-        reason.startsWith('shared-chunk(') && reason.endsWith(':direct'),
-      )).toBe(true)
+      expect(sample.pendingCount).toBe(1)
+      expect(sample.emittedCount).toBe(1)
+      expect(sample.pendingReasonSummary ?? []).toEqual([])
       expect(dev.getOutput()).toContain('小程序已重新构建（')
     }
     finally {

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts
@@ -225,6 +225,36 @@ describe('useLoadEntry emitDirtyEntries', () => {
     expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps auto-mode direct rebuilds scoped even when stable vendor chunks have many importers', async () => {
+    const ctx = createContext()
+    const sharedChunkImporters = new Map<string, Set<string>>()
+    const sharedChunksByEntry = new Map<string, Set<string>>()
+    const sourceSharedChunks = new Set<string>()
+    const hook = useLoadEntry(ctx, {
+      hmr: {
+        sharedChunks: 'auto',
+        sharedChunkImporters,
+        sharedChunksByEntry,
+        sourceSharedChunks,
+      },
+    })
+
+    const ids = Array.from({ length: 75 }, (_, index) => `/project/src/pages/retail-${index}/index.vue`)
+    seedResolvedEntries(hook.resolvedEntryMap, ids)
+    sharedChunkImporters.set('weapp-vendors/wevu-ref.js', new Set(ids))
+    sharedChunksByEntry.set(ids[0], new Set(['weapp-vendors/wevu-ref.js']))
+    sourceSharedChunks.add('weapp-vendors/wevu-ref.js')
+    hook.markEntryDirty(ids[0], 'direct')
+
+    const pluginCtx = createPluginContext()
+    await hook.emitDirtyEntries.call(pluginCtx)
+
+    expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
+    expect(ctx.runtimeState.build.hmr.profile.pendingCount).toBe(1)
+    expect(ctx.runtimeState.build.hmr.profile.emittedCount).toBe(1)
+    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual([])
+  })
+
   it('keeps incremental rebuilds when no shared chunks are detected', async () => {
     const ctx = createContext()
     const sharedChunkImporters = new Map<string, Set<string>>()
@@ -314,7 +344,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
     expect(pluginCtx.emitFile).toHaveBeenCalledTimes(4)
   })
 
-  it('expands direct entry updates across non-source vendor shared chunk importers', async () => {
+  it('keeps direct entry updates scoped across stable vendor shared chunk importers', async () => {
     const ctx = createContext()
     const sharedChunkImporters = new Map<string, Set<string>>()
     const sharedChunksByEntry = new Map<string, Set<string>>()
@@ -335,11 +365,11 @@ describe('useLoadEntry emitDirtyEntries', () => {
     const pluginCtx = createPluginContext()
     await hook.emitDirtyEntries.call(pluginCtx)
 
-    expect(pluginCtx.emitFile).toHaveBeenCalledTimes(3)
-    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual(['shared-chunk(wevu-src.js)+2:direct'])
+    expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
+    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual([])
   })
 
-  it('expands direct entry updates across stable root shared chunk importers', async () => {
+  it('keeps direct entry updates incremental across stable root shared chunk importers', async () => {
     const ctx = createContext()
     const sharedChunkImporters = new Map<string, Set<string>>()
     const sharedChunksByEntry = new Map<string, Set<string>>()
@@ -367,10 +397,10 @@ describe('useLoadEntry emitDirtyEntries', () => {
     const pluginCtx = createPluginContext()
     await hook.emitDirtyEntries.call(pluginCtx)
 
-    expect(pluginCtx.emitFile).toHaveBeenCalledTimes(3)
-    expect(setDidEmitAllEntries).toHaveBeenLastCalledWith(true)
-    expect(setLastEmittedEntries).toHaveBeenLastCalledWith(new Set(ids))
-    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual(['shared-chunk(common.js)+2:direct'])
+    expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
+    expect(setDidEmitAllEntries).toHaveBeenLastCalledWith(false)
+    expect(setLastEmittedEntries).toHaveBeenLastCalledWith(new Set([ids[0]]))
+    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual([])
   })
 
   it('records only actual chunk emits when root inputs participate in stable shared chunks', async () => {
@@ -403,12 +433,12 @@ describe('useLoadEntry emitDirtyEntries', () => {
     const pluginCtx = createPluginContext()
     await hook.emitDirtyEntries.call(pluginCtx)
 
-    expect(pluginCtx.emitFile).toHaveBeenCalledTimes(2)
-    expect(setDidEmitAllEntries).toHaveBeenLastCalledWith(true)
-    expect(setLastEmittedEntries).toHaveBeenLastCalledWith(new Set(ids))
+    expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
+    expect(setDidEmitAllEntries).toHaveBeenLastCalledWith(false)
+    expect(setLastEmittedEntries).toHaveBeenLastCalledWith(new Set([ids[1]]))
   })
 
-  it('expands stable root shared chunk updates to the app entry', async () => {
+  it('keeps stable root shared chunk direct updates scoped to the dirty entry', async () => {
     const ctx = createContext()
     const sharedChunkImporters = new Map<string, Set<string>>()
     const sharedChunksByEntry = new Map<string, Set<string>>()
@@ -434,12 +464,12 @@ describe('useLoadEntry emitDirtyEntries', () => {
     const pluginCtx = createPluginContext()
     await hook.emitDirtyEntries.call(pluginCtx)
 
-    expect(pluginCtx.emitFile).toHaveBeenCalledTimes(3)
-    expect(setDidEmitAllEntries).toHaveBeenLastCalledWith(true)
-    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual(['shared-chunk(common.js)+2:direct'])
+    expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
+    expect(setDidEmitAllEntries).toHaveBeenLastCalledWith(false)
+    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual([])
   })
 
-  it('expands direct page template edits across stable vendor chunks even when they contain source modules', async () => {
+  it('keeps direct page template edits scoped across stable vendor chunks even when they contain source modules', async () => {
     const ctx = createContext()
     const sharedChunkImporters = new Map<string, Set<string>>()
     const sharedChunksByEntry = new Map<string, Set<string>>()
@@ -463,8 +493,8 @@ describe('useLoadEntry emitDirtyEntries', () => {
     const pluginCtx = createPluginContext()
     await hook.emitDirtyEntries.call(pluginCtx)
 
-    expect(pluginCtx.emitFile).toHaveBeenCalledTimes(3)
-    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual(['shared-chunk(wevu-ref.js)+2:direct'])
+    expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
+    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual([])
   })
 
   it('keeps large direct importer sets incremental for source-only nested chunks', async () => {
@@ -523,7 +553,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
     expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual(['shared-chunk(common.js)+2:dependency'])
   })
 
-  it('expands direct entry updates across stable vendor chunks even when source chunk ownership is incomplete', async () => {
+  it('keeps direct entry updates scoped across stable vendor chunks even when source chunk ownership is incomplete', async () => {
     const ctx = createContext()
     const sharedChunkImporters = new Map<string, Set<string>>()
     const sharedChunksByEntry = new Map<string, Set<string>>()
@@ -547,8 +577,8 @@ describe('useLoadEntry emitDirtyEntries', () => {
     const pluginCtx = createPluginContext()
     await hook.emitDirtyEntries.call(pluginCtx)
 
-    expect(pluginCtx.emitFile).toHaveBeenCalledTimes(20)
-    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual(['shared-chunk(wevu-ref.js)+19:direct'])
+    expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
+    expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual([])
   })
 
   it('keeps metadata entry updates incremental across nested source shared chunk importers', async () => {

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.ts
@@ -131,13 +131,13 @@ function resolvePendingEntryIds(options: {
     }
     for (const chunkId of chunkIds) {
       const isSourceSharedChunk = options.sourceSharedChunks?.has(chunkId) === true
+      const isStableSharedChunk = shouldExpandStableSharedChunk(chunkId, options.sharedChunkImporters?.get(chunkId))
       if (dirtyReason === 'metadata') {
         continue
       }
       if (
         dirtyReason === 'dependency'
-        || !isSourceSharedChunk
-        || shouldExpandStableSharedChunk(chunkId, options.sharedChunkImporters?.get(chunkId))
+        || (!isSourceSharedChunk && !isStableSharedChunk)
       ) {
         relatedChunkIds.add(chunkId)
       }

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
@@ -451,7 +451,7 @@ describe('runtime buildPlugin service', () => {
     expect(ctx.runtimeState.build.hmr.loadedEntrySet.has('/project/src/pages/about/index.ts')).toBe(true)
     expect(touchMock).not.toHaveBeenCalled()
     expect(loggerSuccessMock).toHaveBeenCalled()
-    expect(forceFullValues).toEqual(['1'])
+    expect(forceFullValues).toEqual([undefined])
   })
 
   it('keeps full snapshot fallback for sidecar topology changes', async () => {

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.ts
@@ -766,14 +766,8 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
         const sidecarEntryId = await resolveSnapshotSidecarEntryId(reason)
         if (sidecarEntryId) {
           markSnapshotEntryDirty(sidecarEntryId)
-          process.env.WEAPP_VITE_FORCE_FULL_HMR_SHARED_CHUNKS = '1'
-          try {
-            await build(snapshotBuildOptions)
-            return 'snapshot'
-          }
-          finally {
-            delete process.env.WEAPP_VITE_FORCE_FULL_HMR_SHARED_CHUNKS
-          }
+          await build(snapshotBuildOptions)
+          return 'snapshot'
         }
         markSnapshotEntriesFullDirty()
         process.env.WEAPP_VITE_FORCE_FULL_HMR_SHARED_CHUNKS = '1'

--- a/scripts/workspace-hmr/baseline.test.ts
+++ b/scripts/workspace-hmr/baseline.test.ts
@@ -125,6 +125,34 @@ describe('workspace HMR baseline thresholds', () => {
     ], { baseline }).issues).toHaveLength(0)
   })
 
+  it('fails fast when template HMR fanout exceeds the optimized pending budget', () => {
+    const evaluation = evaluateWorkspaceHmrThresholds([
+      {
+        ...templateResult,
+        id: 'templates/weapp-vite-wevu-tailwindcss-tdesign-retail-template',
+        scenarios: [
+          {
+            ...templateResult.scenarios[0]!,
+            id: 'vue-script',
+            profile: {
+              dirtyCount: 1,
+              pendingCount: 75,
+              emittedCount: 75,
+            },
+          },
+        ],
+      },
+    ], {
+      overrides: {
+        maxPendingCount: 12,
+        maxEmittedCount: 12,
+      },
+    })
+
+    expect(evaluation.issues.map(issue => issue.metric)).toEqual(['pendingCount', 'emittedCount'])
+    expect(renderThresholdMarkdown(evaluation)).toContain('templates/weapp-vite-wevu-tailwindcss-tdesign-retail-template')
+  })
+
   it('uses a template baseline alias for mirrored e2e apps', () => {
     const baseline = createWorkspaceHmrBaseline([
       {
@@ -402,5 +430,73 @@ describe('workspace HMR baseline thresholds', () => {
 
     expect(evaluation.issues).toHaveLength(2)
     expect(evaluation.issues.every(issue => issue.metric === 'baseline')).toBe(true)
+  })
+
+  it('allows scenario-level impact budgets while still blocking extra emitted files', () => {
+    const baseline = createWorkspaceHmrBaseline([{
+      ...templateResult,
+      id: 'templates/weapp-vite-lib-template',
+      scenarios: [{
+        ...templateResult.scenarios[0]!,
+        id: 'native-script',
+        impact: [
+          { path: 'components/sfc-both/index.js', status: 'modified' },
+          { path: 'components/sfc-setup/index.js', status: 'modified' },
+          { path: 'pages/index/index.js', status: 'modified' },
+          { path: 'pages/index/index.wxml', status: 'modified' },
+        ],
+      }],
+    }], {
+      generatedAt: '2026-04-29T00:00:00.000Z',
+      mode: 'templates-baseline',
+      thresholds: {
+        maxImpactFileDelta: 2,
+      },
+    })
+    baseline.projects['templates/weapp-vite-lib-template']!.scenarios['native-script']!.thresholds = {
+      maxImpactFileDelta: 0,
+    }
+
+    const stable = evaluateWorkspaceHmrThresholds([{
+      ...templateResult,
+      id: 'templates/weapp-vite-lib-template',
+      scenarios: [{
+        ...templateResult.scenarios[0]!,
+        id: 'native-script',
+        impact: [
+          { path: 'components/sfc-both/index.js', status: 'modified' },
+          { path: 'components/sfc-setup/index.js', status: 'modified' },
+          { path: 'pages/index/index.js', status: 'modified' },
+          { path: 'pages/index/index.wxml', status: 'modified' },
+        ],
+      }],
+    }], { baseline })
+
+    expect(stable.issues).toHaveLength(0)
+
+    const regressed = evaluateWorkspaceHmrThresholds([{
+      ...templateResult,
+      id: 'templates/weapp-vite-lib-template',
+      scenarios: [{
+        ...templateResult.scenarios[0]!,
+        id: 'native-script',
+        impact: [
+          { path: 'components/sfc-both/index.js', status: 'modified' },
+          { path: 'components/sfc-setup/index.js', status: 'modified' },
+          { path: 'pages/index/index.js', status: 'modified' },
+          { path: 'pages/index/index.wxml', status: 'modified' },
+          { path: 'pages/index/index.wxss', status: 'modified' },
+        ],
+      }],
+    }], { baseline })
+
+    expect(regressed.issues).toMatchObject([{
+      project: 'templates/weapp-vite-lib-template',
+      scenario: 'native-script',
+      metric: 'impactFiles',
+      actual: 5,
+      limit: 4,
+      baseline: 4,
+    }])
   })
 })

--- a/scripts/workspace-hmr/templates-baseline.json
+++ b/scripts/workspace-hmr/templates-baseline.json
@@ -138,7 +138,10 @@
           "dirtyCount": 1,
           "pendingCount": 1,
           "emittedCount": 1,
-          "impactFiles": 1
+          "impactFiles": 4,
+          "thresholds": {
+            "maxImpactFileDelta": 0
+          }
         },
         "native-style": {
           "totalMs": 514,


### PR DESCRIPTION
## Summary
- 优化默认 `auto` 模式下的 HMR pending 入口收敛逻辑，直接编辑页面或组件入口时不再因为稳定公共 chunk importer 过多而扩散成大量入口重建。
- 保留依赖驱动、layout 和配置类更新的跨入口刷新能力。
- 补充 HMR 扇出守卫测试和模板 HMR 报告。

## Reports
- `docs/reports/2026-06-14-tdesign-template-hmr-report.md`

## Testing
- `pnpm --filter weapp-vite build`
- `pnpm vitest run packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts scripts/workspace-hmr/baseline.test.ts packages/weapp-vite/src/plugins/core.test.ts packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts packages/weapp-vite/src/plugins/core/helpers/graph.test.ts`
- `pnpm exec eslint --max-warnings=0 --no-warn-ignored packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.ts packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts scripts/workspace-hmr/baseline.test.ts docs/reports/2026-06-14-tdesign-template-hmr-report.md .changeset/scoped-tdesign-template-hmr.md`
- `WORKSPACE_HMR_MODE=smoke WORKSPACE_HMR_SCOPE=templates WORKSPACE_HMR_FILTER=weapp-vite-wevu-tailwindcss-tdesign WORKSPACE_HMR_REPORT_DIR=.tmp/workspace-hmr-tdesign-auto WORKSPACE_HMR_FAIL_ON_ERROR=1 WORKSPACE_HMR_MAX_STARTUP_MS=60000 pnpm exec tsx ./scripts/audit-workspace-hmr.ts`