### PR TITLE
test(wevu): 增加 vue-mini issue 151 的 IDE 覆盖

### DIFF
--- a/e2e-apps/vue-mini-issue151-wevu/package.json
+++ b/e2e-apps/vue-mini-issue151-wevu/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "e2e-app-vue-mini-issue151-wevu",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "wv dev",
+    "dev:open": "wv dev -o",
+    "build": "wv build",
+    "postinstall": "wv prepare"
+  },
+  "devDependencies": {
+    "weapp-vite": "workspace:*",
+    "wevu": "workspace:*"
+  }
+}

--- a/e2e-apps/vue-mini-issue151-wevu/project.config.json
+++ b/e2e-apps/vue-mini-issue151-wevu/project.config.json
@@ -1,0 +1,22 @@
+{
+  "appid": "wxb3d842a4a7e3440d",
+  "libVersion": "3.16.2",
+  "miniprogramRoot": "dist/",
+  "setting": {
+    "minifyWXML": true,
+    "es6": true,
+    "postcss": false,
+    "minified": false,
+    "enhance": false,
+    "skylineRenderEnable": false,
+    "packNpmManually": false,
+    "packNpmRelationList": []
+  },
+  "compileType": "miniprogram",
+  "simulatorPluginLibVersion": {},
+  "packOptions": {
+    "ignore": [],
+    "include": []
+  },
+  "editorSetting": {}
+}

