### PR TITLE
fix(miniprogram-automator): 恢复 Page RPC 超时降级

### DIFF
--- a/.changeset/fix-issue-706-page-rpc.md
+++ b/.changeset/fix-issue-706-page-rpc.md
@@ -1,0 +1,5 @@
+---
+"@weapp-vite/miniprogram-automator": patch
+---
+
+修复微信开发者工具新版自动化连接中 `Page.*` 域 RPC 超时后页面查询和数据读取会长期卡住的问题。页面元素查询、数据读取、`setData` 和页面方法调用会在可恢复的 Page 协议异常后降级到 App-Service route 查询，避免 `page.$$`、`page.$`、`page.data()` 探针硬超时。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -505,6 +505,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-706/index",
+          "pathName": "pages/issue-706/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-528/index",
           "pathName": "pages/issue-528/index",
           "query": "",

--- a/e2e-apps/github-issues/src/pages/issue-706/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-706/index.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { ref } from 'wevu'
+
+definePageJson({
+  navigationBarTitleText: 'issue-706',
+})
+
+const probeStatus = ref('ready')
+const probeMessage = ref('issue-706 automator page rpc ready')
+
+function _runE2E() {
+  return {
+    message: probeMessage.value,
+    ok: probeStatus.value === 'ready',
+    status: probeStatus.value,
+  }
+}
+
+defineExpose({
+  _runE2E,
+})
+</script>
+
+<template>
+  <view
+    id="issue706-page"
+    class="issue706-page"
+  >
+    <view class="hello" data-issue706-status="ready">
+      {{ probeMessage }}
+    </view>
+    <text class="issue706-status">
+      {{ probeStatus }}
+    </text>
+  </view>
+</template>
+
+<style scoped>
+.issue706-page {
+  padding: 24rpx;
+}
+
+.hello,
+.issue706-status {
+  display: block;
+  margin-top: 16rpx;
+}
+</style>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -87,6 +87,9 @@ const githubIssuesRouteGroups: Record<string, string[]> = {
     'pages/issue-674/**',
     'components/issue-674/**',
   ],
+  'github-issues.runtime.issue706.test.ts': [
+    'pages/issue-706/**',
+  ],
   'github-issues.runtime.issue581.test.ts': [
     'pages/issue-581/**',
   ],

--- a/e2e/ide/github-issues.runtime.issue706.test.ts
+++ b/e2e/ide/github-issues.runtime.issue706.test.ts
@@ -1,0 +1,58 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  closeSharedMiniProgram,
+  getSharedMiniProgram,
+  PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT,
+  prepareGithubIssuesBuild,
+  relaunchPage,
+  releaseSharedMiniProgram,
+} from './github-issues.runtime.shared'
+
+describe.sequential('e2e app: github-issues / issue #706', () => {
+  beforeAll(async () => {
+    await prepareGithubIssuesBuild()
+  }, PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT)
+
+  afterAll(async () => {
+    await closeSharedMiniProgram()
+  })
+
+  it('keeps Page query and data probes responsive when DevTools Page RPC degrades', async (ctx) => {
+    const miniProgram = await getSharedMiniProgram(ctx)
+    try {
+      const issuePage = await relaunchPage(
+        miniProgram,
+        '/pages/issue-706/index',
+        'issue-706 automator page rpc ready',
+        30_000,
+        {
+          readiness: async (page: any) => {
+            const runtime = await page.callMethodWithOptions('_runE2E', {
+              timeout: 5_000,
+            }).catch(() => undefined)
+            return runtime?.ok === true
+          },
+        },
+      )
+      if (!issuePage) {
+        throw new Error('Failed to launch issue-706 page')
+      }
+
+      await issuePage.waitForRendered({
+        selector: '.hello',
+        timeout: 10_000,
+      })
+
+      const helloElements = await issuePage.$$('.hello', { timeout: 5_000 })
+      const hello = await issuePage.$('.hello', { timeout: 5_000 })
+      const status = await issuePage.data('probeStatus', { timeout: 5_000 })
+
+      expect(helloElements.length).toBeGreaterThan(0)
+      expect(hello).not.toBeNull()
+      expect(status).toBe('ready')
+    }
+    finally {
+      await releaseSharedMiniProgram(miniProgram)
+    }
+  })
+})

