### PR TITLE
fix(dashboard): report latest event timestamp per source instead of first

### DIFF
--- a/packages/dashboard/src/features/dashboard/utils/runtimeEvents.test.ts
+++ b/packages/dashboard/src/features/dashboard/utils/runtimeEvents.test.ts
@@ -144,7 +144,7 @@ describe('normalizeRuntimeEvents', () => {
         source: 'cli',
         count: 2,
         errorCount: 1,
-        latestTimestamp: '10:00:00',
+        latestTimestamp: '10:01:00',
         averageDurationMs: 200,
       },
       {
@@ -153,6 +153,46 @@ describe('normalizeRuntimeEvents', () => {
         errorCount: 0,
         latestTimestamp: '10:02:00',
         averageDurationMs: 40,
+      },
+    ])
+  })
+
+  it('reports the latest event timestamp per source, not the first', () => {
+    expect(summarizeRuntimeEventsBySource([
+      {
+        id: 'evt-a',
+        kind: 'command',
+        level: 'success',
+        title: 'first',
+        detail: 'first detail',
+        timestamp: '09:00:00',
+        source: 'cli',
+      },
+      {
+        id: 'evt-b',
+        kind: 'command',
+        level: 'info',
+        title: 'middle',
+        detail: 'middle detail',
+        timestamp: '09:05:00',
+        source: 'cli',
+      },
+      {
+        id: 'evt-c',
+        kind: 'command',
+        level: 'error',
+        title: 'last',
+        detail: 'last detail',
+        timestamp: '09:10:00',
+        source: 'cli',
+      },
+    ])).toEqual([
+      {
+        source: 'cli',
+        count: 3,
+        errorCount: 1,
+        latestTimestamp: '09:10:00',
+        averageDurationMs: undefined,
       },
     ])
   })

--- a/packages/dashboard/src/features/dashboard/utils/runtimeEvents.ts
+++ b/packages/dashboard/src/features/dashboard/utils/runtimeEvents.ts
@@ -130,7 +130,7 @@ function mergeRuntimeSourceSummaryAccumulator(
   return {
     count: existing.count + 1,
     errorCount: existing.errorCount + (event.level === 'error' ? 1 : 0),
-    latestTimestamp: existing.latestTimestamp,
+    latestTimestamp: event.timestamp,
     durationTotal: existing.durationTotal + (event.durationMs ?? 0),
     timedCount: existing.timedCount + (typeof event.durationMs === 'number' ? 1 : 0),
   }


### PR DESCRIPTION
## Summary

`mergeRuntimeSourceSummaryAccumulator` copied `existing.latestTimestamp` on every merge, so the accumulator was seeded with the **first** event's timestamp and then frozen. `latestTimestamp` therefore always reflected the **earliest** event for a source, contradicting its name and the dashboard's "last activity" semantics.

This fix sets the merged value to `event.timestamp`, so it tracks the most recent event as events are folded into the accumulator in array order.

## Test plan

- Added a regression test with multiple same-source events (09:00 / 09:05 / 09:10) asserting `latestTimestamp` equals `09:10:00`.
- Updated the existing assertion that encoded the buggy value (now `10:01:00` for the same-source fixture).
- `packages/dashboard` suite: 38 tests pass, ESLint clean.

Only `runtimeEvents.ts` and its test are changed; the unrelated `catalog.ts` postinstall bump is intentionally left out of this PR.