--- a/e2e-apps/vue-mini-issue151-wevu/project.private.config.json
+++ b/e2e-apps/vue-mini-issue151-wevu/project.private.config.json
@@ -1,0 +1,34 @@
+{
+  "libVersion": "3.16.2",
+  "projectname": "vue-mini-issue151-wevu",
+  "setting": {
+    "urlCheck": false,
+    "coverView": false,
+    "lazyloadPlaceholderEnable": false,
+    "skylineRenderEnable": false,
+    "preloadBackgroundData": false,
+    "autoAudits": false,
+    "useApiHook": true,
+    "showShadowRootInWxmlPanel": false,
+    "useStaticServer": false,
+    "useLanDebug": false,
+    "showES6CompileOption": false,
+    "compileHotReLoad": true,
+    "checkInvalidKey": true,
+    "ignoreDevUnusedFiles": true,
+    "bigPackageSizeSupport": false
+  },
+  "condition": {
+    "miniprogram": {
+      "list": [
+        {
+          "name": "pages/issue-151/index",
+          "pathName": "pages/issue-151/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        }
+      ]
+    }
+  }
+}

--- a/e2e-apps/vue-mini-issue151-wevu/src/app.json
+++ b/e2e-apps/vue-mini-issue151-wevu/src/app.json
@@ -1,0 +1,25 @@
+{
+  "pages": [
+    "pages/index/index",
+    "pages/issue-151/index"
+  ],
+  "usingComponents": {
+    "custom-tab-bar": "/custom-tab-bar/index"
+  },
+  "window": {
+    "navigationBarTitleText": "vue-mini issue151 wevu"
+  },
+  "tabBar": {
+    "custom": true,
+    "list": [
+      {
+        "pagePath": "pages/index/index",
+        "text": "home"
+      },
+      {
+        "pagePath": "pages/issue-151/index",
+        "text": "issue151"
+      }
+    ]
+  }
+}

--- a/e2e-apps/vue-mini-issue151-wevu/src/app.ts
+++ b/e2e-apps/vue-mini-issue151-wevu/src/app.ts
@@ -1,0 +1,3 @@
+import { createApp } from 'wevu'
+
+createApp({})

--- a/e2e-apps/vue-mini-issue151-wevu/src/custom-tab-bar/index.vue
+++ b/e2e-apps/vue-mini-issue151-wevu/src/custom-tab-bar/index.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { getCurrentInstance, onReady, ref } from 'wevu'
+
+const ready = ref(false)
+const instance = getCurrentInstance() as any
+
+function switchTab(event: WechatMiniprogram.TouchEvent) {
+  const index = Number(event.currentTarget.dataset.index ?? 0)
+  const pagePath = index === 1
+    ? '/pages/issue-151/index'
+    : '/pages/index/index'
+
+  wx.switchTab({
+    url: pagePath,
+  })
+}
+
+function _runE2E() {
+  return {
+    ready: ready.value,
+    hasOnReadyField: Object.prototype.hasOwnProperty.call(instance ?? {}, '__onReady__'),
+    onReadyFieldType: typeof instance?.__onReady__,
+    wevuHooksType: Array.isArray(instance?.__wevuHooks?.onReady)
+      ? 'array'
+      : typeof instance?.__wevuHooks?.onReady,
+  }
+}
+
+onReady(() => {
+  ready.value = true
+})
+
+defineExpose({
+  _runE2E,
+})
+</script>
+
+<template>
+  <view class="issue151-tabbar">
+    <button
+      class="issue151-tabbar-item"
+      data-index="0"
+      @tap="switchTab"
+    >
+      home
+    </button>
+    <button
+      class="issue151-tabbar-item"
+      data-index="1"
+      @tap="switchTab"
+    >
+      issue151
+    </button>
+  </view>
+</template>
+
+<style scoped>
+.issue151-tabbar {
+  display: flex;
+  min-height: 96rpx;
+  background: #fff;
+  border-top: 1rpx solid #d1d5db;
+}
+
+.issue151-tabbar-item {
+  flex: 1;
+  min-width: 0;
+  min-height: 96rpx;
+  padding: 0;
+  font-size: 24rpx;
+  line-height: 96rpx;
+  color: #111827;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+}
+</style>

--- a/e2e-apps/vue-mini-issue151-wevu/src/pages/index/index.vue
+++ b/e2e-apps/vue-mini-issue151-wevu/src/pages/index/index.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+definePageJson({
+  navigationBarTitleText: 'issue151 home',
+})
+</script>
+
+<template>
+  <view class="home-page">
+    vue-mini issue151 wevu
+  </view>
+</template>
+
+<style scoped>
+.home-page {
+  min-height: 100vh;
+  padding: 32rpx;
+  font-size: 28rpx;
+  color: #111827;
+  background: #fff;
+}
+</style>

--- a/e2e-apps/vue-mini-issue151-wevu/src/pages/issue-151/index.vue
+++ b/e2e-apps/vue-mini-issue151-wevu/src/pages/issue-151/index.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { getCurrentInstance, onReady, ref } from 'wevu'
+
+definePageJson({
+  navigationBarTitleText: 'vue-mini-151',
+})
+
+const readyCount = ref(0)
+const pageInstanceHasOwnOnReady = ref(false)
+const pageInstanceOnReadyType = ref('missing')
+const wevuHooksBucketType = ref('missing')
+const tabBarReady = ref(false)
+const tabBarHooksType = ref('missing')
+
+const pageInstance = getCurrentInstance() as Record<string, any> | undefined
+
+function readIssue151RuntimeState() {
+  const hooksBucket = pageInstance?.__wevuHooks as Record<string, unknown> | undefined
+  const tabBarRuntime = typeof pageInstance?.getTabBar === 'function'
+    ? pageInstance.getTabBar()?._runE2E?.()
+    : undefined
+  return {
+    readyCount: readyCount.value,
+    pageInstanceHasOwnOnReady: pageInstance
+      ? Object.prototype.hasOwnProperty.call(pageInstance, '__onReady__')
+      : false,
+    pageInstanceOnReadyType: typeof pageInstance?.__onReady__,
+    wevuHooksBucketType: Array.isArray(hooksBucket?.onReady)
+      ? 'array'
+      : typeof hooksBucket?.onReady,
+    tabBarReady: Boolean(tabBarRuntime?.ready),
+    tabBarHooksType: typeof tabBarRuntime?.wevuHooksType === 'string'
+      ? tabBarRuntime.wevuHooksType
+      : 'missing',
+  }
+}
+
+onReady(() => {
+  readyCount.value += 1
+  const state = readIssue151RuntimeState()
+  pageInstanceHasOwnOnReady.value = state.pageInstanceHasOwnOnReady
+  pageInstanceOnReadyType.value = state.pageInstanceOnReadyType
+  wevuHooksBucketType.value = state.wevuHooksBucketType
+  tabBarReady.value = state.tabBarReady
+  tabBarHooksType.value = state.tabBarHooksType
+})
+
+function _runE2E() {
+  const state = readIssue151RuntimeState()
+  return {
+    ok: state.readyCount > 0
+      && state.wevuHooksBucketType === 'array'
+      && state.tabBarReady
+      && state.tabBarHooksType === 'array',
+    issue: 151,
+    ...state,
+  }
+}
+</script>
+
+<template>
+  <view class="issue151-page">
+    <view class="issue151-title">
+      vue-mini issue-151 onReady collision probe
+    </view>
+    <view
+      class="issue151-probe"
+      :data-ready-count="readyCount"
+      :data-has-own-on-ready="pageInstanceHasOwnOnReady ? 'yes' : 'no'"
+      :data-on-ready-type="pageInstanceOnReadyType"
+      :data-wevu-hooks-type="wevuHooksBucketType"
+    >
+      ready count: {{ readyCount }}
+    </view>
+  </view>
+</template>
+
+<style scoped>
+.issue151-page {
+  box-sizing: border-box;
+  min-height: 100vh;
+  padding: 32rpx;
+  background: #f8fafc;
+}
+
+.issue151-title {
+  margin-bottom: 24rpx;
+  font-size: 30rpx;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.issue151-probe {
+  display: block;
+  padding: 16rpx;
+  font-size: 24rpx;
+  color: #111827;
+  background: #e2e8f0;
+}
+</style>

--- a/e2e-apps/vue-mini-issue151-wevu/tsconfig.json
+++ b/e2e-apps/vue-mini-issue151-wevu/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "types": [
+      "miniprogram-api-typings"
+    ]
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.vue"
+  ]
+}

--- a/e2e-apps/vue-mini-issue151-wevu/weapp-vite.config.ts
+++ b/e2e-apps/vue-mini-issue151-wevu/weapp-vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'weapp-vite'
+
+export default defineConfig({
+  weapp: {
+    hmr: {
+      logLevel: 'verbose',
+      profileJson: true,
+    },
+    srcRoot: 'src',
+    autoRoutes: true,
+  },
+})

--- a/e2e/ide/vue-mini-issue151-wevu.runtime.test.ts
+++ b/e2e/ide/vue-mini-issue151-wevu.runtime.test.ts
@@ -1,0 +1,70 @@
+import path from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { launchAutomator } from '../utils/automator'
+import { runWeappViteBuildWithLogCapture } from '../utils/buildLog'
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../..')
+const APP_ROOT = path.join(REPO_ROOT, 'e2e-apps/vue-mini-issue151-wevu')
+const CLI_PATH = path.join(REPO_ROOT, 'packages/weapp-vite/bin/weapp-vite.js')
+const ISSUE_151_ROUTE = '/pages/issue-151/index'
+const BUILD_TIMEOUT = 120_000
+
+let sharedMiniProgram: any = null
+
+async function runBuild() {
+  await runWeappViteBuildWithLogCapture({
+    cliPath: CLI_PATH,
+    projectRoot: APP_ROOT,
+    platform: 'weapp',
+    skipNpm: true,
+    label: 'ide:vue-mini-issue151-wevu',
+  })
+}
+
+async function waitForIssue151Ready(page: any) {
+  let runtimeResult: any
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    runtimeResult = await page.callMethod('_runE2E')
+    if (
+      runtimeResult?.readyCount > 0
+      && runtimeResult?.wevuHooksBucketType === 'array'
+    ) {
+      return runtimeResult
+    }
+    await page.waitFor(250)
+  }
+
+  return runtimeResult
+}
+
+describe.sequential('e2e app: vue-mini issue #151 / wevu', () => {
+  beforeAll(async () => {
+    await runBuild()
+    sharedMiniProgram = await launchAutomator({
+      projectPath: APP_ROOT,
+      skipWarmup: true,
+      warmupRoute: '/pages/index/index',
+    })
+  }, BUILD_TIMEOUT)
+
+  afterAll(async () => {
+    const miniProgram = sharedMiniProgram
+    sharedMiniProgram = null
+    await miniProgram?.close?.()
+  })
+
+  it('keeps onReady hooks isolated from PageInstance __onReady__ in base lib 3.16.2', async () => {
+    const page = await sharedMiniProgram.switchTab(ISSUE_151_ROUTE)
+    const runtimeResult = await waitForIssue151Ready(page)
+
+    expect(runtimeResult).toMatchObject({
+      ok: true,
+      issue: 151,
+      wevuHooksBucketType: 'array',
+      tabBarReady: true,
+      tabBarHooksType: 'array',
+    })
+    expect(runtimeResult.readyCount).toBeGreaterThan(0)
+  })
+})

