### PR TITLE
perf(weapp-vite): 加速 Vue JSON 宏页面配置热更新

### DIFF
--- a/.changeset/fast-vue-json-macro-hmr.md
+++ b/.changeset/fast-vue-json-macro-hmr.md
@@ -1,0 +1,7 @@
+---
+'@wevu/compiler': patch
+'create-weapp-vite': patch
+'weapp-vite': patch
+---
+
+优化 Vue SFC 页面配置热更新：仅修改 JSON 宏或 `<json>` 时复用已编译的脚本、模板与样式结果，避免重复执行完整 Vue 编译，并在混合变更或缓存不可用时自动回退。

--- a/packages-runtime/wevu-compiler/src/index.ts
+++ b/packages-runtime/wevu-compiler/src/index.ts
@@ -56,7 +56,7 @@ export type {
 } from './plugins/vue/compiler/template/types'
 
 export { buildClassStyleComputedCode } from './plugins/vue/transform/classStyleComputed'
-export { compileVueFile as compileSfc, compileVueFile } from './plugins/vue/transform/compileVueFile'
+export { compileVueFile as compileSfc, compileVueFile, refreshVueFileJsonConfig } from './plugins/vue/transform/compileVueFile'
 export type {
   AutoImportTagsOptions,
   AutoUsingComponentsOptions,

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/index.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/index.ts
@@ -8,6 +8,8 @@ import { compileScriptPhase, resolveEffectivePropsDerivedKeys, resolveScriptSetu
 import { compileStylePhase } from './style'
 import { compileTemplatePhase } from './template'
 
+export { refreshVueFileJsonConfig } from './jsonOnly'
+
 export type {
   AutoImportTagsOptions,
   AutoUsingComponentsOptions,
@@ -140,6 +142,13 @@ export async function compileVueFile(
     result,
     warn: options?.warn,
   })
+
+  result.meta!.jsonConfigCache = {
+    autoUsingComponentsMap: { ...scriptPhase.autoUsingComponentsMap },
+    autoImportTagsMap: componentSourceInfo.autoImportTagsMap
+      ? { ...componentSourceInfo.autoImportTagsMap }
+      : undefined,
+  }
 
   finalizeResult(result, {
     scriptSetupMacroHash: parsed.scriptSetupMacroHash,

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/jsonOnly.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/jsonOnly.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from 'vitest'
+import { compileVueFile } from './index'
+import { refreshVueFileJsonConfig } from './jsonOnly'
+
+const filename = '/project/src/pages/home/index.vue'
+
+function cachedResult(overrides: Record<string, any> = {}) {
+  return {
+    script: 'Component({ cached: true })',
+    template: '<view />',
+    style: '.page{}',
+    meta: {
+      jsonConfigCache: {
+        autoImportTagsMap: {
+          't-button': 'tdesign/button/button',
+        },
+        autoUsingComponentsMap: {
+          AutoCard: '/components/auto-card/index',
+        },
+      },
+      jsonMacroHash: 'old-hash',
+      styleBlocks: [],
+    },
+    componentGenerics: {
+      selectable: true,
+    },
+    ...overrides,
+  }
+}
+
+describe('refreshVueFileJsonConfig', () => {
+  it('returns undefined when the cached compilation predates json config caching', async () => {
+    await expect(refreshVueFileJsonConfig(
+      '<template><view /></template>',
+      filename,
+      { script: 'Component({})', template: '<view />' },
+      { isPage: true },
+    )).resolves.toBeUndefined()
+  })
+
+  it('rebuilds json blocks and macros while preserving generated config inputs', async () => {
+    const source = `<script setup lang="ts">
+definePageJson({
+  navigationBarTitleText: '新标题',
+  usingComponents: { macroCard: '/components/macro-card/index' },
+})
+</script>
+<template><view /></template>
+<json>
+{
+  "navigationStyle": "custom",
+  "usingComponents": {
+    "legacy-card": "/components/legacy-card/index"
+  }
+}
+</json>`
+    const result = await refreshVueFileJsonConfig(
+      source,
+      filename,
+      cachedResult(),
+      {
+        isPage: true,
+        json: {
+          defaults: {
+            page: {
+              enablePullDownRefresh: true,
+            },
+          },
+        },
+      },
+    )
+
+    expect(result?.script).toBe('Component({ cached: true })')
+    expect(result?.template).toBe('<view />')
+    expect(result?.style).toBe('.page{}')
+    expect(JSON.parse(result!.config!)).toEqual({
+      navigationStyle: 'custom',
+      usingComponents: {
+        'legacy-card': '/components/legacy-card/index',
+        't-button': 'tdesign/button/button',
+        'AutoCard': '/components/auto-card/index',
+        'macroCard': '/components/macro-card/index',
+      },
+      componentGenerics: {
+        selectable: true,
+      },
+      enablePullDownRefresh: true,
+      navigationBarTitleText: '新标题',
+    })
+    expect(result?.meta?.jsonMacroHash).not.toBe('old-hash')
+  })
+
+  it('removes stale config and macro hash when json sources are deleted', async () => {
+    const result = await refreshVueFileJsonConfig(
+      '<template><view /></template>',
+      filename,
+      cachedResult({
+        componentGenerics: undefined,
+        config: '{"navigationBarTitleText":"旧标题"}',
+        meta: {
+          jsonConfigCache: {
+            autoUsingComponentsMap: {},
+          },
+          jsonMacroHash: 'old-hash',
+          styleBlocks: [],
+        },
+      }),
+      { isPage: true },
+    )
+
+    expect(result?.config).toBeUndefined()
+    expect(result?.meta?.jsonMacroHash).toBeUndefined()
+    expect(result?.script).toBe('Component({ cached: true })')
+  })
+
+  it('uses the configured merge strategy for every json stage', async () => {
+    const stages: string[] = []
+    const mergeStrategy = vi.fn((target, source, context) => {
+      stages.push(context.stage)
+      return { ...target, ...source, lastStage: context.stage }
+    })
+    const source = `<script setup>
+definePageJson({ navigationBarTitleText: '宏标题' })
+</script>
+<template><view /></template>
+<json>{ "navigationStyle": "custom" }</json>`
+
+    const result = await refreshVueFileJsonConfig(
+      source,
+      filename,
+      cachedResult(),
+      {
+        isPage: true,
+        json: {
+          defaults: {
+            page: { enablePullDownRefresh: true },
+          },
+          mergeStrategy,
+        },
+      },
+    )
+
+    expect(stages).toEqual([
+      'macro',
+      'json-block',
+      'auto-using-components',
+      'component-generics',
+      'defaults',
+      'macro',
+    ])
+    expect(JSON.parse(result!.config!)).toMatchObject({
+      lastStage: 'macro',
+      navigationBarTitleText: '宏标题',
+    })
+  })
+
+  it('records reusable json config inputs during a full compilation', async () => {
+    const result = await compileVueFile(
+      `<script setup>definePageJson({ navigationBarTitleText: '首页' })</script>
+<template><view /></template>`,
+      filename,
+      { isPage: true, sourceMap: false },
+    )
+
+    expect(result.meta?.jsonConfigCache).toEqual({
+      autoImportTagsMap: {},
+      autoUsingComponentsMap: {},
+    })
+    expect(JSON.parse(result.config!)).toEqual({
+      navigationBarTitleText: '首页',
+    })
+  })
+
+  it('reapplies defaults for the resolved json kind', async () => {
+    const result = await refreshVueFileJsonConfig(
+      '<template><view /></template>',
+      '/project/src/components/card/index.vue',
+      cachedResult({
+        componentGenerics: undefined,
+        meta: {
+          jsonConfigCache: {
+            autoUsingComponentsMap: {},
+          },
+          styleBlocks: [],
+        },
+      }),
+      {
+        json: {
+          defaults: {
+            component: {
+              component: true,
+              styleIsolation: 'apply-shared',
+            },
+          },
+        },
+      },
+    )
+
+    expect(JSON.parse(result!.config!)).toEqual({
+      component: true,
+      styleIsolation: 'apply-shared',
+    })
+  })
+})

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/jsonOnly.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/jsonOnly.ts
@@ -1,0 +1,58 @@
+import type { CompileVueFileOptions, VueTransformResult } from './types'
+import { compileConfigPhase } from './config'
+import { parseVueFile } from './parse'
+
+/**
+ * 只重算 Vue SFC 的 JSON 配置，并复用脚本、模板与样式编译结果。
+ *
+ * @internal
+ */
+export async function refreshVueFileJsonConfig(
+  source: string,
+  filename: string,
+  cachedResult: VueTransformResult,
+  options?: CompileVueFileOptions,
+): Promise<VueTransformResult | undefined> {
+  const jsonConfigCache = cachedResult.meta?.jsonConfigCache
+  if (!jsonConfigCache) {
+    return undefined
+  }
+
+  const parsed = await parseVueFile(source, filename, options)
+  const meta = {
+    ...cachedResult.meta,
+    hasScriptSetup: parsed.meta.hasScriptSetup,
+    hasSetupOption: parsed.meta.hasSetupOption,
+    sfcSrcDeps: parsed.meta.sfcSrcDeps,
+  }
+  const result: VueTransformResult = {
+    ...cachedResult,
+    meta,
+  }
+  delete result.config
+
+  await compileConfigPhase({
+    descriptor: parsed.descriptor,
+    filename,
+    autoUsingComponentsMap: { ...jsonConfigCache.autoUsingComponentsMap },
+    autoImportTagsMap: jsonConfigCache.autoImportTagsMap
+      ? { ...jsonConfigCache.autoImportTagsMap }
+      : undefined,
+    autoUsingComponents: options?.autoUsingComponents,
+    autoImportTags: options?.autoImportTags,
+    jsonDefaults: parsed.jsonDefaults as Record<string, any> | undefined,
+    mergeJson: parsed.mergeJson,
+    scriptSetupMacroConfig: parsed.scriptSetupMacroConfig,
+    result,
+    warn: options?.warn,
+  })
+
+  if (parsed.scriptSetupMacroHash) {
+    meta.jsonMacroHash = parsed.scriptSetupMacroHash
+  }
+  else {
+    delete meta.jsonMacroHash
+  }
+
+  return result
+}

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/types.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/types.ts
@@ -35,6 +35,15 @@ export interface VueTransformResult {
     defineOptionsHash?: string
     sfcSrcDeps?: string[]
     styleBlocks?: SFCStyleBlock[]
+    /**
+     * JSON-only HMR 重算所需的稳定编译输入。
+     *
+     * @internal
+     */
+    jsonConfigCache?: {
+      autoImportTagsMap?: Record<string, string>
+      autoUsingComponentsMap: Record<string, string>
+    }
   }
 }
 

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile.ts
@@ -1,30 +1,28 @@
 import type { SFCStyleBlock } from 'vue/compiler-sfc'
-import type { VueTransformResult } from 'wevu/compiler'
 import type { CompilerContext } from '../../../../context'
 import type { ResolvedAppShell } from '../appShell'
 import type { CompileVueFileResolvedOptions } from '../compileOptions'
+import type { VueCompilationCache, VueStyleBlocksCache } from './transformFile/types'
 import { performance } from 'node:perf_hooks'
 import { compileJsxFile, compileVueFile } from 'wevu/compiler'
-import { resolveVueSfcStyleIndependentSignature } from '../../../../utils/file/vueSfcSignature'
 import { recordHmrProfileDuration } from '../../../../utils/hmrProfile'
 import { readFile as readFileCached } from '../../../utils/cache'
-import { syncVueSfcStyleDependencies } from '../../../utils/invalidateEntry'
 import { addNormalizedWatchFile } from '../../../utils/watchFiles'
 import { createPageEntryMatcher } from '../../../wevu'
 import { getSourceFromVirtualId } from '../../resolver'
 import { createCompileVueFileOptions, isVueTransformSourceMapEnabled } from '../compileOptions'
-import { emitScopedSlotChunks, registerScopedSlotHostGenerics } from '../scopedSlot'
-import { refreshStyleOnlyVueTransformResult } from '../styleOnly'
-import { compileTransformEntryResult, createTransformStageMeasurer, finalizeTransformCompiledResult, finalizeTransformEntryCode, isVueCssImporterDirtyReasonSummary, isVueStyleOnlyDirtyReasonSummary, loadTransformSource, logTransformFileError, normalizeVueTransformResult, resolveDirtyVueEntryId, resolveTransformAutoRoutesSource, resolveTransformEntryFlags, resolveTransformFilename } from './shared'
-import { createSfcStyleBlocksSignature, loadStyleBlocksForStyleOnlyRefresh } from './styleOnlyRefresh'
-import { parseUsingComponents } from './usingComponents'
+import { compileTransformEntryResult, createTransformStageMeasurer, isVueCssImporterDirtyReasonSummary, isVueStyleOnlyDirtyReasonSummary, loadTransformSource, logTransformFileError, normalizeVueTransformResult, resolveDirtyVueEntryId, resolveTransformAutoRoutesSource, resolveTransformEntryFlags, resolveTransformFilename } from './shared'
+import { createSfcStyleBlocksSignature } from './styleOnlyRefresh'
+import { finalizeVueTransform } from './transformFile/finalize'
+import { tryRefreshJsonOnlyVueCompilation } from './transformFile/jsonOnly'
+import { tryReuseVueCompilation } from './transformFile/reuse'
 
 export async function transformVueLikeFile(options: {
   ctx: CompilerContext
   pluginCtx: any
   code: string
   id: string
-  compilationCache: Map<string, { result: VueTransformResult, source?: string, isPage: boolean, autoRoutesSignature?: string, refreshToken?: number, styleIndependentSignature?: string }>
+  compilationCache: VueCompilationCache
   setAppShell: (shell: ResolvedAppShell | undefined) => void
   pageMatcher: ReturnType<typeof createPageEntryMatcher> | null
   setPageMatcher: (matcher: ReturnType<typeof createPageEntryMatcher>) => void
@@ -33,7 +31,7 @@ export async function transformVueLikeFile(options: {
   reExportResolutionCache: Map<string, Map<string, string | undefined>>
   compileOptionsCache: Map<string, CompileVueFileResolvedOptions>
   componentMetaCache: NonNullable<CompileVueFileResolvedOptions['componentMetaCache']>
-  styleBlocksCache: Map<string, SFCStyleBlock[]>
+  styleBlocksCache: VueStyleBlocksCache
   styleRefreshTokens: Map<string, number | string>
   scopedSlotModules: Map<string, string>
   emittedScopedSlotChunks: Set<string>
@@ -143,147 +141,89 @@ export async function transformVueLikeFile(options: {
     const canAttemptStyleOnlyReuse = isVueStyleOnlyDirtyReasonSummary(
       ctx.runtimeState?.build?.hmr?.profile?.dirtyReasonSummary,
     )
-    if (
-      configService.isDev
-      && cachedCompilation
-      && !ctx.runtimeState.scan.isDirty
-      && cachedCompilation.source === transformedSource
-      && cachedCompilation.autoRoutesSignature === autoRoutesSignature
-    ) {
-      cachedCompilation.refreshToken = 0
-      const cachedResult = normalizeVueTransformResult(cachedCompilation.result)
-      let cachedStyleBlocks = (cachedResult.meta?.styleBlocks as SFCStyleBlock[] | undefined) ?? styleBlocksCache.get(filename)
-      let canReturnCachedCompilation = true
-      if (dirtyEntryId && canAttemptStyleOnlyReuse && filename.endsWith('.vue')) {
-        const refreshedStyleBlocks = await measureStage('loadStyleOnlySfcStyles', async () => await loadStyleBlocksForStyleOnlyRefresh({
-          filename,
-          source: transformedSource,
-          styleBlocksCache,
-          force: true,
-          readAndParseSfc,
-          createReadAndParseSfcOptions,
-          pluginCtx,
-          configService,
-        }))
-        const didRefreshStyle = refreshStyleOnlyVueTransformResult(cachedResult, filename, refreshedStyleBlocks)
-        if (!didRefreshStyle) {
-          cachedCompilation.styleIndependentSignature = undefined
-          canReturnCachedCompilation = false
-        }
-        else {
-          cachedStyleBlocks = refreshedStyleBlocks
-          cachedCompilation.result = cachedResult
-          const currentStyleSignature = createSfcStyleBlocksSignature(cachedStyleBlocks)
-          const hmrEventId = ctx.runtimeState.build?.hmr?.profile?.eventId
-          if (
-            hmrEventId != null
-            && (
-              isCssImporterDirty
-              || (currentStyleSignature && currentStyleSignature !== previousStyleSignature)
-            )
-          ) {
-            styleRefreshTokens.set(filename, hmrEventId)
-          }
-          else {
-            styleRefreshTokens.delete(filename)
-          }
-        }
-      }
-      if (!canReturnCachedCompilation) {
-        cachedCompilation.refreshToken = 1
-      }
-      else {
-        const returnedCode = await measureVueHmrStage('finalizeCode', 'vueFinalizeCodeMs', async () => finalizeTransformEntryCode({
-          result: cachedResult,
-          filename,
-          styleBlocks: cachedStyleBlocks,
-          isPage: cachedCompilation.isPage,
-          isApp,
-          isDev: configService.isDev,
-          sourceMap,
-          hmrStyleToken: styleRefreshTokens.get(filename),
-        }))
-
-        if (dirtyEntryId) {
-          dirtyVueEntryIds?.delete(dirtyEntryId)
-        }
-        reportTiming(filename, cachedCompilation.isPage)
-
-        return {
-          code: returnedCode.code,
-          map: returnedCode.map,
-        }
+    const reuseResult = await tryReuseVueCompilation({
+      ctx,
+      pluginCtx,
+      filename,
+      source: transformedSource,
+      cachedCompilation,
+      previousStyleSignature,
+      autoRoutesSignature,
+      dirtyEntryId,
+      dirtyVueEntryIds,
+      isCssImporterDirty,
+      canAttemptStyleOnlyReuse,
+      sourceMap,
+      isApp,
+      styleBlocksCache,
+      styleRefreshTokens,
+      readAndParseSfc,
+      createReadAndParseSfcOptions,
+      measureStage,
+      measureVueHmrStage,
+      reportTiming,
+    })
+    if (reuseResult.returnedCode) {
+      return {
+        code: reuseResult.returnedCode.code,
+        map: reuseResult.returnedCode.map,
       }
     }
-    const currentStyleIndependentSignature = (configService.isDev && dirtyEntryId && canAttemptStyleOnlyReuse && filename.endsWith('.vue'))
-      ? resolveVueSfcStyleIndependentSignature(transformedSource, filename)
-      : undefined
-    const canReuseStyleOnlyVueCompilation = Boolean(
-      configService.isDev
-      && cachedCompilation
-      && dirtyEntryId
-      && canAttemptStyleOnlyReuse
-      && filename.endsWith('.vue')
-      && !ctx.runtimeState.scan.isDirty
-      && cachedCompilation.autoRoutesSignature === autoRoutesSignature
-      && cachedCompilation.styleIndependentSignature
-      && currentStyleIndependentSignature
-      && cachedCompilation.styleIndependentSignature === currentStyleIndependentSignature
-      && cachedCompilation.source !== transformedSource,
-    )
-    if (canReuseStyleOnlyVueCompilation && cachedCompilation) {
-      const cachedResult = normalizeVueTransformResult(cachedCompilation.result)
-      const styleBlocks = await measureStage('loadStyleOnlySfcStyles', async () => await loadStyleBlocksForStyleOnlyRefresh({
-        filename,
-        source: transformedSource,
-        styleBlocksCache,
-        force: true,
-        readAndParseSfc,
-        createReadAndParseSfcOptions,
-        pluginCtx,
-        configService,
-      }))
-      const didRefreshStyle = refreshStyleOnlyVueTransformResult(cachedResult, filename, styleBlocks)
-      if (!didRefreshStyle) {
-        cachedCompilation.styleIndependentSignature = undefined
-      }
-      else {
-        cachedCompilation.source = transformedSource
-        cachedCompilation.result = cachedResult
-        cachedCompilation.styleIndependentSignature = currentStyleIndependentSignature
-        cachedCompilation.refreshToken = 0
-        const hmrEventId = ctx.runtimeState.build?.hmr?.profile?.eventId
-        if (hmrEventId != null && (isCssImporterDirty || styleBlocks?.length)) {
-          styleRefreshTokens.set(filename, hmrEventId)
-        }
-        const returnedCode = await measureVueHmrStage('finalizeCode', 'vueFinalizeCodeMs', async () => finalizeTransformEntryCode({
-          result: cachedResult,
-          filename,
-          styleBlocks,
-          isPage: cachedCompilation.isPage,
-          isApp,
-          isDev: configService.isDev,
-          sourceMap,
-          hmrStyleToken: styleRefreshTokens.get(filename),
-        }))
-
-        if (dirtyEntryId) {
-          dirtyVueEntryIds?.delete(dirtyEntryId)
-        }
-        reportTiming(filename, cachedCompilation.isPage)
-
-        return {
-          code: returnedCode.code,
-          map: returnedCode.map,
-        }
-      }
-    }
+    const { currentStyleIndependentSignature } = reuseResult
     const compileOptions = createCompileVueFileOptions(ctx, pluginCtx, filename, isPage, isApp, configService, {
       reExportResolutionCache,
       classStyleRuntimeWarned,
       compileOptionsCache,
       componentMetaCache,
     })
+
+    const jsonOnlyResult = await measureVueHmrStage('refreshJsonConfig', 'vueCompileMs', async () => {
+      return await tryRefreshJsonOnlyVueCompilation({
+        cachedResult: cachedCompilation?.result,
+        compileOptions,
+        dirtyEntryId,
+        dirtyReasonSummary: ctx.runtimeState?.build?.hmr?.profile?.dirtyReasonSummary,
+        filename,
+        isDev: configService.isDev,
+        scanDirty: ctx.runtimeState.scan.isDirty,
+        source: transformedSource,
+        autoRoutesSignature,
+        cachedAutoRoutesSignature: cachedCompilation?.autoRoutesSignature,
+      })
+    })
+    if (jsonOnlyResult) {
+      const returnedCode = await finalizeVueTransform({
+        ctx,
+        pluginCtx,
+        filename,
+        source: transformedSource,
+        autoRoutesSignature,
+        result: jsonOnlyResult,
+        compilationCache,
+        currentStyleIndependentSignature: cachedCompilation?.styleIndependentSignature,
+        previousStyleSignature,
+        dirtyEntryId,
+        dirtyVueEntryIds,
+        isCssImporterDirty,
+        isPage,
+        isApp,
+        sourceMap,
+        styleBlocksCache,
+        styleRefreshTokens,
+        scopedSlotModules,
+        emittedScopedSlotChunks,
+        setAppShell,
+        readAndParseSfc,
+        createReadAndParseSfcOptions,
+        measureStage,
+        measureVueHmrStage,
+        reportTiming,
+      })
+      return {
+        code: returnedCode.code,
+        map: returnedCode.map,
+      }
+    }
 
     const result = normalizeVueTransformResult(await measureVueHmrStage('compile', 'vueCompileMs', async () => await compileTransformEntryResult({
       transformedSource,
@@ -292,86 +232,33 @@ export async function transformVueLikeFile(options: {
       compileVueFile,
       compileJsxFile,
     })))
-    let currentStyleBlocks = Array.isArray(result.meta?.styleBlocks)
-      ? result.meta.styleBlocks as SFCStyleBlock[]
-      : styleBlocksCache.get(filename)
-    if (!currentStyleBlocks) {
-      currentStyleBlocks = await measureStage('preloadSfcStyles', async () => await loadStyleBlocksForStyleOnlyRefresh({
-        filename,
-        source: transformedSource,
-        styleBlocksCache,
-        readAndParseSfc,
-        createReadAndParseSfcOptions,
-        pluginCtx,
-        configService,
-      }))
-    }
-    if (currentStyleBlocks) {
-      styleBlocksCache.set(filename, currentStyleBlocks)
-    }
-    if (configService.isDev && dirtyEntryId) {
-      const currentStyleSignature = createSfcStyleBlocksSignature(currentStyleBlocks)
-      const hmrEventId = ctx.runtimeState.build?.hmr?.profile?.eventId
-      if (
-        hmrEventId != null
-        && (
-          isCssImporterDirty
-          || (currentStyleSignature && currentStyleSignature !== previousStyleSignature)
-        )
-      ) {
-        styleRefreshTokens.set(filename, hmrEventId)
-      }
-      else {
-        styleRefreshTokens.delete(filename)
-      }
-      dirtyVueEntryIds?.delete(dirtyEntryId)
-    }
-    const sfcStyleDependencies = syncVueSfcStyleDependencies(
+    const returnedCode = await finalizeVueTransform({
       ctx,
+      pluginCtx,
       filename,
-      currentStyleBlocks,
-    )
-    for (const dependency of sfcStyleDependencies) {
-      addNormalizedWatchFile(pluginCtx, dependency)
-    }
-    registerScopedSlotHostGenerics(ctx, result.scopedSlotComponents, parseUsingComponents(result.config))
-
-    await measureVueHmrStage('finalizeCompiledResult', 'vueFinalizeCompiledMs', async () => {
-      await finalizeTransformCompiledResult({
-        ctx,
-        pluginCtx,
-        filename,
-        source: transformedSource,
-        autoRoutesSignature,
-        result,
-        compilationCache,
-        styleIndependentSignature: filename.endsWith('.vue')
-          ? (currentStyleIndependentSignature ?? resolveVueSfcStyleIndependentSignature(transformedSource, filename))
-          : undefined,
-        setAppShell,
-        configService,
-        isPage,
-        isApp,
-        sourceMap,
-        scopedSlotModules,
-        emittedScopedSlotChunks,
-        addWatchFile: addNormalizedWatchFile,
-        emitScopedSlotChunks,
-      })
-    })
-
-    const returnedCode = await measureVueHmrStage('finalizeCode', 'vueFinalizeCodeMs', async () => finalizeTransformEntryCode({
+      source: transformedSource,
+      autoRoutesSignature,
       result,
-      filename,
-      styleBlocks: (result.meta?.styleBlocks as SFCStyleBlock[] | undefined) ?? styleBlocksCache.get(filename),
+      compilationCache,
+      currentStyleIndependentSignature,
+      previousStyleSignature,
+      dirtyEntryId,
+      dirtyVueEntryIds,
+      isCssImporterDirty,
       isPage,
       isApp,
-      isDev: configService.isDev,
       sourceMap,
-      hmrStyleToken: configService.isDev ? styleRefreshTokens.get(filename) : undefined,
-    }))
-
-    reportTiming(filename, isPage)
+      styleBlocksCache,
+      styleRefreshTokens,
+      scopedSlotModules,
+      emittedScopedSlotChunks,
+      setAppShell,
+      readAndParseSfc,
+      createReadAndParseSfcOptions,
+      measureStage,
+      measureVueHmrStage,
+      reportTiming,
+    })
 
     return {
       code: returnedCode.code,

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile/finalize.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile/finalize.ts
@@ -1,0 +1,150 @@
+import type { SFCStyleBlock } from 'vue/compiler-sfc'
+import type { VueTransformResult } from 'wevu/compiler'
+import type { CompilerContext } from '../../../../../context'
+import type { ResolvedAppShell } from '../../appShell'
+import type { TransformStageMeasurer, VueCompilationCache, VueHmrStageMeasurer, VueStyleBlocksCache } from './types'
+import { resolveVueSfcStyleIndependentSignature } from '../../../../../utils/file/vueSfcSignature'
+import { syncVueSfcStyleDependencies } from '../../../../utils/invalidateEntry'
+import { addNormalizedWatchFile } from '../../../../utils/watchFiles'
+import { emitScopedSlotChunks, registerScopedSlotHostGenerics } from '../../scopedSlot'
+import { finalizeTransformCompiledResult, finalizeTransformEntryCode } from '../shared'
+import { createSfcStyleBlocksSignature, loadStyleBlocksForStyleOnlyRefresh } from '../styleOnlyRefresh'
+import { parseUsingComponents } from '../usingComponents'
+
+export async function finalizeVueTransform(options: {
+  ctx: CompilerContext
+  pluginCtx: any
+  filename: string
+  source: string
+  autoRoutesSignature?: string
+  result: VueTransformResult
+  compilationCache: VueCompilationCache
+  currentStyleIndependentSignature?: string
+  previousStyleSignature?: string
+  dirtyEntryId?: string
+  dirtyVueEntryIds?: Set<string>
+  isCssImporterDirty: boolean
+  isPage: boolean
+  isApp: boolean
+  sourceMap: boolean
+  styleBlocksCache: VueStyleBlocksCache
+  styleRefreshTokens: Map<string, number | string>
+  scopedSlotModules: Map<string, string>
+  emittedScopedSlotChunks: Set<string>
+  setAppShell: (shell: ResolvedAppShell | undefined) => void
+  readAndParseSfc: typeof import('../../../../utils/vueSfc').readAndParseSfc
+  createReadAndParseSfcOptions: typeof import('../../../../utils/vueSfc').createReadAndParseSfcOptions
+  measureStage: TransformStageMeasurer
+  measureVueHmrStage: VueHmrStageMeasurer
+  reportTiming: (filename: string, isPage: boolean) => void
+}) {
+  const {
+    ctx,
+    pluginCtx,
+    filename,
+    source,
+    autoRoutesSignature,
+    result,
+    compilationCache,
+    currentStyleIndependentSignature,
+    previousStyleSignature,
+    dirtyEntryId,
+    dirtyVueEntryIds,
+    isCssImporterDirty,
+    isPage,
+    isApp,
+    sourceMap,
+    styleBlocksCache,
+    styleRefreshTokens,
+    scopedSlotModules,
+    emittedScopedSlotChunks,
+    setAppShell,
+    readAndParseSfc,
+    createReadAndParseSfcOptions,
+    measureStage,
+    measureVueHmrStage,
+    reportTiming,
+  } = options
+  const configService = ctx.configService!
+  let currentStyleBlocks = Array.isArray(result.meta?.styleBlocks)
+    ? result.meta.styleBlocks as SFCStyleBlock[]
+    : styleBlocksCache.get(filename)
+  if (!currentStyleBlocks) {
+    currentStyleBlocks = await measureStage('preloadSfcStyles', async () => await loadStyleBlocksForStyleOnlyRefresh({
+      filename,
+      source,
+      styleBlocksCache,
+      readAndParseSfc,
+      createReadAndParseSfcOptions,
+      pluginCtx,
+      configService,
+    }))
+  }
+  if (currentStyleBlocks) {
+    styleBlocksCache.set(filename, currentStyleBlocks)
+  }
+  if (configService.isDev && dirtyEntryId) {
+    const currentStyleSignature = createSfcStyleBlocksSignature(currentStyleBlocks)
+    const hmrEventId = ctx.runtimeState.build?.hmr?.profile?.eventId
+    if (
+      hmrEventId != null
+      && (
+        isCssImporterDirty
+        || (currentStyleSignature && currentStyleSignature !== previousStyleSignature)
+      )
+    ) {
+      styleRefreshTokens.set(filename, hmrEventId)
+    }
+    else {
+      styleRefreshTokens.delete(filename)
+    }
+    dirtyVueEntryIds?.delete(dirtyEntryId)
+  }
+  const sfcStyleDependencies = syncVueSfcStyleDependencies(
+    ctx,
+    filename,
+    currentStyleBlocks,
+  )
+  for (const dependency of sfcStyleDependencies) {
+    addNormalizedWatchFile(pluginCtx, dependency)
+  }
+  registerScopedSlotHostGenerics(ctx, result.scopedSlotComponents, parseUsingComponents(result.config))
+
+  await measureVueHmrStage('finalizeCompiledResult', 'vueFinalizeCompiledMs', async () => {
+    await finalizeTransformCompiledResult({
+      ctx,
+      pluginCtx,
+      filename,
+      source,
+      autoRoutesSignature,
+      result,
+      compilationCache,
+      styleIndependentSignature: filename.endsWith('.vue')
+        ? (currentStyleIndependentSignature ?? resolveVueSfcStyleIndependentSignature(source, filename))
+        : undefined,
+      setAppShell,
+      configService,
+      isPage,
+      isApp,
+      sourceMap,
+      scopedSlotModules,
+      emittedScopedSlotChunks,
+      addWatchFile: addNormalizedWatchFile,
+      emitScopedSlotChunks,
+    })
+  })
+
+  const returnedCode = await measureVueHmrStage('finalizeCode', 'vueFinalizeCodeMs', async () => finalizeTransformEntryCode({
+    result,
+    filename,
+    styleBlocks: (result.meta?.styleBlocks as SFCStyleBlock[] | undefined) ?? styleBlocksCache.get(filename),
+    isPage,
+    isApp,
+    isDev: configService.isDev,
+    sourceMap,
+    hmrStyleToken: configService.isDev ? styleRefreshTokens.get(filename) : undefined,
+  }))
+
+  reportTiming(filename, isPage)
+  return returnedCode
+}

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile/jsonOnly.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile/jsonOnly.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { transformVueLikeFile } from '../transformFile'
+import { tryRefreshJsonOnlyVueCompilation } from './jsonOnly'
+
+const compileVueFileMock = vi.hoisted(() => vi.fn(async () => ({
+  config: '{"navigationBarTitleText":"新标题"}',
+  script: 'Component({ refreshed: true })',
+  template: '<view />',
+  meta: { styleBlocks: [] },
+})))
+const compileJsxFileMock = vi.hoisted(() => vi.fn())
+
+vi.mock('wevu/compiler', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('wevu/compiler')>()
+  return {
+    ...actual,
+    compileJsxFile: compileJsxFileMock,
+    compileVueFile: compileVueFileMock,
+  }
+})
+
+vi.mock('../../../../utils/cache', () => ({
+  readFile: vi.fn(),
+}))
+
+vi.mock('../../../../utils/invalidateEntry', () => ({
+  syncVueSfcStyleDependencies: vi.fn(() => []),
+}))
+
+vi.mock('../../../../utils/watchFiles', () => ({
+  addNormalizedWatchFile: vi.fn(),
+}))
+
+vi.mock('../../../wevu', () => ({
+  createPageEntryMatcher: vi.fn(() => ({
+    isPageFile: vi.fn(async () => true),
+    markDirty: vi.fn(),
+  })),
+}))
+
+vi.mock('../../../vue/transform/resolver', () => ({
+  getSourceFromVirtualId: vi.fn((id: string) => id),
+}))
+
+vi.mock('../compileOptions', () => ({
+  createCompileVueFileOptions: vi.fn(() => ({})),
+  isVueTransformSourceMapEnabled: vi.fn(() => false),
+}))
+
+vi.mock('../scopedSlot', () => ({
+  emitScopedSlotChunks: vi.fn(),
+  registerScopedSlotHostGenerics: vi.fn(),
+}))
+
+function createOptions() {
+  const filename = '/project/src/pages/home/index.vue'
+  const previousSource = `<script setup lang="ts">
+definePageJson({ navigationBarTitleText: '旧标题' })
+</script>
+<template><view /></template>`
+  const nextSource = previousSource.replace('旧标题', '新标题')
+  const dirtyVueEntryIds = new Set([filename])
+  const compilationCache = new Map<string, any>([
+    [filename, {
+      result: {
+        config: '{"navigationBarTitleText":"旧标题"}',
+        script: 'Component({ cached: true })',
+        template: '<view />',
+        meta: {
+          jsonConfigCache: {
+            autoUsingComponentsMap: {},
+          },
+          jsonMacroHash: 'old-hash',
+          styleBlocks: [],
+        },
+      },
+      source: previousSource,
+      isPage: true,
+      refreshToken: 1,
+    }],
+  ])
+
+  return {
+    filename,
+    nextSource,
+    dirtyVueEntryIds,
+    compilationCache,
+    options: {
+      ctx: {
+        configService: {
+          isDev: true,
+          platform: 'weapp',
+          outputExtensions: { js: 'js' },
+          relativeOutputPath: (value: string) => value.replace('/project/src/', ''),
+          weappViteConfig: {},
+        },
+        runtimeState: {
+          scan: { isDirty: false },
+          build: {
+            hmr: {
+              dirtyVueEntryIds,
+              profile: {
+                eventId: 'hmr-json-1',
+                dirtyReasonSummary: ['entry-json-only:1'],
+              },
+            },
+          },
+        },
+        autoImportService: { resolve: () => undefined },
+      },
+      pluginCtx: {
+        addWatchFile: vi.fn(),
+        emitFile: vi.fn(),
+      },
+      code: nextSource,
+      id: filename,
+      compilationCache,
+      setAppShell: vi.fn(),
+      pageMatcher: null,
+      setPageMatcher: vi.fn(),
+      scanDirtySynced: true,
+      setScanDirtySynced: vi.fn(),
+      reExportResolutionCache: new Map(),
+      compileOptionsCache: new Map(),
+      componentMetaCache: new Map(),
+      styleBlocksCache: new Map(),
+      styleRefreshTokens: new Map(),
+      scopedSlotModules: new Map(),
+      emittedScopedSlotChunks: new Set(),
+      classStyleRuntimeWarned: { value: false },
+      readAndParseSfc: vi.fn(),
+      createReadAndParseSfcOptions: vi.fn(),
+    } as any,
+  }
+}
+
+describe('transformVueLikeFile json-only reuse', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('refreshes page json without recompiling unchanged script and template output', async () => {
+    const { compilationCache, dirtyVueEntryIds, filename, nextSource, options } = createOptions()
+
+    await transformVueLikeFile(options)
+
+    expect(compileVueFileMock).not.toHaveBeenCalled()
+    expect(compilationCache.get(filename)).toMatchObject({
+      source: nextSource,
+      result: {
+        config: JSON.stringify({ navigationBarTitleText: '新标题' }, null, 2),
+        script: 'Component({ cached: true })',
+        template: '<view />',
+      },
+    })
+    expect(dirtyVueEntryIds.size).toBe(0)
+  })
+})
+
+describe('tryRefreshJsonOnlyVueCompilation', () => {
+  const source = `<script setup>definePageJson({ navigationBarTitleText: '新标题' })</script>
+<template><view /></template>`
+
+  function createRefreshOptions() {
+    return {
+      cachedResult: {
+        config: '{"navigationBarTitleText":"旧标题"}',
+        script: 'Component({ cached: true })',
+        template: '<view />',
+        meta: {
+          jsonConfigCache: {
+            autoUsingComponentsMap: {},
+          },
+          styleBlocks: [],
+        },
+      },
+      compileOptions: { isPage: true },
+      dirtyEntryId: '/project/src/pages/home/index.vue',
+      dirtyReasonSummary: ['entry-json-only:1'],
+      filename: '/project/src/pages/home/index.vue',
+      isDev: true,
+      scanDirty: false,
+      source,
+      autoRoutesSignature: undefined,
+      cachedAutoRoutesSignature: undefined,
+    }
+  }
+
+  it.each([
+    ['production mode', { isDev: false }],
+    ['dirty route scan', { scanDirty: true }],
+    ['missing dirty entry', { dirtyEntryId: undefined }],
+    ['missing compilation cache', { cachedResult: undefined }],
+    ['non-vue entry', { filename: '/project/src/pages/home/index.tsx' }],
+    ['changed auto-route signature', { autoRoutesSignature: 'next', cachedAutoRoutesSignature: 'previous' }],
+    ['missing dirty reasons', { dirtyReasonSummary: undefined }],
+    ['mixed dirty reasons', { dirtyReasonSummary: ['entry-json-only:1', 'entry-script:1'] }],
+  ])('falls back for %s', async (_label, overrides) => {
+    await expect(tryRefreshJsonOnlyVueCompilation({
+      ...createRefreshOptions(),
+      ...overrides,
+    } as any)).resolves.toBeUndefined()
+  })
+
+  it('returns undefined when the cached result has no json config inputs', async () => {
+    const options = createRefreshOptions()
+    options.cachedResult.meta = { styleBlocks: [] } as any
+
+    await expect(tryRefreshJsonOnlyVueCompilation(options)).resolves.toBeUndefined()
+  })
+
+  it('refreshes and normalizes a valid json-only compilation', async () => {
+    const result = await tryRefreshJsonOnlyVueCompilation(createRefreshOptions())
+
+    expect(result).toMatchObject({
+      config: JSON.stringify({ navigationBarTitleText: '新标题' }, null, 2),
+      script: 'Component({ cached: true })',
+      template: '<view />',
+    })
+  })
+})

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile/jsonOnly.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile/jsonOnly.ts
@@ -1,0 +1,56 @@
+import type { CompileVueFileOptions, VueTransformResult } from 'wevu/compiler'
+import { refreshVueFileJsonConfig } from 'wevu/compiler'
+import { normalizeVueTransformResult } from '../shared'
+
+function isVueJsonOnlyDirtyReasonSummary(dirtyReasonSummary: string[] | undefined) {
+  return Boolean(
+    dirtyReasonSummary?.length
+    && dirtyReasonSummary.every(item => item.startsWith('entry-json-only:')),
+  )
+}
+
+export async function tryRefreshJsonOnlyVueCompilation(options: {
+  cachedResult: VueTransformResult | undefined
+  compileOptions: CompileVueFileOptions
+  dirtyEntryId: string | undefined
+  dirtyReasonSummary: string[] | undefined
+  filename: string
+  isDev: boolean
+  scanDirty: boolean
+  source: string
+  autoRoutesSignature?: string
+  cachedAutoRoutesSignature?: string
+}) {
+  const {
+    cachedResult,
+    compileOptions,
+    dirtyEntryId,
+    dirtyReasonSummary,
+    filename,
+    isDev,
+    scanDirty,
+    source,
+    autoRoutesSignature,
+    cachedAutoRoutesSignature,
+  } = options
+
+  if (
+    !isDev
+    || scanDirty
+    || !dirtyEntryId
+    || !cachedResult
+    || !filename.endsWith('.vue')
+    || cachedAutoRoutesSignature !== autoRoutesSignature
+    || !isVueJsonOnlyDirtyReasonSummary(dirtyReasonSummary)
+  ) {
+    return undefined
+  }
+
+  const refreshed = await refreshVueFileJsonConfig(
+    source,
+    filename,
+    cachedResult,
+    compileOptions,
+  )
+  return refreshed ? normalizeVueTransformResult(refreshed) : undefined
+}

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile/reuse.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile/reuse.ts
@@ -1,0 +1,187 @@
+import type { SFCStyleBlock } from 'vue/compiler-sfc'
+import type { CompilerContext } from '../../../../../context'
+import type { TransformStageMeasurer, VueCompilationCacheEntry, VueHmrStageMeasurer, VueStyleBlocksCache } from './types'
+import { resolveVueSfcStyleIndependentSignature } from '../../../../../utils/file/vueSfcSignature'
+import { refreshStyleOnlyVueTransformResult } from '../../styleOnly'
+import { finalizeTransformEntryCode, normalizeVueTransformResult } from '../shared'
+import { createSfcStyleBlocksSignature, loadStyleBlocksForStyleOnlyRefresh } from '../styleOnlyRefresh'
+
+export async function tryReuseVueCompilation(options: {
+  ctx: CompilerContext
+  pluginCtx: any
+  filename: string
+  source: string
+  cachedCompilation: VueCompilationCacheEntry | undefined
+  previousStyleSignature?: string
+  autoRoutesSignature?: string
+  dirtyEntryId?: string
+  dirtyVueEntryIds?: Set<string>
+  isCssImporterDirty: boolean
+  canAttemptStyleOnlyReuse: boolean
+  sourceMap: boolean
+  isApp: boolean
+  styleBlocksCache: VueStyleBlocksCache
+  styleRefreshTokens: Map<string, number | string>
+  readAndParseSfc: typeof import('../../../../utils/vueSfc').readAndParseSfc
+  createReadAndParseSfcOptions: typeof import('../../../../utils/vueSfc').createReadAndParseSfcOptions
+  measureStage: TransformStageMeasurer
+  measureVueHmrStage: VueHmrStageMeasurer
+  reportTiming: (filename: string, isPage: boolean) => void
+}) {
+  const {
+    ctx,
+    pluginCtx,
+    filename,
+    source,
+    cachedCompilation,
+    previousStyleSignature,
+    autoRoutesSignature,
+    dirtyEntryId,
+    dirtyVueEntryIds,
+    isCssImporterDirty,
+    canAttemptStyleOnlyReuse,
+    sourceMap,
+    isApp,
+    styleBlocksCache,
+    styleRefreshTokens,
+    readAndParseSfc,
+    createReadAndParseSfcOptions,
+    measureStage,
+    measureVueHmrStage,
+    reportTiming,
+  } = options
+  const configService = ctx.configService!
+
+  if (
+    configService.isDev
+    && cachedCompilation
+    && !ctx.runtimeState.scan.isDirty
+    && cachedCompilation.source === source
+    && cachedCompilation.autoRoutesSignature === autoRoutesSignature
+  ) {
+    cachedCompilation.refreshToken = 0
+    const cachedResult = normalizeVueTransformResult(cachedCompilation.result)
+    let cachedStyleBlocks = (cachedResult.meta?.styleBlocks as SFCStyleBlock[] | undefined) ?? styleBlocksCache.get(filename)
+    let canReturnCachedCompilation = true
+    if (dirtyEntryId && canAttemptStyleOnlyReuse && filename.endsWith('.vue')) {
+      const refreshedStyleBlocks = await measureStage('loadStyleOnlySfcStyles', async () => await loadStyleBlocksForStyleOnlyRefresh({
+        filename,
+        source,
+        styleBlocksCache,
+        force: true,
+        readAndParseSfc,
+        createReadAndParseSfcOptions,
+        pluginCtx,
+        configService,
+      }))
+      const didRefreshStyle = refreshStyleOnlyVueTransformResult(cachedResult, filename, refreshedStyleBlocks)
+      if (!didRefreshStyle) {
+        cachedCompilation.styleIndependentSignature = undefined
+        canReturnCachedCompilation = false
+      }
+      else {
+        cachedStyleBlocks = refreshedStyleBlocks
+        cachedCompilation.result = cachedResult
+        const currentStyleSignature = createSfcStyleBlocksSignature(cachedStyleBlocks)
+        const hmrEventId = ctx.runtimeState.build?.hmr?.profile?.eventId
+        if (
+          hmrEventId != null
+          && (
+            isCssImporterDirty
+            || (currentStyleSignature && currentStyleSignature !== previousStyleSignature)
+          )
+        ) {
+          styleRefreshTokens.set(filename, hmrEventId)
+        }
+        else {
+          styleRefreshTokens.delete(filename)
+        }
+      }
+    }
+    if (!canReturnCachedCompilation) {
+      cachedCompilation.refreshToken = 1
+    }
+    else {
+      const returnedCode = await measureVueHmrStage('finalizeCode', 'vueFinalizeCodeMs', async () => finalizeTransformEntryCode({
+        result: cachedResult,
+        filename,
+        styleBlocks: cachedStyleBlocks,
+        isPage: cachedCompilation.isPage,
+        isApp,
+        isDev: configService.isDev,
+        sourceMap,
+        hmrStyleToken: styleRefreshTokens.get(filename),
+      }))
+
+      if (dirtyEntryId) {
+        dirtyVueEntryIds?.delete(dirtyEntryId)
+      }
+      reportTiming(filename, cachedCompilation.isPage)
+
+      return { returnedCode }
+    }
+  }
+
+  const currentStyleIndependentSignature = (configService.isDev && dirtyEntryId && canAttemptStyleOnlyReuse && filename.endsWith('.vue'))
+    ? resolveVueSfcStyleIndependentSignature(source, filename)
+    : undefined
+  const canReuseStyleOnlyVueCompilation = Boolean(
+    configService.isDev
+    && cachedCompilation
+    && dirtyEntryId
+    && canAttemptStyleOnlyReuse
+    && filename.endsWith('.vue')
+    && !ctx.runtimeState.scan.isDirty
+    && cachedCompilation.autoRoutesSignature === autoRoutesSignature
+    && cachedCompilation.styleIndependentSignature
+    && currentStyleIndependentSignature
+    && cachedCompilation.styleIndependentSignature === currentStyleIndependentSignature
+    && cachedCompilation.source !== source,
+  )
+  if (canReuseStyleOnlyVueCompilation && cachedCompilation) {
+    const cachedResult = normalizeVueTransformResult(cachedCompilation.result)
+    const styleBlocks = await measureStage('loadStyleOnlySfcStyles', async () => await loadStyleBlocksForStyleOnlyRefresh({
+      filename,
+      source,
+      styleBlocksCache,
+      force: true,
+      readAndParseSfc,
+      createReadAndParseSfcOptions,
+      pluginCtx,
+      configService,
+    }))
+    const didRefreshStyle = refreshStyleOnlyVueTransformResult(cachedResult, filename, styleBlocks)
+    if (!didRefreshStyle) {
+      cachedCompilation.styleIndependentSignature = undefined
+    }
+    else {
+      cachedCompilation.source = source
+      cachedCompilation.result = cachedResult
+      cachedCompilation.styleIndependentSignature = currentStyleIndependentSignature
+      cachedCompilation.refreshToken = 0
+      const hmrEventId = ctx.runtimeState.build?.hmr?.profile?.eventId
+      if (hmrEventId != null && (isCssImporterDirty || styleBlocks?.length)) {
+        styleRefreshTokens.set(filename, hmrEventId)
+      }
+      const returnedCode = await measureVueHmrStage('finalizeCode', 'vueFinalizeCodeMs', async () => finalizeTransformEntryCode({
+        result: cachedResult,
+        filename,
+        styleBlocks,
+        isPage: cachedCompilation.isPage,
+        isApp,
+        isDev: configService.isDev,
+        sourceMap,
+        hmrStyleToken: styleRefreshTokens.get(filename),
+      }))
+
+      if (dirtyEntryId) {
+        dirtyVueEntryIds?.delete(dirtyEntryId)
+      }
+      reportTiming(filename, cachedCompilation.isPage)
+
+      return { currentStyleIndependentSignature, returnedCode }
+    }
+  }
+
+  return { currentStyleIndependentSignature }
+}

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile/types.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile/types.ts
@@ -1,0 +1,24 @@
+import type { SFCStyleBlock } from 'vue/compiler-sfc'
+import type { VueTransformResult } from 'wevu/compiler'
+import type { HmrProfileDurationKey } from '../../../../../utils/hmrProfile'
+
+export interface VueCompilationCacheEntry {
+  result: VueTransformResult
+  source?: string
+  isPage: boolean
+  autoRoutesSignature?: string
+  refreshToken?: number
+  styleIndependentSignature?: string
+}
+
+export type VueCompilationCache = Map<string, VueCompilationCacheEntry>
+
+export type TransformStageMeasurer = <T>(stage: string, action: () => Promise<T>) => Promise<T>
+
+export type VueHmrStageMeasurer = <T>(
+  stage: string,
+  profileKey: HmrProfileDurationKey,
+  action: () => Promise<T>,
+) => Promise<T>
+
+export type VueStyleBlocksCache = Map<string, SFCStyleBlock[]>


### PR DESCRIPTION
## 背景

watcher 已经能把仅修改 `defineAppJson`、`definePageJson`、`defineComponentJson` 或 `<json>` 的更新识别为 `entry-json-only`，但 Vue transform 仍会调用完整 `compileVueFile`，重复编译未变化的 script、template 和 style，因此页面配置热更新的耗时与普通 SFC 重编译接近。

## 修改

- 完整编译时缓存自动组件注册与模板标签自动导入结果，作为 JSON 配置重算的稳定输入。
- 新增 JSON-only refresh：只重新解析配置来源、重算 JSON 宏与 `<json>`，复用已有 script、template、style、componentGenerics 等编译结果。
- 仅在 dev、dirty reason 全部为 `entry-json-only`、Vue 缓存存在、scan 未失效且 auto-routes 签名一致时启用快速路径。
- 对旧缓存、混合变更、非 Vue 文件、生产构建、路由扫描变化等情况自动回退完整编译。
- 将 transform 缓存复用与编译收尾拆成独立模块，主入口降到 300 行以内。
- 添加 `@wevu/compiler`、`weapp-vite`、`create-weapp-vite` 中文 changeset。

## 性能参考

同一 SFC 重复 50 次的 micro benchmark：

- 完整 `compileVueFile`：35.06ms
- JSON-only refresh：3.36ms
- 约 10.43x 加速

该数据仅用于说明量级，正确性由单元测试、集成测试与 dev-watch E2E 保证。

## 验证

- `pnpm --filter @wevu/compiler build`
- `pnpm --filter weapp-vite build`
- `pnpm --filter @wevu/compiler typecheck`
- `pnpm --filter weapp-vite typecheck`
- 受影响 Vue 编译、transform、watch 与 emit 矩阵：35 个文件、367 个测试通过
- JSON-only 快速路径覆盖率：statements / branches / functions / lines 均为 100%
- `pnpm vitest run -c e2e/vitest.e2e.ci.config.ts e2e/ci/template-wevu-tdesign-retail-hmr-vendor.test.ts -t "updates definePageJson metadata"`
- changeset 联动与 catalog 检查通过
