### PR TITLE
refactor(weapp-vite): 引入平台后端架构基础

### DIFF
--- a/docs/architecture/platform-backend-runtime.md
+++ b/docs/architecture/platform-backend-runtime.md
@@ -1,0 +1,78 @@
+# Platform Backend 运行时架构
+
+## 背景
+
+第一阶段改造解决 CLI 平台选择与服务编排的所有权分散问题。此前 `build`、`serve`、`analyze`、`open` 等命令分别依赖 `runMini` / `runWeb` 布尔值，并直接选择 `BuildService` 或 `WebService`。随着 Web、lib、workers、npm 和 IDE 能力继续扩展，这种控制流会让目标解析、执行顺序、资源关闭和能力判断在命令之间重复。
+
+本阶段只建立内部 platform backend contract，不提供第三方 backend 注册 API，也不改变现有配置、日志和构建产物契约。
+
+## 第一阶段边界
+
+`packages/weapp-vite/src/backends/` 包含四类内部对象：
+
+- `PlatformBackendDescriptor`：声明 backend id、别名、runtime 与 capabilities。
+- `PlatformBackendDriver`：生成目标 inline config，委托配置合并与 build/dev 生命周期，并关闭 backend 资源。
+- `PlatformBackendRegistry`：负责注册唯一性、别名解析、默认目标、组合目标和稳定执行顺序。
+- `ResolvedBackendExecution`：CLI 的有序执行计划，也是命令控制流的单一事实源。
+
+当前内置 backend 的注册顺序固定为：
+
+1. `miniprogram`
+2. `web`
+
+因此 `--platform all` 与 `--platform both` 保持先执行小程序、再执行 Web。单目标别名仍兼容 `h5`、六个小程序平台及各平台别名；未知平台仍回退到默认小程序平台并输出原警告。
+
+## Capabilities
+
+第一阶段声明以下 capabilities：
+
+| Capability | miniprogram | web | 当前实现所有者                       |
+| ---------- | ----------- | --- | ------------------------------------ |
+| `build`    | 是          | 是  | `BuildService` / `WebService`        |
+| `dev`      | 是          | 是  | `BuildService` / `WebService`        |
+| `ide`      | 是          | 否  | 现有 IDE/open 命令与 `weapp-ide-cli` |
+| `analyze`  | 是          | 是  | 分包分析 / Web 静态分析              |
+| `npm`      | 是          | 否  | 现有 npm 服务与 IDE npm 命令         |
+| `workers`  | 是          | 否  | 现有 `BuildService` workers 流程     |
+| `lib`      | 是          | 否  | 现有 `BuildService` lib 流程         |
+
+capability 是声明式路由依据，不意味着第一阶段移动所有业务实现。特别是 `npm`、`workers` 和 `lib` 仍由现有服务实现，只归属于 miniprogram backend。
+
+## 数据流与所有权
+
+```text
+CLI platform input
+  -> PlatformBackendRegistry.resolve()
+  -> ResolvedBackendExecution(entries in stable order)
+  -> backend driver inline config
+  -> createCompilerContext()
+  -> command filters entries by capability
+  -> driver delegates BuildService/WebService/config merge
+  -> driver closes watcher/dev-server resources
+```
+
+`ConfigService.merge()` 与 `ConfigService.mergeWeb()` 保留原签名。它们通过 registry 取得对应内置 backend，再由 driver 调用现有 miniprogram/web merge delegate。`mergeWeb` 仍使用 `@weapp-vite/web` 插件路径，最终产物仍完全由 Vite/Rolldown emit/write，不增加手工 bundle 写盘路径。
+
+`runtimeTarget.ts` 保留 `ResolvedWeappViteTarget`、`runMini` 和 `runWeb` 等公开兼容形状，但这些值只是 `ResolvedBackendExecution` 的投影。CLI 不再使用这些布尔值作为核心控制流。
+
+## 小程序平台能力来源
+
+miniprogram backend 不维护第二份平台表。微信、支付宝、百度、抖音、京东和小红书平台的 id、别名及编译/runtime 静态能力继续统一来自 `@weapp-core/shared` 的 `MiniProgramPlatformDescriptor`。backend registry 只负责把这些平台目标路由到同一个 miniprogram driver。
+
+## 后续阶段
+
+### 第二阶段：Module Graph Backend
+
+第二阶段可把 module graph、增量失效和构建图分析收敛为 backend 可消费的稳定接口。它不应改变第一阶段 registry 的目标解析职责，也不应让 driver 绕过 Vite/Rolldown 的 emit/write 阶段。
+
+### 第三阶段：Runtime Provider
+
+第三阶段可为真实宿主、Web runtime 或模拟器建立 runtime provider contract，处理运行时连接、页面状态和调试能力。runtime provider 不等同于 build backend：前者描述产物运行位置与调试通道，后者负责构建目标与生命周期委托。两者应通过明确接口组合，避免重新把 IDE、runtime 和 bundler 所有权混在同一服务中。
+
+## 非目标
+
+- 不开放第三方 backend 注册 API。
+- 不新增公开配置项或改变 `weapp.platform` / `weapp.web` 结构。
+- 不实现 module graph backend 或 runtime provider。
+- 不改变日志文本、输出目录、host metadata 或最终 bundle 内容。
+- 不用 `writeFile` 补写、修补或同步最终构建产物。

--- a/docs/core-architecture.md
+++ b/docs/core-architecture.md
@@ -29,6 +29,7 @@ packages/weapp-vite/
 ├── src/                          # 源代码目录
 │   ├── cli/                      # CLI 命令实现
 │   │   └── commands/             # 各个子命令（build, serve, npm 等）
+│   ├── backends/                 # 内部平台后端 contract、registry 与内置 driver
 │   ├── context/                  # 编译器上下文管理
 │   ├── plugins/                  # 核心 Vite 插件
 │   ├── runtime/                  # 运行时服务实现
@@ -53,9 +54,14 @@ packages/weapp-vite/
 
 ### 1. 整体架构
 
-weapp-vite 采用**服务导向架构（Service-Oriented Architecture）**，通过 `CompilerContext` 将各个服务协调起来：
+weapp-vite 采用**服务导向架构（Service-Oriented Architecture）**。CLI 先通过内部 platform backend registry 生成有序执行计划，再由 backend driver 委托 `CompilerContext` 中的既有服务：
 
 ```
+┌─────────────────────────────────────────────────────────────┐
+│ PlatformBackendRegistry / ResolvedBackendExecution          │
+│ miniprogram backend → web backend（按 capability 过滤）      │
+└──────────────────────────────┬──────────────────────────────┘
+                               │ driver delegation
 ┌─────────────────────────────────────────────────────────────┐
 │                     CompilerContext                         │
 ├─────────────────────────────────────────────────────────────┤
@@ -73,6 +79,8 @@ weapp-vite 采用**服务导向架构（Service-Oriented Architecture）**，通
 │  └──────────────┘  └──────────────┘                        │
 └─────────────────────────────────────────────────────────────┘
 ```
+
+platform backend 是 CLI 与服务层之间的内部编排边界，不是第三方注册 API。第一阶段的详细 contract、执行顺序与后续阶段边界见 [平台后端运行时架构](./architecture/platform-backend-runtime.md)。
 
 ### 2. 入口文件
 
@@ -307,6 +315,18 @@ JSON 配置处理服务。
 
 Web 运行时服务，用于 H5 平台构建。
 
+### 11. **Platform Backend** (`src/backends/`)
+
+平台后端层负责：
+
+- 通过 `PlatformBackendDescriptor` 声明 backend id、别名、runtime 和 capabilities。
+- 通过 `PlatformBackendRegistry` 校验唯一性、解析平台别名并确定执行顺序。
+- 通过 `ResolvedBackendExecution` 向 CLI 提供单一执行计划，替代散落的 `runMini` / `runWeb` 控制流。
+- 通过内置 driver 生成目标 inline config，并委托 `BuildService`、`WebService` 与现有 config merge 实现。
+- 在命令结束时关闭 backend 持有的 watcher 或 Vite dev server 资源。
+
+`runtimeTarget.ts` 继续保留公开兼容门面，但其目标解析来自 backend registry。六个小程序平台的标识、别名与静态平台能力仍统一来自 `@weapp-core/shared` 的 `MiniProgramPlatformDescriptor`。
+
 ---
 
 ## Chunk 共享策略
@@ -343,6 +363,7 @@ type SharedChunkStrategy = 'hoist' | 'duplicate'
 | `src/context/CompilerContext.ts` | 14-29 | 上下文类型定义 |
 | `src/types/config.ts` | 329-477 | 配置类型定义 |
 | `src/runtime/buildPlugin.ts` | 31-374 | 构建服务实现 |
+| `src/backends/` | - | 内部平台后端 contract、registry、执行计划与内置 driver |
 
 ---
 

--- a/packages/weapp-vite/src/backends/index.ts
+++ b/packages/weapp-vite/src/backends/index.ts
@@ -1,0 +1,44 @@
+import type { PlatformBackendCapability, ResolvedBackendExecution } from './types'
+import { DEFAULT_MP_PLATFORM } from '../platform'
+import { miniprogramBackend } from './miniprogram'
+import { PlatformBackendRegistry } from './registry'
+import { webBackend } from './web'
+
+export const platformBackendRegistry = new PlatformBackendRegistry()
+platformBackendRegistry.register(miniprogramBackend)
+platformBackendRegistry.register(webBackend)
+
+export function resolveBackendExecution(
+  input?: string | null,
+  options: {
+    fallbackMiniPlatform?: string
+    warn?: (message: string) => void
+  } = {},
+): ResolvedBackendExecution {
+  return platformBackendRegistry.resolve(input, {
+    fallbackBackendId: 'miniprogram',
+    fallbackPlatform: options.fallbackMiniPlatform ?? DEFAULT_MP_PLATFORM,
+    warn: options.warn,
+  })
+}
+
+export function getBackendForCapability(
+  execution: ResolvedBackendExecution,
+  backendId: string,
+  capability: PlatformBackendCapability,
+) {
+  const backend = execution.get(backendId)
+  return backend?.descriptor.capabilities[capability] ? backend : undefined
+}
+
+export type {
+  PlatformBackend,
+  PlatformBackendCapabilities,
+  PlatformBackendCapability,
+  PlatformBackendDescriptor,
+  PlatformBackendDriver,
+  PlatformBackendInlineConfigOptions,
+  PlatformBackendMergeContext,
+  ResolvedBackendExecution,
+  ResolvedPlatformBackend,
+} from './types'

