### PR TITLE
fix(web-apis): 修复 Request FormData 请求体上传

### DIFF
--- a/.changeset/fix-request-formdata-body.md
+++ b/.changeset/fix-request-formdata-body.md
@@ -1,0 +1,5 @@
+---
+"@wevu/web-apis": patch
+---
+
+修复 `RequestPolyfill` 携带 `FormData` 请求体时被字符串化的问题，确保 `fetch(new Request(...))` 与直接传入 `FormData` 一样生成 multipart 请求体和对应请求头。

--- a/e2e-apps/github-issues/src/pages/issue-448/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-448/index.vue
@@ -60,6 +60,9 @@ interface MultipartUploadPayload {
   path: string
 }
 
+type UploadFormDataInput = Parameters<typeof fetch>[0]
+type UploadFormDataInit = Parameters<typeof fetch>[1]
+
 interface Issue448WxApi {
   downloadFile: (options: {
     fail?: (error: unknown) => void
@@ -132,6 +135,11 @@ function assertUploadPayload(payload: MultipartUploadPayload, expectedNames: str
   }
 }
 
+async function uploadFormData(input: UploadFormDataInput, init?: UploadFormDataInit) {
+  const response = await fetch(input, init)
+  return await response.json() as MultipartUploadPayload
+}
+
 async function uploadDownloadedFileAsFormData() {
   if (!baseUrl.value) {
     throw new Error('missing issue-448 baseUrl')
@@ -146,26 +154,33 @@ async function uploadDownloadedFileAsFormData() {
   const buffer = await readDownloadedFile(download.tempFilePath)
   const blobFormData = new FormData()
   blobFormData.append('blob-file', new Blob([buffer], { type: 'application/octet-stream' }), 'downloaded-blob.bin')
-  const blobResponse = await fetch(`${baseUrl.value}/issue-448/upload`, {
+  const blobPayload = await uploadFormData(`${baseUrl.value}/issue-448/upload`, {
     body: blobFormData,
     method: 'POST',
   })
-  const blobPayload = await blobResponse.json() as MultipartUploadPayload
   assertUploadPayload(blobPayload, ['blob-file'])
 
   const fileFormData = new FormData()
   fileFormData.append('file-file', new File([buffer], 'downloaded-file.bin', { type: 'application/octet-stream' }))
-  const fileResponse = await fetch(`${baseUrl.value}/issue-448/upload`, {
+  const filePayload = await uploadFormData(`${baseUrl.value}/issue-448/upload`, {
     body: fileFormData,
     method: 'POST',
   })
-  const filePayload = await fileResponse.json() as MultipartUploadPayload
   assertUploadPayload(filePayload, ['file-file'])
+
+  const requestFormData = new FormData()
+  requestFormData.append('request-file', new File([buffer], 'downloaded-request.bin', { type: 'application/octet-stream' }))
+  const requestPayload = await uploadFormData(new Request(`${baseUrl.value}/issue-448/upload`, {
+    body: requestFormData,
+    method: 'POST',
+  }))
+  assertUploadPayload(requestPayload, ['request-file'])
 
   const payload = {
     blob: blobPayload.files.find(item => item.name === 'blob-file'),
     expectedSha256: blobPayload.expectedSha256,
     file: filePayload.files.find(item => item.name === 'file-file'),
+    request: requestPayload.files.find(item => item.name === 'request-file'),
   }
   formDataUploadPayload.value = JSON.stringify(payload)
   formDataUploadStatus.value = 'passed'

--- a/e2e/ide/github-issues.runtime.issue448-formdata-upload.test.ts
+++ b/e2e/ide/github-issues.runtime.issue448-formdata-upload.test.ts
@@ -52,7 +52,7 @@ describe.sequential('github-issues runtime issue #448 FormData upload', () => {
     }
   })
 
-  it('uploads wx.downloadFile data as Blob and File FormData bodies in real DevTools', async (ctx) => {
+  it('uploads wx.downloadFile data as Blob, File, and Request FormData bodies in real DevTools', async (ctx) => {
     if (sharedInfraUnavailableMessage) {
       ctx.skip(sharedInfraUnavailableMessage)
     }
@@ -84,14 +84,22 @@ describe.sequential('github-issues runtime issue #448 FormData upload', () => {
         filename: 'downloaded-file.bin',
         name: 'file-file',
       })
+      expect(result?.payload?.request).toMatchObject({
+        contentType: 'application/octet-stream',
+        filename: 'downloaded-request.bin',
+        name: 'request-file',
+      })
       expect(result?.payload?.blob?.sha256).toBe(result?.payload?.expectedSha256)
       expect(result?.payload?.file?.sha256).toBe(result?.payload?.expectedSha256)
+      expect(result?.payload?.request?.sha256).toBe(result?.payload?.expectedSha256)
       expect(result?.payload?.blob?.size).toBeGreaterThan(0)
       expect(result?.payload?.file?.size).toBe(result?.payload?.blob?.size)
+      expect(result?.payload?.request?.size).toBe(result?.payload?.blob?.size)
       expect(runtime.formDataUploadStatus).toBe('passed')
       expect(runtime.formDataUploadPayload).toContain('downloaded-blob.bin')
       expect(runtime.formDataUploadPayload).toContain('downloaded-file.bin')
-      expect(serverHandle?.requestCounts.formDataUpload).toBe(2)
+      expect(runtime.formDataUploadPayload).toContain('downloaded-request.bin')
+      expect(serverHandle?.requestCounts.formDataUpload).toBe(3)
     }
     finally {
       await releaseSharedMiniProgram(miniProgram)

--- a/packages-runtime/web-apis/src/fetch.ts
+++ b/packages-runtime/web-apis/src/fetch.ts
@@ -7,7 +7,7 @@ import type { RequestGlobalsMiniProgramOptions } from './networkDefaults'
 import type { URLPolyfill } from './url'
 import { wpi } from '@wevu/api'
 import { isUrlInstance, isUrlSearchParamsInstance } from './constructors'
-import { HeadersPolyfill, ResponsePolyfill } from './http'
+import { getRequestBodyValue, HeadersPolyfill, RequestPolyfill, ResponsePolyfill } from './http'
 import { encodeMultipartFormData } from './multipart'
 import { resolveRequestMiniProgramOptions } from './networkDefaults'
 import { cloneArrayBuffer, cloneArrayBufferView, normalizeHeaderName } from './shared'
@@ -169,6 +169,9 @@ async function extractRequestBodyFromInput(input: RequestLikeInput | undefined) 
   }
   if (input.bodyUsed) {
     throw new TypeError('Failed to execute fetch: request body is already used')
+  }
+  if (input instanceof RequestPolyfill) {
+    return getRequestBodyValue(input)
   }
   const cloned = input.clone()
   if (cloned?.arrayBuffer) {

--- a/packages-runtime/web-apis/src/http.ts
+++ b/packages-runtime/web-apis/src/http.ts
@@ -7,6 +7,7 @@ import {
   encodeText,
   normalizeHeaderName,
 } from './shared'
+import { FormDataPolyfill } from './web'
 
 type HeaderTuple = readonly [string, string]
 type HeaderRecord = Record<string, string>
@@ -117,7 +118,7 @@ export class HeadersPolyfill {
   }
 }
 
-type RequestBodyLike = string | ArrayBuffer | ArrayBufferView | Blob | null | undefined
+type RequestBodyLike = string | ArrayBuffer | ArrayBufferView | Blob | FormData | FormDataPolyfill | null | undefined
 const requestBodyStore = new WeakMap<RequestPolyfill, RequestBodyLike>()
 const requestBodyUsedStore = new WeakMap<RequestPolyfill, boolean>()
 const responseBodyStore = new WeakMap<ResponsePolyfill, RequestBodyLike>()
@@ -128,6 +129,12 @@ function normalizeBody(body: unknown): RequestBodyLike {
     return body as RequestBodyLike
   }
   if (typeof Blob !== 'undefined' && body instanceof Blob) {
+    return body
+  }
+  if (typeof FormData !== 'undefined' && body instanceof FormData) {
+    return body
+  }
+  if (body instanceof FormDataPolyfill) {
     return body
   }
   return String(body)
@@ -160,7 +167,7 @@ async function readBodyAsText(body: RequestBodyLike) {
   return decodeText(buffer)
 }
 
-function getRequestBodyValue(request?: RequestPolyfill) {
+export function getRequestBodyValue(request?: RequestPolyfill) {
   return request ? requestBodyStore.get(request) : undefined
 }
 

--- a/packages-runtime/web-apis/test/runtime.test.ts
+++ b/packages-runtime/web-apis/test/runtime.test.ts
@@ -453,6 +453,48 @@ describe('request globals runtime', () => {
     expect(multipartBody).toContain('file payload')
   })
 
+  it('preserves FormData bodies when fetch receives a Request polyfill', async () => {
+    let requestOptions: Record<string, any> | undefined
+    wpiRequestMock.mockImplementation((options: Record<string, any>) => {
+      requestOptions = options
+      options.success?.({
+        data: '{"ok":true}',
+        statusCode: 200,
+        header: {
+          'content-type': 'application/json',
+        },
+      })
+      return {
+        abort: vi.fn(),
+      }
+    })
+
+    const { installRequestGlobals } = await import('../src')
+    installRequestGlobals({
+      targets: ['fetch', 'Request'],
+    })
+
+    const formData = new globalThis.FormData()
+    formData.append('message', 'hello')
+    formData.append('file', new globalThis.File(['file payload'], 'file.txt', { type: 'text/plain' }))
+
+    const request = new globalThis.Request('https://request-globals.invalid/upload', {
+      body: formData,
+      method: 'POST',
+    })
+    const response = await globalThis.fetch(request)
+
+    expect(await response.json()).toEqual({ ok: true })
+    expect(requestOptions?.header['content-type']).toMatch(/^multipart\/form-data; boundary=----weapp-vite-formdata-/)
+    expect(requestOptions?.data).toBeInstanceOf(ArrayBuffer)
+
+    const multipartBody = new TextDecoder().decode(requestOptions?.data)
+    expect(multipartBody).toContain('name="message"')
+    expect(multipartBody).toContain('hello')
+    expect(multipartBody).toContain('name="file"; filename="file.txt"')
+    expect(multipartBody).toContain('file payload')
+  })
+
   it('installs request globals onto additional mini-program host globals discovered from shared platform registry', async () => {
     ;(globalThis as Record<string, any>).swan = {}
 


### PR DESCRIPTION
## 背景

修复 #448 中关于 `RequestPolyfill` 的评论反馈：`fetch(new Request(url, { body: new FormData() }))` 应与 `fetch(url, { body: new FormData() })` 保持等价。此前 `RequestPolyfill` 会把 `FormData` 请求体字符串化，导致后续 `fetch(request)` 无法生成 multipart 请求体和请求头。

## 修改

- 保留 `RequestPolyfill` 内部的 `FormData` / `FormDataPolyfill` body 值。
- `fetch` 接收 `RequestPolyfill` 时直接读取内部原始 body，再复用现有 multipart 编码路径。
- 补充 `@wevu/web-apis` runtime 回归用例。
- 扩展 `e2e-apps/github-issues` 的 issue-448 上传场景，覆盖 `new Request(...FormData...)`。
- 补充 `@wevu/web-apis` patch changeset。

## 验证

- `pnpm --filter @wevu/web-apis test`
- `pnpm -C packages-runtime/web-apis test:types`
- `pnpm -C packages-runtime/web-apis typecheck`
- `pnpm exec eslint packages-runtime/web-apis/src/fetch.ts packages-runtime/web-apis/src/http.ts packages-runtime/web-apis/test/runtime.test.ts e2e-apps/github-issues/src/pages/issue-448/index.vue e2e/ide/github-issues.runtime.issue448-formdata-upload.test.ts`
- `pnpm build:pkgs`
- `pnpm --filter e2e-app-github-issues build`
- `pnpm vitest run -c ./e2e/vitest.e2e.config.ts e2e/ci/github-issues.build.test.ts -t "issue #448"`
- `pnpm run check:changeset:frontmatter`
- `pnpm run check:publishable-workspace-changeset`
- `pnpm run check:create-weapp-vite-changeset`

## 备注

未在本轮启动 WeChat DevTools IDE 自动化；已同步更新 `github-issues.runtime.issue448-formdata-upload.test.ts`，将真实运行时断言从 Blob/File 两条上传扩展到 Blob/File/Request 三条上传。