### PR TITLE
fix(vscode): 修复 WXML 格式化异常

### DIFF
--- a/.changeset/quiet-wxml-format.md
+++ b/.changeset/quiet-wxml-format.md
@@ -1,0 +1,5 @@
+---
+"@weapp-vite/vscode": patch
+---
+
+修复 VS Code 扩展格式化 WXML 时会打开临时 HTML 文档、并可能把格式化结果拼出 `undefined` 的问题；现在使用内置 WXML formatter 直接在当前文档内生成格式化结果。

--- a/extensions/vscode/extension/editor/format.test.ts
+++ b/extensions/vscode/extension/editor/format.test.ts
@@ -18,22 +18,9 @@ function createDocument(text: string) {
   }
 }
 
-it('delegates wxml formatting to the html formatter and returns a full-document replacement edit', async () => {
-  const openTextDocument = vi.fn(async (options: { language: string, content: string }) => ({
-    uri: { scheme: 'untitled', path: '/virtual/demo.html' },
-    getText() {
-      return options.content
-    },
-  }))
-  const executeCommand = vi.fn(async (_command: string, _uri: unknown, _options: unknown) => [
-    {
-      range: {
-        start: { line: 1, character: 0 },
-        end: { line: 1, character: 0 },
-      },
-      newText: '  ',
-    },
-  ])
+it('formats wxml in-process without opening an html formatter document', async () => {
+  const openTextDocument = vi.fn()
+  const executeCommand = vi.fn()
 
   vi.doMock('vscode', () => {
     const mockVscode = {
@@ -67,34 +54,32 @@ it('delegates wxml formatting to the html formatter and returns a full-document 
     WeappWxmlDocumentFormattingProvider,
   } = await import('./format')
   const provider = new WeappWxmlDocumentFormattingProvider()
-  const sourceText = '<view>\n<text>{{ msg }}</text>\n</view>\n'
+  const sourceText = '<view> <text>{{ msg }}</text> </view>\n'
   const edits = await provider.provideDocumentFormattingEdits(createDocument(sourceText) as never, {
     insertSpaces: true,
     tabSize: 2,
   })
 
-  assert.equal(openTextDocument.mock.calls[0]?.[0]?.language, 'html')
-  assert.equal(openTextDocument.mock.calls[0]?.[0]?.content, sourceText)
-  assert.equal(executeCommand.mock.calls[0]?.[0], 'vscode.executeFormatDocumentProvider')
+  assert.equal(openTextDocument.mock.calls.length, 0)
+  assert.equal(executeCommand.mock.calls.length, 0)
   assert.equal(edits.length, 1)
   assert.deepEqual(edits[0]?.range.start, { line: 0, character: 0 })
-  assert.deepEqual(edits[0]?.range.end, { line: 3, character: 0 })
+  assert.deepEqual(edits[0]?.range.end, { line: 1, character: 0 })
+  assert.equal(edits[0]?.newText.includes('undefined'), false)
   assert.equal(edits[0]?.newText, '<view>\n  <text>{{ msg }}</text>\n</view>\n')
 
   vi.doUnmock('vscode')
   vi.resetModules()
 })
 
-it('returns no edits when the delegated html formatter does not change the wxml content', async () => {
+it('returns no edits when the in-process formatter does not change the wxml content', async () => {
+  const openTextDocument = vi.fn()
+  const executeCommand = vi.fn()
+
   vi.doMock('vscode', () => {
     const mockVscode = {
       workspace: {
-        openTextDocument: async (options: { content: string }) => ({
-          uri: { scheme: 'untitled', path: '/virtual/demo.html' },
-          getText() {
-            return options.content
-          },
-        }),
+        openTextDocument,
         getConfiguration: () => ({
           get(_key: string, defaultValue: unknown) {
             return defaultValue
@@ -102,7 +87,7 @@ it('returns no edits when the delegated html formatter does not change the wxml 
         }),
       },
       commands: {
-        executeCommand: async () => [],
+        executeCommand,
       },
       Range: class {
         start: { line: number, character: number }
@@ -123,12 +108,14 @@ it('returns no edits when the delegated html formatter does not change the wxml 
     WeappWxmlDocumentFormattingProvider,
   } = await import('./format')
   const provider = new WeappWxmlDocumentFormattingProvider()
-  const edits = await provider.provideDocumentFormattingEdits(createDocument('<view />') as never, {
+  const edits = await provider.provideDocumentFormattingEdits(createDocument('<view />\n') as never, {
     insertSpaces: true,
     tabSize: 2,
   })
 
   assert.deepEqual(edits, [])
+  assert.equal(openTextDocument.mock.calls.length, 0)
+  assert.equal(executeCommand.mock.calls.length, 0)
 
   vi.doUnmock('vscode')
   vi.resetModules()

--- a/extensions/vscode/extension/editor/format.ts
+++ b/extensions/vscode/extension/editor/format.ts
@@ -4,21 +4,9 @@ import {
   isStandaloneWxmlEnhancementEnabled,
   isWxmlEnhancementEnabled,
 } from '../shared/config'
-
-interface PositionLike {
-  line: number
-  character: number
-}
-
-interface RangeLike {
-  start: PositionLike
-  end: PositionLike
-}
-
-interface TextEditLike {
-  range: RangeLike
-  newText: string
-}
+import {
+  formatWxmlText,
+} from './wxmlFormatter'
 
 function getLineOffsets(text: string) {
   const lineOffsets = [0]
@@ -30,17 +18,6 @@ function getLineOffsets(text: string) {
   }
 
   return lineOffsets
-}
-
-function getOffsetAt(text: string, position: PositionLike) {
-  const lineOffsets = getLineOffsets(text)
-  const safeLine = Math.max(0, Math.min(position.line, lineOffsets.length - 1))
-  const lineStart = lineOffsets[safeLine]
-  const nextLineStart = lineOffsets[safeLine + 1] ?? text.length
-  const lineLength = nextLineStart - lineStart
-  const safeCharacter = Math.max(0, Math.min(position.character, lineLength))
-
-  return Math.min(lineStart + safeCharacter, text.length)
 }
 
 function getPositionAt(text: string, offset: number) {
@@ -58,45 +35,17 @@ function getPositionAt(text: string, offset: number) {
   }
 }
 
-function applyTextEdits(text: string, edits: readonly TextEditLike[]) {
-  const normalizedEdits = edits
-    .map(edit => ({
-      ...edit,
-      startOffset: getOffsetAt(text, edit.range.start),
-      endOffset: getOffsetAt(text, edit.range.end),
-    }))
-    .sort((left, right) => right.startOffset - left.startOffset || right.endOffset - left.endOffset)
-
-  let nextText = text
-
-  for (const edit of normalizedEdits) {
-    nextText = `${nextText.slice(0, edit.startOffset)}${edit.newText}${nextText.slice(edit.endOffset)}`
-  }
-
-  return nextText
-}
-
 function getFullDocumentRange(text: string) {
   const end = getPositionAt(text, text.length)
   return new vscode.Range(0, 0, end.line, end.character)
 }
 
-async function formatWxmlTextWithHtmlFormatter(text: string, options: vscode.FormattingOptions) {
-  const htmlDocument = await vscode.workspace.openTextDocument({
-    language: 'html',
-    content: text,
-  })
-  const edits = await vscode.commands.executeCommand<readonly TextEditLike[]>(
-    'vscode.executeFormatDocumentProvider',
-    htmlDocument.uri,
-    options,
-  )
-
-  if (!edits || edits.length === 0) {
-    return text
+function getFormatIndent(options: vscode.FormattingOptions) {
+  if (!options.insertSpaces) {
+    return '\t'
   }
 
-  return applyTextEdits(text, edits)
+  return ' '.repeat(Math.max(1, options.tabSize))
 }
 
 export class WeappWxmlDocumentFormattingProvider implements vscode.DocumentFormattingEditProvider {
@@ -106,7 +55,9 @@ export class WeappWxmlDocumentFormattingProvider implements vscode.DocumentForma
     }
 
     const sourceText = document.getText()
-    const formattedText = await formatWxmlTextWithHtmlFormatter(sourceText, options)
+    const formattedText = formatWxmlText(sourceText, {
+      indent: getFormatIndent(options),
+    })
 
     if (formattedText === sourceText) {
       return []

--- a/extensions/vscode/extension/editor/wxmlFormatter.test.ts
+++ b/extensions/vscode/extension/editor/wxmlFormatter.test.ts
@@ -1,0 +1,147 @@
+/// <reference types="node" />
+
+import assert from 'node:assert/strict'
+import {
+  describe,
+  it,
+} from 'vitest'
+import {
+  formatWxmlText,
+} from './wxmlFormatter'
+
+function format(input: string) {
+  return formatWxmlText(input, { indent: '  ' })
+}
+
+const exactCases = [
+  {
+    name: 'wraps many attributes and preserves WXML directives',
+    input: '<button class="btn" style="color: red;" bind:tap="onTap" data-id="{{item.id}}" data-type="{{item.type}}" disabled="{{loading}}">提交</button>',
+    expected: `<button
+  class="btn"
+  style="color: red;"
+  bind:tap="onTap"
+  data-id="{{item.id}}"
+  data-type="{{item.type}}"
+  disabled="{{loading}}"
+>
+  提交
+</button>
+`,
+  },
+  {
+    name: 'formats nested swiper tags',
+    input: '<swiper indicator-dots="true"><swiper-item><view>页面1</view></swiper-item><swiper-item><view>页面2</view></swiper-item></swiper>',
+    expected: `<swiper indicator-dots="true">
+  <swiper-item>
+    <view>页面1</view>
+  </swiper-item>
+  <swiper-item>
+    <view>页面2</view>
+  </swiper-item>
+</swiper>
+`,
+  },
+  {
+    name: 'preserves boolean attributes',
+    input: '<input type="text" disabled required placeholder="请输入" maxlength="100" />',
+    expected: `<input
+  type="text"
+  disabled
+  required
+  placeholder="请输入"
+  maxlength="100" />
+`,
+  },
+  {
+    name: 'keeps wrapped text content with the closing text tag',
+    input: '<text class="tip-wrap cashback-wrap" wx:if="{{item.incomeSource && item.incomeSource === \'platform_cashback\'}}" >限时奖励</text>',
+    expected: `<text
+  class="tip-wrap cashback-wrap"
+  wx:if="{{item.incomeSource && item.incomeSource === 'platform_cashback'}}"
+>限时奖励</text>
+`,
+  },
+  {
+    name: 'wraps text attributes while preserving inline text content',
+    input: '<text class="title" data-id="123" bind:tap="handleTap" style="color:red">这是文本内容</text>',
+    expected: `<text
+  class="title"
+  data-id="123"
+  bind:tap="handleTap"
+  style="color:red"
+>这是文本内容</text>
+`,
+  },
+  {
+    name: 'wraps text boolean attributes while preserving inline text content',
+    input: '<text class="asda" tabindex assdassd asd>asdasdasdsaaszdasd asdasdasd asdasd asd asd asd asd asd asd asd a</text>',
+    expected: `<text
+  class="asda"
+  tabindex
+  assdassd
+  asd
+>asdasdasdsaaszdasd asdasdasd asdasd asd asd asd asd asd asd asd a</text>
+`,
+  },
+  {
+    name: 'keeps short text tags on one line',
+    input: '<text class="tip-wrap cashback-wrap">限时奖励</text>',
+    expected: '<text class="tip-wrap cashback-wrap">限时奖励</text>\n',
+  },
+]
+
+const upstreamScriptCases = [
+  '<view class="container"><text wx:if="{{show}}">Hello World</text><button bind:tap="onTap" class="btn">Click Me</button></view>',
+  '<view><text wx:if="{{condition}}">显示文本</text><text wx:elif="{{other}}">其他文本</text><text wx:else>默认文本</text></view>',
+  '<view wx:for="{{list}}" wx:key="id" wx:for-item="item" wx:for-index="index"><text>{{item.name}}</text></view>',
+  '<button bind:tap="onTap" catch:touchstart="onTouch" capture-bind:longpress="onLongPress">按钮</button>',
+  '<text>{{user.name + " - " + user.age}}</text><view class="{{isActive ? \'active\' : \'inactive\'}}">内容</view>',
+  '<view class="{{item.status === \'active\' ? (item.type === \'vip\' ? \'vip-active\' : \'normal-active\') : \'inactive\'}}"><text>{{item.data && item.data.user ? item.data.user.name : \'未知用户\'}}</text></view>',
+  '<view><image src="{{avatar}}" mode="aspectFit"></image><input type="text" placeholder="请输入"></input><icon type="success" size="20"></icon></view>',
+  '<scroll-view scroll-y="true" class="scroll-area"><swiper indicator-dots="{{true}}" autoplay="{{false}}" interval="{{5000}}"><swiper-item><image src="{{item.url}}" mode="aspectFill"></image></swiper-item></swiper></scroll-view>',
+  '<form bind:submit="onSubmit"><input name="username" placeholder="用户名" value="{{form.username}}" bind:input="onInput"/><textarea name="content" placeholder="请输入内容" value="{{form.content}}" bind:input="onTextareaInput"></textarea><button form-type="submit">提交</button></form>',
+  '<view class="container"><view class="header"><text class="title">标题</text></view><view class="content"><view class="item"><text>项目1</text></view><view class="item"><text>项目2</text></view></view></view>',
+  '<view class="very-long-class-name-that-makes-the-tag-exceed-100-characters" data-id="12345" style="color: red;">内容</view>',
+]
+
+const upstreamExampleMaterials = [
+  '<!-- 复杂的WXML示例 --><view class="page"><view class="header" wx:if="{{showHeader}}"><text class="title">{{pageTitle}}</text><button bind:tap="onBack" class="back-btn">返回</button></view><scroll-view scroll-y="true" class="content"><view wx:for="{{dataList}}" wx:key="id" wx:for-item="item" wx:for-index="idx" class="item-container"><view class="item-header"><text class="item-title">{{item.title}}</text><text wx:if="{{item.isNew}}" class="new-tag">新</text></view><view class="item-content"><text class="description">{{item.description}}</text><image wx:if="{{item.imageUrl}}" src="{{item.imageUrl}}" class="item-image" bind:tap="onImageTap" data-url="{{item.imageUrl}}"/></view><view class="item-actions"><button wx:if="{{item.canEdit}}" bind:tap="onEdit" data-id="{{item.id}}" class="edit-btn">编辑</button><button bind:tap="onDelete" data-id="{{item.id}}" class="delete-btn" wx:if="{{item.canDelete}}">删除</button></view></view><view wx:if="{{dataList.length === 0}}" class="empty-state"><text>暂无数据</text></view></scroll-view><view class="footer"><button bind:tap="onAdd" class="add-btn">添加新项目</button></view></view>',
+  '<view class="container"><text wx:if="{{user.isVip}}">VIP用户</text><text wx:elif="{{user.isActive}}">活跃用户</text><text wx:else>普通用户</text><view wx:if="{{showDetails}}"><text>详细信息：{{user.details}}</text><button wx:if="{{canEdit}}" bind:tap="onEdit">编辑</button></view></view>',
+  '<view class="event-demo"><button bind:tap="onTap" data-id="{{item.id}}">普通点击</button><button catch:tap="onCatchTap" class="catch-btn">阻止冒泡点击</button><view capture-bind:touchstart="onCaptureStart" capture-catch:touchend="onCaptureEnd" class="capture-area"><text>捕获事件区域</text><button bind:longpress="onLongPress" bind:touchstart="onTouchStart" bind:touchend="onTouchEnd">多事件按钮</button></view></view>',
+  '<view class="expressions"><text>用户名：{{user.name || \'未知用户\'}}</text><text>年龄：{{user.age > 18 ? \'成年\' : \'未成年\'}}</text><view class="{{isActive ? \'active\' : \'inactive\'}} {{user.vip ? \'vip\' : \'\'}}">状态显示</view><text>计算结果：{{(price * quantity * (1 - discount)).toFixed(2)}}</text><image src="{{baseUrl + \'/images/\' + user.avatar}}" class="avatar"/></view>',
+  '<view class="list-container"><view wx:for="{{categories}}" wx:key="id" wx:for-item="category" class="category"><text class="category-title">{{category.name}}</text><view wx:for="{{category.items}}" wx:key="itemId" wx:for-item="item" wx:for-index="itemIndex" class="item"><text>{{itemIndex + 1}}. {{item.title}}</text><text class="price">¥{{item.price}}</text></view></view></view>',
+  '<view class="container"><text wx:if="{{user.isVip}}">VIP用户</text><text wx:elif="{{user.isActive}}">活跃用户</text><text wx:else>普通用户</text><view wx:if="{{showDetails}}"><text>详细信息：{{user.details}}</text><button wx:if="{{canEdit}}" bind:tap="onEdit">编辑</button></view><image src="{{user.avatar}}" class="avatar" mode="aspectFit" bind:tap="onImageTap"></image><button wx:if="{{item.canEdit}}" bind:tap="onEdit" data-id="{{item.id}}" class="edit-btn" disabled="{{loading}}">编辑按钮</button></view>',
+  '<view class="container"><text wx:if="{{show}}">Hello World</text><button bind:tap="onTap" class="btn">Click Me</button><view wx:for="{{list}}" wx:key="id" wx:for-item="item" wx:for-index="index"><text>{{item.name}}</text></view></view>',
+  '<text class="asda" tabindex assdassd asd>asdasdasdsaaszdasd asdasdasd asdasd asd asd asd asd asd asd asd a</text>\n\n<text class="asda" tabindex assdassd asd>asdasdasdsaaszdasd asdasdasd asdasd asd asd asd asd asd asd asd a</text>\n\n<view class="container" data-id="123" bind:tap="handleTap">Some text content here</view>',
+  '<!-- 测试 text 标签多属性换行 -->\n\n<!-- 测试1: 3个属性 -->\n<text class="title" data-id="123" bind:tap="handleTap">这是文本内容</text>\n\n<!-- 测试2: 4个属性 -->\n<text class="asda" tabindex assdassd asd>asdasdasdsaaszdasd asdasdasd asdasd asd asd asd asd asd asd asd a</text>\n\n<!-- 测试3: 长内容 -->\n<text class="a" data-id="b" style="color:red">这是一段很长很长很长很长很长很长的文本内容</text>\n\n<!-- 对比: view 标签 3个属性 -->\n<view class="container" data-id="123" bind:tap="handleTap">这是内容</view>\n\n<!-- 对比: button 标签 4个属性 -->\n<button class="btn" data-id="123" bind:tap="handleTap" disabled>按钮文本</button>',
+]
+
+describe('formatWxmlText', () => {
+  for (const testCase of exactCases) {
+    it(testCase.name, () => {
+      assert.equal(format(testCase.input), testCase.expected)
+    })
+  }
+
+  it('formats the formatter-wxml script cases without corrupting expressions or directives', () => {
+    for (const input of upstreamScriptCases) {
+      const output = format(input)
+
+      assert.equal(output.includes('undefined'), false)
+      assert.equal(output.includes('__WEAPP_VITE_WXML_'), false)
+      assert.match(output, /\n$/u)
+    }
+  })
+
+  it('formats all formatter-wxml example materials without placeholder leakage', () => {
+    for (const input of upstreamExampleMaterials) {
+      const output = format(input)
+
+      assert.equal(output.includes('undefined'), false)
+      assert.equal(output.includes('__WEAPP_VITE_WXML_'), false)
+      assert.match(output, /<[\w-]+|<!--/u)
+      assert.match(output, /\n$/u)
+    }
+  })
+})

--- a/extensions/vscode/extension/editor/wxmlFormatter.ts
+++ b/extensions/vscode/extension/editor/wxmlFormatter.ts
@@ -1,0 +1,300 @@
+interface WxmlFormatterOptions {
+  indent: string
+  inlineTags?: readonly string[]
+  selfClosingTags?: readonly string[]
+  wrapAttributes?: number
+}
+interface ParsedAttribute {
+  name: string
+  value: string
+}
+
+interface Token {
+  attributes?: ParsedAttribute[]
+  content: string
+  originalLength?: number
+  tagName?: string
+  type: 'open' | 'close' | 'selfClose' | 'text' | 'comment'
+}
+
+const EXPRESSION_PLACEHOLDER = '__WEAPP_VITE_WXML_EXPR_'
+const DIRECTIVE_PLACEHOLDER = '__WEAPP_VITE_WXML_DIR_'
+const DEFAULT_WRAP_ATTRIBUTES = 3
+const DEFAULT_INLINE_TAGS = ['text', 'icon', 'rich-text']
+const DEFAULT_SELF_CLOSING_TAGS = 'image,input,icon,video,audio,camera,live-player,live-pusher,map,canvas,web-view,ad,official-account,open-data'.split(',')
+
+function getAttributeText(attribute: ParsedAttribute) {
+  return attribute.value ? `${attribute.name}=${attribute.value}` : attribute.name
+}
+
+function getTagName(content: string) {
+  return content.match(/^<\/?([\w-]+)/u)?.[1] ?? ''
+}
+
+function getLineEnd(text: string) {
+  return text.includes('\r\n') ? '\r\n' : '\n'
+}
+
+function recordTagLengths(text: string) {
+  const lengths = new Map<string, number[]>()
+  const tagPattern = /<[^>]*>/gu
+  let match = tagPattern.exec(text)
+
+  while (match) {
+    const tagName = getTagName(match[0])
+    if (!tagName) {
+      match = tagPattern.exec(text)
+      continue
+    }
+
+    const tagLengths = lengths.get(tagName) ?? []
+    tagLengths.push(match[0].length)
+    lengths.set(tagName, tagLengths)
+    match = tagPattern.exec(text)
+  }
+
+  return lengths
+}
+
+function protectSpecialSyntax(text: string, expressions: string[], directives: string[]) {
+  return text
+    .replace(/\{\{[\s\S]*?\}\}/gu, (match) => {
+      const index = expressions.length
+      expressions.push(match)
+      return `${EXPRESSION_PLACEHOLDER}${index}__`
+    })
+    .replace(/(wx:|bind:|catch:|mut-bind:|capture-bind:|capture-catch:)[\w-]+/gu, (match) => {
+      const index = directives.length
+      directives.push(match)
+      return `${DIRECTIVE_PLACEHOLDER}${index}__`
+    })
+}
+
+function restoreSpecialSyntax(text: string, expressions: readonly string[], directives: readonly string[]) {
+  return text
+    .replace(new RegExp(`${DIRECTIVE_PLACEHOLDER}(\\d+)__`, 'gu'), (placeholder, index: string) => {
+      return directives[Number(index)] ?? placeholder
+    })
+    .replace(new RegExp(`${EXPRESSION_PLACEHOLDER}(\\d+)__`, 'gu'), (placeholder, index: string) => {
+      return expressions[Number(index)] ?? placeholder
+    })
+}
+
+function normalizeSelfClosingTags(text: string, selfClosingTags: readonly string[]) {
+  let result = text
+
+  for (const tagName of selfClosingTags) {
+    result = result.replace(
+      new RegExp(`<${tagName}(?=[\\s/>])(\\s[^>]*?)?></${tagName}>`, 'gu'),
+      (_, attributes: string | undefined) => `<${tagName}${attributes ?? ''} />`,
+    )
+    result = result.replace(
+      new RegExp(`<${tagName}(?=\\s)(\\s[^>]*)\\s*/>`, 'gu'),
+      (_, attributes: string) => {
+        const trimmedAttributes = attributes.trim()
+        return trimmedAttributes ? `<${tagName} ${trimmedAttributes} />` : `<${tagName} />`
+      },
+    )
+  }
+
+  return result
+}
+
+function parseAttributes(attributeText: string): ParsedAttribute[] {
+  const attributes: ParsedAttribute[] = []
+  const cleaned = attributeText.replace(/\s+/gu, ' ').trim()
+  const attributePattern = /([\w:-]+)(?:=("[^"]*"|'[^']*'))?/gu
+  let match = attributePattern.exec(cleaned)
+
+  while (match) {
+    attributes.push({
+      name: match[1]!,
+      value: match[2] ?? '',
+    })
+    match = attributePattern.exec(cleaned)
+  }
+
+  return attributes
+}
+
+function tokenize(text: string) {
+  const tokens: Token[] = []
+  const cleaned = text.replace(/\s+/gu, ' ').trim()
+  const tokenPattern = /<!--[\s\S]*?-->|<\/[\w-]+\s*>|<[^>]+>|[^<]+|</gu
+  let match = tokenPattern.exec(cleaned)
+
+  while (match) {
+    const rawContent = match[0].trim()
+
+    if (!rawContent) {
+      match = tokenPattern.exec(cleaned)
+      continue
+    }
+
+    const content = rawContent.startsWith('<')
+      ? rawContent.replace(/\/\s*>$/u, '/>').replace(/\s+>$/u, '>')
+      : rawContent
+
+    if (content.startsWith('<!--')) {
+      tokens.push({ type: 'comment', content })
+      match = tokenPattern.exec(cleaned)
+      continue
+    }
+
+    if (content === '<') {
+      tokens.push({ type: 'text', content })
+      match = tokenPattern.exec(cleaned)
+      continue
+    }
+
+    if (content.startsWith('</')) {
+      tokens.push({ type: 'close', content, tagName: getTagName(content) })
+      match = tokenPattern.exec(cleaned)
+      continue
+    }
+
+    if (/\/>$/u.test(content)) {
+      const tagName = getTagName(content)
+      tokens.push(tagName
+        ? {
+            type: 'selfClose',
+            content,
+            tagName,
+            attributes: parseAttributes(content.slice(tagName.length + 1, -2)),
+          }
+        : { type: 'text', content })
+      match = tokenPattern.exec(cleaned)
+      continue
+    }
+
+    if (content.startsWith('<')) {
+      const tagName = getTagName(content)
+      tokens.push(tagName
+        ? {
+            type: 'open',
+            content,
+            tagName,
+            attributes: parseAttributes(content.slice(tagName.length + 1, -1)),
+          }
+        : { type: 'text', content })
+      match = tokenPattern.exec(cleaned)
+      continue
+    }
+
+    tokens.push({ type: 'text', content })
+    match = tokenPattern.exec(cleaned)
+  }
+
+  return tokens
+}
+
+function attachOriginalLengths(tokens: Token[], lengths: Map<string, number[]>) {
+  const counters = new Map<string, number>()
+
+  for (const token of tokens) {
+    if ((token.type !== 'open' && token.type !== 'selfClose') || !token.tagName) {
+      continue
+    }
+
+    const index = counters.get(token.tagName) ?? 0
+    token.originalLength = lengths.get(token.tagName)?.[index]
+    counters.set(token.tagName, index + 1)
+  }
+}
+
+function buildDocument(tokens: readonly Token[], options: Required<WxmlFormatterOptions>) {
+  const lines: string[] = []
+  let depth = 0
+  const inlineTags = new Set(options.inlineTags)
+  const shouldWrapAttributes = (token: Token) => {
+    const attributeCount = token.attributes?.length ?? 0
+    return attributeCount >= options.wrapAttributes || Boolean(token.originalLength && token.originalLength > 100)
+  }
+  const isInlineSandwich = (token: Token, next: Token | undefined, nextNext: Token | undefined) => {
+    return next?.type === 'text' && nextNext?.type === 'close' && nextNext.tagName === token.tagName
+  }
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index]!
+    const nextToken = tokens[index + 1]
+    const nextNextToken = tokens[index + 2]
+
+    if (token.type === 'close') {
+      depth = Math.max(0, depth - 1)
+      lines.push(`${options.indent.repeat(depth)}${token.content}`)
+      continue
+    }
+
+    if (token.type === 'open' && shouldWrapAttributes(token)) {
+      const shouldInline = isInlineSandwich(token, nextToken, nextNextToken) && inlineTags.has(token.tagName ?? '')
+      lines.push(`${options.indent.repeat(depth)}<${token.tagName}`)
+
+      for (const attribute of token.attributes ?? []) {
+        lines.push(`${options.indent.repeat(depth + 1)}${getAttributeText(attribute)}`)
+      }
+
+      if (shouldInline) {
+        lines.push(`${options.indent.repeat(depth)}>${nextToken!.content}${nextNextToken!.content}`)
+        index += 2
+        continue
+      }
+
+      lines.push(`${options.indent.repeat(depth)}>`)
+      depth += 1
+      continue
+    }
+
+    if (token.type === 'open' && isInlineSandwich(token, nextToken, nextNextToken)) {
+      if (inlineTags.has(token.tagName ?? '') || nextToken!.content.length <= 50) {
+        lines.push(`${options.indent.repeat(depth)}${token.content}${nextToken!.content}${nextNextToken!.content}`)
+        index += 2
+        continue
+      }
+    }
+
+    if (token.type === 'selfClose' && shouldWrapAttributes(token)) {
+      lines.push(`${options.indent.repeat(depth)}<${token.tagName}`)
+
+      for (const [attributeIndex, attribute] of (token.attributes ?? []).entries()) {
+        const suffix = attributeIndex === (token.attributes!.length - 1) ? ' />' : ''
+        lines.push(`${options.indent.repeat(depth + 1)}${getAttributeText(attribute)}${suffix}`)
+      }
+
+      continue
+    }
+
+    lines.push(`${options.indent.repeat(depth)}${token.content}`)
+
+    if (token.type === 'open') {
+      depth += 1
+    }
+  }
+
+  return lines.join('\n')
+}
+
+function cleanup(text: string) {
+  return text
+    .replace(/(wx:|bind:|catch:|mut-bind:|capture-bind:|capture-catch:)(\w+)(\s*=\s*)(['"])/gu, '$1$2=$4')
+}
+
+export function formatWxmlText(text: string, formatterOptions: WxmlFormatterOptions) {
+  const lineEnd = getLineEnd(text)
+  const expressions: string[] = []
+  const directives: string[] = []
+  const options: Required<WxmlFormatterOptions> = {
+    indent: formatterOptions.indent,
+    inlineTags: formatterOptions.inlineTags ?? DEFAULT_INLINE_TAGS,
+    selfClosingTags: formatterOptions.selfClosingTags ?? DEFAULT_SELF_CLOSING_TAGS,
+    wrapAttributes: formatterOptions.wrapAttributes ?? DEFAULT_WRAP_ATTRIBUTES,
+  }
+  const tagLengths = recordTagLengths(text)
+  const protectedText = protectSpecialSyntax(text, expressions, directives)
+  const normalizedText = normalizeSelfClosingTags(protectedText, options.selfClosingTags)
+  const tokens = tokenize(normalizedText)
+
+  attachOriginalLengths(tokens, tagLengths)
+
+  const formattedText = cleanup(restoreSpecialSyntax(buildDocument(tokens, options), expressions, directives))
+  return `${formattedText.replace(/\n/gu, lineEnd)}${lineEnd}`
+}


### PR DESCRIPTION
## 摘要

- 修复 VS Code 扩展格式化 WXML 时会打开临时 HTML 文档的问题
- 改为扩展内部 WXML formatter，避免 HTML formatter 把结果拼出 `undefined`
- 补充 issue #707 回归测试，并覆盖 formatter-wxml 的精确用例、脚本输入和示例素材 smoke

## 验证

- `pnpm --filter @weapp-vite/vscode lint`
- `pnpm --filter @weapp-vite/vscode typecheck`
- `pnpm --filter @weapp-vite/vscode test`
- `pnpm --filter @weapp-vite/vscode build`

Fixes #707