--- a/packages/weapp-vite/src/backends/miniprogram.ts
+++ b/packages/weapp-vite/src/backends/miniprogram.ts
@@ -1,0 +1,73 @@
+import type { PlatformBackend } from './types'
+import { MINI_PROGRAM_PLATFORM_DESCRIPTORS, resolveMiniProgramPlatform } from '@weapp-core/shared'
+import { createBuildScopeConfigFromCli } from '../runtime/buildScope'
+
+const aliases = Object.freeze(
+  Array.from(new Set(MINI_PROGRAM_PLATFORM_DESCRIPTORS.flatMap(descriptor => descriptor.aliases))),
+)
+
+export const miniprogramBackend: PlatformBackend = {
+  descriptor: {
+    id: 'miniprogram',
+    aliases,
+    runtime: 'miniprogram',
+    capabilities: Object.freeze({
+      build: true,
+      dev: true,
+      ide: true,
+      analyze: true,
+      npm: true,
+      workers: true,
+      lib: true,
+    }),
+  },
+  driver: {
+    createInlineConfig({ execution, platform, scope }) {
+      const buildScope = createBuildScopeConfigFromCli(scope)
+      const runsWeb = execution.get('web') !== undefined
+      const miniPlatform = platform === 'web' ? undefined : platform
+      const config = miniPlatform || buildScope || runsWeb
+        ? {
+            ...(miniPlatform || buildScope
+              ? {
+                  weapp: {
+                    ...(miniPlatform ? { platform: miniPlatform } : {}),
+                    ...(buildScope ? { buildScope } : {}),
+                  },
+                }
+              : {}),
+            ...(runsWeb
+              ? {
+                  build: {
+                    watch: {},
+                  },
+                  server: {
+                    port: 0,
+                    watch: {
+                      usePolling: true,
+                      interval: 100,
+                    },
+                  },
+                }
+              : {}),
+          }
+        : undefined
+      return config
+    },
+    mergeConfig(context, ...configs) {
+      return context.merge(...configs)
+    },
+    async build(ctx, options) {
+      return await ctx.buildService.build(options)
+    },
+    async dev(ctx, options) {
+      return await ctx.buildService.build(options)
+    },
+    close(ctx) {
+      ctx.watcherService.closeAll()
+    },
+    resolvePlatformAlias(input) {
+      return resolveMiniProgramPlatform(input)
+    },
+  },
+}

--- a/packages/weapp-vite/src/backends/registry.test.ts
+++ b/packages/weapp-vite/src/backends/registry.test.ts
@@ -1,0 +1,86 @@
+import type { PlatformBackend } from './types'
+import { describe, expect, it, vi } from 'vitest'
+import { resolveBackendExecution } from '.'
+import { PlatformBackendRegistry } from './registry'
+
+function createBackend(id: string, aliases: readonly string[] = []): PlatformBackend {
+  return {
+    descriptor: {
+      id,
+      aliases,
+      runtime: id === 'web' ? 'web' : 'miniprogram',
+      capabilities: {
+        build: true,
+        dev: true,
+        ide: id !== 'web',
+        analyze: true,
+        npm: id !== 'web',
+        workers: id !== 'web',
+        lib: id !== 'web',
+      },
+    },
+    driver: {
+      createInlineConfig: () => undefined,
+      mergeConfig: () => undefined,
+      build: vi.fn(),
+      dev: vi.fn(),
+      close: vi.fn(),
+    },
+  }
+}
+
+describe('platform backend registry', () => {
+  it('rejects duplicate backend ids and aliases', () => {
+    const registry = new PlatformBackendRegistry()
+    registry.register(createBackend('mini', ['wx']))
+
+    expect(() => registry.register(createBackend('mini'))).toThrow('平台后端 id "mini" 已注册。')
+    expect(() => registry.register(createBackend('other', ['WX']))).toThrow('平台后端别名 "wx" 已由 "mini" 注册。')
+    expect(() => registry.register(createBackend('reserved', ['both']))).toThrow('平台后端别名 "both" 为保留目标。')
+  })
+
+  it('resolves shared mini-program aliases without duplicating platform data', () => {
+    const execution = resolveBackendExecution('douyin')
+
+    expect(execution.kind).toBe('miniprogram')
+    expect(execution.get('miniprogram')?.platform).toBe('tt')
+    expect(execution.label).toBe('tt')
+  })
+
+  it('uses config-driven miniprogram as the default target', () => {
+    const execution = resolveBackendExecution()
+
+    expect(execution.label).toBe('config')
+    expect(execution.entries.map(entry => entry.descriptor.id)).toEqual(['miniprogram'])
+    expect(execution.get('miniprogram')?.platform).toBeUndefined()
+  })
+
+  it.each(['all', 'both'])('selects all backends in registration order for %s', (target) => {
+    const execution = resolveBackendExecution(target)
+
+    expect(execution.kind).toBe('all')
+    expect(execution.entries.map(entry => entry.descriptor.id)).toEqual(['miniprogram', 'web'])
+    expect(execution.select('build').map(entry => entry.descriptor.id)).toEqual(['miniprogram', 'web'])
+  })
+
+  it('exposes declarative capabilities for backend filtering', () => {
+    const execution = resolveBackendExecution('all')
+
+    expect(execution.has('build')).toBe(true)
+    expect(execution.select('ide').map(entry => entry.descriptor.id)).toEqual(['miniprogram'])
+    expect(execution.select('npm').map(entry => entry.descriptor.id)).toEqual(['miniprogram'])
+    expect(execution.select('workers').map(entry => entry.descriptor.id)).toEqual(['miniprogram'])
+    expect(execution.select('lib').map(entry => entry.descriptor.id)).toEqual(['miniprogram'])
+  })
+
+  it('falls back to the configured default platform for unknown input', () => {
+    const warn = vi.fn()
+    const execution = resolveBackendExecution('unknown', {
+      fallbackMiniPlatform: 'alipay',
+      warn,
+    })
+
+    expect(execution.get('miniprogram')?.platform).toBe('alipay')
+    expect(warn).toHaveBeenCalledWith('未识别的平台 "unknown"，已回退到 alipay')
+  })
+})

--- a/packages/weapp-vite/src/backends/registry.ts
+++ b/packages/weapp-vite/src/backends/registry.ts
@@ -1,0 +1,155 @@
+import type {
+  PlatformBackend,
+  PlatformBackendCapability,
+  ResolvedBackendExecution,
+  ResolvedPlatformBackend,
+} from './types'
+
+const RESERVED_COMBINED_TARGETS = new Set(['all', 'both'])
+
+function normalizeBackendKey(value: string) {
+  return value.trim().toLowerCase()
+}
+
+function createExecution(
+  entries: readonly ResolvedPlatformBackend[],
+  options: Pick<ResolvedBackendExecution, 'kind' | 'label' | 'raw'>,
+): ResolvedBackendExecution {
+  return {
+    ...options,
+    entries,
+    get: backendId => entries.find(entry => entry.descriptor.id === backendId),
+    has: capability => entries.some(entry => entry.descriptor.capabilities[capability]),
+    select: capability => entries.filter(entry => entry.descriptor.capabilities[capability]),
+  }
+}
+
+export class PlatformBackendRegistry {
+  private readonly backends: PlatformBackend[] = []
+  private readonly backendById = new Map<string, PlatformBackend>()
+  private readonly backendByAlias = new Map<string, PlatformBackend>()
+
+  register(backend: PlatformBackend) {
+    const id = normalizeBackendKey(backend.descriptor.id)
+    if (!id) {
+      throw new Error('平台后端 id 不能为空。')
+    }
+    if (this.backendById.has(id)) {
+      throw new Error(`平台后端 id "${id}" 已注册。`)
+    }
+
+    const aliases = [id, ...backend.descriptor.aliases.map(normalizeBackendKey)]
+    const uniqueAliases = new Set<string>()
+    for (const alias of aliases) {
+      if (!alias) {
+        continue
+      }
+      if (RESERVED_COMBINED_TARGETS.has(alias)) {
+        throw new Error(`平台后端别名 "${alias}" 为保留目标。`)
+      }
+      if (uniqueAliases.has(alias)) {
+        continue
+      }
+      const existing = this.backendByAlias.get(alias)
+      if (existing) {
+        throw new Error(`平台后端别名 "${alias}" 已由 "${existing.descriptor.id}" 注册。`)
+      }
+      uniqueAliases.add(alias)
+    }
+
+    this.backends.push(backend)
+    this.backendById.set(id, backend)
+    for (const alias of uniqueAliases) {
+      this.backendByAlias.set(alias, backend)
+    }
+  }
+
+  getExecutionOrder(capability?: PlatformBackendCapability): readonly PlatformBackend[] {
+    if (!capability) {
+      return this.backends
+    }
+    return this.backends.filter(backend => backend.descriptor.capabilities[capability])
+  }
+
+  get(backendId: string): PlatformBackend | undefined {
+    return this.backendById.get(normalizeBackendKey(backendId))
+  }
+
+  resolve(
+    input?: string | null,
+    options: {
+      fallbackBackendId: string
+      fallbackPlatform?: string
+      warn?: (message: string) => void
+    } = { fallbackBackendId: 'miniprogram' },
+  ): ResolvedBackendExecution {
+    const raw = typeof input === 'string' ? input : undefined
+    const normalized = raw ? normalizeBackendKey(raw) : undefined
+    const fallbackBackend = this.backendById.get(normalizeBackendKey(options.fallbackBackendId))
+    if (!fallbackBackend) {
+      throw new Error(`默认平台后端 "${options.fallbackBackendId}" 未注册。`)
+    }
+
+    if (!raw) {
+      return createExecution([
+        {
+          descriptor: fallbackBackend.descriptor,
+          driver: fallbackBackend.driver,
+        },
+      ], {
+        kind: fallbackBackend.descriptor.runtime,
+        label: 'config',
+        raw,
+      })
+    }
+    const targetKey = normalized ?? ''
+
+    if (RESERVED_COMBINED_TARGETS.has(targetKey)) {
+      const entries = this.backends.map(backend => ({
+        descriptor: backend.descriptor,
+        driver: backend.driver,
+        platform: backend.descriptor.runtime === 'web'
+          ? backend.driver.resolvePlatformAlias?.(backend.descriptor.aliases[0] ?? backend.descriptor.id)
+          : undefined,
+      }))
+      return createExecution(entries, {
+        kind: 'all',
+        label: 'weapp + web',
+        raw,
+      })
+    }
+
+    const backend = this.backendByAlias.get(targetKey)
+    if (backend) {
+      const platform = backend.driver.resolvePlatformAlias?.(targetKey)
+      return createExecution([
+        {
+          descriptor: backend.descriptor,
+          driver: backend.driver,
+          platform,
+        },
+      ], {
+        kind: backend.descriptor.runtime,
+        label: platform ?? backend.descriptor.runtime,
+        raw,
+      })
+    }
+
+    const fallbackPlatform = options.fallbackPlatform
+      ? fallbackBackend.driver.resolvePlatformAlias?.(options.fallbackPlatform)
+      : undefined
+    const fallbackLabel = fallbackPlatform ?? fallbackBackend.descriptor.runtime
+    options.warn?.(`未识别的平台 "${raw}"，已回退到 ${fallbackLabel}`)
+    return createExecution([
+      {
+        descriptor: fallbackBackend.descriptor,
+        driver: fallbackBackend.driver,
+        platform: fallbackPlatform,
+      },
+    ], {
+      kind: fallbackBackend.descriptor.runtime,
+      label: fallbackLabel,
+      raw,
+    })
+  }
+}