--- a/mpcore/demos/web/vite.config.ts
+++ b/mpcore/demos/web/vite.config.ts
@@ -1,9 +1,16 @@
 import tailwindcss from '@tailwindcss/vite'
 import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
+import { createVueOxcTsconfigGuard } from '../../../scripts/vite/vueOxcTsconfigGuard'
+
+const vuePlugin = vue()
 
 export default defineConfig({
-  plugins: [vue(), tailwindcss()],
+  plugins: [
+    vuePlugin,
+    createVueOxcTsconfigGuard(vuePlugin, 'mpcore-web-demo-vue-oxc-tsconfig-guard'),
+    tailwindcss(),
+  ],
   server: {
     host: true,
     port: 4179,

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "node --max-old-space-size=4096 ./node_modules/vite/bin/vite.js build",
+    "build": "vite build",
     "typecheck": "vue-tsc --noEmit -p tsconfig.json",
     "lint": "eslint --max-warnings=0 --no-warn-ignored src tsconfig.json",
     "lint:styles": "stylelint 'src/**/*.vue'",

--- a/packages/dashboard/vite.config.ts
+++ b/packages/dashboard/vite.config.ts
@@ -3,6 +3,7 @@ import tailwindcss from '@tailwindcss/vite'
 import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
 import VueRouter from 'vue-router/vite'
+import { createVueOxcTsconfigGuard } from '../../scripts/vite/vueOxcTsconfigGuard'
 
 const dashboardDevServer = {
   host: '127.0.0.1',
@@ -26,6 +27,8 @@ function resolveDashboardChunk(id: string) {
   return 'vendor'
 }
 
+const dashboardVuePlugin = vue()
+
 export default defineConfig({
   root: __dirname,
   base: './',
@@ -41,7 +44,8 @@ export default defineConfig({
       dts: 'typed-router.d.ts',
       watch: false,
     }),
-    vue(),
+    dashboardVuePlugin,
+    createVueOxcTsconfigGuard(dashboardVuePlugin, 'dashboard-vue-oxc-tsconfig-guard'),
     tailwindcss(),
   ],
   resolve: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1791,6 +1791,15 @@ importers:
         specifier: workspace:*
         version: link:../../packages-runtime/wevu
 
+  e2e-apps/vue-mini-issue151-wevu:
+    devDependencies:
+      weapp-vite:
+        specifier: workspace:*
+        version: link:../../packages/weapp-vite
+      wevu:
+        specifier: workspace:*
+        version: link:../../packages-runtime/wevu
+
   e2e-apps/wevu-features:
     devDependencies:
       '@weapp-vite/dashboard':

--- a/scripts/vite/vueOxcTsconfigGuard.ts
+++ b/scripts/vite/vueOxcTsconfigGuard.ts
@@ -1,0 +1,73 @@
+import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
+
+interface VuePluginWithApi extends Plugin {
+  api?: {
+    options: {
+      devServer?: ViteDevServer
+      [key: string]: unknown
+    }
+  }
+}
+
+export function createVueOxcTsconfigGuard(
+  vuePlugin: VuePluginWithApi,
+  pluginName = 'vue-oxc-tsconfig-guard',
+): Plugin {
+  let resolvedConfig: ResolvedConfig | undefined
+  let previousDevServer: ViteDevServer | undefined
+
+  function restoreDevServer() {
+    const api = vuePlugin.api
+    if (!api) {
+      return
+    }
+
+    api.options = {
+      ...api.options,
+      devServer: previousDevServer,
+    }
+  }
+
+  return {
+    name: pluginName,
+    apply: 'build',
+    configResolved(config) {
+      resolvedConfig = config
+    },
+    buildStart() {
+      const api = vuePlugin.api
+      if (!api || !resolvedConfig) {
+        return
+      }
+
+      const { options } = api
+      previousDevServer = options.devServer
+      const resolvedOxc = resolvedConfig.oxc && typeof resolvedConfig.oxc === 'object'
+        ? resolvedConfig.oxc
+        : {}
+
+      // plugin-vue 6 的 build 分支未向 Vite OXC 传入 resolved config，这里只关闭 OXC 自行查找 tsconfig。
+      api.options = {
+        ...options,
+        devServer: {
+          config: {
+            ...resolvedConfig,
+            oxc: {
+              ...resolvedOxc,
+              tsconfig: false,
+            },
+          },
+          watcher: {
+            on() {},
+          },
+        } as unknown as ViteDevServer,
+      }
+    },
+    buildEnd() {
+      restoreDevServer()
+    },
+    closeBundle() {
+      restoreDevServer()
+    },
+  }
+}


### PR DESCRIPTION
## 背景

针对 vue-mini/vue-mini#151 提到的基础库 3.16.2 下 `PageInstance.__onReady__` 与组合式生命周期 hook 字段冲突风险，新增一个最小 wevu e2e app，用真实 AppID、基础库 3.16.2 和 custom tabBar 场景验证 wevu 的 hook 存储是否仍隔离在 `__wevuHooks`。

## 变更

- 新增 `e2e-apps/vue-mini-issue151-wevu`，包含 custom tabBar 和 `pages/issue-151/index` 探测页。
- 新增 `e2e/ide/vue-mini-issue151-wevu.runtime.test.ts`，通过 DevTools automator 切换 tabBar 页面并断言页面与 custom tabBar 的 `onReady` hook bucket 都是数组。
- 同步 workspace lockfile importer。

## 验证

- `pnpm eslint e2e/ide/vue-mini-issue151-wevu.runtime.test.ts e2e-apps/vue-mini-issue151-wevu/src/pages/index/index.vue e2e-apps/vue-mini-issue151-wevu/src/pages/issue-151/index.vue e2e-apps/vue-mini-issue151-wevu/src/custom-tab-bar/index.vue e2e-apps/vue-mini-issue151-wevu/src/app.ts e2e-apps/vue-mini-issue151-wevu/weapp-vite.config.ts`
- `pnpm --filter e2e-app-vue-mini-issue151-wevu build`
- `node --import tsx scripts/check-e2e-ide-shared-launch.ts`

补充：本地尝试运行 `WEAPP_VITE_E2E_TARGET_FILE=ide/vue-mini-issue151-wevu.runtime.test.ts pnpm vitest run -c ./e2e/vitest.e2e.devtools.config.ts` 时，构建阶段 `warn=0 error=0`，运行时日志统计 `warn=0 error=0 exception=0`，但当前 DevTools protocol 对 `App.getPageStack` / `App.callWxMethod` 无响应导致未能跑到最终断言。