### PR TITLE
fix(wevu): 修复 router 导航后路由状态同步

### DIFF
--- a/.changeset/fix-wevu-router-route-sync.md
+++ b/.changeset/fix-wevu-router-route-sync.md
@@ -1,0 +1,6 @@
+---
+"wevu": patch
+"create-weapp-vite": patch
+---
+
+修复 wevu router 成功导航后 `currentRoute` 未及时同步的问题，确保后续 `beforeEach` / `afterEach` 能拿到正确的 `from`，并让原生 `switchTab` 成功后同步 `useRoute()` 状态。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -505,6 +505,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-705/index",
+          "pathName": "pages/issue-705/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-528/index",
           "pathName": "pages/issue-528/index",
           "query": "",

--- a/e2e-apps/github-issues/src/pages/issue-705/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-705/index.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { computed } from 'wevu'
+import { useRoute, useRouter } from 'wevu/router'
+
+definePageJson({
+  navigationBarTitleText: 'issue-705',
+})
+
+const route = useRoute()
+const router = useRouter()
+const routePath = computed(() => route.path)
+const hookCalls: Array<{ phase: string, to?: string, from: string }> = []
+
+router.beforeEach((to, from) => {
+  hookCalls.push({
+    phase: 'before',
+    to: to?.path,
+    from: from.path,
+  })
+})
+
+router.afterEach((to, from) => {
+  hookCalls.push({
+    phase: 'after',
+    to: to?.path,
+    from: from.path,
+  })
+})
+
+async function _runE2E(action?: 'push') {
+  if (action === 'push') {
+    await router.push('/pages/issue-550/index')
+  }
+
+  return {
+    route: {
+      path: route.path,
+      fullPath: route.fullPath,
+      name: route.name,
+    },
+    hooks: hookCalls.slice(),
+  }
+}
+
+defineExpose({
+  _runE2E,
+})
+</script>
+
+<template>
+  <view
+    class="issue705-page"
+    :data-route-path="routePath"
+  >
+    <text class="issue705-title">
+      issue-705 router route sync
+    </text>
+  </view>
+</template>
+
+<style scoped>
+.issue705-page {
+  box-sizing: border-box;
+  min-height: 100vh;
+  padding: 24rpx;
+  background: #fff;
+}
+
+.issue705-title {
+  display: block;
+  font-size: 30rpx;
+  font-weight: 700;
+  color: #111827;
+}
+</style>

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -608,6 +608,19 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageJs).toContain('route.name')
   })
 