--- a/e2e/scripts/e2e-suite-manifest.ts
+++ b/e2e/scripts/e2e-suite-manifest.ts
@@ -26,6 +26,7 @@ const IDE_GITHUB_ISSUES_PATTERNS = [
   'ide/github-issues.runtime.issue642-bug7-default.test.ts',
   'ide/github-issues.runtime.issue642-bug7-performance.test.ts',
   'ide/github-issues.runtime.issue642.test.ts',
+  'ide/github-issues.runtime.issue706.test.ts',
   'ide/github-issues.runtime.issue553-555.test.ts',
   'ide/github-issues.runtime.lifecycle.test.ts',
   'ide/github-issues.runtime.props.test.ts',

--- a/e2e/scripts/suiteRunner.test.ts
+++ b/e2e/scripts/suiteRunner.test.ts
@@ -292,10 +292,11 @@ describe('suiteRunner', () => {
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue642-bug7-default.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue642-bug7-performance.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue642.test.ts')
+    expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue706.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.lifecycle.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.slot-fallback-compiler-off.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.slot-fallback.test.ts')
-    expect(ideGithubIssuesTasks.length).toBe(15)
+    expect(ideGithubIssuesTasks.length).toBe(16)
     expect(ideGithubIssuesTasks.find(task => task.env?.WEAPP_VITE_E2E_AUTOMATOR_LAUNCH_MODE === 'direct')).toBeUndefined()
   })
 

--- a/packages/miniprogram-automator/src/Page.ts
+++ b/packages/miniprogram-automator/src/Page.ts
@@ -4,6 +4,7 @@
 import type Connection from './Connection'
 import Element from './Element'
 import { isFn, isNum, isStr, sleep, waitUntil } from './internal/compat'
+import { createRouteFallbackElement } from './pageRouteFallback'
 /** IPageOptions 的类型定义。 */
 export interface IPageOptions {
   id: number
@@ -14,6 +15,8 @@ type PageMap = Map<number, Page>
 type WaitCondition = string | number | (() => unknown | Promise<unknown>)
 interface PageQueryOptions {
   componentSelectors?: string[]
+  fallback?: boolean
+  routeOnly?: boolean
   timeout?: number
 }
 interface PageDataOptions {
@@ -47,7 +50,9 @@ export interface RenderedNodeSnapshot {
 export type RenderedSelectorNodesSnapshot = Record<string, RenderedNodeSnapshot[]>
 const PAGE_QUERY_TIMEOUT = 2_500
 const PAGE_DATA_TIMEOUT = 12_000
+const PAGE_DATA_PROTOCOL_TIMEOUT = 2_500
 const PAGE_SET_DATA_TIMEOUT = 12_000
+const PAGE_SET_DATA_PROTOCOL_TIMEOUT = 2_500
 const PAGE_CALL_METHOD_TIMEOUT = 12_000
 const PAGE_CALL_METHOD_PROTOCOL_TIMEOUT = 2_500
 const PAGE_CALL_METHOD_FALLBACK_RETRIES = 3
@@ -102,6 +107,7 @@ export default class Page {
   query: any = {}
   private id: number
   private elementMap = new Map<string, Element>()
+  private preferRoutePageFallback = false
   constructor(private connection: Connection, options: IPageOptions) {
     this.id = options.id
     this.path = options.path
@@ -128,24 +134,43 @@ export default class Page {
   }
 
   async $(selector: string, options: PageQueryOptions = {}) {
+    if (options.routeOnly || this.preferRoutePageFallback) {
+      return await this.queryRouteElement(selector, options)
+    }
     try {
       const element = await this.send('Page.getElement', { selector }, {
         timeout: options.timeout ?? PAGE_QUERY_TIMEOUT,
       })
       return Element.create(this.connection, { ...element, pageId: this.id }, this.elementMap)
     }
-    catch {
+    catch (error) {
+      if (options.fallback !== false && isRecoverablePageProtocolError(error, 'Page.getElement')) {
+        this.preferRoutePageFallback = true
+        return await this.queryRouteElement(selector, options)
+      }
       return null
     }
   }
 
   async $$(selector: string, options: PageQueryOptions = {}) {
-    const { elements } = await this.send('Page.getElements', { selector }, {
-      timeout: options.timeout ?? PAGE_QUERY_TIMEOUT,
-    })
-    return elements.map((element: any) => {
-      return Element.create(this.connection, { ...element, pageId: this.id }, this.elementMap)
-    })
+    if (options.routeOnly || this.preferRoutePageFallback) {
+      return await this.queryRouteElements(selector, options)
+    }
+    try {
+      const { elements } = await this.send('Page.getElements', { selector }, {
+        timeout: options.timeout ?? PAGE_QUERY_TIMEOUT,
+      })
+      return elements.map((element: any) => {
+        return Element.create(this.connection, { ...element, pageId: this.id }, this.elementMap)
+      })
+    }
+    catch (error) {
+      if (options.fallback === false || !isRecoverablePageProtocolError(error, 'Page.getElements')) {
+        throw error
+      }
+      this.preferRoutePageFallback = true
+      return await this.queryRouteElements(selector, options)
+    }
   }
 
   async getElementByXpath(selector: string, options: PageQueryOptions = {}) {
@@ -661,12 +686,12 @@ export default class Page {
       payload.path = path
     }
     const timeout = options.timeout ?? PAGE_DATA_TIMEOUT
-    if (options.routeOnly) {
+    if (options.routeOnly || this.preferRoutePageFallback) {
       return await this.readRouteData(path, timeout)
     }
     try {
       return (await this.send('Page.getData', payload, {
-        timeout,
+        timeout: Math.min(timeout, PAGE_DATA_PROTOCOL_TIMEOUT),
       })).data
     }
     catch (error) {
@@ -676,6 +701,7 @@ export default class Page {
       if (!isRecoverablePageProtocolError(error, 'Page.getData')) {
         throw error
       }
+      this.preferRoutePageFallback = true
       return await this.readRouteData(path, timeout)
     }
   }
@@ -734,15 +760,20 @@ export default class Page {
   }
 
   async setData(data: any) {
+    if (this.preferRoutePageFallback) {
+      await this.setRouteData(data)
+      return
+    }
     try {
       await this.send('Page.setData', { data }, {
-        timeout: PAGE_SET_DATA_TIMEOUT,
+        timeout: PAGE_SET_DATA_PROTOCOL_TIMEOUT,
       })
     }
     catch (error) {
       if (!isRecoverablePageProtocolError(error, 'Page.setData') && !isPageStackStaleError(error)) {
         throw error
       }
+      this.preferRoutePageFallback = true
       await this.setRouteData(data)
     }
   }
@@ -760,7 +791,7 @@ export default class Page {
   }
 
   async callMethodWithOptions(method: string, options: PageCallMethodOptions = {}, ...args: any[]) {
-    if (options.routeOnly) {
+    if (options.routeOnly || this.preferRoutePageFallback) {
       return await this.callRouteMethod(method, args, options.timeout)
     }
     try {
@@ -775,8 +806,29 @@ export default class Page {
       if (!isRecoverablePageProtocolError(error, 'Page.callMethod') && !isPageStackStaleError(error)) {
         throw error
       }
+      this.preferRoutePageFallback = true
     }
     return await this.callRouteMethod(method, args, options.timeout)
+  }
+
+  private async queryRouteElement(selector: string, options: PageQueryOptions) {
+    const elements = await this.queryRouteElements(selector, options)
+    return elements[0] ?? null
+  }
+
+  private async queryRouteElements(selector: string, options: PageQueryOptions) {
+    const nodes = await this.renderedNodes(selector, {
+      componentSelectors: options.componentSelectors,
+      timeout: options.timeout ?? PAGE_QUERY_TIMEOUT,
+    })
+    return nodes.map((node, index) => createRouteFallbackElement(
+      this.connection,
+      this.elementMap,
+      this.id,
+      selector,
+      node,
+      index,
+    ))
   }
 
   private async callRouteMethod(method: string, args: any[], timeout = PAGE_CALL_METHOD_TIMEOUT) {

--- a/packages/miniprogram-automator/src/objects.test.ts
+++ b/packages/miniprogram-automator/src/objects.test.ts
@@ -101,6 +101,113 @@ describe('Page', () => {
     })
   })
 
+  it('falls back to app-service rendered nodes when Page.getElements times out', async () => {
+    const timeoutError = Object.assign(
+      new Error('DevTools did not respond to protocol method Page.getElements within 2500ms'),
+      {
+        code: 'DEVTOOLS_PROTOCOL_TIMEOUT',
+        method: 'Page.getElements',
+      },
+    )
+    const send = vi.fn(async (method: string) => {
+      if (method === 'Page.getElements') {
+        throw timeoutError
+      }
+      if (method === 'App.callFunction') {
+        return {
+          result: [
+            { id: 'root' },
+            { id: 'child' },
+          ],
+        }
+      }
+      return {}
+    })
+    const page = new Page(createConnection(send), { id: 7, path: '/pages/index', query: {} })
+
+    const elements = await page.$$('view')
+
+    expect(elements).toHaveLength(2)
+    expect(elements[0]?.tagName).toBe('view')
+    expect(send).toHaveBeenNthCalledWith(1, 'Page.getElements', {
+      pageId: 7,
+      selector: 'view',
+    }, {
+      timeout: 2_500,
+    })
+    expect(send).toHaveBeenNthCalledWith(2, 'App.callFunction', {
+      args: ['pages/index', {}, 'view', []],
+      functionDeclaration: expect.stringContaining('createSelectorQuery'),
+    }, {
+      timeout: 2_500,
+    })
+  })
+
+  it('keeps using app-service fallbacks after Page element RPC times out', async () => {
+    const timeoutError = Object.assign(
+      new Error('DevTools did not respond to protocol method Page.getElements within 2500ms'),
+      {
+        code: 'DEVTOOLS_PROTOCOL_TIMEOUT',
+        method: 'Page.getElements',
+      },
+    )
+    const send = vi.fn(async (method: string) => {
+      if (method === 'Page.getElements') {
+        throw timeoutError
+      }
+      if (method === 'App.callFunction') {
+        return { result: [{ id: 'fallback-node' }] }
+      }
+      throw new Error(`${method} should not be called after route fallback is active`)
+    })
+    const page = new Page(createConnection(send), { id: 7, path: '/pages/index', query: {} })
+
+    await expect(page.$$('view')).resolves.toHaveLength(1)
+    await expect(page.$('.hello')).resolves.not.toBeNull()
+
+    expect(send).not.toHaveBeenCalledWith('Page.getElement', expect.anything(), expect.anything())
+    expect(send).toHaveBeenCalledTimes(3)
+    expect(send).toHaveBeenNthCalledWith(3, 'App.callFunction', {
+      args: ['pages/index', {}, '.hello', []],
+      functionDeclaration: expect.stringContaining('createSelectorQuery'),
+    }, {
+      timeout: 2_500,
+    })
+  })
+
+  it('reads data through app-service after Page element RPC times out', async () => {
+    const timeoutError = Object.assign(
+      new Error('DevTools did not respond to protocol method Page.getElements within 2500ms'),
+      {
+        code: 'DEVTOOLS_PROTOCOL_TIMEOUT',
+        method: 'Page.getElements',
+      },
+    )
+    const send = vi.fn(async (method: string, params?: Record<string, any>) => {
+      if (method === 'Page.getElements') {
+        throw timeoutError
+      }
+      if (method === 'App.callFunction') {
+        return params?.args?.[2] === 'probeStatus'
+          ? { result: 'ready' }
+          : { result: [{ id: 'fallback-node' }] }
+      }
+      throw new Error(`${method} should not be called after route fallback is active`)
+    })
+    const page = new Page(createConnection(send), { id: 7, path: '/pages/index', query: {} })
+
+    await expect(page.$$('view')).resolves.toHaveLength(1)
+    await expect(page.data('probeStatus')).resolves.toBe('ready')
+
+    expect(send).not.toHaveBeenCalledWith('Page.getData', expect.anything(), expect.anything())
+    expect(send).toHaveBeenNthCalledWith(3, 'App.callFunction', {
+      args: ['/pages/index', {}, 'probeStatus'],
+      functionDeclaration: expect.stringContaining('readPath'),
+    }, {
+      timeout: 12_000,
+    })
+  })
+
   it('queries data and window properties with page id', async () => {
     const send = vi.fn(async (method: string) => {
       if (method === 'Page.getData') {
@@ -117,7 +224,7 @@ describe('Page', () => {
     await expect(page.size()).resolves.toEqual({ width: 320, height: 640 })
 
     expect(send).toHaveBeenNthCalledWith(1, 'Page.getData', { path: 'foo', pageId: 8 }, {
-      timeout: 12_000,
+      timeout: 2_500,
     })
     expect(send).toHaveBeenNthCalledWith(2, 'Page.getWindowProperties', {
       names: ['document.documentElement.scrollWidth', 'document.documentElement.scrollHeight'],
@@ -309,7 +416,7 @@ describe('Page', () => {
       pageId: 8,
       path: '__e2eResult.status',
     }, {
-      timeout: 12_000,
+      timeout: 2_500,
     })
     expect(send).toHaveBeenNthCalledWith(2, 'App.callFunction', {
       functionDeclaration: expect.stringContaining('getCurrentPages'),
@@ -570,7 +677,7 @@ describe('Page', () => {
       data: { title: 'updated' },
       pageId: 8,
     }, {
-      timeout: 12_000,
+      timeout: 2_500,
     })
     expect(send).toHaveBeenNthCalledWith(2, 'App.callFunction', {
       functionDeclaration: expect.stringContaining('getCurrentPages'),

--- a/packages/miniprogram-automator/src/pageRouteFallback.ts
+++ b/packages/miniprogram-automator/src/pageRouteFallback.ts
@@ -1,0 +1,41 @@
+/**
+ * @file 页面 route 降级查询工具。
+ */
+import type Connection from './Connection'
+import Element from './Element'
+
+interface RouteRenderedNode {
+  id?: string
+}
+
+function normalizeFallbackIdPart(value: string) {
+  return encodeURIComponent(value).replace(/%/g, '_')
+}
+
+function resolveFallbackTagName(selector: string) {
+  const tagSelector = selector.trim()
+  if (/^[a-z][\w-]*$/i.test(tagSelector)) {
+    return tagSelector.toLowerCase()
+  }
+  return 'view'
+}
+
+/** 将 App-Service 查询到的渲染节点包装为 Element 兼容对象。 */
+export function createRouteFallbackElement(
+  connection: Connection,
+  elementMap: Map<string, Element>,
+  pageId: number,
+  selector: string,
+  node: RouteRenderedNode,
+  index: number,
+) {
+  const nodeId = typeof node.id === 'string' && node.id
+    ? normalizeFallbackIdPart(node.id)
+    : String(index)
+  const elementId = `__weapp_vite_route_fallback_${pageId}_${normalizeFallbackIdPart(selector)}_${nodeId}_${index}`
+  return Element.create(connection, {
+    elementId,
+    pageId,
+    tagName: resolveFallbackTagName(selector),
+  }, elementMap)
+}


### PR DESCRIPTION
## 摘要

修复 #706。新版微信开发者工具在 automator connect/bridge 场景下可能出现 `Page.*` 域 RPC 超时，导致 `page.50322`、`page.$`、`page.data()` 等探针长时间卡住。本 PR 保留官方 Page 协议优先路径，在可恢复的 Page 协议异常后降级到 App-Service route 查询。

## 改动

- 为 `Page.getElement(s)` 增加 App-Service 渲染节点降级，并在首次 Page 域异常后复用 route fallback，避免后续调用继续等待坏协议域。
- 将 `Page.getData`、`Page.setData` 的协议等待窗口收敛到短超时，失败后继续使用已有 route fallback。
- 新增 `pageRouteFallback` helper，避免继续扩张 `Page.ts`；`Page.ts` 已超过 300 行，本次只抽出新增 fallback 包装逻辑，未重拆既有大块 App-Service function 字符串，避免把修复扩大成无关重构。
- 在 `e2e-apps/github-issues` 增加 issue-706 复现页和 IDE runtime canary，覆盖 `page.50322`、`page.$`、`page.data()`。
- 添加 patch changeset。

## 验证

- `pnpm --filter @weapp-vite/miniprogram-automator test`
- `pnpm --filter @weapp-vite/miniprogram-automator typecheck`
- `pnpm --filter @weapp-vite/miniprogram-automator lint`
- `pnpm eslint packages/miniprogram-automator/src/Page.ts packages/miniprogram-automator/src/pageRouteFallback.ts packages/miniprogram-automator/src/objects.test.ts e2e/ide/github-issues.runtime.issue706.test.ts e2e/scripts/e2e-suite-manifest.ts e2e/scripts/suiteRunner.test.ts e2e-apps/github-issues/weapp-vite.config.ts e2e-apps/github-issues/src/pages/issue-706/index.vue`
- `pnpm vitest run e2e/scripts/suiteRunner.test.ts`
- `pnpm build:pkgs`
- `WEAPP_VITE_E2E_TARGET_FILE=e2e/ide/github-issues.runtime.issue706.test.ts pnpm --filter e2e-app-github-issues build`
- `pnpm vitest run -c e2e/vitest.e2e.devtools.config.ts e2e/ide/github-issues.runtime.issue706.test.ts`

## 取舍

fallback 返回的是由 App-Service 渲染节点包装出的 Element 兼容对象，用于让页面级存在性查询不再硬超时；它不把 Element 域能力伪装成完整替代协议。正常 DevTools 仍优先使用 `Page.*` 原生协议。