### PR TITLE
fix(miniprogram-automator): 修复 DevTools Page 协议超时

### DIFF
--- a/.changeset/fix-devtools-page-protocol.md
+++ b/.changeset/fix-devtools-page-protocol.md
@@ -1,0 +1,5 @@
+---
+'@weapp-vite/miniprogram-automator': patch
+---
+
+针对微信开发者工具 2.01.2510290 的 Page frame 协议无响应问题，自动选择 App-service Page 协议，避免元素查询、数据读写和页面方法调用等待协议超时后才降级。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -512,6 +512,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-705-tab/index",
+          "pathName": "pages/issue-705-tab/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-706/index",
           "pathName": "pages/issue-706/index",
           "query": "",

--- a/e2e-apps/github-issues/src/app.vue
+++ b/e2e-apps/github-issues/src/app.vue
@@ -5,6 +5,14 @@ import { ensureGithubIssuesRouter } from './shared/appRouter'
 
 const tabBarList = [
   {
+    pagePath: 'pages/issue-705/index',
+    text: 'issue-705',
+  },
+  {
+    pagePath: 'pages/issue-705-tab/index',
+    text: 'issue-705-tab',
+  },
+  {
     pagePath: 'pages/issue-380/index',
     text: 'issue-380',
   },

--- a/e2e-apps/github-issues/src/pages/issue-705-tab/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-705-tab/index.vue
@@ -3,15 +3,14 @@ import { computed, onReady, onUnload } from 'wevu'
 import { useRoute, useRouter } from 'wevu/router'
 
 definePageJson({
-  navigationBarTitleText: 'issue-705',
+  navigationBarTitleText: 'issue-705-tab',
 })
 
 const route = useRoute()
 const router = useRouter()
 const routePath = computed(() => route.path)
 const hookCalls: Array<{ phase: string, to?: string, from: string }> = []
-const PUSH_RESULT_STORAGE_KEY = '__weapp_vite_issue_705_push_result__'
-const SWITCH_TAB_RESULT_STORAGE_KEY = '__weapp_vite_issue_705_switch_tab_result__'
+const TAB_PUSH_RESULT_STORAGE_KEY = '__weapp_vite_issue_705_tab_push_result__'
 let lastFailure: null | { cause: string, type: number } = null
 let ready = false
 
@@ -34,7 +33,7 @@ const removeBeforeEach = router.beforeEach((to, from) => {
     to: to?.path,
     from: from.path,
   })
-  wx.setStorageSync(PUSH_RESULT_STORAGE_KEY, {
+  wx.setStorageSync(TAB_PUSH_RESULT_STORAGE_KEY, {
     from: from.path,
     stage: 'before',
     to: to?.path,
@@ -53,7 +52,7 @@ const removeAfterEach = router.afterEach((to, from, failure) => {
         type: failure.type,
       }
     : null
-  wx.setStorageSync(PUSH_RESULT_STORAGE_KEY, createSnapshot())
+  wx.setStorageSync(TAB_PUSH_RESULT_STORAGE_KEY, createSnapshot())
 })
 
 onUnload(() => {
@@ -65,30 +64,16 @@ onReady(() => {
   ready = true
 })
 
-async function _runE2E(action?: 'push' | 'switchTab') {
-  if (action === 'push') {
-    hookCalls.length = 0
-    lastFailure = null
-    wx.setStorageSync(PUSH_RESULT_STORAGE_KEY, {
-      stage: 'started',
-    })
-    await router.push('/pages/issue-550/index')
+async function _runE2E(action?: 'push') {
+  if (action !== 'push') {
     return createSnapshot()
   }
-
-  if (action === 'switchTab') {
-    await new Promise<void>((resolve, reject) => {
-      wx.switchTab({
-        url: '/pages/issue-705-tab/index',
-        success() {
-          wx.setStorageSync(SWITCH_TAB_RESULT_STORAGE_KEY, createSnapshot())
-          resolve()
-        },
-        fail: reject,
-      })
-    })
-  }
-
+  hookCalls.length = 0
+  lastFailure = null
+  wx.setStorageSync(TAB_PUSH_RESULT_STORAGE_KEY, {
+    stage: 'started',
+  })
+  await router.push('/pages/issue-550/index')
   return createSnapshot()
 }
 
@@ -99,24 +84,24 @@ defineExpose({
 
 <template>
   <view
-    class="issue705-page"
+    class="issue705-tab-page"
     :data-route-path="routePath"
   >
-    <text class="issue705-title">
-      issue-705 router route sync
+    <text class="issue705-tab-title">
+      issue-705 native switchTab target
     </text>
   </view>
 </template>
 
 <style scoped>
-.issue705-page {
+.issue705-tab-page {
   box-sizing: border-box;
   min-height: 100vh;
   padding: 24rpx;
   background: #fff;
 }
 
-.issue705-title {
+.issue705-tab-title {
   display: block;
   font-size: 30rpx;
   font-weight: 700;

--- a/e2e-apps/github-issues/src/pages/issue-706/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-706/index.vue
@@ -16,8 +16,14 @@ function _runE2E() {
   }
 }
 
+function _setProbeStatus(status: string) {
+  probeStatus.value = status
+  return _runE2E()
+}
+
 defineExpose({
   _runE2E,
+  _setProbeStatus,
 })
 </script>
 

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -87,6 +87,12 @@ const githubIssuesRouteGroups: Record<string, string[]> = {
     'pages/issue-674/**',
     'components/issue-674/**',
   ],
+  'github-issues.runtime.issue705.test.ts': [
+    'pages/issue-550/**',
+    'pages/issue-705/**',
+    'pages/issue-705-tab/**',
+    'custom-tab-bar/**',
+  ],
   'github-issues.runtime.issue706.test.ts': [
     'pages/issue-706/**',
   ],

--- a/e2e/ide/github-issues.runtime.issue705.test.ts
+++ b/e2e/ide/github-issues.runtime.issue705.test.ts
@@ -1,0 +1,157 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  closeSharedMiniProgram,
+  getSharedMiniProgram,
+  PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT,
+  prepareGithubIssuesBuild,
+  relaunchPage,
+  releaseSharedMiniProgram,
+  waitForCurrentPagePath,
+} from './github-issues.runtime.shared'
+
+const PUSH_RESULT_STORAGE_KEY = '__weapp_vite_issue_705_push_result__'
+const SWITCH_TAB_RESULT_STORAGE_KEY = '__weapp_vite_issue_705_switch_tab_result__'
+const TAB_PUSH_RESULT_STORAGE_KEY = '__weapp_vite_issue_705_tab_push_result__'
+const STORAGE_TIMEOUT = 8_000
+
+async function removeStorage(miniProgram: any, key: string) {
+  await miniProgram.callWxMethodWithOptions('removeStorageSync', {
+    timeout: 2_500,
+  }, key).catch(() => {})
+}
+
+async function waitForStorage(miniProgram: any, key: string) {
+  const start = Date.now()
+  let latest: any
+  while (Date.now() - start <= STORAGE_TIMEOUT) {
+    latest = await miniProgram.callWxMethodWithOptions('getStorageSync', {
+      timeout: 2_500,
+    }, key).catch(() => undefined)
+    if (latest?.route?.path) {
+      return latest
+    }
+    await new Promise(resolve => setTimeout(resolve, 200))
+  }
+  throw new Error(`Timed out waiting for issue #705 storage probe: key=${key} latest=${JSON.stringify(latest)}`)
+}
+
+function expectNavigationResult(result: any, from: string) {
+  expect(result.hooks).toEqual([
+    {
+      phase: 'before',
+      to: 'pages/issue-550/index',
+      from,
+    },
+    {
+      phase: 'after',
+      to: 'pages/issue-550/index',
+      from,
+    },
+  ])
+  if (result.failure) {
+    // 当前 DevTools 在 Page.callMethod 内导航时可能超时；hooks 参数仍必须正确。
+    expect(result.failure.cause).toContain('navigateTo:fail timeout')
+    expect(result.route.path).toBe(from)
+  }
+  else {
+    expect(result.route.path).toBe('pages/issue-550/index')
+  }
+}
+
+async function isIssue705PageReady(page: any) {
+  const runtime = await page.callMethodWithOptions('_runE2E', {
+    timeout: 5_000,
+  }).catch(() => undefined)
+  return runtime?.ready === true && runtime?.route?.path === 'pages/issue-705/index'
+}
+
+async function waitForIssue705TabReady(page: any) {
+  const start = Date.now()
+  let latest: any
+  while (Date.now() - start <= STORAGE_TIMEOUT) {
+    latest = await page.callMethodWithOptions('_runE2E', {
+      timeout: 5_000,
+    }).catch(() => undefined)
+    if (latest?.ready === true && latest?.route?.path === 'pages/issue-705-tab/index') {
+      return latest
+    }
+    await new Promise(resolve => setTimeout(resolve, 200))
+  }
+  throw new Error(`Timed out waiting for issue #705 tab readiness: ${JSON.stringify(latest)}`)
+}
+
+describe.sequential('e2e app: github-issues / issue #705', () => {
+  beforeAll(async () => {
+    await prepareGithubIssuesBuild()
+  }, PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT)
+
+  afterAll(async () => {
+    await closeSharedMiniProgram()
+  })
+
+  it('keeps route state and hook origins synchronized across router and native tab navigation', async (ctx) => {
+    const miniProgram = await getSharedMiniProgram(ctx)
+    try {
+      await Promise.all([
+        removeStorage(miniProgram, PUSH_RESULT_STORAGE_KEY),
+        removeStorage(miniProgram, SWITCH_TAB_RESULT_STORAGE_KEY),
+        removeStorage(miniProgram, TAB_PUSH_RESULT_STORAGE_KEY),
+      ])
+
+      const issuePage = await relaunchPage(
+        miniProgram,
+        '/pages/issue-705/index',
+        undefined,
+        30_000,
+        {
+          readiness: isIssue705PageReady,
+        },
+      )
+      if (!issuePage) {
+        throw new Error('Failed to launch issue-705 page')
+      }
+
+      await issuePage.callMethodWithOptions('_runE2E', {
+        timeout: 12_000,
+      }, 'push').catch(() => undefined)
+      const pushResult = await waitForStorage(miniProgram, PUSH_RESULT_STORAGE_KEY)
+      expectNavigationResult(pushResult, 'pages/issue-705/index')
+
+      const reloadedIssuePage = await relaunchPage(
+        miniProgram,
+        '/pages/issue-705/index',
+        undefined,
+        30_000,
+        {
+          readiness: isIssue705PageReady,
+        },
+      )
+      if (!reloadedIssuePage) {
+        throw new Error('Failed to relaunch issue-705 page')
+      }
+
+      await reloadedIssuePage.callMethodWithOptions('_runE2E', {
+        timeout: 12_000,
+      }, 'switchTab').catch(() => undefined)
+      const switchTabResult = await waitForStorage(miniProgram, SWITCH_TAB_RESULT_STORAGE_KEY)
+      expect(switchTabResult.route.path).toBe('pages/issue-705-tab/index')
+
+      const tabPage = await waitForCurrentPagePath(miniProgram, '/pages/issue-705-tab/index', 8_000)
+      if (!tabPage) {
+        throw new Error('Failed to switch to issue-705 tab page')
+      }
+
+      const tabSnapshot = await waitForIssue705TabReady(tabPage)
+      expect(tabSnapshot.route.path).toBe('pages/issue-705-tab/index')
+
+      await tabPage.callMethodWithOptions('_runE2E', {
+        timeout: 12_000,
+      }, 'push').catch(() => undefined)
+      const tabPushResult = await waitForStorage(miniProgram, TAB_PUSH_RESULT_STORAGE_KEY)
+      expectNavigationResult(tabPushResult, 'pages/issue-705-tab/index')
+    }
+    finally {
+      await releaseSharedMiniProgram(miniProgram)
+    }
+  })
+})

--- a/e2e/ide/github-issues.runtime.issue706.test.ts
+++ b/e2e/ide/github-issues.runtime.issue706.test.ts
@@ -17,7 +17,7 @@ describe.sequential('e2e app: github-issues / issue #706', () => {
     await closeSharedMiniProgram()
   })
 
-  it('keeps Page query and data probes responsive when DevTools Page RPC degrades', async (ctx) => {
+  it('uses the app-service Page protocol when the DevTools page-frame channel is unavailable', async (ctx) => {
     const miniProgram = await getSharedMiniProgram(ctx)
     try {
       const issuePage = await relaunchPage(
@@ -43,13 +43,20 @@ describe.sequential('e2e app: github-issues / issue #706', () => {
         timeout: 10_000,
       })
 
+      const startedAt = Date.now()
       const helloElements = await issuePage.$$('.hello', { timeout: 5_000 })
       const hello = await issuePage.$('.hello', { timeout: 5_000 })
       const status = await issuePage.data('probeStatus', { timeout: 5_000 })
+      await issuePage.setData({ probeStatus: 'updated' })
+      const updatedStatus = await issuePage.data('probeStatus', { timeout: 5_000 })
+      const runtime = await issuePage.callMethodWithOptions('_setProbeStatus', { timeout: 5_000 }, 'method')
 
       expect(helloElements.length).toBeGreaterThan(0)
       expect(hello).not.toBeNull()
       expect(status).toBe('ready')
+      expect(updatedStatus).toBe('updated')
+      expect(runtime).toMatchObject({ ok: false, status: 'method' })
+      expect(Date.now() - startedAt).toBeLessThan(2_000)
     }
     finally {
       await releaseSharedMiniProgram(miniProgram)

--- a/e2e/scripts/e2e-suite-manifest.ts
+++ b/e2e/scripts/e2e-suite-manifest.ts
@@ -30,6 +30,7 @@ const IDE_GITHUB_ISSUES_PATTERNS = [
   'ide/github-issues.runtime.issue642-bug7-default.test.ts',
   'ide/github-issues.runtime.issue642-bug7-performance.test.ts',
   'ide/github-issues.runtime.issue642.test.ts',
+  'ide/github-issues.runtime.issue705.test.ts',
   'ide/github-issues.runtime.issue706.test.ts',
   'ide/github-issues.runtime.issue553-555.test.ts',
   'ide/github-issues.runtime.lifecycle.test.ts',

--- a/e2e/scripts/suiteRunner.test.ts
+++ b/e2e/scripts/suiteRunner.test.ts
@@ -294,11 +294,12 @@ describe('suiteRunner', () => {
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue642-bug7-default.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue642-bug7-performance.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue642.test.ts')
+    expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue705.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.issue706.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.lifecycle.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.slot-fallback-compiler-off.test.ts')
     expect(ideGithubIssuesLabels).toContain('ide/github-issues.runtime.slot-fallback.test.ts')
-    expect(ideGithubIssuesTasks.length).toBe(16)
+    expect(ideGithubIssuesTasks.length).toBe(17)
     expect(ideGithubIssuesTasks.find(task => task.env?.WEAPP_VITE_E2E_AUTOMATOR_LAUNCH_MODE === 'direct')).toBeUndefined()
   })
 

--- a/packages/miniprogram-automator/src/Connection.ts
+++ b/packages/miniprogram-automator/src/Connection.ts
@@ -28,9 +28,17 @@ interface ProtocolResponse {
   result?: any
   params?: any
 }
+interface ToolInfo {
+  version?: string
+}
+/** Page frame 定向消息失效、需要切换到 App-service Page 协议的 DevTools 版本。 */
+const APP_SERVICE_PAGE_PROTOCOL_VERSIONS = new Set([
+  '2.01.2510290',
+])
 /** Connection 的实现。 */
 export default class Connection extends EventEmitter {
   private callbacks = new Map<string, PendingCallback>()
+  private useAppServicePageProtocol = false
   constructor(private transport: Transport) {
     super()
     transport.on('message', this.onMessage)
@@ -68,6 +76,15 @@ export default class Connection extends EventEmitter {
 
   dispose() {
     this.transport.close()
+  }
+
+  /** 根据 DevTools 版本选择稳定的 Page 协议实现。 */
+  configureToolInfo(info: ToolInfo) {
+    this.useAppServicePageProtocol = APP_SERVICE_PAGE_PROTOCOL_VERSIONS.has(String(info.version ?? ''))
+  }
+
+  get prefersAppServicePageProtocol() {
+    return this.useAppServicePageProtocol
   }
 
   private onMessage = (message: string) => {

--- a/packages/miniprogram-automator/src/MiniProgram.ts
+++ b/packages/miniprogram-automator/src/MiniProgram.ts
@@ -464,7 +464,9 @@ export default class MiniProgram extends EventEmitter {
   }
 
   async checkVersion() {
-    const sdkVersion = (await this.send('Tool.getInfo')).SDKVersion
+    const toolInfo = await this.send('Tool.getInfo')
+    this.connection.configureToolInfo(toolInfo)
+    const sdkVersion = toolInfo.SDKVersion
     if (sdkVersion !== 'dev' && cmpVersion(sdkVersion, '2.7.3') < 0) {
       throw new Error(`SDKVersion is currently ${sdkVersion}, while automator(${pkg.version}) requires at least version 2.7.3`)
     }

--- a/packages/miniprogram-automator/src/Page.ts
+++ b/packages/miniprogram-automator/src/Page.ts
@@ -107,11 +107,12 @@ export default class Page {
   query: any = {}
   private id: number
   private elementMap = new Map<string, Element>()
-  private preferRoutePageFallback = false
+  private preferAppServicePageProtocol = false
   constructor(private connection: Connection, options: IPageOptions) {
     this.id = options.id
     this.path = options.path
     this.query = options.query
+    this.preferAppServicePageProtocol = connection.prefersAppServicePageProtocol
   }
 
   updateFromOptions(options: IPageOptions) {
@@ -134,7 +135,7 @@ export default class Page {
   }
 
   async $(selector: string, options: PageQueryOptions = {}) {
-    if (options.routeOnly || this.preferRoutePageFallback) {
+    if (options.routeOnly || (options.fallback !== false && this.preferAppServicePageProtocol)) {
       return await this.queryRouteElement(selector, options)
     }
     try {
@@ -145,7 +146,7 @@ export default class Page {
     }
     catch (error) {
       if (options.fallback !== false && isRecoverablePageProtocolError(error, 'Page.getElement')) {
-        this.preferRoutePageFallback = true
+        this.preferAppServicePageProtocol = true
         return await this.queryRouteElement(selector, options)
       }
       return null
@@ -153,7 +154,7 @@ export default class Page {
   }
 
   async $$(selector: string, options: PageQueryOptions = {}) {
-    if (options.routeOnly || this.preferRoutePageFallback) {
+    if (options.routeOnly || (options.fallback !== false && this.preferAppServicePageProtocol)) {
       return await this.queryRouteElements(selector, options)
     }
     try {
@@ -168,7 +169,7 @@ export default class Page {
       if (options.fallback === false || !isRecoverablePageProtocolError(error, 'Page.getElements')) {
         throw error
       }
-      this.preferRoutePageFallback = true
+      this.preferAppServicePageProtocol = true
       return await this.queryRouteElements(selector, options)
     }
   }
@@ -690,7 +691,7 @@ export default class Page {
       payload.path = path
     }
     const timeout = options.timeout ?? PAGE_DATA_TIMEOUT
-    if (options.routeOnly || this.preferRoutePageFallback) {
+    if (options.routeOnly || (options.fallback !== false && this.preferAppServicePageProtocol)) {
       return await this.readRouteData(path, timeout)
     }
     try {
@@ -705,7 +706,7 @@ export default class Page {
       if (!isRecoverablePageProtocolError(error, 'Page.getData')) {
         throw error
       }
-      this.preferRoutePageFallback = true
+      this.preferAppServicePageProtocol = true
       return await this.readRouteData(path, timeout)
     }
   }
@@ -764,7 +765,7 @@ export default class Page {
   }
 
   async setData(data: any) {
-    if (this.preferRoutePageFallback) {
+    if (this.preferAppServicePageProtocol) {
       await this.setRouteData(data)
       return
     }
@@ -777,7 +778,7 @@ export default class Page {
       if (!isRecoverablePageProtocolError(error, 'Page.setData') && !isPageStackStaleError(error)) {
         throw error
       }
-      this.preferRoutePageFallback = true
+      this.preferAppServicePageProtocol = true
       await this.setRouteData(data)
     }
   }
@@ -795,7 +796,7 @@ export default class Page {
   }
 
   async callMethodWithOptions(method: string, options: PageCallMethodOptions = {}, ...args: any[]) {
-    if (options.routeOnly || this.preferRoutePageFallback) {
+    if (options.routeOnly || (options.fallback !== false && this.preferAppServicePageProtocol)) {
       return await this.callRouteMethod(method, args, options.timeout)
     }
     try {
@@ -810,7 +811,7 @@ export default class Page {
       if (!isRecoverablePageProtocolError(error, 'Page.callMethod') && !isPageStackStaleError(error)) {
         throw error
       }
-      this.preferRoutePageFallback = true
+      this.preferAppServicePageProtocol = true
     }
     return await this.callRouteMethod(method, args, options.timeout)
   }

--- a/packages/miniprogram-automator/src/connection.test.ts
+++ b/packages/miniprogram-automator/src/connection.test.ts
@@ -63,6 +63,18 @@ describe('Connection', () => {
     await expect(pending).resolves.toEqual({ data: { ok: true } })
   })
 
+  it('selects the app-service Page protocol for affected DevTools versions', async () => {
+    const { default: Connection } = await import('./Connection')
+    const transport = new FakeTransport()
+    const connection = new Connection(transport as any)
+
+    connection.configureToolInfo({ version: '2.01.2510290' })
+    expect(connection.prefersAppServicePageProtocol).toBe(true)
+
+    connection.configureToolInfo({ version: '2.01.2601010' })
+    expect(connection.prefersAppServicePageProtocol).toBe(false)
+  })
+
   it('rejects protocol errors and pending callbacks on close', async () => {
     const { default: Connection } = await import('./Connection')
     const transport = new FakeTransport()

--- a/packages/miniprogram-automator/src/miniprogram.test.ts
+++ b/packages/miniprogram-automator/src/miniprogram.test.ts
@@ -22,6 +22,7 @@ vi.mock('./util', () => ({
 
 class FakeConnection extends EventEmitter {
   send = vi.fn<(method: string, params?: Record<string, any>, options?: Record<string, any>) => Promise<any>>(async () => ({}))
+  configureToolInfo = vi.fn()
   dispose = vi.fn()
 }
 
@@ -142,8 +143,12 @@ describe('MiniProgram', () => {
     const connection = new FakeConnection()
     const miniProgram = new MiniProgram(connection as any)
 
-    connection.send.mockResolvedValueOnce({ SDKVersion: '2.7.2' })
+    connection.send.mockResolvedValueOnce({ SDKVersion: '2.7.2', version: '2.01.2510290' })
     await expect(miniProgram.checkVersion()).rejects.toThrow('requires at least version 2.7.3')
+    expect(connection.configureToolInfo).toHaveBeenCalledWith({
+      SDKVersion: '2.7.2',
+      version: '2.01.2510290',
+    })
 
     connection.send.mockResolvedValueOnce({ SDKVersion: 'dev' })
     await expect(miniProgram.checkVersion()).resolves.toBeUndefined()

--- a/packages/miniprogram-automator/src/objects.test.ts
+++ b/packages/miniprogram-automator/src/objects.test.ts
@@ -23,6 +23,15 @@ function createConnection(send: (method: string, params?: Record<string, any>, o
   return { send } as any
 }
 
+function createAppServicePageConnection(
+  send: (method: string, params?: Record<string, any>, options?: Record<string, any>) => any,
+) {
+  return {
+    prefersAppServicePageProtocol: true,
+    send,
+  } as any
+}
+
 describe('Automator', () => {
   it('delegates connect and launch to the inner launcher', async () => {
     const automator = new Automator()
@@ -101,6 +110,34 @@ describe('Page', () => {
     })
   })
 
+  it('uses app-service Page protocol immediately for affected DevTools versions', async () => {
+    const send = vi.fn(async (method: string, params?: Record<string, any>) => {
+      if (method !== 'App.callFunction') {
+        throw new Error(`${method} should not use the broken page-frame protocol`)
+      }
+      if (params?.args?.[2] === 'status') {
+        return { result: 'ready' }
+      }
+      if (params?.args?.[2] === 'runE2E') {
+        return { result: { ok: true } }
+      }
+      return { result: [{ id: 'app-service-node' }] }
+    })
+    const page = new Page(
+      createAppServicePageConnection(send),
+      { id: 7, path: '/pages/index', query: {} },
+    )
+
+    await expect(page.$$('.hello')).resolves.toHaveLength(1)
+    await expect(page.data('status')).resolves.toBe('ready')
+    await expect(page.callMethod('runE2E')).resolves.toEqual({ ok: true })
+
+    expect(send).toHaveBeenCalledTimes(3)
+    expect(send).not.toHaveBeenCalledWith('Page.getElements', expect.anything(), expect.anything())
+    expect(send).not.toHaveBeenCalledWith('Page.getData', expect.anything(), expect.anything())
+    expect(send).not.toHaveBeenCalledWith('Page.callMethod', expect.anything(), expect.anything())
+  })
+
   it('falls back to app-service rendered nodes when Page.getElements times out', async () => {
     const timeoutError = Object.assign(
       new Error('DevTools did not respond to protocol method Page.getElements within 2500ms'),
@@ -170,6 +207,62 @@ describe('Page', () => {
     expect(send).toHaveBeenNthCalledWith(3, 'App.callFunction', {
       args: ['pages/index', {}, '.hello', []],
       functionDeclaration: expect.stringContaining('createSelectorQuery'),
+    }, {
+      timeout: 2_500,
+    })
+  })
+
+  it('forces native Page RPC when fallback is disabled after a prior protocol timeout', async () => {
+    const timeoutError = Object.assign(
+      new Error('DevTools did not respond to protocol method Page.getElements within 2500ms'),
+      {
+        code: 'DEVTOOLS_PROTOCOL_TIMEOUT',
+        method: 'Page.getElements',
+      },
+    )
+    let queryAttempts = 0
+    const send = vi.fn(async (method: string) => {
+      if (method === 'Page.getElements') {
+        queryAttempts += 1
+        if (queryAttempts === 1) {
+          throw timeoutError
+        }
+        return { elements: [{ elementId: 'native-element', tagName: 'view' }] }
+      }
+      if (method === 'Page.getData') {
+        return { data: 'native-data' }
+      }
+      if (method === 'Page.callMethod') {
+        return { result: 'native-method' }
+      }
+      if (method === 'App.callFunction') {
+        return { result: [{ id: 'fallback-node' }] }
+      }
+      return {}
+    })
+    const page = new Page(createConnection(send), { id: 7, path: '/pages/index', query: {} })
+
+    await expect(page.$$('view')).resolves.toHaveLength(1)
+    await expect(page.$$('view', { fallback: false })).resolves.toHaveLength(1)
+    await expect(page.data('status', { fallback: false })).resolves.toBe('native-data')
+    await expect(page.callMethodWithOptions('runE2E', { fallback: false })).resolves.toBe('native-method')
+
+    expect(send).toHaveBeenCalledWith('Page.getElements', {
+      pageId: 7,
+      selector: 'view',
+    }, {
+      timeout: 2_500,
+    })
+    expect(send).toHaveBeenCalledWith('Page.getData', {
+      pageId: 7,
+      path: 'status',
+    }, {
+      timeout: 2_500,
+    })
+    expect(send).toHaveBeenCalledWith('Page.callMethod', {
+      args: [],
+      method: 'runE2E',
+      pageId: 7,
     }, {
       timeout: 2_500,
     })


### PR DESCRIPTION
## 结论

- #705：路由状态同步修复已由真实 DevTools E2E 覆盖，包括 beforeEach/afterEach 的 from/to、useRoute 状态、原生 switchTab 以及 tab 后再次导航。
- #706：确认 DevTools 2.01.2510290 的 app-service → page-frame 定向消息通道不回包，数值 pageId 与 App.getCurrentPage/App.getPageStack 完全一致，排除客户端参数和页面栈映射问题。
- 本 PR 在 miniprogram-automator 连接协议层读取 Tool.getInfo.version，对已确认受影响的版本直接选择 App-service Page 协议，避免每个 Page 调用先等待 page-frame 超时再降级。
- 显式 fallback: false 现在能够真正绕过缓存的兼容协议偏好，继续用于原生 Page 协议诊断。

## 回归覆盖

- issue706 真实运行时覆盖 page.$、page.$$、page.data、page.setData 和 page.callMethod。
- issue706 整组 Page 操作要求在 2 秒内完成，低于原生协议 2.5 秒超时阈值，防止重新退化为超时后 fallback。
- 单元测试覆盖 DevTools 版本能力选择、首次调用直接使用 App-service 协议，以及 fallback: false 强制原生协议。
- issue705 双 tab 真实运行时回归继续通过。

## 结构说明

Page.ts 已是现有 Page API 的集中所有者且超过 300 行。本次只调整协议选择状态，不拆分该文件，避免把无关的大规模重构并入协议修复；连接级版本能力判断收敛在 Connection.ts。

## Changeset

- @weapp-vite/miniprogram-automator：patch
- 不涉及 weapp-vite、wevu 或 templates，不联动 create-weapp-vite。

## 验证

- pnpm --filter @weapp-vite/miniprogram-automator typecheck
- pnpm --filter @weapp-vite/miniprogram-automator test
- pnpm --filter @weapp-vite/miniprogram-automator build
- node --import tsx scripts/check-e2e-ide-shared-launch.ts
- pnpm exec eslint <本次变更文件>
- pnpm exec stylelint e2e-apps/github-issues/src/pages/issue-706/index.vue
- node --import tsx scripts/check-create-weapp-vite-changeset.ts
- node --import tsx scripts/check-catalog-changeset.ts
- pnpm e2e:ide:full:github-issues --filter=issue705
- pnpm e2e:ide:full:github-issues --filter=issue706

Refs #705
Fixes #706