### PR TITLE
fix(weapp-vite): 修复 Vue SFC 编译分流

### DIFF
--- a/.changeset/fix-issue-724-sfc-routing.md
+++ b/.changeset/fix-issue-724-sfc-routing.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复复杂插件调度下 Vue SFC 主请求与样式虚拟请求可能跳过编译分流的问题，避免原始 `<template>`、`<script>` 或 `<style>` 内容进入 Babel 与 Vite CSS 处理阶段。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -664,6 +664,13 @@
           "query": "",
           "scene": null,
           "launchMode": "default"
+        },
+        {
+          "name": "pages/issue-724/index",
+          "pathName": "pages/issue-724/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
         }
       ]
     }

--- a/e2e-apps/github-issues/src/components/issue-724/RoutingProbe/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-724/RoutingProbe/index.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+const issue724ComponentScriptMarker = 'issue-724-component-script-marker'
+</script>
+
+<template>
+  <view class="issue-724-component">
+    issue-724-component-template-marker
+    {{ issue724ComponentScriptMarker }}
+  </view>
+</template>
+
+<style>
+.issue-724-component {
+  padding: 12rpx;
+}
+</style>

--- a/e2e-apps/github-issues/src/pages/issue-724/external.scss
+++ b/e2e-apps/github-issues/src/pages/issue-724/external.scss
@@ -1,0 +1,5 @@
+$issue-724-color: #2468ac;
+
+.issue-724-style-src {
+  color: $issue-724-color;
+}

--- a/e2e-apps/github-issues/src/pages/issue-724/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-724/index.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+definePageJson({
+  navigationBarTitleText: 'issue-724',
+})
+
+const issue724ScriptMarker = 'issue-724-script-marker'
+</script>
+
+<template>
+  <view class="issue-724-page issue-724-style-src">
+    <text class="issue-724-template-marker">
+      issue-724-template-marker
+    </text>
+    <text class="issue-724-script-marker">
+      {{ issue724ScriptMarker }}
+    </text>
+    <Issue724RoutingProbe />
+  </view>
+</template>
+
+<style>
+.issue-724-page {
+  display: block;
+}
+</style>
+
+<style lang="scss">
+.issue-724-template-marker {
+  font-weight: 600;
+}
+
+.issue-724-template-marker + .issue-724-script-marker {
+  display: block;
+}
+</style>
+
+<style lang="scss" src="./external.scss"></style>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -11,6 +11,7 @@ const issue615AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_615_AUGMENTED
 const issue621AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_621_AUGMENTED === 'true'
 const issue595ScopedBuildEnabled = process.env.WEAPP_GITHUB_ISSUE_595_SCOPED === 'true'
 const issue642ScopedBuildEnabled = process.env.WEAPP_GITHUB_ISSUE_642_SCOPED === 'true'
+const issue724ProbeEnabled = process.env.WEAPP_GITHUB_ISSUE_724_PROBE === 'true'
 const issue651NoExtResolvedId = path.resolve(import.meta.dirname, 'src/issue-fixtures/issue-651/ResolverNoExt/index')
 const issue651WithExtResolvedId = path.resolve(import.meta.dirname, 'src/issue-fixtures/issue-651/ResolverWithExt/index.vue')
 const e2eTargetFile = process.env.WEAPP_VITE_E2E_TARGET_FILE?.replaceAll('\\', '/') ?? ''