--- a/packages/weapp-vite/src/backends/types.ts
+++ b/packages/weapp-vite/src/backends/types.ts
@@ -1,0 +1,67 @@
+import type { InlineConfig } from 'vite'
+import type { CompilerContext } from '../context'
+import type { BuildOptions } from '../runtime/buildPlugin'
+import type { WeappVitePlatform, WeappViteRuntime } from '../runtimeTarget'
+
+export interface PlatformBackendCapabilities {
+  build: boolean
+  dev: boolean
+  ide: boolean
+  analyze: boolean
+  npm: boolean
+  workers: boolean
+  lib: boolean
+}
+
+export type PlatformBackendCapability = keyof PlatformBackendCapabilities
+
+export interface PlatformBackendDescriptor {
+  id: string
+  aliases: readonly string[]
+  runtime: WeappViteRuntime
+  capabilities: Readonly<PlatformBackendCapabilities>
+}
+
+export interface ResolvedPlatformBackend {
+  descriptor: PlatformBackendDescriptor
+  driver: PlatformBackendDriver
+  platform?: WeappVitePlatform
+}
+
+export interface ResolvedBackendExecution {
+  kind: WeappViteRuntime | 'all'
+  label: string
+  raw?: string
+  entries: readonly ResolvedPlatformBackend[]
+  get: (backendId: string) => ResolvedPlatformBackend | undefined
+  has: (capability: PlatformBackendCapability) => boolean
+  select: (capability: PlatformBackendCapability) => readonly ResolvedPlatformBackend[]
+}
+
+export interface PlatformBackendInlineConfigOptions {
+  execution: ResolvedBackendExecution
+  platform?: WeappVitePlatform
+  scope?: string
+  host?: string | boolean
+}
+
+export interface PlatformBackendMergeContext {
+  merge: (...configs: Partial<InlineConfig | undefined>[]) => InlineConfig | undefined
+}
+
+export interface PlatformBackendDriver {
+  createInlineConfig: (options: PlatformBackendInlineConfigOptions) => InlineConfig | undefined
+  mergeConfig: (
+    context: PlatformBackendMergeContext,
+    ...configs: Partial<InlineConfig | undefined>[]
+  ) => InlineConfig | undefined
+  build: (ctx: CompilerContext, options?: BuildOptions) => Promise<unknown>
+  dev: (ctx: CompilerContext, options?: BuildOptions) => Promise<unknown>
+  close: (ctx: CompilerContext) => Promise<void> | void
+  resolvePlatformAlias?: (input: string) => WeappVitePlatform | undefined
+}
+
+export interface PlatformBackend {
+  descriptor: PlatformBackendDescriptor
+  driver: PlatformBackendDriver
+}

--- a/packages/weapp-vite/src/backends/web.ts
+++ b/packages/weapp-vite/src/backends/web.ts
@@ -1,0 +1,45 @@
+import type { PlatformBackend } from './types'
+
+export const webBackend: PlatformBackend = {
+  descriptor: {
+    id: 'web',
+    aliases: Object.freeze(['web', 'h5']),
+    runtime: 'web',
+    capabilities: Object.freeze({
+      build: true,
+      dev: true,
+      ide: false,
+      analyze: true,
+      npm: false,
+      workers: false,
+      lib: false,
+    }),
+  },
+  driver: {
+    createInlineConfig({ host }) {
+      if (host === undefined) {
+        return undefined
+      }
+      return {
+        server: {
+          host,
+        },
+      }
+    },
+    mergeConfig(context, ...configs) {
+      return context.merge(...configs)
+    },
+    async build(ctx) {
+      return await ctx.webService.build()
+    },
+    async dev(ctx) {
+      return await ctx.webService.startDevServer()
+    },
+    async close(ctx) {
+      await ctx.webService.close()
+    },
+    resolvePlatformAlias() {
+      return 'web'
+    },
+  },
+}

--- a/packages/weapp-vite/src/cli/commands/analyze.test.ts
+++ b/packages/weapp-vite/src/cli/commands/analyze.test.ts
@@ -8,12 +8,25 @@ import { registerAnalyzeCommand } from './analyze'
 
 const filterDuplicateOptionsMock = vi.hoisted(() => vi.fn())
 const resolveConfigFileMock = vi.hoisted(() => vi.fn())
-const resolveRuntimeTargetsMock = vi.hoisted(() => vi.fn(() => ({
-  runMini: true,
-  runWeb: false,
-  platform: 'weapp',
-  rawPlatform: 'weapp',
-})))
+const resolveRuntimeTargetsMock = vi.hoisted(() => {
+  const miniBackend = {
+    descriptor: {
+      id: 'miniprogram',
+      capabilities: {
+        analyze: true,
+      },
+    },
+    platform: 'weapp',
+  }
+  return vi.fn(() => ({
+    kind: 'miniprogram',
+    label: 'weapp',
+    entries: [miniBackend],
+    platform: 'weapp',
+    rawPlatform: 'weapp',
+    get: (id: string) => id === 'miniprogram' ? miniBackend : undefined,
+  }))
+})
 const createInlineConfigMock = vi.hoisted(() => vi.fn(() => ({})))
 const logRuntimeTargetMock = vi.hoisted(() => vi.fn())
 const createCompilerContextMock = vi.hoisted(() => vi.fn())
@@ -377,5 +390,47 @@ describe('analyze cli command', () => {
     expect(loggerMock.info).toHaveBeenCalledWith('组件依赖：1 个组件，1 条分包优化建议')
     expect(loggerMock.info).toHaveBeenCalledWith(expect.stringContaining('components/detail-card'))
     expect(startAnalyzeDashboard).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the web analyze capability without running mini analysis', async () => {
+    const webBackend = {
+      descriptor: {
+        id: 'web',
+        capabilities: { analyze: true },
+      },
+      platform: 'web',
+    }
+    resolveRuntimeTargetsMock.mockReturnValueOnce({
+      kind: 'web',
+      label: 'web',
+      entries: [webBackend],
+      rawPlatform: 'web',
+      get: (id: string) => id === 'web' ? webBackend : undefined,
+    })
+    createCompilerContextMock.mockResolvedValueOnce({
+      configService: {
+        platform: 'weapp',
+        cwd: '/project',
+        mode: 'production',
+        packageManager: { agent: 'pnpm' },
+        relativeCwd: (input: string) => input.replace('/project/', ''),
+        weappViteConfig: { hmr: { profileJson: false } },
+        weappWebConfig: {
+          enabled: true,
+          root: '/project/web',
+          srcDir: 'src',
+          outDir: '/project/dist/web',
+          pluginOptions: {
+            executionMode: 'compat',
+          },
+        },
+      },
+    })
+    const action = createAnalyzeActionHandler()
+
+    await action('/project', { platform: 'web' })
+
+    expect(analyzeSubpackages).not.toHaveBeenCalled()
+    expect(loggerMock.success).toHaveBeenCalledWith('Web 静态分析完成')
   })
 })

--- a/packages/weapp-vite/src/cli/commands/analyze.ts
+++ b/packages/weapp-vite/src/cli/commands/analyze.ts
@@ -10,6 +10,7 @@ import { analyzeHmrProfile } from '../../analyze/hmr'
 import { analyzeSubpackages } from '../../analyze/subpackages'
 import { readLatestAnalyzeHistorySnapshot, writeAnalyzeHistorySnapshot } from '../../analyze/subpackages/history'
 import { createAnalyzeBudgetCheck, createAnalyzeMarkdownReport, createAnalyzePrMarkdownReport, formatAnalyzeBytes } from '../../analyze/subpackages/report'
+import { getBackendForCapability } from '../../backends'
 import { createCompilerContext } from '../../createContext'
 import logger, { colors } from '../../logger'
 import { resolveHmrProfileJsonPath } from '../../utils/hmrProfile'
@@ -348,7 +349,7 @@ export function registerAnalyzeCommand(cli: CAC) {
       }
       const budgetCheck = coerceBooleanOption(options.budgetCheck)
       const targets = resolveRuntimeTargets(options)