+  it('issue #705: compiles router route sync runtime probe', async () => {
+    await runBuild()
+
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-705/index.wxml')
+    const pageJsPath = path.join(DIST_ROOT, 'pages/issue-705/index.js')
+    const pageWxml = await fs.readFile(pageWxmlPath, 'utf-8')
+    const pageJs = await fs.readFile(pageJsPath, 'utf-8')
+
+    expect(pageWxml).toContain('data-route-path="{{routePath}}"')
+    expect(pageJs).toContain('_runE2E')
+    expect(pageJs).toContain('pages/issue-550/index')
+  })
+
   it('issue #553: maps component v-model arguments to the matching prop and update event', async () => {
     await runBuild()
 

--- a/packages-runtime/wevu/src/router/createRouter.ts
+++ b/packages-runtime/wevu/src/router/createRouter.ts
@@ -23,18 +23,21 @@ import {
   stringifyQuery,
   warnDuplicateRouteEntries,
 } from '../routerInternal/shared'
+import { getMiniProgramGlobalObject } from '../runtime/platform'
 import { setActiveRouter } from './instance'
 import { createNavigationApi } from './navigationApi'
 import { createNavigationResultController } from './navigationResult'
 import { resolveRouteLocation } from './resolve'
 import { createRouteRegistry } from './routeRegistry'
-import { useNativeRouter, useRoute } from './useRoute'
+import { installRouteStateSyncOnNativeRouter } from './routeSync'
+import { createRouteStateController, useNativeRouter } from './useRoute'
 
 /**
  * @description 创建高阶路由导航器（对齐 Vue Router 的 createRouter 心智）
  */
 export function createRouter(options: UseRouterOptions = {}): RouterNavigation {
   const nativeRouter = useNativeRouter()
+  installRouteStateSyncOnNativeRouter(getMiniProgramGlobalObject())
   const beforeEachGuards = new Set<NavigationGuard>()
   const beforeResolveGuards = new Set<NavigationGuard>()
   const afterEachHooks = new Set<NavigationAfterEach>()
@@ -100,9 +103,10 @@ export function createRouter(options: UseRouterOptions = {}): RouterNavigation {
     return enrichRouteRecordState(resolveRouteLocation(rawTo, currentPath, routeResolveCodec))
   }
 
-  const route = useRoute({
+  const routeController = createRouteStateController({
     resolveRoute: enrichRouteRecordState,
   })
+  const route = routeController.route
 
   function resolve(to: RouteLocationRaw): RouteLocationNormalizedLoaded {
     return resolveWithCodec(to, route.path)

--- a/packages-runtime/wevu/src/router/navigationResult.ts
+++ b/packages-runtime/wevu/src/router/navigationResult.ts
@@ -7,6 +7,7 @@ import type {
   RouteLocationNormalizedLoaded,
 } from './types'
 import { runAfterEachHooks, runNavigationErrorHooks, shouldEmitNavigationError } from './navigationCore'
+import { notifyRouteStateSync } from './routeSync'
 
 export interface NavigationRunResult {
   mode: NavigationMode
@@ -71,6 +72,9 @@ export function createNavigationResultController(options: {
   }
 
   async function settleNavigationResult(result: NavigationRunResult): Promise<void | NavigationFailure> {
+    if (!result.failure && result.to) {
+      notifyRouteStateSync({ route: result.to })
+    }
     await emitNavigationAfterEach(result)
     if (result.failure && shouldRejectNavigationFailure(result.failure)) {
       throw result.failure

--- a/packages-runtime/wevu/src/router/routeSync.ts
+++ b/packages-runtime/wevu/src/router/routeSync.ts
@@ -1,0 +1,92 @@
+import type { RouteLocationNormalizedLoaded } from './types'
+
+export interface RouteStateSyncPayload {
+  route?: RouteLocationNormalizedLoaded
+  url?: string
+}
+
+type RouteStateSyncHandler = (payload?: RouteStateSyncPayload) => void
+type NativeRouterMethodName = 'switchTab' | 'reLaunch' | 'redirectTo' | 'navigateTo' | 'navigateBack'
+
+const ROUTE_SYNC_NATIVE_METHODS: readonly NativeRouterMethodName[] = ['switchTab', 'reLaunch', 'redirectTo', 'navigateTo', 'navigateBack']
+const routeStateSyncHandlers = new Set<RouteStateSyncHandler>()
+const patchedNativeRouters = new WeakSet<Record<string, any>>()
+
+export function registerRouteStateSyncHandler(handler: RouteStateSyncHandler): () => void {
+  routeStateSyncHandlers.add(handler)
+  return () => {
+    routeStateSyncHandlers.delete(handler)
+  }
+}
+
+export function notifyRouteStateSync(payload?: RouteStateSyncPayload) {
+  for (const handler of routeStateSyncHandlers) {
+    try {
+      handler(payload)
+    }
+    catch {
+      // 忽略单个 route 订阅者异常，避免阻塞原生导航成功回调。
+    }
+  }
+}
+
+function createNativeRouteStateSyncPayload(methodName: NativeRouterMethodName, option: unknown): RouteStateSyncPayload | undefined {
+  if (methodName === 'navigateBack') {
+    return undefined
+  }
+  if (option && typeof option === 'object') {
+    const url = (option as Record<string, unknown>).url
+    if (typeof url === 'string') {
+      return { url }
+    }
+  }
+  return undefined
+}
+
+export function installRouteStateSyncOnNativeRouter(nativeRouter: unknown) {
+  if (!nativeRouter || typeof nativeRouter !== 'object') {
+    return
+  }
+  const router = nativeRouter as Record<string, any>
+  if (patchedNativeRouters.has(router)) {
+    return
+  }
+  patchedNativeRouters.add(router)
+
+  for (const methodName of ROUTE_SYNC_NATIVE_METHODS) {
+    const original = router[methodName]
+    if (typeof original !== 'function') {
+      continue
+    }
+
+    router[methodName] = function routeStateSyncNativeRouterMethod(this: unknown, option?: unknown, ...args: any[]) {
+      let synced = false
+      const syncRouteState = () => {
+        if (synced) {
+          return
+        }
+        synced = true
+        notifyRouteStateSync(createNativeRouteStateSyncPayload(methodName, option))
+      }
+
+      const nextOption = option && typeof option === 'object'
+        ? {
+            ...(option as Record<string, any>),
+            success: (...successArgs: any[]) => {
+              syncRouteState()
+              const originalSuccess = (option as Record<string, any>).success
+              return typeof originalSuccess === 'function'
+                ? originalSuccess(...successArgs)
+                : undefined
+            },
+          }
+        : option
+
+      const result = original.call(this, nextOption, ...args)
+      if (result && typeof (result as PromiseLike<unknown>).then === 'function') {
+        ;(result as PromiseLike<unknown>).then(syncRouteState, () => {})
+      }
+      return result
+    }
+  }
+}

--- a/packages-runtime/wevu/src/router/useRoute.ts
+++ b/packages-runtime/wevu/src/router/useRoute.ts
@@ -3,15 +3,21 @@ import type { SetupContextRouter } from '../runtime/types/props'
 import type { LocationQueryRaw, RouteLocationNormalizedLoaded } from './types'
 import { reactive, readonly } from '../reactivity'
 import { cloneLocationQuery, cloneRouteLocationRedirectedFrom, cloneRouteMeta, cloneRouteParams, cloneRouteRecordMatchedList, resolveCurrentRoute } from '../routerInternal/shared'
-import { getCurrentSetupContext, onLoad, onReady, onRouteDone, onShow } from '../runtime/hooks'
+import { getCurrentSetupContext, onLoad, onReady, onRouteDone, onShow, onUnload } from '../runtime/hooks'
 import {
   useNativePageRouter as useNativePageRouterInternal,
   useNativeRouter as useNativeRouterInternal,
 } from '../runtime/vueCompat'
 import { getActiveRouter } from './instance'
+import { resolveRouteLocation } from './resolve'
+import { registerRouteStateSyncHandler } from './routeSync'
 
 export interface UseRouteOptions {
   resolveRoute?: (route: RouteLocationNormalizedLoaded) => RouteLocationNormalizedLoaded
+}
+
+export interface RouteStateController {
+  route: Readonly<RouteLocationNormalizedLoaded>
 }
 
 function applyRouteState(
@@ -55,7 +61,7 @@ function applyRouteState(
   }
 }
 
-export function useRoute(options: UseRouteOptions = {}): Readonly<RouteLocationNormalizedLoaded> {
+export function createRouteStateController(options: UseRouteOptions = {}): RouteStateController {
   const setupContext = getCurrentSetupContext()
   if (!setupContext) {
     throw new Error('useRoute() 必须在 setup() 的同步阶段调用')
@@ -74,8 +80,10 @@ export function useRoute(options: UseRouteOptions = {}): Readonly<RouteLocationN
   })
   applyRouteState(routeState, currentRoute)
 
-  function syncRoute(queryOverride?: LocationQueryRaw) {
-    const nextRoute = resolveRoute(resolveCurrentRoute(queryOverride, fallbackPage))
+  function syncRoute(queryOverride?: LocationQueryRaw, routeOverride?: RouteLocationNormalizedLoaded) {
+    const nextRoute = routeOverride
+      ? resolveRoute(routeOverride)
+      : resolveRoute(resolveCurrentRoute(queryOverride, fallbackPage))
     applyRouteState(routeState, nextRoute)
   }
 
@@ -91,8 +99,28 @@ export function useRoute(options: UseRouteOptions = {}): Readonly<RouteLocationN
   onRouteDone(() => {
     syncRoute()
   })
+  const unregisterRouteStateSync = registerRouteStateSyncHandler((payload) => {
+    if (payload?.route) {
+      syncRoute(undefined, payload.route)
+      return
+    }
+    if (payload?.url) {
+      syncRoute(undefined, resolveRouteLocation(payload.url, routeState.path))
+      return
+    }
+    syncRoute()
+  })
+  onUnload(() => {
+    unregisterRouteStateSync()
+  })
 
-  return readonly(routeState) as Readonly<RouteLocationNormalizedLoaded>
+  return {
+    route: readonly(routeState) as Readonly<RouteLocationNormalizedLoaded>,
+  }
+}
+
+export function useRoute(options: UseRouteOptions = {}): Readonly<RouteLocationNormalizedLoaded> {
+  return createRouteStateController(options).route
 }
 
 /**

--- a/packages-runtime/wevu/src/runtime/vueCompat/router.ts
+++ b/packages-runtime/wevu/src/runtime/vueCompat/router.ts
@@ -1,4 +1,5 @@
 import type { SetupContextRouter } from '../types'
+import { notifyRouteStateSync } from '../../router/routeSync'
 import { parsePathInput } from '../../routerInternal/location'
 import { createAbsoluteRoutePath, resolvePath, stringifyQuery } from '../../routerInternal/shared'
 import { getCurrentSetupContext } from '../hooks'
@@ -80,9 +81,19 @@ function createScopedRuntimeRouter(rawRouter: RuntimeRouter, basePath?: string):
       const nextUrl = typeof option.url === 'string'
         ? resolveScopedRouterUrl(option.url, basePath)
         : option.url
-      const nextOption = nextUrl === option.url
-        ? option
-        : { ...option, url: nextUrl }
+      const originalSuccess = option.success
+      const nextOption = {
+        ...option,
+        url: nextUrl,
+        success: (...args: any[]) => {
+          if (typeof nextUrl === 'string') {
+            notifyRouteStateSync({ url: nextUrl })
+          }
+          return typeof originalSuccess === 'function'
+            ? originalSuccess(...args)
+            : undefined
+        },
+      }
       return rawMethod.call(rawRouter, nextOption)
     }
   }

--- a/packages-runtime/wevu/test/router-navigation.test.ts
+++ b/packages-runtime/wevu/test/router-navigation.test.ts
@@ -15,6 +15,7 @@ describe('router navigation helpers', () => {
     setCurrentSetupContext(undefined)
     clearActiveRouter()
     delete (globalThis as any).getCurrentPages
+    delete (globalThis as any).wx
   })
 
   it('creates and detects navigation failure', () => {
@@ -3237,6 +3238,178 @@ describe('router navigation helpers', () => {
       failure: undefined,
       context: { mode: 'push' },
     })
+  })
+
+  it('uses the last successful router navigation as from in following hooks', async () => {
+    const navigateTo = vi.fn((options: any) => {
+      options.success?.({})
+    })
+    const guardCalls: any[] = []
+    const afterCalls: any[] = []
+    const instance = {
+      __wevu: {},
+      [WEVU_HOOKS_KEY]: {},
+      router: {
+        switchTab: vi.fn(),
+        reLaunch: vi.fn(),
+        redirectTo: vi.fn(),
+        navigateTo,
+        navigateBack: vi.fn(),
+      },
+    } as any
+
+    setCurrentInstance(instance)
+    setCurrentSetupContext({ instance, emit: vi.fn(), attrs: {}, slots: {} })
+
+    ;(globalThis as any).getCurrentPages = vi.fn(() => [
+      {
+        route: 'pages/home/index',
+        options: {},
+      },
+    ])
+
+    const router = createRouter()
+    router.beforeEach((to, from) => {
+      guardCalls.push({ to, from })
+    })
+    router.afterEach((to, from) => {
+      afterCalls.push({ to, from })
+    })
+
+    await router.push('/pages/detail/index')
+    await router.push('/pages/profile/index')
+
+    expect(router.currentRoute.path).toBe('pages/profile/index')
+    expect(guardCalls).toMatchObject([
+      {
+        from: { path: 'pages/home/index' },
+        to: { path: 'pages/detail/index' },
+      },
+      {
+        from: { path: 'pages/detail/index' },
+        to: { path: 'pages/profile/index' },
+      },
+    ])
+    expect(afterCalls).toMatchObject([
+      {
+        from: { path: 'pages/home/index' },
+        to: { path: 'pages/detail/index' },
+      },
+      {
+        from: { path: 'pages/detail/index' },
+        to: { path: 'pages/profile/index' },
+      },
+    ])
+  })
+
+  it('syncs currentRoute after native switchTab succeeds', async () => {
+    const switchTab = vi.fn((options: any) => {
+      options.success?.({})
+    })
+    const success = vi.fn()
+    const instance = {
+      __wevu: {},
+      [WEVU_HOOKS_KEY]: {},
+      router: {
+        switchTab,
+        reLaunch: vi.fn(),
+        redirectTo: vi.fn(),
+        navigateTo: vi.fn(),
+        navigateBack: vi.fn(),
+      },
+    } as any
+
+    setCurrentInstance(instance)
+    setCurrentSetupContext({ instance, emit: vi.fn(), attrs: {}, slots: {} })
+
+    ;(globalThis as any).getCurrentPages = vi.fn(() => [
+      {
+        route: 'pages/home/index',
+        options: {},
+      },
+    ])
+
+    const router = createRouter({
+      routes: [
+        {
+          name: 'home',
+          path: '/pages/home/index',
+        },
+        {
+          name: 'profile',
+          path: '/pages/profile/index',
+        },
+      ],
+    })
+
+    router.nativeRouter.switchTab({
+      url: '/pages/profile/index',
+      success,
+    })
+
+    expect(success).toHaveBeenCalledTimes(1)
+    expect(switchTab).toHaveBeenCalledWith(expect.objectContaining({
+      url: '/pages/profile/index',
+    }))
+    expect(router.currentRoute.path).toBe('pages/profile/index')
+    expect(router.currentRoute.name).toBe('profile')
+  })
+
+  it('syncs currentRoute after wx.switchTab succeeds', async () => {
+    const switchTab = vi.fn((options: any) => {
+      options.success?.({})
+    })
+    ;(globalThis as any).wx = {
+      switchTab,
+      reLaunch: vi.fn(),
+      redirectTo: vi.fn(),
+      navigateTo: vi.fn(),
+      navigateBack: vi.fn(),
+    }
+    const instance = {
+      __wevu: {},
+      [WEVU_HOOKS_KEY]: {},
+      router: {
+        switchTab: vi.fn(),
+        reLaunch: vi.fn(),
+        redirectTo: vi.fn(),
+        navigateTo: vi.fn(),
+        navigateBack: vi.fn(),
+      },
+    } as any
+
+    setCurrentInstance(instance)
+    setCurrentSetupContext({ instance, emit: vi.fn(), attrs: {}, slots: {} })
+
+    ;(globalThis as any).getCurrentPages = vi.fn(() => [
+      {
+        route: 'pages/home/index',
+        options: {},
+      },
+    ])
+
+    const router = createRouter({
+      routes: [
+        {
+          name: 'home',
+          path: '/pages/home/index',
+        },
+        {
+          name: 'profile',
+          path: '/pages/profile/index',
+        },
+      ],
+    })
+
+    ;(globalThis as any).wx.switchTab({
+      url: '/pages/profile/index',
+    })
+
+    expect(switchTab).toHaveBeenCalledWith(expect.objectContaining({
+      url: '/pages/profile/index',
+    }))
+    expect(router.currentRoute.path).toBe('pages/profile/index')
+    expect(router.currentRoute.name).toBe('profile')
   })
 
   it('onError receives thrown guard errors and supports unregister', async () => {

--- a/packages-runtime/wevu/test/runtime-vue-compat.test.ts
+++ b/packages-runtime/wevu/test/runtime-vue-compat.test.ts
@@ -4,6 +4,11 @@ import { createWevuComponent, defineComponent, mergeModels, useAttrs, useBindMod
 
 const registeredComponents: Record<string, any>[] = []
 
+function expectRouteOption(call: unknown[], url: string): void {
+  expect(call[0]).toMatchObject({ url })
+  expect(call[0]).toMatchObject({ success: expect.any(Function) })
+}
+
 beforeEach(() => {
   registeredComponents.length = 0
   delete (globalThis as any).wx
@@ -374,8 +379,8 @@ describe('runtime: vue compat helpers', () => {
     opts.lifetimes.created.call(inst)
     opts.lifetimes.attached.call(inst)
 
-    expect(componentRouter.navigateTo).toHaveBeenCalledWith({ url: '/components/demo-card/from-component' })
-    expect(pageRouter.navigateTo).toHaveBeenCalledWith({ url: '/pages/demo/from-page' })
+    expectRouteOption(componentRouter.navigateTo.mock.calls[0], '/components/demo-card/from-component')
+    expectRouteOption(pageRouter.navigateTo.mock.calls[0], '/pages/demo/from-page')
   })
 
   it('useNativeRouter/useNativePageRouter fallback to global route methods when instance router is unavailable', () => {
@@ -410,8 +415,8 @@ describe('runtime: vue compat helpers', () => {
     opts.lifetimes.created.call(inst)
     opts.lifetimes.attached.call(inst)
 
-    expect(wxNavigateTo).toHaveBeenCalledWith({ url: '/pages/a/index' })
-    expect(wxRedirectTo).toHaveBeenCalledWith({ url: '/pages/b/index' })
+    expectRouteOption(wxNavigateTo.mock.calls[0], '/pages/a/index')
+    expectRouteOption(wxRedirectTo.mock.calls[0], '/pages/b/index')
   })
 
   it('useNativeRouter/useNativePageRouter fallback to complementary instance accessor before global fallback', () => {
@@ -473,11 +478,11 @@ describe('runtime: vue compat helpers', () => {
     componentRouterOnlyOptions.lifetimes.attached.call(componentRouterOnlyInstance)
 
     expect(pageRouterOnly.navigateTo).toHaveBeenCalledTimes(2)
-    expect(pageRouterOnly.navigateTo).toHaveBeenNthCalledWith(1, { url: '/components/fallback-card/from-component-fallback' })
-    expect(pageRouterOnly.navigateTo).toHaveBeenNthCalledWith(2, { url: '/pages/fallback/from-page-fallback' })
+    expectRouteOption(pageRouterOnly.navigateTo.mock.calls[0], '/components/fallback-card/from-component-fallback')
+    expectRouteOption(pageRouterOnly.navigateTo.mock.calls[1], '/pages/fallback/from-page-fallback')
     expect(componentRouterOnly.navigateTo).toHaveBeenCalledTimes(2)
-    expect(componentRouterOnly.navigateTo).toHaveBeenNthCalledWith(1, { url: '/components/router-only/from-component-only' })
-    expect(componentRouterOnly.navigateTo).toHaveBeenNthCalledWith(2, { url: '/pages/router-only/from-page-only' })
+    expectRouteOption(componentRouterOnly.navigateTo.mock.calls[0], '/components/router-only/from-component-only')
+    expectRouteOption(componentRouterOnly.navigateTo.mock.calls[1], '/pages/router-only/from-page-only')
   })
 
   it('useNativeRouter/useNativePageRouter fallback to my route methods when wx is unavailable', () => {
@@ -524,7 +529,7 @@ describe('runtime: vue compat helpers', () => {
     opts.lifetimes.created.call(inst)
     opts.lifetimes.attached.call(inst)
 
-    expect(myGlobal.navigateTo).toHaveBeenCalledWith({ url: '/pages/fallback-my/index' })
+    expectRouteOption(myGlobal.navigateTo.mock.calls[0], '/pages/fallback-my/index')
     expect(myGlobal.navigateBack).toHaveBeenCalledWith({ delta: 1 })
     expect(myContexts).toHaveLength(2)
     expect(myContexts.every(context => context === myGlobal)).toBe(true)
@@ -574,8 +579,8 @@ describe('runtime: vue compat helpers', () => {
     opts.lifetimes.created.call(inst)
     opts.lifetimes.attached.call(inst)
 
-    expect(ttGlobal.reLaunch).toHaveBeenCalledWith({ url: '/pages/fallback-tt/index' })
-    expect(ttGlobal.redirectTo).toHaveBeenCalledWith({ url: '/pages/fallback-tt/detail' })
+    expectRouteOption(ttGlobal.reLaunch.mock.calls[0], '/pages/fallback-tt/index')
+    expectRouteOption(ttGlobal.redirectTo.mock.calls[0], '/pages/fallback-tt/detail')
     expect(ttContexts).toHaveLength(2)
     expect(ttContexts.every(context => context === ttGlobal)).toBe(true)
   })


### PR DESCRIPTION
## 摘要

修复 #705。wevu router 成功导航后会立即同步 `currentRoute` / `useRoute()`，后续 `beforeEach` / `afterEach` 可以拿到正确的 `from`；原生 `switchTab` 成功后也会同步路由状态。

## 变更

- 新增 router route sync 广播机制，成功导航后统一更新已注册的 route state。
- 包装 wevu 原生 router 与当前宿主全局 router 的成功回调，同步原生导航后的 route。
- 补充 issue #705 单测、github-issues fixture 和 changeset。

## 验证

- `pnpm vitest run packages-runtime/wevu/test/router-navigation.test.ts packages-runtime/wevu/test/router-api.test.ts packages-runtime/wevu/src/runtime/platform.test.ts`
- `pnpm exec eslint packages-runtime/wevu/src/router/createRouter.ts packages-runtime/wevu/src/router/navigationResult.ts packages-runtime/wevu/src/router/routeSync.ts packages-runtime/wevu/src/router/useRoute.ts packages-runtime/wevu/src/runtime/vueCompat/router.ts packages-runtime/wevu/test/router-navigation.test.ts e2e-apps/github-issues/src/pages/issue-705/index.vue e2e/ci/github-issues.build.test.ts`
- `pnpm --filter wevu build`
- `pnpm --filter wevu test:types`
- `node packages/weapp-vite/bin/weapp-vite.js build e2e-apps/github-issues --platform weapp --skipNpm`
- 手动断言 `pages/issue-705/index.js` 包含 `_runE2E` 和 `pages/issue-550/index`，`pages/issue-705/index.wxml` 包含 `data-route-path`

## 说明

- `pnpm --filter wevu typecheck` 仍受既有非本次改动文件的类型错误阻塞：`src/runtime/define/initialComputed.ts` 与 `test/fetch.test.ts`。
- 单个 `e2e/ci/github-issues.build.test.ts -t "issue #705"` 未继续重跑，因为同一机器上已有另一个 DevTools e2e 进程占用，按 e2e 串行规则改用普通 app build 和产物断言验证。