@@ -160,6 +161,14 @@ const matchedGithubIssuesTestFile = Object.keys(githubIssuesRouteGroups)
   .find(testFile => e2eTargetFile.endsWith(testFile))
 
 function resolveGithubIssuesAutoRoutes() {
+  if (issue724ProbeEnabled) {
+    return {
+      include: [
+        'pages/issue-724/**',
+        'components/issue-724/**',
+      ],
+    }
+  }
   if (issue510AugmentedEnabled) {
     return {
       include: [
@@ -307,7 +316,41 @@ function resolveGithubIssuesNpm() {
   }
 }
 
+const issue724ProbePlugins = issue724ProbeEnabled
+  ? [
+      {
+        name: 'github-issues:issue-724-style-load-probe',
+        enforce: 'pre' as const,
+        transform(code: string, id: string) {
+          const normalizedId = id.replaceAll('\\', '/')
+          if (!normalizedId.includes('/issue-724/') || !id.includes('?weapp-vite-vue&type=style')) {
+            return null
+          }
+          if (/<(?:template|script|style)(?:\s|>)/.test(code)) {
+            throw new Error(`issue #724 style request leaked another SFC block: ${normalizedId}`)
+          }
+          return null
+        },
+      },
+      {
+        name: 'github-issues:issue-724-post-transform-probe',
+        enforce: 'post' as const,
+        transform(code: string, id: string) {
+          const normalizedId = id.replaceAll('\\', '/')
+          if (!normalizedId.includes('/issue-724/') || !normalizedId.endsWith('.vue')) {
+            return null
+          }
+          if (/<(?:template|script|style)(?:\s|>)/.test(code)) {
+            throw new Error(`issue #724 downstream JS received a raw SFC: ${normalizedId}`)
+          }
+          return null
+        },
+      },
+    ]
+  : []
+
 export default defineConfig({
+  plugins: issue724ProbePlugins,
   define: {
     'import.meta.env.ISSUE_484_FLAG': '123456',
   },
@@ -341,6 +384,7 @@ export default defineConfig({
         {
           components: {
             Issue520ResolverSlotCard: '/components/issue-520/ResolverSlotCard/index',
+            Issue724RoutingProbe: '/components/issue-724/RoutingProbe/index',
           },
         },
         {
@@ -403,29 +447,35 @@ export default defineConfig({
           minify: false,
         },
       }
-    : issue510AugmentedEnabled
+    : issue724ProbeEnabled
       ? {
           build: {
-            outDir: 'dist-issue-510',
+            outDir: 'dist-issue-724',
           },
         }
-      : slotFallbackCompilerOffEnabled
+      : issue510AugmentedEnabled
         ? {
             build: {
-              outDir: 'dist-slot-fallback-compiler-off',
+              outDir: 'dist-issue-510',
             },
           }
-        : issue595ScopedBuildEnabled
+        : slotFallbackCompilerOffEnabled
           ? {
               build: {
-                outDir: 'dist-issue-595',
+                outDir: 'dist-slot-fallback-compiler-off',
               },
             }
-          : issue642ScopedBuildEnabled
+          : issue595ScopedBuildEnabled
             ? {
                 build: {
-                  outDir: 'dist-issue-642',
+                  outDir: 'dist-issue-595',
                 },
               }
-            : {}),
+            : issue642ScopedBuildEnabled
+              ? {
+                  build: {
+                    outDir: 'dist-issue-642',
+                  },
+                }
+              : {}),
 })

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -14,6 +14,7 @@ const ISSUE_393_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-393')
 const ISSUE_510_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-510')
 const ISSUE_595_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-595')
 const ISSUE_642_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-642')
+const ISSUE_724_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-724')
 const SLOT_FALLBACK_COMPILER_OFF_DIST_ROOT = path.join(APP_ROOT, 'dist-slot-fallback-compiler-off')
 const SLOT_OWNER_ATTR = `__wvSlotOwnerId="{{__wvSlotOwnerId || __wvOwnerId || ''}}"`
 let standardBuildPromise: Promise<void> | null = null
@@ -314,6 +315,26 @@ async function runIssue642Build() {
   distVariant = null
 }
 
+async function runIssue724Build() {
+  standardBuildPromise = null
+  await fs.remove(ISSUE_724_DIST_ROOT)
+
+  await runWeappViteBuildWithLogCapture({
+    cliPath: CLI_PATH,
+    projectRoot: APP_ROOT,
+    platform: 'weapp',
+    cwd: APP_ROOT,
+    label: 'ci:github-issues:issue724',
+    outDir: 'dist-issue-724',
+    skipNpm: true,
+    env: {
+      WEAPP_GITHUB_ISSUE_724_PROBE: 'true',
+    },
+  })
+
+  distVariant = null
+}
+
 interface AppJsonWithSubPackages {
   pages?: string[]
   subPackages?: Array<{ root?: string, pages?: string[] }>
@@ -368,6 +389,40 @@ async function runSlotFallbackCompilerOffBuild() {
 }
 
 describe.sequential('e2e app: github-issues (build)', () => {
+  it('issue #724: keeps Vue SFC script, template, and style requests isolated', async () => {
+    await runIssue724Build()
+
+    const pageBase = path.join(ISSUE_724_DIST_ROOT, 'pages/issue-724/index')
+    const componentBase = path.join(ISSUE_724_DIST_ROOT, 'components/issue-724/RoutingProbe/index')
+    const pageJs = await fs.readFile(`${pageBase}.js`, 'utf-8')
+    const pageWxml = await fs.readFile(`${pageBase}.wxml`, 'utf-8')
+    const pageWxss = await fs.readFile(`${pageBase}.wxss`, 'utf-8')
+    const pageJson = await fs.readJSON(`${pageBase}.json`) as { usingComponents?: Record<string, string> }
+    const componentJs = await fs.readFile(`${componentBase}.js`, 'utf-8')
+    const componentWxml = await fs.readFile(`${componentBase}.wxml`, 'utf-8')
+    const componentWxss = await fs.readFile(`${componentBase}.wxss`, 'utf-8')
+
+    expect(pageJs).toContain('issue-724-script-marker')
+    expect(pageWxml).toContain('issue-724-template-marker')
+    expect(pageWxml).toContain('<Issue724RoutingProbe />')
+    expect(pageWxss).toContain('.issue-724-page')
+    expect(pageWxss).toContain('.issue-724-template-marker')
+    expect(pageWxss).toContain('.issue-724-style-src')
+    expect(pageWxss).not.toContain('.issue-724-component')
+    expect(pageJson.usingComponents).toMatchObject({
+      Issue724RoutingProbe: '/components/issue-724/RoutingProbe/index',
+    })
+
+    expect(componentJs).toContain('issue-724-component-script-marker')
+    expect(componentWxml).toContain('issue-724-component-template-marker')
+    expect(componentWxss).toContain('.issue-724-component')
+    expect(componentWxss).not.toContain('.issue-724-page')
+
+    for (const output of [pageJs, pageWxml, pageWxss, componentJs, componentWxml, componentWxss]) {
+      expect(output).not.toMatch(/<(?:template|script|style)(?:\s|>)/)
+    }
+  })
+
   it('discussion #338: emits mapped wxml tags from vue html-style templates', async () => {
     await runBuild()
 

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/index.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/index.test.ts
@@ -183,11 +183,14 @@ describe('createVueTransformPlugin lifecycle', () => {
     } as any)
 
     const load = getHookHandler(plugin.load as any)
-    const result = await load.call({ loader: true } as any, 'virtual:style')
+    const result = await load.call(
+      { loader: true } as any,
+      '/project/src/demo.vue?weapp-vite-vue&type=style&index=0&lang.css',
+    )
 
     expect(loadTransformStyleBlockMock).toHaveBeenCalledTimes(1)
     expect(loadTransformStyleBlockMock).toHaveBeenCalledWith(expect.objectContaining({
-      id: 'virtual:style',
+      id: '/project/src/demo.vue?weapp-vite-vue&type=style&index=0&lang.css',
       pluginCtx: { loader: true },
       configService: { cwd: '/project' },
     }))
@@ -203,7 +206,7 @@ describe('createVueTransformPlugin lifecycle', () => {
     } as any)
 
     const transform = getHookHandler(plugin.transform as any)
-    await expect(transform.call({ addWatchFile: vi.fn() } as any, 'code', '/project/src/demo.ts')).resolves.toBeNull()
+    await expect(transform.call({ addWatchFile: vi.fn() } as any, 'code', '/project/src/demo.jsx')).resolves.toBeNull()
     await expect(transform.call({ addWatchFile: vi.fn() } as any, 'code', '/project/src/demo.vue')).resolves.toEqual({
       code: 'transformed',
       map: null,
@@ -290,41 +293,34 @@ describe('createVueTransformPlugin lifecycle', () => {
     } as any)
 
     const resolveId = getHookHandler(plugin.resolveId as any)
-    expect(resolveId('virtual:slot')).toBe('resolved:virtual:slot')
-    expect(resolveScopedSlotVirtualIdMock).toHaveBeenCalledWith('virtual:slot')
+    const scopedSlotId = '\0weapp-vite:scoped-slot:pages/home.__scoped-slot-0'
+    expect(resolveId(scopedSlotId)).toBe(`resolved:${scopedSlotId}`)
+    expect(resolveScopedSlotVirtualIdMock).toHaveBeenCalledWith(scopedSlotId)
     expect(profile).toEqual(expect.objectContaining({
       pluginResolveMs: expect.any(Number),
       resolveCount: 1,
     }))
   })
 
-  it('declares rolldown filters for hot transform paths', async () => {
+  it('keeps SFC routing on deterministic hooks with local fast guards', async () => {
     const { createVueTransformPlugin } = await import('./index')
     const plugin = createVueTransformPlugin({} as any)
 
-    expect(plugin.transform).toEqual(expect.objectContaining({
-      filter: {
-        id: expect.any(RegExp),
-      },
-      handler: expect.any(Function),
-    }))
-    expect(plugin.load).toEqual(expect.objectContaining({
-      filter: {
-        id: expect.any(RegExp),
-      },
-      handler: expect.any(Function),
-    }))
-    expect(plugin.resolveId).toEqual(expect.objectContaining({
-      filter: {
-        id: expect.any(RegExp),
-      },
-      handler: expect.any(Function),
-    }))
+    expect(plugin.transform).toEqual(expect.any(Function))
+    expect(plugin.load).toEqual(expect.any(Function))
+    expect(plugin.resolveId).toEqual(expect.any(Function))
 
-    expect((plugin.transform as any).filter.id.test('/project/src/pages/home.vue')).toBe(true)
-    expect((plugin.transform as any).filter.id.test('/project/src/utils/plain.ts')).toBe(false)
-    expect((plugin.load as any).filter.id.test('\0weapp-vite:scoped-slot:pages/home.__scoped-slot-0')).toBe(true)
-    expect((plugin.load as any).filter.id.test('/project/src/pages/home.vue?weapp-vite-vue&type=style&index=0')).toBe(true)
-    expect((plugin.resolveId as any).filter.id.test('\0weapp-vite:scoped-slot:pages/home.__scoped-slot-0')).toBe(true)
+    const transform = getHookHandler(plugin.transform as any)
+    const load = getHookHandler(plugin.load as any)
+    const resolveId = getHookHandler(plugin.resolveId as any)
+
+    await expect(transform.call({}, 'const value = 1', '/project/src/utils/plain.ts')).resolves.toBeNull()
+    await expect(load.call({}, '/project/src/utils/plain.ts')).resolves.toBeNull()
+    expect(resolveId.call({}, '/project/src/utils/plain.ts')).toBeNull()
+
+    expect(isVueLikeIdMock).not.toHaveBeenCalled()
+    expect(transformVueLikeFileMock).not.toHaveBeenCalled()
+    expect(loadTransformStyleBlockMock).not.toHaveBeenCalled()
+    expect(resolveScopedSlotVirtualIdMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/index.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/index.ts
@@ -90,86 +90,77 @@ export function createVueTransformPlugin(ctx: CompilerContext): Plugin {
       })
     },
 
-    resolveId: {
-      filter: {
-        id: SCOPED_SLOT_VIRTUAL_ID_RE,
-      },
-      handler(id) {
-        const startedAt = performance.now()
-        try {
-          return resolveScopedSlotVirtualId(id)
-        }
-        finally {
-          const profile = ctx.runtimeState?.build?.hmr?.profile
-          recordHmrProfileDuration(profile, 'pluginResolveMs', performance.now() - startedAt)
-          recordHmrProfileOperation(profile, 'resolveCount')
-        }
-      },
+    resolveId(id) {
+      if (!SCOPED_SLOT_VIRTUAL_ID_RE.test(id)) {
+        return null
+      }
+      const startedAt = performance.now()
+      try {
+        return resolveScopedSlotVirtualId(id)
+      }
+      finally {
+        const profile = ctx.runtimeState?.build?.hmr?.profile
+        recordHmrProfileDuration(profile, 'pluginResolveMs', performance.now() - startedAt)
+        recordHmrProfileOperation(profile, 'resolveCount')
+      }
     },
 
-    load: {
-      filter: {
-        id: VUE_LOAD_FILTER_RE,
-      },
-      async handler(id) {
-        return await loadTransformStyleBlock({
-          id,
-          pluginCtx: this,
+    async load(id) {
+      if (!VUE_LOAD_FILTER_RE.test(id)) {
+        return null
+      }
+      return await loadTransformStyleBlock({
+        id,
+        pluginCtx: this,
+        ctx,
+        configService: ctx.configService,
+        styleBlocksCache,
+        loadScopedSlotModule: (id) => {
+          const loaded = loadScopedSlotModule(id, scopedSlotModules)
+          return loaded?.code ?? null
+        },
+        scopedSlotModules,
+        parseWeappVueStyleRequest: id => parseWeappVueStyleRequest(id) ?? null,
+        readAndParseSfc,
+        createReadAndParseSfcOptions,
+      })
+    },
+
+    async transform(code, id) {
+      if (!VUE_TRANSFORM_FILTER_RE.test(id) || !isVueLikeId(id)) {
+        return null
+      }
+      const startedAt = performance.now()
+
+      try {
+        return await transformVueLikeFile({
           ctx,
-          configService: ctx.configService,
+          pluginCtx: this,
+          code,
+          id,
+          compilationCache,
+          setAppShell: shell => (appShell = shell),
+          pageMatcher,
+          setPageMatcher: matcher => (pageMatcher = matcher),
+          scanDirtySynced,
+          setScanDirtySynced: synced => (scanDirtySynced = synced),
+          reExportResolutionCache,
+          compileOptionsCache,
+          componentMetaCache,
           styleBlocksCache,
-          loadScopedSlotModule: (id) => {
-            const loaded = loadScopedSlotModule(id, scopedSlotModules)
-            return loaded?.code ?? null
-          },
+          styleRefreshTokens,
           scopedSlotModules,
-          parseWeappVueStyleRequest: id => parseWeappVueStyleRequest(id) ?? null,
+          emittedScopedSlotChunks,
+          classStyleRuntimeWarned,
           readAndParseSfc,
           createReadAndParseSfcOptions,
         })
-      },
-    },
-
-    transform: {
-      filter: {
-        id: VUE_TRANSFORM_FILTER_RE,
-      },
-      async handler(code, id) {
-        if (!isVueLikeId(id)) {
-          return null
-        }
-        const startedAt = performance.now()
-
-        try {
-          return await transformVueLikeFile({
-            ctx,
-            pluginCtx: this,
-            code,
-            id,
-            compilationCache,
-            setAppShell: shell => (appShell = shell),
-            pageMatcher,
-            setPageMatcher: matcher => (pageMatcher = matcher),
-            scanDirtySynced,
-            setScanDirtySynced: synced => (scanDirtySynced = synced),
-            reExportResolutionCache,
-            compileOptionsCache,
-            componentMetaCache,
-            styleBlocksCache,
-            styleRefreshTokens,
-            scopedSlotModules,
-            emittedScopedSlotChunks,
-            classStyleRuntimeWarned,
-            readAndParseSfc,
-            createReadAndParseSfcOptions,
-          })
-        }
-        finally {
-          const durationMs = performance.now() - startedAt
-          recordHmrProfileDuration(ctx.runtimeState?.build?.hmr?.profile, 'transformMs', durationMs)
-          recordHmrProfileDuration(ctx.runtimeState?.build?.hmr?.profile, 'vueTransformMs', durationMs)
-        }
-      },
+      }
+      finally {
+        const durationMs = performance.now() - startedAt
+        recordHmrProfileDuration(ctx.runtimeState?.build?.hmr?.profile, 'transformMs', durationMs)
+        recordHmrProfileDuration(ctx.runtimeState?.build?.hmr?.profile, 'vueTransformMs', durationMs)
+      }
     },
 
     async generateBundle(_options, bundle) {

--- a/packages/weapp-vite/test/vue/style-pipeline.test.ts
+++ b/packages/weapp-vite/test/vue/style-pipeline.test.ts
@@ -1,6 +1,9 @@
+import type { Plugin } from 'vite'
 import os from 'node:os'
 import { fs } from '@weapp-core/shared/fs'
 import path from 'pathe'
+import { build } from 'vite'
+import { createVueResolverPlugin } from '../../src/plugins/vue/resolver'
 import { createVueTransformPlugin } from '../../src/plugins/vue/transform'
 import { WEAPP_VUE_STYLE_VIRTUAL_PREFIX } from '../../src/plugins/vue/transform/styleRequest'
 import { callPluginHook } from '../pluginHook'
@@ -63,6 +66,127 @@ defineAppJson({ pages: ['pages/index/index'] })
       const loaded = await callPluginHook(plugin.load as any, {}, styleRequestId) as any
 
       expect(loaded?.code).toContain('.a { color: red; }')
+    }
+    finally {
+      await fs.remove(root)
+    }
+  })
+
+  it('keeps SFC blocks isolated through real Vite/Rolldown plugin scheduling', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'weapp-vite-sfc-routing-'))
+    const srcRoot = path.join(root, 'src')
+    const pageDir = path.join(srcRoot, 'pages', 'index')
+    const componentDir = path.join(srcRoot, 'components')
+    const pageFile = path.join(pageDir, 'index.vue')
+    const componentFile = path.join(componentDir, 'RoutingProbe.vue')
+    const styleInputs = new Map<string, string>()
+    const vueInputs = new Map<string, string>()
+
+    try {
+      await fs.ensureDir(pageDir)
+      await fs.ensureDir(componentDir)
+      await fs.writeFile(path.join(pageDir, 'logic.ts'), [
+        'import RoutingProbe from \'../../components/RoutingProbe.vue\'',
+        'export const issue724ScriptMarker = \'issue-724-script-marker\'',
+        'export default { components: { RoutingProbe } }',
+      ].join('\n'), 'utf8')
+      await fs.writeFile(path.join(pageDir, 'external.scss'), [
+        '$issue724Color: #123456;',
+        '.issue-724-style-src { color: $issue724Color; }',
+      ].join('\n'), 'utf8')
+      await fs.writeFile(pageFile, [
+        '<template><view class="issue-724-inline issue-724-style-src">issue-724-template-marker<RoutingProbe /></view></template>',
+        '<script lang="ts" src="./logic.ts"></script>',
+        '<style>.issue-724-inline { display: block; }</style>',
+        '<style lang="scss" src="./external.scss"></style>',
+      ].join('\n'), 'utf8')
+      await fs.writeFile(componentFile, [
+        '<template><view class="issue-724-component">component marker</view></template>',
+        '<script setup lang="ts">',
+        'const componentMarker = \'issue-724-component-script\'',
+        'void componentMarker',
+        '</script>',
+        '<style>.issue-724-component { font-weight: 600; }</style>',
+      ].join('\n'), 'utf8')
+
+      const runBuild = async () => {
+        styleInputs.clear()
+        vueInputs.clear()
+        const vuePlugin = createVueTransformPlugin(createCtx(root))
+        const vueResolverPlugin = createVueResolverPlugin(createCtx(root))
+        const sfcRoutingPlugin: Plugin = {
+          name: 'weapp-vite:test-sfc-routing',
+          resolveId: vuePlugin.resolveId,
+          load: vuePlugin.load,
+          transform: vuePlugin.transform,
+        }
+        const sfcResolverPlugin: Plugin = {
+          name: 'weapp-vite:test-sfc-resolver',
+          resolveId: vueResolverPlugin.resolveId,
+        }
+        const styleLoadProbe: Plugin = {
+          name: 'weapp-vite:test-style-load-probe',
+          enforce: 'pre',
+          transform(code, id) {
+            if (!id.includes('?weapp-vite-vue&type=style')) {
+              return null
+            }
+            expect(code).not.toMatch(/<(?:template|script|style)(?:\s|>)/)
+            styleInputs.set(id, code)
+            return null
+          },
+        }
+        const downstreamJsProbe: Plugin = {
+          name: 'weapp-vite:test-downstream-js-probe',
+          enforce: 'post',
+          transform(code, id) {
+            if (!id.endsWith('.vue')) {
+              return null
+            }
+            expect(code).not.toMatch(/<(?:template|script|style)(?:\s|>)/)
+            vueInputs.set(id, code)
+            return null
+          },
+        }
+
+        await build({
+          configFile: false,
+          root,
+          logLevel: 'silent',
+          plugins: [styleLoadProbe, sfcResolverPlugin, sfcRoutingPlugin, downstreamJsProbe],
+          build: {
+            write: false,
+            minify: false,
+            lib: {
+              entry: pageFile,
+              formats: ['es'],
+              name: 'Issue724RoutingFixture',
+              cssFileName: 'issue-724-routing',
+            },
+            rolldownOptions: {
+              external: id => !id.startsWith('.') && !path.isAbsolute(id) && !id.startsWith('\0'),
+            },
+          },
+        })
+
+        expect(styleInputs.size).toBe(3)
+        const findVueInput = (filename: string) => [...vueInputs]
+          .find(([id]) => id.includes(filename))?.[1]
+        expect(findVueInput(pageFile)).toContain('issue-724-script-marker')
+        expect(findVueInput(componentFile)).toContain('issue-724-component-script')
+        expect([...styleInputs.values()]).toEqual(expect.arrayContaining([
+          expect.stringContaining('.issue-724-inline'),
+          expect.stringContaining('.issue-724-style-src'),
+          expect.stringContaining('.issue-724-component'),
+        ]))
+        for (const styleCode of styleInputs.values()) {
+          expect(styleCode).not.toContain('issue-724-template-marker')
+          expect(styleCode).not.toContain('issue-724-script-marker')
+        }
+      }
+
+      await runBuild()
+      await runBuild()
     }
     finally {
       await fs.remove(root)


### PR DESCRIPTION
## 背景

关联并修复 #724。

问题与 6.17 引入的 Rolldown hook filter 调度优化高度相关。Vue SFC 主请求、样式虚拟请求和 scoped-slot 虚拟模块属于编译正确性边界，不应依赖原生 filter 是否在特定插件图或缓存调度下命中。

## 改动

- 将 Vue SFC 的 `transform`、style/scoped-slot `load` 和 scoped-slot `resolveId` 恢复为确定执行的函数 hook，并在 handler 内保留正则快速退出。
- 增加真实 Vite 8/Rolldown 集成测试，覆盖多个 SFC、多个 style block、SCSS、`script/style src`、pre/post 插件顺序和重复构建。
- 增加 issue #724 构建 fixture 与 pre style-load/post transform 泄漏探针，断言 JS、WXML、WXSS 各自只包含对应 SFC block。
- 增加 `weapp-vite` 与 `create-weapp-vite` patch changeset。

## 验证

- `pnpm --filter weapp-vite build`
- `pnpm --filter weapp-vite typecheck`
- `pnpm --filter weapp-vite lint:src`
- `pnpm vitest run packages/weapp-vite/src/plugins/vue/transform/plugin/index.test.ts packages/weapp-vite/test/vue/style-pipeline.test.ts packages/weapp-vite/test/vue/transform-plugin.test.ts`
- `pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #724"`
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`
- `node --import tsx scripts/check-catalog-changeset.ts`

`lint:src` 无错误，保留仓库现有的 8 条 warning。