-      const inlineConfig = createInlineConfig(targets.platform)
+      const inlineConfig = createInlineConfig(targets)
       try {
         const ctx = await createCompilerContext({
           cwd: root,
@@ -389,7 +390,8 @@ export function registerAnalyzeCommand(cli: CAC) {
           }
           return
         }
-        if (targets.runWeb) {
+        const webBackend = getBackendForCapability(targets, 'web', 'analyze')
+        if (webBackend) {
           const webResult = createWebAnalyzeResult(ctx.configService, {
             platform: 'web',
           })
@@ -405,7 +407,7 @@ export function registerAnalyzeCommand(cli: CAC) {
           return
         }
 
-        if (!targets.runMini) {
+        if (!getBackendForCapability(targets, 'miniprogram', 'analyze')) {
           logger.warn('当前命令不支持该平台，请通过 --platform weapp 或 --platform web 指定目标。')
           return
         }

--- a/packages/weapp-vite/src/cli/commands/build.test.ts
+++ b/packages/weapp-vite/src/cli/commands/build.test.ts
@@ -11,12 +11,39 @@ import {
 const filterDuplicateOptionsMock = vi.hoisted(() => vi.fn())
 const resolveConfigFileMock = vi.hoisted(() => vi.fn())
 const isUiEnabledMock = vi.hoisted(() => vi.fn(() => true))
-const resolveRuntimeTargetsMock = vi.hoisted(() => vi.fn(() => ({
-  runMini: true,
-  runWeb: false,
-  platform: 'weapp',
-  rawPlatform: 'weapp',
-})))
+const resolveRuntimeTargetsMock = vi.hoisted(() => {
+  const miniBackend = {
+    descriptor: {
+      id: 'miniprogram',
+      runtime: 'miniprogram',
+      aliases: ['weapp'],
+      capabilities: {
+        build: true,
+        dev: true,
+        ide: true,
+        analyze: true,
+        npm: true,
+        workers: true,
+        lib: true,
+      },
+    },
+    driver: {
+      build: (ctx: any, options: any) => ctx.buildService.build(options),
+      close: (ctx: any) => ctx.watcherService.closeAll(),
+    },
+    platform: 'weapp',
+  }
+  return vi.fn(() => ({
+    kind: 'miniprogram',
+    label: 'weapp',
+    entries: [miniBackend],
+    platform: 'weapp',
+    rawPlatform: 'weapp',
+    get: (id: string) => id === 'miniprogram' ? miniBackend : undefined,
+    has: (capability: string) => Boolean((miniBackend.descriptor.capabilities as any)[capability]),
+    select: (capability: string) => (miniBackend.descriptor.capabilities as any)[capability] ? [miniBackend] : [],
+  }))
+})
 const createInlineConfigMock = vi.hoisted(() => vi.fn(() => ({})))
 const logRuntimeTargetMock = vi.hoisted(() => vi.fn())
 const createCompilerContextMock = vi.hoisted(() => vi.fn())
@@ -242,6 +269,58 @@ describe('build cli command', () => {
     })).rejects.toThrow(buildError)
 
     expect(closeAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('executes a web-only build through the web backend capability', async () => {
+    const webBuild = vi.fn().mockResolvedValue(undefined)
+    const webClose = vi.fn().mockResolvedValue(undefined)
+    const webBackend = {
+      descriptor: {
+        id: 'web',
+        capabilities: { build: true, ide: false },
+      },
+      driver: {
+        build: webBuild,
+        close: webClose,
+      },
+      platform: 'web',
+    }
+    resolveRuntimeTargetsMock.mockReturnValueOnce({
+      kind: 'web',
+      label: 'web',
+      entries: [webBackend],
+      rawPlatform: 'web',
+      get: (id: string) => id === 'web' ? webBackend : undefined,
+      has: () => true,
+      select: (capability: string) => capability === 'build' ? [webBackend] : [],
+    })
+    createCompilerContextMock.mockResolvedValueOnce({
+      buildService: { build: vi.fn() },
+      configService: {
+        platform: 'weapp',
+        cwd: '/project',
+        mode: 'production',
+        outDir: '/project/dist',
+        mpDistRoot: '/project/dist',
+        packageManager: { agent: 'pnpm' },
+        relativeCwd: (input: string) => input.replace('/project/', ''),
+        weappViteConfig: { packageSizeWarningBytes: 0 },
+        weappWebConfig: {
+          enabled: true,
+          outDir: '/project/dist/web',
+        },
+      },
+      scanService: { subPackageMap: new Map() },
+      watcherService: { closeAll: vi.fn() },
+      webService: { build: vi.fn(), close: vi.fn() },
+    })
+    const action = createBuildActionHandler()
+
+    await action('/project', { platform: 'web' })
+
+    expect(webBuild).toHaveBeenCalledTimes(1)
+    expect(webClose).toHaveBeenCalledTimes(1)
+    expect(loggerSuccessMock).toHaveBeenCalledWith(expect.stringContaining('Web 构建完成'))
   })
 
   it('schedules process exit only for completed one-shot production cli builds', () => {

--- a/packages/weapp-vite/src/cli/commands/build.ts
+++ b/packages/weapp-vite/src/cli/commands/build.ts
@@ -5,6 +5,7 @@ import type { GlobalCLIOptions } from '../types'
 import process from 'node:process'
 import { analyzeSubpackages } from '../../analyze/subpackages'
 import { readLatestAnalyzeHistorySnapshot, writeAnalyzeHistorySnapshot } from '../../analyze/subpackages/history'
+import { getBackendForCapability } from '../../backends'
 import { createCompilerContext } from '../../createContext'
 import logger, { colors } from '../../logger'
 import { startAnalyzeDashboard } from '../analyze/dashboard'
@@ -99,13 +100,14 @@ export function registerBuildCommand(cli: CAC) {
     .action(async (root: string, options: GlobalCLIOptions) => {
       let analyzeHandle: AnalyzeDashboardHandle | undefined
       let ctx: Awaited<ReturnType<typeof createCompilerContext>> | undefined
+      let targets: ReturnType<typeof resolveRuntimeTargets> | undefined
       let buildCompleted = false
       try {
         filterDuplicateOptions(options)
         const cwd = root ?? process.cwd()
         const configFile = resolveConfigFile(options)
-        const targets = resolveRuntimeTargets(options)
-        const inlineConfig = createInlineConfig(targets.platform, options.scope)
+        targets = resolveRuntimeTargets(options)
+        const inlineConfig = createInlineConfig(targets, { scope: options.scope })
         ctx = await createCompilerContext({
           cwd,
           mode: options.mode ?? 'production',
@@ -116,59 +118,66 @@ export function registerBuildCommand(cli: CAC) {
           emitDefaultAutoImportOutputs: false,
           preloadAppEntry: false,
         })
-        const { buildService, configService, webService } = ctx
+        const { configService } = ctx
+        const miniBackend = getBackendForCapability(targets, 'miniprogram', 'build')
+        const webBackend = getBackendForCapability(targets, 'web', 'build')
         logRuntimeTarget(targets, { resolvedConfigPlatform: configService.platform })
-        const enableAnalyze = Boolean(isUiEnabled(options) && targets.runMini)
-        if (targets.runMini) {
-          const miniBuildStartedAt = Date.now()
-          const output = await buildService.build(options)
-          const miniBuildDurationMs = Date.now() - miniBuildStartedAt
-          logger.success(`小程序构建完成，耗时：${colors.green(formatDuration(miniBuildDurationMs))}`)
-          if (!Array.isArray(output) && 'output' in output) {
-            logBuildPackageSizeReport({
-              output,
-              subPackageMap: ctx.scanService?.subPackageMap,
-              warningBytes: configService.weappViteConfig.packageSizeWarningBytes,
-            })
+        const enableAnalyze = Boolean(isUiEnabled(options) && miniBackend)
+        for (const backend of targets.select('build')) {
+          if (backend.descriptor.id === 'miniprogram') {
+            const miniBuildStartedAt = Date.now()
+            const output = await backend.driver.build(ctx, options) as Awaited<ReturnType<typeof ctx.buildService.build>>
+            const miniBuildDurationMs = Date.now() - miniBuildStartedAt
+            logger.success(`小程序构建完成，耗时：${colors.green(formatDuration(miniBuildDurationMs))}`)
+            if (!Array.isArray(output) && 'output' in output) {
+              logBuildPackageSizeReport({
+                output,
+                subPackageMap: ctx.scanService?.subPackageMap,
+                warningBytes: configService.weappViteConfig.packageSizeWarningBytes,
+              })
+            }
+            if (enableAnalyze) {
+              const analyzeStartedAt = Date.now()
+              const previousAnalyzeResult = await readLatestAnalyzeHistorySnapshot(configService)
+              const analyzeResult = await analyzeSubpackages(ctx)
+              await writeAnalyzeHistorySnapshot(analyzeResult, configService)
+              const analyzeDurationMs = Date.now() - analyzeStartedAt
+              analyzeHandle = await startAnalyzeDashboard(analyzeResult, {
+                watch: true,
+                artifactRoot: configService.outDir,
+                cwd: configService.cwd,
+                packageManagerAgent: configService.packageManager.agent,
+                previousResult: previousAnalyzeResult,
+                initialEvents: [
+                  {
+                    kind: 'build',
+                    level: 'success',
+                    title: 'mini build completed',
+                    detail: `生产构建已完成，当前 analyze 结果包含 ${analyzeResult.packages.length} 个包。`,
+                    durationMs: miniBuildDurationMs,
+                    tags: ['build', 'mini'],
+                  },
+                  {
+                    kind: 'build',
+                    level: 'success',
+                    title: 'analyze completed',
+                    detail: `分析已完成，当前包含 ${analyzeResult.packages.length} 个包与 ${analyzeResult.modules.length} 个模块。`,
+                    durationMs: analyzeDurationMs,
+                    tags: ['build', 'analyze'],
+                  },
+                ],
+              }) ?? undefined
+            }
+            continue
           }
-          if (enableAnalyze) {
-            const analyzeStartedAt = Date.now()
-            const previousAnalyzeResult = await readLatestAnalyzeHistorySnapshot(configService)
-            const analyzeResult = await analyzeSubpackages(ctx)
-            await writeAnalyzeHistorySnapshot(analyzeResult, configService)
-            const analyzeDurationMs = Date.now() - analyzeStartedAt
-            analyzeHandle = await startAnalyzeDashboard(analyzeResult, {
-              watch: true,
-              artifactRoot: configService.outDir,
-              cwd: configService.cwd,
-              packageManagerAgent: configService.packageManager.agent,
-              previousResult: previousAnalyzeResult,
-              initialEvents: [
-                {
-                  kind: 'build',
-                  level: 'success',
-                  title: 'mini build completed',
-                  detail: `生产构建已完成，当前 analyze 结果包含 ${analyzeResult.packages.length} 个包。`,
-                  durationMs: miniBuildDurationMs,
-                  tags: ['build', 'mini'],
-                },
-                {
-                  kind: 'build',
-                  level: 'success',
-                  title: 'analyze completed',
-                  detail: `分析已完成，当前包含 ${analyzeResult.packages.length} 个包与 ${analyzeResult.modules.length} 个模块。`,
-                  durationMs: analyzeDurationMs,
-                  tags: ['build', 'analyze'],
-                },
-              ],
-            }) ?? undefined
+
+          const webConfig = configService.weappWebConfig
+          if (backend.descriptor.id !== 'web' || !webConfig?.enabled) {
+            continue
           }
-        }
-        const webConfig = configService.weappWebConfig
-        if (targets.runWeb && webConfig?.enabled) {
           const webBuildStartedAt = Date.now()
           try {
-            await webService?.build()
+            await backend.driver.build(ctx, options)
             const webBuildDurationMs = Date.now() - webBuildStartedAt
             logger.success(`Web 构建完成，输出目录：${colors.green(configService.relativeCwd(webConfig.outDir))}，耗时：${colors.green(formatDuration(webBuildDurationMs))}`)
             emitDashboardEvents(analyzeHandle, [
@@ -197,10 +206,10 @@ export function registerBuildCommand(cli: CAC) {
             throw error
           }
         }
-        if (targets.runMini) {
-          logBuildAppFinish(configService, undefined, { skipWeb: !targets.runWeb })
+        if (miniBackend) {
+          logBuildAppFinish(configService, undefined, { skipWeb: !webBackend })
         }
-        if (options.open && targets.runMini) {
+        if (options.open && getBackendForCapability(targets, 'miniprogram', 'ide')) {
           emitDashboardEvents(analyzeHandle, [
             {
               kind: 'command',
@@ -222,7 +231,11 @@ export function registerBuildCommand(cli: CAC) {
         buildCompleted = true
       }
       finally {
-        ctx?.watcherService?.closeAll()
+        if (ctx && targets) {
+          for (const backend of [...targets.select('build')].reverse()) {
+            await backend.driver.close(ctx)
+          }
+        }
         terminateStaleSassEmbeddedProcess()
         if (buildCompleted) {
           scheduleCompletedProductionBuildExit(options, analyzeHandle)

--- a/packages/weapp-vite/src/cli/commands/ide.ts
+++ b/packages/weapp-vite/src/cli/commands/ide.ts
@@ -10,6 +10,7 @@ import {
   resolveProjectAutomatorPort,
   setWechatIdeTicket,
 } from 'weapp-ide-cli'
+import { getBackendForCapability } from '../../backends'
 import logger from '../../logger'
 import { resolveForwardConsoleOptions, startForwardConsoleBridge } from '../forwardConsole'
 import { readLatestHmrProfileSummary } from '../hmrProfileSummary'
@@ -70,10 +71,14 @@ export async function runIdeCommand(action: string | undefined, root: string | u
   filterDuplicateOptions(options)
   const configFile = resolveConfigFile(options)
   const targets = resolveRuntimeTargets(options)
+  const ideBackend = getBackendForCapability(targets, 'miniprogram', 'ide')
+  if (!ideBackend) {
+    throw new Error('`weapp-vite ide` 当前仅支持小程序平台。')
+  }
   const resolved = await resolveIdeCommandContext({
     configFile,
     mode: options.mode ?? 'development',
-    platform: targets.platform,
+    platform: ideBackend.platform as typeof targets.platform,
     projectPath: root,
     cliPlatform: targets.rawPlatform,
   })

--- a/packages/weapp-vite/src/cli/commands/open.test.ts
+++ b/packages/weapp-vite/src/cli/commands/open.test.ts
@@ -6,10 +6,25 @@ const resolveIdeCommandContextMock = vi.hoisted(() => vi.fn())
 const resolveIdeProjectRootMock = vi.hoisted(() => vi.fn())
 const filterDuplicateOptionsMock = vi.hoisted(() => vi.fn())
 const resolveConfigFileMock = vi.hoisted(() => vi.fn())
-const resolveRuntimeTargetsMock = vi.hoisted(() => vi.fn(() => ({
-  platform: 'weapp',
-  rawPlatform: 'weapp',
-})))
+const resolveRuntimeTargetsMock = vi.hoisted(() => {
+  const miniBackend = {
+    descriptor: {
+      id: 'miniprogram',
+      capabilities: {
+        ide: true,
+      },
+    },
+    platform: 'weapp',
+  }
+  return vi.fn(() => ({
+    kind: 'miniprogram',
+    label: 'weapp',
+    entries: [miniBackend],
+    platform: 'weapp',
+    rawPlatform: 'weapp',
+    get: (id: string) => id === 'miniprogram' ? miniBackend : undefined,
+  }))
+})
 const readLatestHmrProfileSummaryMock = vi.hoisted(() => vi.fn())
 const maybeStartDetachedMcpServerMock = vi.hoisted(() => vi.fn())
 const detectAiDevelopmentEnvironmentMock = vi.hoisted(() => vi.fn())
@@ -160,5 +175,26 @@ describe('open cli command', () => {
       nonInteractive: true,
       trustProject: false,
     })
+  })
+
+  it('rejects a backend without ide capability', async () => {
+    const webBackend = {
+      descriptor: {
+        id: 'web',
+        capabilities: { ide: false },
+      },
+      platform: 'web',
+    }
+    resolveRuntimeTargetsMock.mockReturnValueOnce({
+      kind: 'web',
+      label: 'web',
+      entries: [webBackend],
+      rawPlatform: 'web',
+      get: (id: string) => id === 'web' ? webBackend : undefined,
+    })
+    const action = createOpenActionHandler()
+
+    await expect(action(undefined, { platform: 'web' })).rejects.toThrow('`weapp-vite open` 当前仅支持小程序平台。')
+    expect(resolveIdeCommandContextMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/weapp-vite/src/cli/commands/open.ts
+++ b/packages/weapp-vite/src/cli/commands/open.ts
@@ -2,6 +2,7 @@ import type { CAC } from 'cac'
 import type { GlobalCLIOptions } from '../types'
 import process from 'node:process'
 import { detectAiDevelopmentEnvironment } from '../../aiEnvironment'
+import { getBackendForCapability } from '../../backends'
 import logger from '../../logger'
 import { readLatestHmrProfileSummary } from '../hmrProfileSummary'
 import { maybeStartDetachedMcpServer } from '../mcpDetached'
@@ -25,10 +26,14 @@ export function registerOpenCommand(cli: CAC) {
       filterDuplicateOptions(options)
       const configFile = resolveConfigFile(options)
       const targets = resolveRuntimeTargets(options)
+      const ideBackend = getBackendForCapability(targets, 'miniprogram', 'ide')
+      if (!ideBackend) {
+        throw new Error('`weapp-vite open` 当前仅支持小程序平台。')
+      }
       const { cwd, platform, projectPath, mpDistRoot, weappViteConfig } = await resolveIdeCommandContext({
         configFile,
         mode: options.mode ?? 'development',
-        platform: targets.platform,
+        platform: ideBackend.platform as typeof targets.platform,
         projectPath: root,
         cliPlatform: targets.rawPlatform,
       })

--- a/packages/weapp-vite/src/cli/commands/serve.test.ts
+++ b/packages/weapp-vite/src/cli/commands/serve.test.ts
@@ -8,12 +8,39 @@ import { registerServeCommand } from './serve'
 const filterDuplicateOptionsMock = vi.hoisted(() => vi.fn())
 const resolveConfigFileMock = vi.hoisted(() => vi.fn())
 const isUiEnabledMock = vi.hoisted(() => vi.fn(() => true))
-const resolveRuntimeTargetsMock = vi.hoisted(() => vi.fn(() => ({
-  runMini: true,
-  runWeb: false,
-  platform: 'weapp',
-  rawPlatform: 'weapp',
-})))
+const resolveRuntimeTargetsMock = vi.hoisted(() => {
+  const miniBackend = {
+    descriptor: {
+      id: 'miniprogram',
+      runtime: 'miniprogram',
+      aliases: ['weapp'],
+      capabilities: {
+        build: true,
+        dev: true,
+        ide: true,
+        analyze: true,
+        npm: true,
+        workers: true,
+        lib: true,
+      },
+    },
+    driver: {
+      dev: (ctx: any, options: any) => ctx.buildService.build(options),
+      close: (ctx: any) => ctx.watcherService.closeAll(),
+    },
+    platform: 'weapp',
+  }
+  return vi.fn(() => ({
+    kind: 'miniprogram',
+    label: 'weapp',
+    entries: [miniBackend],
+    platform: 'weapp',
+    rawPlatform: 'weapp',
+    get: (id: string) => id === 'miniprogram' ? miniBackend : undefined,
+    has: (capability: string) => Boolean((miniBackend.descriptor.capabilities as any)[capability]),
+    select: (capability: string) => (miniBackend.descriptor.capabilities as any)[capability] ? [miniBackend] : [],
+  }))
+})
 const createInlineConfigMock = vi.hoisted(() => vi.fn(() => ({})))
 const logRuntimeTargetMock = vi.hoisted(() => vi.fn())
 const createCompilerContextMock = vi.hoisted(() => vi.fn())
@@ -48,6 +75,9 @@ const fakeProcess = vi.hoisted(() => {
     off(event: string, listener: (...args: any[]) => void) {
       listeners.get(event)?.delete(listener)
       return this
+    },
+    listenerCount(event: string) {
+      return listeners.get(event)?.size ?? 0
     },
     removeAllListeners() {
       listeners.clear()
@@ -560,6 +590,61 @@ describe('serve cli command', () => {
       cwd: '/cwd-project',
       preloadAppEntry: false,
     }))
+  })
+
+  it('starts and closes a web-only dev backend without mini build actions', async () => {
+    const webServer = {}
+    const webDev = vi.fn().mockResolvedValue(webServer)
+    const webClose = vi.fn().mockResolvedValue(undefined)
+    const webBackend = {
+      descriptor: {
+        id: 'web',
+        capabilities: { dev: true, ide: false },
+      },
+      driver: {
+        dev: webDev,
+        close: webClose,
+      },
+      platform: 'web',
+    }
+    resolveRuntimeTargetsMock.mockReturnValueOnce({
+      kind: 'web',
+      label: 'web',
+      entries: [webBackend],
+      rawPlatform: 'web',
+      get: (id: string) => id === 'web' ? webBackend : undefined,
+      has: (capability: string) => capability === 'dev',
+      select: (capability: string) => capability === 'dev' ? [webBackend] : [],
+    })
+    createCompilerContextMock.mockReset()
+    createCompilerContextMock.mockResolvedValueOnce({
+      buildService: { build: buildServiceBuildMock },
+      configService: {
+        platform: 'weapp',
+        cwd: '/project',
+        mode: 'development',
+        outDir: '/project/dist',
+        mpDistRoot: '/project/dist',
+        packageManager: { agent: 'pnpm' },
+        weappViteConfig: {},
+      },
+      webService: { startDevServer: vi.fn(), close: vi.fn() },
+      watcherService: { closeAll: watcherCloseAllMock },
+    })
+    const action = createServeActionHandler()
+
+    const actionPromise = action('/project', { platform: 'web' })
+    for (let index = 0; index < 20 && fakeProcess.listenerCount('SIGINT') === 0; index++) {
+      await Promise.resolve()
+    }
+    expect(webDev).toHaveBeenCalledTimes(1)
+    expect(fakeProcess.listenerCount('SIGINT')).toBeGreaterThan(0)
+    fakeProcess.emit('SIGINT')
+    await actionPromise
+
+    expect(buildServiceBuildMock).not.toHaveBeenCalled()
+    expect(webClose).toHaveBeenCalledTimes(1)
+    expect(logBuildAppFinishMock).toHaveBeenCalledWith(expect.anything(), webServer, { skipMini: true })
   })
 
   it('injects rebuild and reopen callbacks into dev hotkeys session', async () => {

--- a/packages/weapp-vite/src/cli/commands/serve/analyze.ts
+++ b/packages/weapp-vite/src/cli/commands/serve/analyze.ts
@@ -192,7 +192,7 @@ export function createAnalyzeController(options: {
         mode: configService.mode,
         isDev: false,
         configFile,
-        inlineConfig: createInlineConfig(targets.platform),
+        inlineConfig: createInlineConfig(targets),
         cliPlatform: targets.rawPlatform,
         projectConfigPath: cliOptions.projectConfig,
         syncSupportFiles: false,

--- a/packages/weapp-vite/src/cli/commands/serve/index.ts
+++ b/packages/weapp-vite/src/cli/commands/serve/index.ts
@@ -4,6 +4,7 @@ import type { AnalyzeDashboardHandle } from '../../analyze/dashboard'
 import type { GlobalCLIOptions } from '../../types'
 import process from 'node:process'
 import { detectAiDevelopmentEnvironment } from '../../../aiEnvironment'
+import { getBackendForCapability } from '../../../backends'
 import { createCompilerContext } from '../../../createContext'
 import logger from '../../../logger'
 import { startAnalyzeDashboard } from '../../analyze/dashboard'
@@ -47,40 +48,12 @@ export function registerServeCommand(cli: CAC) {
       const cwd = root ?? process.cwd()
       const configFile = resolveConfigFile(options)
       const targets = resolveRuntimeTargets(options)
-      let inlineConfig = createInlineConfig(targets.platform, options.scope)
-      if (targets.runWeb) {
-        const host = resolveWebHost(options.host)
-        if (host !== undefined) {
-          inlineConfig = {
-            ...inlineConfig,
-            server: {
-              ...(inlineConfig?.server ?? {}),
-              host,
-            },
-          }
-        }
-        if (targets.runMini) {
-          const existingServer = inlineConfig?.server ?? {}
-          inlineConfig = {
-            ...inlineConfig,
-            build: {
-              ...(inlineConfig?.build ?? {}),
-              watch: typeof inlineConfig?.build?.watch === 'object' && inlineConfig.build.watch
-                ? { ...inlineConfig.build.watch }
-                : {},
-            },
-            server: {
-              ...existingServer,
-              ...(existingServer.port === undefined ? { port: 0 } : {}),
-              watch: {
-                ...(existingServer.watch ?? {}),
-                usePolling: true,
-                interval: 100,
-              },
-            },
-          }
-        }
-      }
+      const webBackend = getBackendForCapability(targets, 'web', 'dev')
+      const host = webBackend ? resolveWebHost(options.host) : undefined
+      const inlineConfig = createInlineConfig(targets, {
+        scope: options.scope,
+        host,
+      })
       const ctx = await createCompilerContext({
         cwd,
         mode: options.mode ?? 'development',
@@ -92,15 +65,16 @@ export function registerServeCommand(cli: CAC) {
         syncAutoImportSupportFiles: false,
         projectConfigPath: options.projectConfig,
       })
-      const { buildService, configService, webService } = ctx
+      const { configService } = ctx
+      const miniBackend = getBackendForCapability(targets, 'miniprogram', 'dev')
       const aiEnvironment = await detectAiDevelopmentEnvironment()
       const mcpConfig = applyMcpCliOptions(configService.weappViteConfig?.mcp, options)
       logRuntimeTarget(targets, { resolvedConfigPlatform: configService.platform })
-      const enableAnalyze = Boolean(isUiEnabled(options) && targets.runMini)
+      const enableAnalyze = Boolean(isUiEnabled(options) && miniBackend)
       let analyzeHandle: AnalyzeDashboardHandle | undefined
       const miniProgramDevActions = createServeMiniProgramDevActions({
         build: async () => {
-          await buildService.build(options)
+          await miniBackend?.driver.dev(ctx, options)
         },
         fallbackProjectPath: configService.cwd,
         openIde: async (projectPath, openOptions) => {
@@ -129,7 +103,7 @@ export function registerServeCommand(cli: CAC) {
           })
         },
       })
-      const devHotkeysSession = targets.runMini
+      const devHotkeysSession = miniBackend
         ? startDevHotkeys({
             cwd: configService.cwd,
             agentName: aiEnvironment.agentName,
@@ -154,38 +128,43 @@ export function registerServeCommand(cli: CAC) {
           targets,
         })
 
-        if (targets.runMini) {
-          const miniBuildStartedAt = Date.now()
-          const buildResult = await buildService.build(options)
-          const miniBuildDurationMs = Date.now() - miniBuildStartedAt
-          logger.success(`小程序初次构建完成，耗时：${formatDuration(miniBuildDurationMs)}`)
-          void ctx.autoImportService?.syncSupportFileResolverComponents().catch((error) => {
-            const message = error instanceof Error ? error.message : String(error)
-            logger.warn(`[prepare] 后台同步 .weapp-vite 支持文件失败：${message}`)
-          })
-
-          if (enableAnalyze) {
-            await analyzeController.startDashboard(startAnalyzeDashboard)
-            analyzeHandle = analyzeController.getHandle()
-            analyzeController.emitRuntimeEvents([
-              {
-                kind: 'build',
-                level: 'success',
-                title: 'mini initial build completed',
-                detail: '小程序开发态初次构建已完成，dashboard 可继续监听后续刷新。',
-                durationMs: miniBuildDurationMs,
-                tags: ['dev', 'mini', 'initial'],
-              },
-            ])
-            const watcherControl = analyzeController.bindWatcher(buildResult)
-            await watcherControl.runInitialUpdate()
-          }
-        }
         let webServer: ViteDevServer | undefined
-        if (targets.runWeb) {
+        for (const backend of targets.select('dev')) {
+          if (backend.descriptor.id === 'miniprogram') {
+            const miniBuildStartedAt = Date.now()
+            const buildResult = await backend.driver.dev(ctx, options)
+            const miniBuildDurationMs = Date.now() - miniBuildStartedAt
+            logger.success(`小程序初次构建完成，耗时：${formatDuration(miniBuildDurationMs)}`)
+            void ctx.autoImportService?.syncSupportFileResolverComponents().catch((error) => {
+              const message = error instanceof Error ? error.message : String(error)
+              logger.warn(`[prepare] 后台同步 .weapp-vite 支持文件失败：${message}`)
+            })
+
+            if (enableAnalyze) {
+              await analyzeController.startDashboard(startAnalyzeDashboard)
+              analyzeHandle = analyzeController.getHandle()
+              analyzeController.emitRuntimeEvents([
+                {
+                  kind: 'build',
+                  level: 'success',
+                  title: 'mini initial build completed',
+                  detail: '小程序开发态初次构建已完成，dashboard 可继续监听后续刷新。',
+                  durationMs: miniBuildDurationMs,
+                  tags: ['dev', 'mini', 'initial'],
+                },
+              ])
+              const watcherControl = analyzeController.bindWatcher(buildResult)
+              await watcherControl.runInitialUpdate()
+            }
+            continue
+          }
+
+          if (backend.descriptor.id !== 'web') {
+            continue
+          }
           const webServerStartedAt = Date.now()
           try {
-            webServer = await webService?.startDevServer()
+            webServer = await backend.driver.dev(ctx, options) as ViteDevServer | undefined
             logger.success(`Web 开发服务启动完成，耗时：${formatDuration(Date.now() - webServerStartedAt)}`)
             analyzeController.emitRuntimeEvents([
               {
@@ -213,17 +192,17 @@ export function registerServeCommand(cli: CAC) {
             throw error
           }
         }
-        if (targets.runMini) {
+        if (miniBackend) {
           logBuildAppFinish(configService, webServer, {
-            skipWeb: !targets.runWeb,
+            skipWeb: !webBackend,
             uiUrls: analyzeHandle?.urls,
           })
           devHotkeysSession?.restore()
         }
-        else if (targets.runWeb) {
+        else if (webBackend) {
           logBuildAppFinish(configService, webServer, { skipMini: true })
         }
-        if (options.open && targets.runMini) {
+        if (options.open && getBackendForCapability(targets, 'miniprogram', 'ide')) {
           analyzeController.emitRuntimeEvents([
             {
               kind: 'command',
@@ -248,13 +227,15 @@ export function registerServeCommand(cli: CAC) {
         if (analyzeHandle) {
           await analyzeController.waitForExit()
         }
-        else if (targets.runMini || targets.runWeb) {
+        else if (targets.has('dev')) {
           await waitForServeShutdownSignal()
         }
       }
       finally {
         devHotkeysSession?.close()
-        ctx.watcherService?.closeAll()
+        for (const backend of [...targets.select('dev')].reverse()) {
+          await backend.driver.close(ctx)
+        }
       }
     })
 }

--- a/packages/weapp-vite/src/cli/openIde.test.ts
+++ b/packages/weapp-vite/src/cli/openIde.test.ts
@@ -29,7 +29,18 @@ const colorsMock = vi.hoisted(() => ({
 }))
 const execFileMock = vi.hoisted(() => vi.fn())
 const createCompilerContextMock = vi.hoisted(() => vi.fn())
-const createInlineConfigMock = vi.hoisted(() => vi.fn((platform?: string) => ({ platform })))
+const [resolveRuntimeTargetsMock, runtimeTargetsMock] = vi.hoisted(() => {
+  const targets = {
+    kind: 'config',
+    label: 'config',
+    entries: [],
+    platform: undefined,
+    rawPlatform: undefined,
+    get: vi.fn(),
+  }
+  return [vi.fn(() => targets), targets] as const
+})
+const createInlineConfigMock = vi.hoisted(() => vi.fn((targets: { platform?: string }) => ({ platform: targets.platform })))
 const miniProgramDisconnectMock = vi.hoisted(() => vi.fn())
 const connectOpenedAutomatorMock = vi.hoisted(() => vi.fn())
 const launchAutomatorMock = vi.hoisted(() => vi.fn())
@@ -72,6 +83,7 @@ vi.mock('../createContext', () => ({
 
 vi.mock('./runtime', () => ({
   createInlineConfig: createInlineConfigMock,
+  resolveRuntimeTargets: resolveRuntimeTargetsMock,
 }))
 
 vi.mock('../logger', () => ({
@@ -111,6 +123,7 @@ describe('openIde', () => {
     resolveProjectAutomatorPortMock.mockReturnValue(9633)
     bootstrapWechatDevtoolsSettingsMock.mockReset()
     createInlineConfigMock.mockClear()
+    resolveRuntimeTargetsMock.mockClear()
     colorsMock.green.mockClear()
     colorsMock.bold.mockClear()
     delete process.env.WEAPP_VITE_DEBUG_AUTOMATOR_OPEN
@@ -1072,7 +1085,8 @@ describe('openIde', () => {
       cliPlatform: 'weapp',
     })
 
-    expect(createInlineConfigMock).toHaveBeenCalledWith(undefined)
+    expect(resolveRuntimeTargetsMock).toHaveBeenCalledWith({ platform: undefined })
+    expect(createInlineConfigMock).toHaveBeenCalledWith(runtimeTargetsMock)
     expect(createCompilerContextMock).toHaveBeenCalledWith({
       cwd: '/workspace/project',
       mode: 'production',

--- a/packages/weapp-vite/src/cli/openIde/index.ts
+++ b/packages/weapp-vite/src/cli/openIde/index.ts
@@ -16,7 +16,7 @@ import {
   getDefaultIdeProjectRoot,
   shouldPassPlatformArgToIdeOpen,
 } from '../../platform'
-import { createInlineConfig } from '../runtime'
+import { createInlineConfig, resolveRuntimeTargets } from '../runtime'
 import { closeIde as closeWechatIde } from './close'
 import {
   logWechatIdeRecoveryHint,
@@ -472,11 +472,12 @@ export async function resolveIdeCommandContext(options: ResolveIdeCommandOptions
 
   if (!platform || !projectPath) {
     try {
+      const targets = resolveRuntimeTargets({ platform })
       const ctx = await createCompilerContext({
         cwd,
         mode: options.mode ?? 'development',
         configFile: options.configFile,
-        inlineConfig: createInlineConfig(platform),
+        inlineConfig: createInlineConfig(targets),
         cliPlatform: options.cliPlatform,
       })
       platform ??= ctx.configService.platform

--- a/packages/weapp-vite/src/cli/runtime.test.ts
+++ b/packages/weapp-vite/src/cli/runtime.test.ts
@@ -21,8 +21,7 @@ describe('cli runtime target resolution', () => {
   it('uses config-driven mini platform when cli platform is missing', () => {
     const targets = resolveRuntimeTargets({})
 
-    expect(targets.runMini).toBe(true)
-    expect(targets.runWeb).toBe(false)
+    expect(targets.entries.map(entry => entry.descriptor.id)).toEqual(['miniprogram'])
     expect(targets.platform).toBeUndefined()
     expect(targets.label).toBe('config')
   })
@@ -30,8 +29,7 @@ describe('cli runtime target resolution', () => {
   it('resolves explicit mini platform from cli option', () => {
     const targets = resolveRuntimeTargets({ platform: 'alipay' })
 
-    expect(targets.runMini).toBe(true)
-    expect(targets.runWeb).toBe(false)
+    expect(targets.entries.map(entry => entry.descriptor.id)).toEqual(['miniprogram'])
     expect(targets.platform).toBe('alipay')
     expect(targets.label).toBe('alipay')
   })
@@ -39,8 +37,7 @@ describe('cli runtime target resolution', () => {
   it('resolves h5 alias to web runtime target from cli option', () => {
     const targets = resolveRuntimeTargets({ platform: 'h5' })
 
-    expect(targets.runMini).toBe(false)
-    expect(targets.runWeb).toBe(true)
+    expect(targets.entries.map(entry => entry.descriptor.id)).toEqual(['web'])
     expect(targets.platform).toBeUndefined()
     expect(targets.label).toBe('web')
   })
@@ -48,14 +45,41 @@ describe('cli runtime target resolution', () => {
   it('resolves combined mini and web runtime target from cli option', () => {
     const targets = resolveRuntimeTargets({ platform: 'all' })
 
-    expect(targets.runMini).toBe(true)
-    expect(targets.runWeb).toBe(true)
+    expect(targets.entries.map(entry => entry.descriptor.id)).toEqual(['miniprogram', 'web'])
     expect(targets.platform).toBeUndefined()
     expect(targets.label).toBe('weapp + web')
   })
 
   it('does not inject mini platform into inline config when platform is omitted', () => {
-    expect(createInlineConfig(undefined)).toBeUndefined()
+    expect(createInlineConfig(resolveRuntimeTargets({}))).toBeUndefined()
+  })
+
+  it('composes backend inline config in execution order', () => {
+    const targets = resolveRuntimeTargets({ platform: 'all' })
+
+    expect(createInlineConfig(targets, {
+      host: '127.0.0.1',
+      scope: 'main',
+    })).toMatchObject({
+      weapp: {
+        buildScope: {
+          includeMainPackage: true,
+          include: [],
+          __weappViteBuildScopeSource: true,
+        },
+      },
+      build: {
+        watch: {},
+      },
+      server: {
+        host: '127.0.0.1',
+        port: 0,
+        watch: {
+          usePolling: true,
+          interval: 100,
+        },
+      },
+    })
   })
 
   it('can skip runtime target logging when silent is enabled', async () => {

--- a/packages/weapp-vite/src/cli/runtime.ts
+++ b/packages/weapp-vite/src/cli/runtime.ts
@@ -1,14 +1,12 @@
 import type { InlineConfig } from 'vite'
+import type { ResolvedBackendExecution } from '../backends'
 import type { MpPlatform } from '../types'
+import { defu } from '@weapp-core/shared'
+import { resolveBackendExecution } from '../backends'
 import logger, { colors } from '../logger'
-import { createBuildScopeConfigFromCli } from '../runtime/buildScope'
-import { resolveWeappViteTarget } from '../runtimeTarget'
 
-export interface RuntimeTargets {
-  runMini: boolean
-  runWeb: boolean
+export interface RuntimeTargets extends ResolvedBackendExecution {
   platform?: MpPlatform
-  label: string
   rawPlatform?: string
 }
 
@@ -37,28 +35,35 @@ export function resolveRuntimeTargets(options: { platform?: string, p?: string }
     : typeof options.p === 'string'
       ? options.p
       : undefined
-  const target = resolveWeappViteTarget(rawPlatform, {
+  const execution = resolveBackendExecution(rawPlatform, {
     warn: message => logger.warn(message),
   })
+  const miniBackend = execution.get('miniprogram')
 
   return {
-    runMini: target.runMini,
-    runWeb: target.runWeb,
-    platform: target.kind === 'miniprogram' ? target.platform as MpPlatform | undefined : undefined,
-    label: target.label,
+    ...execution,
+    platform: miniBackend?.platform as MpPlatform | undefined,
     rawPlatform,
   }
 }
 
-export function createInlineConfig(platform: MpPlatform | undefined, scope?: string): InlineConfig | undefined {
-  const buildScope = createBuildScopeConfigFromCli(scope)
-  if (!platform && !buildScope) {
+export function createInlineConfig(
+  execution: RuntimeTargets,
+  options: { scope?: string, host?: string | boolean } = {},
+): InlineConfig | undefined {
+  const configs = execution.entries
+    .map(entry => entry.driver.createInlineConfig({
+      execution,
+      platform: entry.platform,
+      scope: options.scope,
+      host: options.host,
+    }))
+    .filter((config): config is InlineConfig => Boolean(config))
+  if (configs.length === 0) {
     return undefined
   }
-  return {
-    weapp: {
-      ...(platform ? { platform } : {}),
-      ...(buildScope ? { buildScope } : {}),
-    },
-  }
+  return configs.slice(1).reduce(
+    (merged, config) => defu<InlineConfig, InlineConfig[]>(merged, config),
+    configs[0],
+  )
 }

--- a/packages/weapp-vite/src/runtime/config/internal/merge/index.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/merge/index.ts
@@ -3,6 +3,7 @@ import type { InlineConfig } from 'vite'
 import type { MutableCompilerContext } from '../../../../context'
 import type { SubPackageMetaValue } from '../../../../types'
 import type { LoadConfigResult } from '../../types'
+import { platformBackendRegistry } from '../../../../backends'
 import { createSharedBuildOutput } from '../../../sharedBuildConfig'
 import { ensureConfigService, mergeInlineConfig } from './inline'
 import { mergeMiniprogram } from './miniprogram'
@@ -58,51 +59,63 @@ export function createMergeFactories(options: MergeFactoryOptions): MergeFactory
 
   function mergeFactory(subPackageMeta: SubPackageMetaValue | undefined, ...configs: Partial<InlineConfig | undefined>[]) {
     ensureConfigService(ctx)
+    const backend = platformBackendRegistry.get('miniprogram')
+    if (!backend) {
+      throw new Error('小程序平台后端未注册。')
+    }
     const currentOptions = getOptions()
-    return mergeMiniprogram({
-      ctx,
-      subPackageMeta,
-      config: currentOptions.config,
-      cwd: currentOptions.cwd,
-      srcRoot: currentOptions.srcRoot,
-      mpDistRoot: currentOptions.mpDistRoot,
-      configFileDependencies: currentOptions.configFileDependencies,
-      packageJson: currentOptions.packageJson,
-      isDev: currentOptions.isDev,
-      applyRuntimePlatform,
-      injectBuiltinAliases,
-      getDefineImportMetaEnv,
-      setOptions: next => setOptions({
-        ...currentOptions,
-        ...next,
-      }),
-      oxcRolldownPlugin,
-    }, ...configs)
+    return backend.driver.mergeConfig({
+      merge: (...backendConfigs) => mergeMiniprogram({
+        ctx,
+        subPackageMeta,
+        config: currentOptions.config,
+        cwd: currentOptions.cwd,
+        srcRoot: currentOptions.srcRoot,
+        mpDistRoot: currentOptions.mpDistRoot,
+        configFileDependencies: currentOptions.configFileDependencies,
+        packageJson: currentOptions.packageJson,
+        isDev: currentOptions.isDev,
+        applyRuntimePlatform,
+        injectBuiltinAliases,
+        getDefineImportMetaEnv,
+        setOptions: next => setOptions({
+          ...currentOptions,
+          ...next,
+        }),
+        oxcRolldownPlugin,
+      }, ...backendConfigs),
+    }, ...configs)!
   }
 
   function mergeWebFactory(...configs: Partial<InlineConfig | undefined>[]) {
     ensureConfigService(ctx)
+    const backend = platformBackendRegistry.get('web')
+    if (!backend) {
+      throw new Error('Web 平台后端未注册。')
+    }
     const currentOptions = getOptions()
     const configService = ctx.configService!
     const subPackageRoots = Object.keys(configService.weappViteConfig?.subPackages ?? {})
     const sharedOutput = configService.options.chunksConfigured
       ? createSharedBuildOutput(configService, () => subPackageRoots)
       : undefined
-    return mergeWeb({
-      config: currentOptions.config,
-      web: currentOptions.weappWeb,
-      mode: currentOptions.mode,
-      isDev: currentOptions.isDev,
-      applyRuntimePlatform,
-      injectBuiltinAliases,
-      getDefineImportMetaEnv,
-    }, sharedOutput
-      ? {
-          build: {
-            rolldownOptions: { output: sharedOutput },
-          },
-        }
-      : {}, ...configs)
+    return backend.driver.mergeConfig({
+      merge: (...backendConfigs) => mergeWeb({
+        config: currentOptions.config,
+        web: currentOptions.weappWeb,
+        mode: currentOptions.mode,
+        isDev: currentOptions.isDev,
+        applyRuntimePlatform,
+        injectBuiltinAliases,
+        getDefineImportMetaEnv,
+      }, sharedOutput
+        ? {
+            build: {
+              rolldownOptions: { output: sharedOutput },
+            },
+          }
+        : {}, ...backendConfigs),
+    }, ...configs)
   }
 
   function mergeInlineFactory(...configs: Partial<InlineConfig>[]) {

--- a/packages/weapp-vite/src/runtimeTarget.test.ts
+++ b/packages/weapp-vite/src/runtimeTarget.test.ts
@@ -33,6 +33,12 @@ describe('runtime target', () => {
       runWeb: true,
       label: 'weapp + web',
     })
+    expect(resolveWeappViteTarget('both')).toMatchObject({
+      kind: 'all',
+      runMini: true,
+      runWeb: true,
+      label: 'weapp + web',
+    })
   })
 
   it('reports web aliases and supported target platforms', () => {

--- a/packages/weapp-vite/src/runtimeTarget.ts
+++ b/packages/weapp-vite/src/runtimeTarget.ts
@@ -1,5 +1,7 @@
 import type { MpPlatform } from './types'
-import { DEFAULT_MP_PLATFORM, getSupportedMiniProgramPlatforms, normalizeMiniPlatform, resolveMiniPlatform } from './platform'
+import { MINI_PROGRAM_PLATFORM_DESCRIPTORS } from '@weapp-core/shared'
+import { platformBackendRegistry, resolveBackendExecution } from './backends'
+import { DEFAULT_MP_PLATFORM } from './platform'
 
 export type WebPlatform = 'web'
 export type WeappViteRuntime = 'miniprogram' | 'web'
@@ -34,23 +36,30 @@ export function isWebPlatform(input?: string | null): boolean {
   if (!input) {
     return false
   }
-  return WEB_PLATFORM_ALIASES.includes(input.trim().toLowerCase())
+  return resolveBackendExecution(input).kind === 'web'
 }
 
 export function getSupportedWeappViteTargetDescriptors(): readonly WeappViteTargetDescriptor[] {
+  const supportedBackends = platformBackendRegistry.getExecutionOrder()
+  const miniprogramBackend = supportedBackends.find(backend => backend.descriptor.runtime === 'miniprogram')
+  const webBackend = supportedBackends.find(backend => backend.descriptor.runtime === 'web')
   return [
-    ...getSupportedMiniProgramPlatforms().map(platform => ({
-      platform,
+    ...MINI_PROGRAM_PLATFORM_DESCRIPTORS.map(descriptor => ({
+      platform: descriptor.id,
       runtime: 'miniprogram' as const,
-      aliases: [platform],
-      label: platform,
+      aliases: miniprogramBackend?.descriptor.aliases.includes(descriptor.id)
+        ? [descriptor.id]
+        : [],
+      label: descriptor.id,
     })),
-    {
-      platform: 'web',
-      runtime: 'web',
-      aliases: WEB_PLATFORM_ALIASES,
-      label: 'web',
-    },
+    ...webBackend
+      ? [{
+          platform: 'web' as const,
+          runtime: 'web' as const,
+          aliases: webBackend.descriptor.aliases,
+          label: 'web',
+        }]
+      : [],
   ]
 }
 
@@ -62,60 +71,19 @@ export function resolveWeappViteTarget(
   input?: WeappViteTargetInput | null,
   options: ResolveWeappViteTargetOptions = {},
 ): ResolvedWeappViteTarget {
-  const raw = typeof input === 'string' ? input : undefined
-  if (!raw) {
-    return {
-      kind: 'miniprogram',
-      runMini: true,
-      runWeb: false,
-      label: 'config',
-      raw,
-    }
-  }
-
-  const normalized = normalizeMiniPlatform(raw)
-  const lowerRaw = raw.trim().toLowerCase()
-  if (lowerRaw === 'all' || lowerRaw === 'both') {
-    return {
-      kind: 'all',
-      runMini: true,
-      runWeb: true,
-      label: 'weapp + web',
-      raw,
-    }
-  }
-
-  if (isWebPlatform(normalized ?? lowerRaw)) {
-    return {
-      kind: 'web',
-      runMini: false,
-      runWeb: true,
-      platform: 'web',
-      label: 'web',
-      raw,
-    }
-  }
-
-  const platform = resolveMiniPlatform(normalized ?? raw)
-  if (platform) {
-    return {
-      kind: 'miniprogram',
-      runMini: true,
-      runWeb: false,
-      platform,
-      label: platform,
-      raw,
-    }
-  }
-
   const fallbackMiniPlatform = options.fallbackMiniPlatform ?? DEFAULT_MP_PLATFORM
-  options.warn?.(`未识别的平台 "${raw}"，已回退到 ${fallbackMiniPlatform}`)
+  const execution = resolveBackendExecution(input, {
+    fallbackMiniPlatform,
+    warn: options.warn,
+  })
+  const mini = execution.get('miniprogram')
+  const web = execution.get('web')
   return {
-    kind: 'miniprogram',
-    runMini: true,
-    runWeb: false,
-    platform: fallbackMiniPlatform,
-    label: fallbackMiniPlatform,
-    raw,
+    kind: execution.kind,
+    runMini: Boolean(mini),
+    runWeb: Boolean(web),
+    platform: (mini?.platform ?? web?.platform) as WeappVitePlatform | undefined,
+    label: execution.label,
+    raw: execution.raw,
   }
 }


### PR DESCRIPTION
## 概要

- 新增内部 PlatformBackendDescriptor、PlatformBackendCapabilities、PlatformBackendDriver、PlatformBackendRegistry 与 ResolvedBackendExecution
- 内置 miniprogram/web backend，统一平台别名、capability、inline config、build/dev 委托和资源关闭
- 将 build、serve、analyze、open/IDE 迁移到有序 backend execution plan；runtimeTarget.ts 保留兼容门面
- ConfigService.merge()/mergeWeb() 保持签名并通过 backend driver 委托既有 merge 实现
- 更新核心架构文档，并新增第一阶段平台后端边界说明

## 兼容性

- miniprogram 平台能力与别名继续以 @weapp-core/shared 的 MiniProgramPlatformDescriptor 为唯一来源
- 保持 all/both/h5、平台别名、未知平台回退、构建日志、host metadata 与 Vite/Rolldown 产物写入路径
- backend contract 仅供包内部使用，不导出第三方注册 API
- lib/workers/npm 仅声明为 miniprogram capability，仍由既有服务实现

## 验证

- 目标单测：14 个文件，111 项通过
- pnpm -C packages/weapp-vite test:types
- 定向 ESLint 与 pnpm -C packages/weapp-vite lint:src（0 error，8 个既有 warning）
- pnpm --filter weapp-vite build
- e2e/ci/platform-build.test.ts
- e2e/ci/donut-multi-end.build.test.ts
- e2e/ci/donut-multi-end-wevu-sfc.build.test.ts
- e2e/web-runtime/web-demo.test.ts（5 项通过）

## 已知基线

- package scoped typecheck 仍命中 origin/main 已存在的独立 sourcemap 类型不一致：packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile/finalize.ts。该文件与本 PR 无 diff，按范围要求未纳入修正。

## 发布说明

本次为内部无行为架构重构，不新增公开配置、公开 API 或用户可见产物变化，因此不添加 changeset，也不联动 create-weapp-vite。