### PR TITLE
refactor(weapp-vite): 使用真实模块图驱动增量构建

### DIFF
--- a/.changeset/real-module-graph.md
+++ b/.changeset/real-module-graph.md
@@ -1,0 +1,7 @@
+---
+"@weapp-core/constants": patch
+"create-weapp-vite": patch
+"weapp-vite": patch
+---
+
+使用 Vite/Rolldown 真实模块图追踪静态与动态 import、别名、npm、外部链接源码以及小程序 template、style、JSON、WXS、layout 和 `usingComponents` sidecar 依赖，修复增量构建中 importer 传播不完整、无关入口被重复标脏及 sidecar 新增删除失效不稳定的问题。

--- a/@weapp-core/constants/src/index.ts
+++ b/@weapp-core/constants/src/index.ts
@@ -24,6 +24,13 @@ export const REQUEST_GLOBAL_SYNTHETIC_EXPORT_NAME = '__wvRGI__'
 
 export const WEAPP_VITE_IMPORT_META_ENV_KEY = '__weappViteImportMetaEnv'
 
+export const WEAPP_VITE_LOGICAL_ENTRY_VIRTUAL_PREFIX = 'virtual:weapp-vite-logical-entry:'
+export const WEAPP_VITE_LOGICAL_ENTRY_RESOLVED_PREFIX = 'weapp-vite:logical-entry:'
+export const WEAPP_VITE_SIDECAR_VIRTUAL_PREFIX = 'virtual:weapp-vite-sidecar:'
+export const WEAPP_VITE_SIDECAR_RESOLVED_PREFIX = 'weapp-vite:sidecar:'
+export const WEAPP_VITE_SIDECAR_QUERY_MARKER = 'weapp-vite-sidecar'
+export const WEAPP_VITE_SIDECAR_OWNER_QUERY_MARKER = 'weapp-vite-sidecar-owner'
+
 export const WEAPP_VITE_STATEFUL_HMR_DIRECTORY = '__weapp_vite_hmr'
 export const WEAPP_VITE_STATEFUL_HMR_CONTROL_FILE = `${WEAPP_VITE_STATEFUL_HMR_DIRECTORY}/control.js`
 export const WEAPP_VITE_STATEFUL_HMR_PRELOAD_FILE = `${WEAPP_VITE_STATEFUL_HMR_DIRECTORY}/preload.js`

--- a/docs/architecture/platform-backend-runtime.md
+++ b/docs/architecture/platform-backend-runtime.md
@@ -2,9 +2,9 @@
 
 ## 背景
 
-第一阶段改造解决 CLI 平台选择与服务编排的所有权分散问题。此前 `build`、`serve`、`analyze`、`open` 等命令分别依赖 `runMini` / `runWeb` 布尔值，并直接选择 `BuildService` 或 `WebService`。随着 Web、lib、workers、npm 和 IDE 能力继续扩展，这种控制流会让目标解析、执行顺序、资源关闭和能力判断在命令之间重复。
+第一阶段改造解决 CLI 平台选择与服务编排的所有权分散问题。第二阶段在不改变该边界的前提下，把小程序源码依赖的所有权交还给 Vite/Rolldown 真实模块图。
 
-本阶段只建立内部 platform backend contract，不提供第三方 backend 注册 API，也不改变现有配置、日志和构建产物契约。
+这两个阶段都不提供第三方 backend 注册 API，也不改变现有配置、CLI 和构建产物契约。
 
 ## 第一阶段边界
 
@@ -59,20 +59,36 @@ CLI platform input
 
 miniprogram backend 不维护第二份平台表。微信、支付宝、百度、抖音、京东和小红书平台的 id、别名及编译/runtime 静态能力继续统一来自 `@weapp-core/shared` 的 `MiniProgramPlatformDescriptor`。backend registry 只负责把这些平台目标路由到同一个 miniprogram driver。
 
+## 第二阶段：真实 Module Graph
+
+`ModuleGraphService` 挂载在 `CompilerContext`，属于 compiler/build infrastructure。它不进入 backend registry，也不改变 `ResolvedBackendExecution` 的目标解析和执行顺序。miniprogram driver 仍只委托现有 build/dev 生命周期。
+
+源码图的数据流为：
+
+```text
+app/page/component/layout physical source
+  -> logical entry virtual module
+  -> physical script static import
+  -> sidecar virtual modules
+  -> resolved raw source modules
+  -> Vite/Rolldown importers and dynamicImporters
+  -> ModuleGraphService entry tracing / invalidation
+```
+
+逻辑入口协议覆盖 script、template、style、JSON、WXS、layout 和 `usingComponents`。可解析依赖通过 `resolve()` / `load()` 或静态 import 进入真实图；配置文件、glob/目录拓扑、缺失候选和预处理器 include 才保留为 watch input。topology 变化只有一个显式 full rescan 入口。
+
+source graph 与 output graph 的所有权严格分离。前者只读取 bundler graph，不在 `RuntimeState` 或 core plugin 中复制 import edge；后者可以缓存 emitted chunk membership、chunk imports、文件名和逻辑入口归属。`generateBundle` 只处理 output graph，不再从 bundle 反推 source graph，最终持久化仍由 Vite/Rolldown emit/generate/write 完成。
+
 ## 后续阶段
-
-### 第二阶段：Module Graph Backend
-
-第二阶段可把 module graph、增量失效和构建图分析收敛为 backend 可消费的稳定接口。它不应改变第一阶段 registry 的目标解析职责，也不应让 driver 绕过 Vite/Rolldown 的 emit/write 阶段。
 
 ### 第三阶段：Runtime Provider
 
-第三阶段可为真实宿主、Web runtime 或模拟器建立 runtime provider contract，处理运行时连接、页面状态和调试能力。runtime provider 不等同于 build backend：前者描述产物运行位置与调试通道，后者负责构建目标与生命周期委托。两者应通过明确接口组合，避免重新把 IDE、runtime 和 bundler 所有权混在同一服务中。
+第三阶段可为真实宿主、Web runtime 或模拟器建立 runtime provider contract，处理运行时连接、页面状态和调试能力。runtime provider 不等同于 build backend：前者描述产物运行位置与调试通道，后者负责构建目标与生命周期委托。provider 可以消费稳定的逻辑入口元数据和 output graph 结果，但不能拥有或复制 Vite/Rolldown source graph，也不能绕过 bundler 写盘。两者应通过明确接口组合，避免重新把 IDE、runtime 和 bundler 所有权混在同一服务中。
 
 ## 非目标
 
 - 不开放第三方 backend 注册 API。
 - 不新增公开配置项或改变 `weapp.platform` / `weapp.web` 结构。
-- 不实现 module graph backend 或 runtime provider。
+- 不实现 runtime provider，也不开放 ModuleGraphService 为第三方 API。
 - 不改变日志文本、输出目录、host metadata 或最终 bundle 内容。
 - 不用 `writeFile` 补写、修补或同步最终构建产物。

--- a/docs/core-architecture.md
+++ b/docs/core-architecture.md
@@ -31,6 +31,7 @@ packages/weapp-vite/
 │   │   └── commands/             # 各个子命令（build, serve, npm 等）
 │   ├── backends/                 # 内部平台后端 contract、registry 与内置 driver
 │   ├── context/                  # 编译器上下文管理
+│   ├── moduleGraph/              # 真实模块图 adapter 与逻辑入口协议
 │   ├── plugins/                  # 核心 Vite 插件
 │   ├── runtime/                  # 运行时服务实现
 │   ├── types/                    # TypeScript 类型定义
@@ -75,8 +76,8 @@ weapp-vite 采用**服务导向架构（Service-Oriented Architecture）**。CLI
 │  │WatcherService│  │AutoImportSvc │  │AutoRoutesSvc │      │
 │  └──────────────┘  └──────────────┘  └──────────────┘      │
 │  ┌──────────────┐  ┌──────────────┐                        │
-│  │ WebService   │  │ RuntimeState │                        │
-│  └──────────────┘  └──────────────┘                        │
+│  │ WebService   │  │ModuleGraphSvc│  │ RuntimeState │      │
+│  └──────────────┘  └──────────────┘  └──────────────┘      │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -198,6 +199,7 @@ export function vitePluginWeapp(ctx, subPackageMeta?): Plugin[] {
 
 **核心功能**:
 - 入口加载和模块解析
+- 通过逻辑虚拟入口把 script、template、style、JSON、WXS、layout 与 `usingComponents` 接入真实模块图
 - WXML 文件处理和组件注册
 - Chunk 共享策略（主包与分包之间）
 - 独立分包构建
@@ -326,6 +328,19 @@ Web 运行时服务，用于 H5 平台构建。
 - 在命令结束时关闭 backend 持有的 watcher 或 Vite dev server 资源。
 
 `runtimeTarget.ts` 继续保留公开兼容门面，但其目标解析来自 backend registry。六个小程序平台的标识、别名与静态平台能力仍统一来自 `@weapp-core/shared` 的 `MiniProgramPlatformDescriptor`。
+
+### 12. **ModuleGraphService** (`src/moduleGraph/`)
+
+`ModuleGraphService` 是 `CompilerContext` 内部的 compiler/build infrastructure，不是公开 API，也不是 platform backend。它通过窄 adapter 统一读取两类真实图：
+
+- 构建期 `PluginContext` 的 `getModuleIds()`、`getModuleInfo()`、`resolve()` 与 `load()`。
+- Vite dev server 的只读 `moduleGraph` 查询和模块失效。
+
+源码 import/importer 关系只由 Vite/Rolldown 图持有。app、page、component 与 layout 使用稳定的逻辑虚拟入口；逻辑入口静态导入物理 script，并通过 sidecar virtual module 静态关联 template、style、JSON、WXS、layout 和 `usingComponents`。sidecar source 使用带稳定 marker 的 raw module request，仍经过正常 resolver 链，因此 alias、npm 和 `srcRoot` 外部 linked module 与普通源码依赖采用相同解析语义。
+
+`addWatchFile` 只用于配置依赖、glob/目录拓扑、缺失 sidecar 候选和预处理器 include 等不能合理表示为模块的外部输入。无法直接映射到现有模块的 create/delete 会进入唯一的 topology full rescan 请求，不存在静默全量 fallback。
+
+源码图与输出图分开管理：`ModuleGraphService` 负责源码 importer 追溯和失效；core plugin 只缓存 chunk module membership、chunk imports 与 chunk 到逻辑入口的输出归属。`generateBundle` 不再从 bundle 反推源码 import graph，最终文件仍完全由 Vite/Rolldown emit/generate/write。
 
 ---
 

--- a/e2e/ci/platform-build.test.ts
+++ b/e2e/ci/platform-build.test.ts
@@ -10,7 +10,7 @@ const BASE_APP_ROOT = path.resolve(import.meta.dirname, '../../e2e-apps/base')
 
 const ALL_PLATFORM_OUTPUTS = [
   { platform: 'weapp', templateExt: 'wxml', scriptExt: 'wxs', eventAttr: 'bind:tap', scriptTag: '<wxs' },
-  { platform: 'alipay', templateExt: 'axml', scriptExt: 'sjs', eventAttr: 'onTap', scriptTag: '<import-sjs' },
+  { platform: 'alipay', templateExt: 'axml', scriptExt: 'sjs', eventAttr: 'onTap', scriptTag: '<sjs' },
   { platform: 'tt', templateExt: 'ttml', scriptExt: 'wxs', eventAttr: 'bind:tap', scriptTag: '<wxs' },
   // { platform: 'swan', templateExt: 'swan', scriptExt: 'sjs', eventAttr: 'bind:tap', scriptTag: '<sjs' },
   // { platform: 'jd', templateExt: 'jxml', scriptExt: 'wxs', eventAttr: 'bind:tap', scriptTag: '<wxs' },

--- a/packages/weapp-vite/src/context/CompilerContext.ts
+++ b/packages/weapp-vite/src/context/CompilerContext.ts
@@ -1,3 +1,4 @@
+import type { ModuleGraphService } from '../moduleGraph'
 import type { AutoImportService } from '../runtime/autoImportPlugin'
 import type { AutoRoutesService } from '../runtime/autoRoutesPlugin'
 import type { BuildService } from '../runtime/buildPlugin'
@@ -19,6 +20,7 @@ export interface CompilerContext {
   npmService: NpmService
   wxmlService: WxmlService
   jsonService: JsonService
+  moduleGraphService: ModuleGraphService
   watcherService: WatcherService
   webService: WebService
   autoImportService: AutoImportService
@@ -34,6 +36,7 @@ export type MutableCompilerContext = Partial<Omit<CompilerContext, 'runtimeState
   npmService?: NpmService
   wxmlService?: WxmlService
   jsonService?: JsonService
+  moduleGraphService: ModuleGraphService
   watcherService?: WatcherService
   webService?: WebService
   autoImportService?: AutoImportService

--- a/packages/weapp-vite/src/context/createCompilerContextInstance.ts
+++ b/packages/weapp-vite/src/context/createCompilerContextInstance.ts
@@ -1,4 +1,5 @@
 import type { CompilerContext, MutableCompilerContext } from './CompilerContext'
+import { createModuleGraphService } from '../moduleGraph'
 import { createAutoImportServicePlugin } from '../runtime/autoImportPlugin'
 import { createAutoRoutesServicePlugin } from '../runtime/autoRoutesPlugin'
 import { createBuildServicePlugin } from '../runtime/buildPlugin'
@@ -13,6 +14,7 @@ import { createWxmlServicePlugin } from '../runtime/wxmlPlugin'
 
 export function createCompilerContextInstance(): CompilerContext {
   const context = {
+    moduleGraphService: createModuleGraphService(),
     runtimeState: createRuntimeState(),
   } as MutableCompilerContext
 

--- a/packages/weapp-vite/src/moduleGraph/devProvider.integration.test.ts
+++ b/packages/weapp-vite/src/moduleGraph/devProvider.integration.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createDevModuleGraphProvider } from './devProvider'
 import { createLogicalEntryId } from './protocol'
 import { createModuleGraphService } from './service'
+import { normalizeSourceId } from './traversal'
 
 describe('dev module graph provider integration', () => {
   const temporaryDirectories: string[] = []
@@ -23,14 +24,17 @@ describe('dev module graph provider integration', () => {
     const sharedId = path.join(root, 'shared.ts')
     const lazyId = path.join(root, 'lazy.ts')
     const templateId = path.join(root, 'page.wxml')
+    const styleId = path.join(root, 'page.css')
     await Promise.all([
       writeFile(pageId, `import { value } from '@/shared'\nexport const lazy = () => import('./lazy')\nconsole.log(value)\n`, 'utf8'),
       writeFile(sharedId, `export const value = 'shared'\n`, 'utf8'),
       writeFile(lazyId, `export default 'lazy'\n`, 'utf8'),
       writeFile(templateId, '<view>initial</view>\n', 'utf8'),
+      writeFile(styleId, '.page { color: red; }\n', 'utf8'),
     ])
     const moduleGraphService = createModuleGraphService()
     moduleGraphService.replaceEntryDependencies(pageId, 'template', [templateId])
+    moduleGraphService.replaceEntryDependencies(pageId, 'style', [styleId])
     const onChange = vi.fn()
     const provider = await createDevModuleGraphProvider({ moduleGraphService } as any, {
       root,
@@ -46,12 +50,16 @@ describe('dev module graph provider integration', () => {
         getModuleIds: () => [createLogicalEntryId(pageId, 'page')],
       })
 
-      expect(moduleGraphService.collectAffectedEntries(sharedId)).toEqual(new Set([pageId]))
-      expect(moduleGraphService.collectAffectedEntries(lazyId)).toEqual(new Set([pageId]))
-      expect(moduleGraphService.collectAffectedEntries(templateId)).toEqual(new Set([pageId]))
+      const normalizedPageId = normalizeSourceId(pageId)
+      expect(moduleGraphService.collectAffectedEntries(sharedId)).toEqual(new Set([normalizedPageId]))
+      expect(moduleGraphService.collectAffectedEntries(lazyId)).toEqual(new Set([normalizedPageId]))
+      expect(moduleGraphService.collectAffectedEntries(templateId)).toEqual(new Set([normalizedPageId]))
+      expect(moduleGraphService.collectAffectedEntries(styleId)).toEqual(new Set([normalizedPageId]))
 
       await writeFile(templateId, '<view>updated</view>\n', 'utf8')
       await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith(templateId))
+      await writeFile(styleId, '.page { color: blue; }\n', 'utf8')
+      await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith(styleId))
     }
     finally {
       await provider.close()

--- a/packages/weapp-vite/src/moduleGraph/devProvider.integration.test.ts
+++ b/packages/weapp-vite/src/moduleGraph/devProvider.integration.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, realpath, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -56,10 +56,18 @@ describe('dev module graph provider integration', () => {
       expect(moduleGraphService.collectAffectedEntries(templateId)).toEqual(new Set([normalizedPageId]))
       expect(moduleGraphService.collectAffectedEntries(styleId)).toEqual(new Set([normalizedPageId]))
 
-      await writeFile(templateId, '<view>updated</view>\n', 'utf8')
-      await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith(normalizeSourceId(templateId)))
+      const replacementTemplateId = `${templateId}.tmp`
+      await writeFile(replacementTemplateId, '<view>updated</view>\n', 'utf8')
+      await rename(replacementTemplateId, templateId)
+      await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith({
+        event: expect.stringMatching(/^(?:create|update)$/),
+        file: normalizeSourceId(templateId),
+      }))
       await writeFile(styleId, '.page { color: blue; }\n', 'utf8')
-      await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith(normalizeSourceId(styleId)))
+      await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith({
+        event: 'update',
+        file: normalizeSourceId(styleId),
+      }))
     }
     finally {
       await provider.close()

--- a/packages/weapp-vite/src/moduleGraph/devProvider.integration.test.ts
+++ b/packages/weapp-vite/src/moduleGraph/devProvider.integration.test.ts
@@ -57,9 +57,9 @@ describe('dev module graph provider integration', () => {
       expect(moduleGraphService.collectAffectedEntries(styleId)).toEqual(new Set([normalizedPageId]))
 
       await writeFile(templateId, '<view>updated</view>\n', 'utf8')
-      await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith(templateId))
+      await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith(normalizeSourceId(templateId)))
       await writeFile(styleId, '.page { color: blue; }\n', 'utf8')
-      await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith(styleId))
+      await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith(normalizeSourceId(styleId)))
     }
     finally {
       await provider.close()

--- a/packages/weapp-vite/src/moduleGraph/devProvider.integration.test.ts
+++ b/packages/weapp-vite/src/moduleGraph/devProvider.integration.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createDevModuleGraphProvider } from './devProvider'
+import { createLogicalEntryId } from './protocol'
+import { createModuleGraphService } from './service'
+
+describe('dev module graph provider integration', () => {
+  const temporaryDirectories: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(temporaryDirectories.splice(0).map(directory => rm(directory, {
+      force: true,
+      recursive: true,
+    })))
+  })
+
+  it('lets Vite own alias, dynamic import and sidecar importer edges', async () => {
+    const root = await realpath(await mkdtemp(path.join(tmpdir(), 'weapp-vite-module-graph-')))
+    temporaryDirectories.push(root)
+    const pageId = path.join(root, 'page.ts')
+    const sharedId = path.join(root, 'shared.ts')
+    const lazyId = path.join(root, 'lazy.ts')
+    const templateId = path.join(root, 'page.wxml')
+    await Promise.all([
+      writeFile(pageId, `import { value } from '@/shared'\nexport const lazy = () => import('./lazy')\nconsole.log(value)\n`, 'utf8'),
+      writeFile(sharedId, `export const value = 'shared'\n`, 'utf8'),
+      writeFile(lazyId, `export default 'lazy'\n`, 'utf8'),
+      writeFile(templateId, '<view>initial</view>\n', 'utf8'),
+    ])
+    const moduleGraphService = createModuleGraphService()
+    moduleGraphService.replaceEntryDependencies(pageId, 'template', [templateId])
+    const onChange = vi.fn()
+    const provider = await createDevModuleGraphProvider({ moduleGraphService } as any, {
+      root,
+      resolve: {
+        alias: {
+          '@': root,
+        },
+      },
+    }, onChange)
+
+    try {
+      await moduleGraphService.syncDevGraph({
+        getModuleIds: () => [createLogicalEntryId(pageId, 'page')],
+      })
+
+      expect(moduleGraphService.collectAffectedEntries(sharedId)).toEqual(new Set([pageId]))
+      expect(moduleGraphService.collectAffectedEntries(lazyId)).toEqual(new Set([pageId]))
+      expect(moduleGraphService.collectAffectedEntries(templateId)).toEqual(new Set([pageId]))
+
+      await writeFile(templateId, '<view>updated</view>\n', 'utf8')
+      await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith(templateId))
+    }
+    finally {
+      await provider.close()
+    }
+  })
+})

--- a/packages/weapp-vite/src/moduleGraph/devProvider.test.ts
+++ b/packages/weapp-vite/src/moduleGraph/devProvider.test.ts
@@ -54,18 +54,59 @@ describe('dev module graph provider', () => {
     expect(bindDevServer).toHaveBeenCalledWith(server)
     const providerPlugin = config.plugins[0] as Plugin
     const read = vi.fn(async () => '<view />')
-    await (providerPlugin.handleHotUpdate as any)({
-      file: '/project/src/page.wxml',
-      read,
-    })
+    await (providerPlugin.hotUpdate as any).call(
+      { environment: { name: 'client' } },
+      {
+        type: 'update',
+        file: '/project/src/page.wxml',
+        read,
+      },
+    )
     expect(read).toHaveBeenCalled()
-    expect(onChange).toHaveBeenCalledWith('/project/src/page.wxml')
+    expect(onChange).toHaveBeenCalledWith({
+      event: 'update',
+      file: '/project/src/page.wxml',
+    })
+    expect(providerPlugin.handleHotUpdate).toBeUndefined()
     expect(watcher.on).not.toHaveBeenCalled()
 
     await provider.close()
     expect(watcher.off).not.toHaveBeenCalled()
     expect(close).toHaveBeenCalled()
     expect(bindDevServer).toHaveBeenLastCalledWith(undefined)
+  })
+
+  it('handles atomic create once and leaves delete topology changes to the topology watcher', async () => {
+    const { createDevModuleGraphProvider } = await import('./devProvider')
+    const ctx = {
+      moduleGraphService: {
+        bindDevServer: vi.fn(),
+        getEntryDependencies: vi.fn(() => []),
+      },
+    } as any
+    const onChange = vi.fn()
+    await createDevModuleGraphProvider(ctx, {}, onChange)
+    const config = createServerMock.mock.calls[0]![0]
+    const providerPlugin = config.plugins[0] as Plugin
+    const options = {
+      type: 'create',
+      file: '/project/src/page.wxml',
+      read: vi.fn(async () => '<view />'),
+    }
+
+    await (providerPlugin.hotUpdate as any).call({ environment: { name: 'client' } }, options)
+    await (providerPlugin.hotUpdate as any).call({ environment: { name: 'ssr' } }, options)
+    await (providerPlugin.hotUpdate as any).call(
+      { environment: { name: 'client' } },
+      { ...options, type: 'delete' },
+    )
+
+    expect(options.read).toHaveBeenCalledOnce()
+    expect(onChange).toHaveBeenCalledOnce()
+    expect(onChange).toHaveBeenCalledWith({
+      event: 'create',
+      file: '/project/src/page.wxml',
+    })
   })
 
   it('leaves missing-file topology changes to the topology watcher', async () => {
@@ -82,10 +123,14 @@ describe('dev module graph provider', () => {
     const providerPlugin = config.plugins[0] as Plugin
     const error = Object.assign(new Error('missing'), { code: 'ENOENT' })
 
-    await expect((providerPlugin.handleHotUpdate as any)({
-      file: '/project/src/page.wxml',
-      read: vi.fn(async () => Promise.reject(error)),
-    })).resolves.toBeUndefined()
+    await expect((providerPlugin.hotUpdate as any).call(
+      { environment: { name: 'client' } },
+      {
+        type: 'create',
+        file: '/project/src/page.wxml',
+        read: vi.fn(async () => Promise.reject(error)),
+      },
+    )).resolves.toBeUndefined()
     expect(onChange).not.toHaveBeenCalled()
   })
 

--- a/packages/weapp-vite/src/moduleGraph/devProvider.test.ts
+++ b/packages/weapp-vite/src/moduleGraph/devProvider.test.ts
@@ -52,10 +52,13 @@ describe('dev module graph provider', () => {
     expect(config.build).toMatchObject({ watch: undefined, write: false })
     expect(config.plugins).toEqual([expect.objectContaining({ name: 'weapp-vite:module-graph-provider' }), resolver])
     expect(bindDevServer).toHaveBeenCalledWith(server)
-    expect(watcher.on).toHaveBeenCalledWith('change', onChange)
+    const handleChange = watcher.on.mock.calls[0]![1]
+    expect(handleChange).not.toBe(onChange)
+    handleChange('/project/src/page.wxml', { size: 1 })
+    expect(onChange).toHaveBeenCalledWith('/project/src/page.wxml')
 
     await provider.close()
-    expect(watcher.off).toHaveBeenCalledWith('change', onChange)
+    expect(watcher.off).toHaveBeenCalledWith('change', handleChange)
     expect(close).toHaveBeenCalled()
     expect(bindDevServer).toHaveBeenLastCalledWith(undefined)
   })

--- a/packages/weapp-vite/src/moduleGraph/devProvider.test.ts
+++ b/packages/weapp-vite/src/moduleGraph/devProvider.test.ts
@@ -64,6 +64,7 @@ describe('dev module graph provider', () => {
     const { createDevModuleGraphProvider } = await import('./devProvider')
     const pageId = '/project/src/pages/home/index.ts'
     const templateId = '/project/src/pages/home/index.wxml'
+    const styleId = '/project/src/pages/home/index.css'
     const ctx = {
       moduleGraphService: {
         bindDevServer: vi.fn(),
@@ -78,12 +79,16 @@ describe('dev module graph provider', () => {
     const sidecarSourceId = createSidecarSourceSpecifier(pageId, templateId, 'template')
     const resolvedSidecarSource = await (plugin.resolveId as any).call({}, sidecarSourceId)
     const sidecarSourceCode = await (plugin.load as any).call({}, sidecarSourceId)
+    const styleSourceId = createSidecarSourceSpecifier(pageId, styleId, 'style')
+    const styleSourceCode = await (plugin.load as any).call({}, styleSourceId)
 
     expect(logicalCode).toContain(JSON.stringify(pageId))
     expect(logicalCode).toContain(createSidecarModuleId(pageId, templateId, 'template'))
     expect(sidecarCode).toContain(`${templateId}?raw&`)
     expect(resolvedSidecarSource).toBe(sidecarSourceId)
     expect(sidecarSourceCode).toContain(JSON.stringify(templateId))
+    expect(styleSourceId).toContain('&lang.css')
+    expect(styleSourceCode).toBeNull()
   })
 
   it('stubs build externals while leaving normal resolver requests untouched', async () => {

--- a/packages/weapp-vite/src/moduleGraph/devProvider.test.ts
+++ b/packages/weapp-vite/src/moduleGraph/devProvider.test.ts
@@ -1,0 +1,159 @@
+import type { Plugin } from 'vite'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createLogicalEntryId, createSidecarModuleId, createSidecarSourceSpecifier } from './protocol'
+
+const createServerMock = vi.hoisted(() => vi.fn())
+
+vi.mock('vite', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vite')>()
+  return {
+    ...actual,
+    createServer: createServerMock,
+  }
+})
+
+describe('dev module graph provider', () => {
+  const watcher = {
+    on: vi.fn(),
+    off: vi.fn(),
+  }
+  const close = vi.fn(async () => {})
+  const server = {
+    close,
+    moduleGraph: {},
+    watcher,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    createServerMock.mockResolvedValue(server)
+  })
+
+  it('uses a middleware Vite graph without output and keeps user resolver plugins', async () => {
+    const { createDevModuleGraphProvider } = await import('./devProvider')
+    const resolver = { name: 'vite-tsconfig-paths' }
+    const internal = { name: 'weapp-vite:pre' }
+    const bindDevServer = vi.fn()
+    const ctx = {
+      moduleGraphService: {
+        bindDevServer,
+        getEntryDependencies: vi.fn(() => []),
+      },
+    } as any
+    const onChange = vi.fn()
+
+    const provider = await createDevModuleGraphProvider(ctx, {
+      plugins: [internal, resolver],
+      build: { write: true, watch: {} },
+    }, onChange)
+
+    const config = createServerMock.mock.calls[0]![0]
+    expect(config.server).toMatchObject({ hmr: false, middlewareMode: true })
+    expect(config.build).toMatchObject({ watch: undefined, write: false })
+    expect(config.plugins).toEqual([expect.objectContaining({ name: 'weapp-vite:module-graph-provider' }), resolver])
+    expect(bindDevServer).toHaveBeenCalledWith(server)
+    expect(watcher.on).toHaveBeenCalledWith('change', onChange)
+
+    await provider.close()
+    expect(watcher.off).toHaveBeenCalledWith('change', onChange)
+    expect(close).toHaveBeenCalled()
+    expect(bindDevServer).toHaveBeenLastCalledWith(undefined)
+  })
+
+  it('loads logical entry and sidecar modules from stable metadata', async () => {
+    const { createDevModuleGraphProvider } = await import('./devProvider')
+    const pageId = '/project/src/pages/home/index.ts'
+    const templateId = '/project/src/pages/home/index.wxml'
+    const ctx = {
+      moduleGraphService: {
+        bindDevServer: vi.fn(),
+        getEntryDependencies: vi.fn(() => [{ kind: 'template', sourceId: templateId }]),
+      },
+    } as any
+    await createDevModuleGraphProvider(ctx, {}, vi.fn())
+    const config = createServerMock.mock.calls[0]![0]
+    const plugin = config.plugins[0] as Plugin
+    const logicalCode = await (plugin.load as any).call({}, createLogicalEntryId(pageId, 'page'))
+    const sidecarCode = await (plugin.load as any).call({}, createSidecarModuleId(pageId, templateId, 'template'))
+    const sidecarSourceId = createSidecarSourceSpecifier(pageId, templateId, 'template')
+    const resolvedSidecarSource = await (plugin.resolveId as any).call({}, sidecarSourceId)
+    const sidecarSourceCode = await (plugin.load as any).call({}, sidecarSourceId)
+
+    expect(logicalCode).toContain(JSON.stringify(pageId))
+    expect(logicalCode).toContain(createSidecarModuleId(pageId, templateId, 'template'))
+    expect(sidecarCode).toContain(`${templateId}?raw&`)
+    expect(resolvedSidecarSource).toBe(sidecarSourceId)
+    expect(sidecarSourceCode).toContain(JSON.stringify(templateId))
+  })
+
+  it('stubs build externals while leaving normal resolver requests untouched', async () => {
+    const { createDevModuleGraphProvider } = await import('./devProvider')
+    const ctx = {
+      moduleGraphService: {
+        bindDevServer: vi.fn(),
+        getEntryDependencies: vi.fn(() => []),
+      },
+    } as any
+    await createDevModuleGraphProvider(ctx, {
+      build: {
+        rolldownOptions: {
+          external: [/^tdesign-miniprogram(?:\/|$)/],
+        },
+      } as any,
+    }, vi.fn())
+    const config = createServerMock.mock.calls[0]![0]
+    const plugin = config.plugins[0] as Plugin
+    const resolve = vi.fn(async (id: string) => {
+      if (id === 'normal-package') {
+        return { id: '/resolved/normal-package.js' }
+      }
+      if (id === 'external-package') {
+        return { id, external: true }
+      }
+      return null
+    })
+    const externalId = await (plugin.resolveId as any).call(
+      { resolve },
+      'tdesign-miniprogram/dialog/index',
+      '/project/src/app.ts',
+    )
+
+    expect(externalId).toContain('module-graph-external')
+    expect(await (plugin.load as any).call({}, externalId)).toBe('export default {}')
+    await expect((plugin.resolveId as any).call(
+      { resolve },
+      'normal-package',
+      '/project/src/app.ts',
+    )).resolves.toEqual({ id: '/resolved/normal-package.js' })
+    expect(resolve).toHaveBeenCalledWith('normal-package', '/project/src/app.ts', { skipSelf: true })
+    expect(await (plugin.resolveId as any).call(
+      { resolve },
+      'external-package',
+      '/project/src/app.ts',
+    )).toContain('module-graph-external')
+  })
+
+  it('turns Vue scripts into valid provider modules for static and dynamic imports', async () => {
+    const { createDevModuleGraphProvider } = await import('./devProvider')
+    const ctx = {
+      moduleGraphService: {
+        bindDevServer: vi.fn(),
+        getEntryDependencies: vi.fn(() => []),
+      },
+    } as any
+    await createDevModuleGraphProvider(ctx, {}, vi.fn())
+    const config = createServerMock.mock.calls[0]![0]
+    const plugin = config.plugins[0] as Plugin
+    const result = await (plugin.transform as any).call({}, `
+<script setup lang="ts">
+import { value } from './shared'
+const lazy = () => import('./lazy')
+console.log(value, lazy)
+</script>
+`, '/project/src/pages/home/index.vue')
+
+    expect(result.code).toContain('./shared')
+    expect(result.code).toContain('import(')
+    expect(result.code).toContain('./lazy')
+  })
+})

--- a/packages/weapp-vite/src/moduleGraph/devProvider.test.ts
+++ b/packages/weapp-vite/src/moduleGraph/devProvider.test.ts
@@ -48,19 +48,45 @@ describe('dev module graph provider', () => {
     }, onChange)
 
     const config = createServerMock.mock.calls[0]![0]
-    expect(config.server).toMatchObject({ hmr: false, middlewareMode: true })
+    expect(config.server).toMatchObject({ hmr: true, middlewareMode: true })
     expect(config.build).toMatchObject({ watch: undefined, write: false })
     expect(config.plugins).toEqual([expect.objectContaining({ name: 'weapp-vite:module-graph-provider' }), resolver])
     expect(bindDevServer).toHaveBeenCalledWith(server)
-    const handleChange = watcher.on.mock.calls[0]![1]
-    expect(handleChange).not.toBe(onChange)
-    handleChange('/project/src/page.wxml', { size: 1 })
+    const providerPlugin = config.plugins[0] as Plugin
+    const read = vi.fn(async () => '<view />')
+    await (providerPlugin.handleHotUpdate as any)({
+      file: '/project/src/page.wxml',
+      read,
+    })
+    expect(read).toHaveBeenCalled()
     expect(onChange).toHaveBeenCalledWith('/project/src/page.wxml')
+    expect(watcher.on).not.toHaveBeenCalled()
 
     await provider.close()
-    expect(watcher.off).toHaveBeenCalledWith('change', handleChange)
+    expect(watcher.off).not.toHaveBeenCalled()
     expect(close).toHaveBeenCalled()
     expect(bindDevServer).toHaveBeenLastCalledWith(undefined)
+  })
+
+  it('leaves missing-file topology changes to the topology watcher', async () => {
+    const { createDevModuleGraphProvider } = await import('./devProvider')
+    const ctx = {
+      moduleGraphService: {
+        bindDevServer: vi.fn(),
+        getEntryDependencies: vi.fn(() => []),
+      },
+    } as any
+    const onChange = vi.fn()
+    await createDevModuleGraphProvider(ctx, {}, onChange)
+    const config = createServerMock.mock.calls[0]![0]
+    const providerPlugin = config.plugins[0] as Plugin
+    const error = Object.assign(new Error('missing'), { code: 'ENOENT' })
+
+    await expect((providerPlugin.handleHotUpdate as any)({
+      file: '/project/src/page.wxml',
+      read: vi.fn(async () => Promise.reject(error)),
+    })).resolves.toBeUndefined()
+    expect(onChange).not.toHaveBeenCalled()
   })
 
   it('loads logical entry and sidecar modules from stable metadata', async () => {

--- a/packages/weapp-vite/src/moduleGraph/devProvider.ts
+++ b/packages/weapp-vite/src/moduleGraph/devProvider.ts
@@ -71,7 +71,11 @@ async function isExternalRequest(
   })
 }
 
-function createProviderPlugin(ctx: CompilerContext, config: InlineConfig): Plugin {
+function createProviderPlugin(
+  ctx: CompilerContext,
+  config: InlineConfig,
+  onChange: (file: string) => void,
+): Plugin {
   const npmExternalPackages = new Set(
     ctx.configService?.packageJson
       ? resolveNpmBuildCandidateDependenciesSync(ctx, ctx.configService.packageJson)
@@ -137,6 +141,18 @@ function createProviderPlugin(ctx: CompilerContext, config: InlineConfig): Plugi
       }
       return await transformVueSource(code, id)
     },
+    async handleHotUpdate({ file, read }) {
+      try {
+        await read()
+      }
+      catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          return
+        }
+        throw error
+      }
+      onChange(file)
+    },
   }
 }
 
@@ -151,12 +167,12 @@ export async function createDevModuleGraphProvider(
     configFile: false,
     customLogger: createLogger('silent'),
     plugins: [
-      createProviderPlugin(ctx, buildConfig),
+      createProviderPlugin(ctx, buildConfig, onChange),
       ...collectResolverPlugins(buildConfig),
     ],
     server: {
       ...(buildConfig.server ?? {}),
-      hmr: false,
+      hmr: true,
       middlewareMode: true,
     },
     build: {
@@ -166,12 +182,9 @@ export async function createDevModuleGraphProvider(
     },
   })
   ctx.moduleGraphService.bindDevServer(server)
-  const handleChange = (file: string) => onChange(file)
-  server.watcher.on('change', handleChange)
 
   return {
     async close() {
-      server.watcher.off('change', handleChange)
       await server.close()
       ctx.moduleGraphService.bindDevServer(undefined)
     },

--- a/packages/weapp-vite/src/moduleGraph/devProvider.ts
+++ b/packages/weapp-vite/src/moduleGraph/devProvider.ts
@@ -1,0 +1,175 @@
+import type { InlineConfig, Plugin, ViteDevServer } from 'vite'
+import type { CompilerContext } from '../context'
+import { createLogger, createServer, transformWithOxc } from 'vite'
+import { parse as parseSfc } from 'vue/compiler-sfc'
+import { resolveNpmBuildCandidateDependenciesSync } from '../runtime/npmPlugin/service/dependencies'
+import { createLogicalEntryModuleCode, createSidecarModuleCode } from './logicalEntry'
+import {
+  parseLogicalEntryId,
+  parseSidecarModuleId,
+  parseSidecarSourceRequest,
+  resolveVirtualModuleId,
+} from './protocol'
+
+const DEV_EXTERNAL_PREFIX = '\0weapp-vite:module-graph-external:'
+
+export interface DevModuleGraphProvider {
+  close: () => Promise<void>
+}
+
+function isInternalPlugin(plugin: unknown): plugin is { name: string } {
+  if (!plugin || typeof plugin !== 'object' || !('name' in plugin)) {
+    return false
+  }
+  const name = (plugin as { name?: unknown }).name
+  return typeof name === 'string'
+    && (name.startsWith('weapp-vite:') || name.startsWith('weapp-runtime:'))
+}
+
+function collectResolverPlugins(config: InlineConfig) {
+  const plugins = Array.isArray(config.plugins) ? config.plugins : config.plugins ? [config.plugins] : []
+  return plugins.filter(plugin => !isInternalPlugin(plugin))
+}
+
+async function transformVueSource(code: string, id: string) {
+  const { descriptor, errors } = parseSfc(code, { filename: id })
+  if (errors.length) {
+    throw errors[0]
+  }
+  const blocks = [descriptor.script, descriptor.scriptSetup].filter(block => block?.content)
+  const source = blocks.map(block => block!.content).join('\n') || 'export default {}'
+  const lang = blocks.some(block => block?.lang === 'tsx')
+    ? 'tsx'
+    : blocks.some(block => block?.lang === 'ts') ? 'ts' : 'js'
+  return await transformWithOxc(source, id, {
+    lang,
+    sourcemap: false,
+    target: 'esnext',
+  })
+}
+
+async function isExternalRequest(
+  source: string,
+  importer: string | undefined,
+  config: InlineConfig,
+) {
+  const buildOptions = config.build as (NonNullable<InlineConfig['build']> & {
+    rolldownOptions?: { external?: unknown }
+  }) | undefined
+  const external = buildOptions?.rolldownOptions?.external
+    ?? buildOptions?.rollupOptions?.external
+  if (typeof external === 'function') {
+    return await external(source, importer, false)
+  }
+  const patterns = Array.isArray(external) ? external : external ? [external] : []
+  return patterns.some((pattern) => {
+    if (typeof pattern === 'string') {
+      return pattern === source
+    }
+    pattern.lastIndex = 0
+    return pattern.test(source)
+  })
+}
+
+function createProviderPlugin(ctx: CompilerContext, config: InlineConfig): Plugin {
+  const npmExternalPackages = new Set(
+    ctx.configService?.packageJson
+      ? resolveNpmBuildCandidateDependenciesSync(ctx, ctx.configService.packageJson)
+      : [],
+  )
+  return {
+    name: 'weapp-vite:module-graph-provider',
+    enforce: 'pre',
+    async resolveId(id, importer) {
+      const virtualId = resolveVirtualModuleId(id)
+      if (virtualId) {
+        return virtualId
+      }
+      if (parseSidecarSourceRequest(id)) {
+        return id
+      }
+      if (Array.from(npmExternalPackages).some(pkg => id === pkg || id.startsWith(`${pkg}/`))) {
+        return `${DEV_EXTERNAL_PREFIX}${encodeURIComponent(id)}`
+      }
+      if (await isExternalRequest(id, importer, config)) {
+        return `${DEV_EXTERNAL_PREFIX}${encodeURIComponent(id)}`
+      }
+      const isBareRequest = !id.startsWith('.')
+        && !id.startsWith('/')
+        && !id.startsWith('\0')
+        && !/^[a-z]:[\\/]/i.test(id)
+      if (isBareRequest) {
+        const resolved = await this.resolve(id, importer, { skipSelf: true })
+        if (!resolved || resolved.external) {
+          return `${DEV_EXTERNAL_PREFIX}${encodeURIComponent(id)}`
+        }
+        return resolved
+      }
+      return null
+    },
+    load(id) {
+      if (id.startsWith(DEV_EXTERNAL_PREFIX)) {
+        return 'export default {}'
+      }
+      const logicalEntry = parseLogicalEntryId(id)
+      if (logicalEntry) {
+        return createLogicalEntryModuleCode(
+          logicalEntry,
+          ctx.moduleGraphService.getEntryDependencies(logicalEntry.sourceId),
+        )
+      }
+      const sidecar = parseSidecarModuleId(id)
+      if (sidecar) {
+        return createSidecarModuleCode(sidecar.ownerId, sidecar.sourceId, sidecar.kind)
+      }
+      const sidecarSource = parseSidecarSourceRequest(id)
+      if (sidecarSource) {
+        return `export default ${JSON.stringify(sidecarSource.sourceId)};`
+      }
+      return null
+    },
+    async transform(code, id) {
+      if (!id.endsWith('.vue')) {
+        return null
+      }
+      return await transformVueSource(code, id)
+    },
+  }
+}
+
+export async function createDevModuleGraphProvider(
+  ctx: CompilerContext,
+  buildConfig: InlineConfig,
+  onChange: (file: string) => void,
+): Promise<DevModuleGraphProvider> {
+  const server: ViteDevServer = await createServer({
+    ...buildConfig,
+    appType: 'custom',
+    configFile: false,
+    customLogger: createLogger('silent'),
+    plugins: [
+      createProviderPlugin(ctx, buildConfig),
+      ...collectResolverPlugins(buildConfig),
+    ],
+    server: {
+      ...(buildConfig.server ?? {}),
+      hmr: false,
+      middlewareMode: true,
+    },
+    build: {
+      ...(buildConfig.build ?? {}),
+      watch: undefined,
+      write: false,
+    },
+  })
+  ctx.moduleGraphService.bindDevServer(server)
+  server.watcher.on('change', onChange)
+
+  return {
+    async close() {
+      server.watcher.off('change', onChange)
+      await server.close()
+      ctx.moduleGraphService.bindDevServer(undefined)
+    },
+  }
+}

--- a/packages/weapp-vite/src/moduleGraph/devProvider.ts
+++ b/packages/weapp-vite/src/moduleGraph/devProvider.ts
@@ -166,11 +166,12 @@ export async function createDevModuleGraphProvider(
     },
   })
   ctx.moduleGraphService.bindDevServer(server)
-  server.watcher.on('change', onChange)
+  const handleChange = (file: string) => onChange(file)
+  server.watcher.on('change', handleChange)
 
   return {
     async close() {
-      server.watcher.off('change', onChange)
+      server.watcher.off('change', handleChange)
       await server.close()
       ctx.moduleGraphService.bindDevServer(undefined)
     },

--- a/packages/weapp-vite/src/moduleGraph/devProvider.ts
+++ b/packages/weapp-vite/src/moduleGraph/devProvider.ts
@@ -1,4 +1,4 @@
-import type { InlineConfig, Plugin, ViteDevServer } from 'vite'
+import type { HotUpdateOptions, InlineConfig, Plugin, ViteDevServer } from 'vite'
 import type { CompilerContext } from '../context'
 import { createLogger, createServer, transformWithOxc } from 'vite'
 import { parse as parseSfc } from 'vue/compiler-sfc'
@@ -15,6 +15,11 @@ const DEV_EXTERNAL_PREFIX = '\0weapp-vite:module-graph-external:'
 
 export interface DevModuleGraphProvider {
   close: () => Promise<void>
+}
+
+export interface DevModuleGraphChange {
+  event: Exclude<HotUpdateOptions['type'], 'delete'>
+  file: string
 }
 
 function isInternalPlugin(plugin: unknown): plugin is { name: string } {
@@ -74,7 +79,7 @@ async function isExternalRequest(
 function createProviderPlugin(
   ctx: CompilerContext,
   config: InlineConfig,
-  onChange: (file: string) => void,
+  onChange: (change: DevModuleGraphChange) => void,
 ): Plugin {
   const npmExternalPackages = new Set(
     ctx.configService?.packageJson
@@ -141,7 +146,10 @@ function createProviderPlugin(
       }
       return await transformVueSource(code, id)
     },
-    async handleHotUpdate({ file, read }) {
+    async hotUpdate({ type, file, read }) {
+      if (this.environment.name !== 'client' || type === 'delete') {
+        return
+      }
       try {
         await read()
       }
@@ -151,7 +159,7 @@ function createProviderPlugin(
         }
         throw error
       }
-      onChange(file)
+      onChange({ event: type, file })
     },
   }
 }
@@ -159,7 +167,7 @@ function createProviderPlugin(
 export async function createDevModuleGraphProvider(
   ctx: CompilerContext,
   buildConfig: InlineConfig,
-  onChange: (file: string) => void,
+  onChange: (change: DevModuleGraphChange) => void,
 ): Promise<DevModuleGraphProvider> {
   const server: ViteDevServer = await createServer({
     ...buildConfig,

--- a/packages/weapp-vite/src/moduleGraph/devProvider.ts
+++ b/packages/weapp-vite/src/moduleGraph/devProvider.ts
@@ -124,6 +124,9 @@ function createProviderPlugin(ctx: CompilerContext, config: InlineConfig): Plugi
       }
       const sidecarSource = parseSidecarSourceRequest(id)
       if (sidecarSource) {
+        if (sidecarSource.kind === 'style') {
+          return null
+        }
         return `export default ${JSON.stringify(sidecarSource.sourceId)};`
       }
       return null

--- a/packages/weapp-vite/src/moduleGraph/index.ts
+++ b/packages/weapp-vite/src/moduleGraph/index.ts
@@ -1,0 +1,2 @@
+export type { ModuleGraphService } from './service'
+export { createModuleGraphService } from './service'

--- a/packages/weapp-vite/src/moduleGraph/logicalEntry.test.ts
+++ b/packages/weapp-vite/src/moduleGraph/logicalEntry.test.ts
@@ -51,4 +51,12 @@ describe('logical entry module source', () => {
       'template',
     )).toBe('import "/project/src/pages/home/index.wxml?raw&weapp-vite-sidecar-owner=%2Fproject%2Fsrc%2Fpages%2Fhome%2Findex.ts&weapp-vite-sidecar=template&lang.js";\nexport default "/project/src/pages/home/index.wxml";\n')
   })
+
+  it('links style sidecars through the native CSS pipeline', () => {
+    expect(createSidecarModuleCode(
+      '/project/src/app.ts',
+      '/project/src/app.css',
+      'style',
+    )).toBe('import "/project/src/app.css?weapp-vite-sidecar-owner=%2Fproject%2Fsrc%2Fapp.ts&weapp-vite-sidecar=style&lang.css";\nexport default "/project/src/app.css";\n')
+  })
 })

--- a/packages/weapp-vite/src/moduleGraph/logicalEntry.test.ts
+++ b/packages/weapp-vite/src/moduleGraph/logicalEntry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { createLogicalEntryModuleCode, createSidecarModuleCode } from './logicalEntry'
-import { createLogicalEntryId, createSidecarModuleId } from './protocol'
+import { createSidecarModuleId } from './protocol'
 
 describe('logical entry module source', () => {
   it('expresses script and native sidecars as static module dependencies', () => {
@@ -21,12 +21,12 @@ describe('logical entry module source', () => {
       ['style', '/project/src/pages/home/index.wxss'],
       ['json', '/project/src/pages/home/index.json'],
       ['wxs', '/project/src/pages/home/filter.wxs'],
+      ['layout', '/project/src/layouts/default.vue'],
       ['script', sourceId],
       ['using-component', '/workspace/ui/card/index.ts'],
     ] as const) {
       expect(code).toContain(JSON.stringify(createSidecarModuleId(sourceId, dependency, kind)))
     }
-    expect(code).toContain(JSON.stringify(createLogicalEntryId('/project/src/layouts/default.vue', 'layout')))
     expect(code).toContain(`export * from ${JSON.stringify(sourceId)};`)
   })
 

--- a/packages/weapp-vite/src/moduleGraph/logicalEntry.test.ts
+++ b/packages/weapp-vite/src/moduleGraph/logicalEntry.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { createLogicalEntryModuleCode, createSidecarModuleCode } from './logicalEntry'
+import { createLogicalEntryId, createSidecarModuleId } from './protocol'
+
+describe('logical entry module source', () => {
+  it('expresses script and native sidecars as static module dependencies', () => {
+    const sourceId = '/project/src/pages/home/index.ts'
+    const code = createLogicalEntryModuleCode({ sourceId, type: 'page' }, [
+      { kind: 'template', sourceId: '/project/src/pages/home/index.wxml' },
+      { kind: 'style', sourceId: '/project/src/pages/home/index.wxss' },
+      { kind: 'json', sourceId: '/project/src/pages/home/index.json' },
+      { kind: 'wxs', sourceId: '/project/src/pages/home/filter.wxs' },
+      { kind: 'layout', sourceId: '/project/src/layouts/default.vue' },
+      { kind: 'script', sourceId },
+      { kind: 'using-component', sourceId: '/workspace/ui/card/index.ts' },
+    ])
+
+    expect(code).toContain(`import ${JSON.stringify(sourceId)};`)
+    for (const [kind, dependency] of [
+      ['template', '/project/src/pages/home/index.wxml'],
+      ['style', '/project/src/pages/home/index.wxss'],
+      ['json', '/project/src/pages/home/index.json'],
+      ['wxs', '/project/src/pages/home/filter.wxs'],
+      ['script', sourceId],
+      ['using-component', '/workspace/ui/card/index.ts'],
+    ] as const) {
+      expect(code).toContain(JSON.stringify(createSidecarModuleId(sourceId, dependency, kind)))
+    }
+    expect(code).toContain(JSON.stringify(createLogicalEntryId('/project/src/layouts/default.vue', 'layout')))
+    expect(code).toContain(`export * from ${JSON.stringify(sourceId)};`)
+  })
+
+  it('forwards page defaults but does not invent an app default export', () => {
+    const entry = {
+      sourceId: '/project/src/pages/home/index.vue',
+      type: 'page' as const,
+    }
+
+    expect(createLogicalEntryModuleCode(entry, []))
+      .toContain(`export { default } from ${JSON.stringify(entry.sourceId)};`)
+    expect(createLogicalEntryModuleCode({
+      sourceId: '/project/src/app.vue',
+      type: 'app',
+    }, [])).not.toContain('export default')
+  })
+
+  it('links sidecar modules to inert source requests', () => {
+    expect(createSidecarModuleCode(
+      '/project/src/pages/home/index.ts',
+      '/project/src/pages/home/index.wxml',
+      'template',
+    )).toBe('import "/project/src/pages/home/index.wxml?raw&weapp-vite-sidecar-owner=%2Fproject%2Fsrc%2Fpages%2Fhome%2Findex.ts&weapp-vite-sidecar=template&lang.js";\nexport default "/project/src/pages/home/index.wxml";\n')
+  })
+})

--- a/packages/weapp-vite/src/moduleGraph/logicalEntry.ts
+++ b/packages/weapp-vite/src/moduleGraph/logicalEntry.ts
@@ -1,0 +1,36 @@
+import type { LogicalEntryRequest, SidecarModuleKind } from './protocol'
+import { createLogicalEntryId, createSidecarModuleId, createSidecarSourceSpecifier } from './protocol'
+
+export interface LogicalEntryDependency {
+  kind: SidecarModuleKind
+  sourceId: string
+}
+
+export function createLogicalEntryModuleCode(
+  entry: LogicalEntryRequest,
+  dependencies: Iterable<LogicalEntryDependency>,
+) {
+  const source = JSON.stringify(entry.sourceId)
+  const forwardsDefault = entry.type !== 'app' && /\.(?:vue|jsx|tsx)$/.test(entry.sourceId)
+  const imports = [forwardsDefault
+    ? `export { default } from ${source};`
+    : `import ${source};`]
+  const seen = new Set<string>()
+  for (const dependency of dependencies) {
+    const dependencyId = dependency.kind === 'layout' && dependency.sourceId.endsWith('.vue')
+      ? createLogicalEntryId(dependency.sourceId, 'layout')
+      : createSidecarModuleId(entry.sourceId, dependency.sourceId, dependency.kind)
+    if (seen.has(dependencyId)) {
+      continue
+    }
+    seen.add(dependencyId)
+    imports.push(`import ${JSON.stringify(dependencyId)};`)
+  }
+  imports.push(`export * from ${source};`)
+  return `${imports.join('\n')}\n`
+}
+
+export function createSidecarModuleCode(ownerId: string, sourceId: string, kind: SidecarModuleKind) {
+  const sourceRequest = createSidecarSourceSpecifier(ownerId, sourceId, kind)
+  return `import ${JSON.stringify(sourceRequest)};\nexport default ${JSON.stringify(sourceId)};\n`
+}

--- a/packages/weapp-vite/src/moduleGraph/logicalEntry.ts
+++ b/packages/weapp-vite/src/moduleGraph/logicalEntry.ts
@@ -1,5 +1,5 @@
 import type { LogicalEntryRequest, SidecarModuleKind } from './protocol'
-import { createLogicalEntryId, createSidecarModuleId, createSidecarSourceSpecifier } from './protocol'
+import { createSidecarModuleId, createSidecarSourceSpecifier } from './protocol'
 
 export interface LogicalEntryDependency {
   kind: SidecarModuleKind
@@ -17,9 +17,7 @@ export function createLogicalEntryModuleCode(
     : `import ${source};`]
   const seen = new Set<string>()
   for (const dependency of dependencies) {
-    const dependencyId = dependency.kind === 'layout' && dependency.sourceId.endsWith('.vue')
-      ? createLogicalEntryId(dependency.sourceId, 'layout')
-      : createSidecarModuleId(entry.sourceId, dependency.sourceId, dependency.kind)
+    const dependencyId = createSidecarModuleId(entry.sourceId, dependency.sourceId, dependency.kind)
     if (seen.has(dependencyId)) {
       continue
     }

--- a/packages/weapp-vite/src/moduleGraph/protocol.ts
+++ b/packages/weapp-vite/src/moduleGraph/protocol.ts
@@ -38,7 +38,8 @@ export interface SidecarSourceRequest {
 }
 
 const VIRTUAL_MODULE_SUFFIX = ':module.js'
-const SIDECAR_SOURCE_MODULE_SUFFIX = '&lang.js'
+const SIDECAR_SOURCE_JS_SUFFIX = '&lang.js'
+const SIDECAR_SOURCE_STYLE_SUFFIX = '&lang.css'
 
 function normalizeProtocolPath(id: string) {
   const normalized = path.normalize(id.replaceAll('\\', '/'))
@@ -144,31 +145,36 @@ export function parseSidecarModuleId(id: string): SidecarModuleRequest | undefin
 }
 
 export function createSidecarSourceSpecifier(ownerId: string, sourceId: string, kind: SidecarModuleKind) {
-  return `${normalizeProtocolPath(sourceId)}?raw&${WEAPP_VITE_SIDECAR_OWNER_QUERY_MARKER}=${encodePath(ownerId)}&${WEAPP_VITE_SIDECAR_QUERY_MARKER}=${kind}${SIDECAR_SOURCE_MODULE_SUFFIX}`
+  const queryPrefix = kind === 'style' ? '?' : '?raw&'
+  const suffix = kind === 'style' ? SIDECAR_SOURCE_STYLE_SUFFIX : SIDECAR_SOURCE_JS_SUFFIX
+  return `${normalizeProtocolPath(sourceId)}${queryPrefix}${WEAPP_VITE_SIDECAR_OWNER_QUERY_MARKER}=${encodePath(ownerId)}&${WEAPP_VITE_SIDECAR_QUERY_MARKER}=${kind}${suffix}`
 }
 
 export function parseSidecarSourceRequest(id: string): SidecarSourceRequest | undefined {
-  const marker = `&${WEAPP_VITE_SIDECAR_QUERY_MARKER}=`
-  const markerIndex = id.lastIndexOf(marker)
-  const ownerMarker = `&${WEAPP_VITE_SIDECAR_OWNER_QUERY_MARKER}=`
-  const ownerMarkerIndex = id.lastIndexOf(ownerMarker)
-  if (
-    markerIndex < 0
-    || ownerMarkerIndex < 0
-    || ownerMarkerIndex > markerIndex
-    || !id.endsWith(SIDECAR_SOURCE_MODULE_SUFFIX)
-  ) {
+  const queryIndex = id.indexOf('?')
+  if (queryIndex < 0) {
     return
   }
-  const kind = id.slice(markerIndex + marker.length, -SIDECAR_SOURCE_MODULE_SUFFIX.length)
-  if (!['json', 'layout', 'script', 'style', 'template', 'using-component', 'wxs'].includes(kind)) {
+  const query = new URLSearchParams(id.slice(queryIndex + 1))
+  const kind = query.get(WEAPP_VITE_SIDECAR_QUERY_MARKER)
+  const ownerId = query.get(WEAPP_VITE_SIDECAR_OWNER_QUERY_MARKER)
+  if (!kind || !['json', 'layout', 'script', 'style', 'template', 'using-component', 'wxs'].includes(kind)) {
     return
   }
-  const rawSourceId = id.slice(0, ownerMarkerIndex)
+  if (!ownerId) {
+    return
+  }
+  const isStyle = kind === 'style'
+  const hasExpectedLang = query.has(isStyle ? 'lang.css' : 'lang.js')
+  const hasUnexpectedLang = query.has(isStyle ? 'lang.js' : 'lang.css')
+  const hasExpectedRawMode = query.has('raw') !== isStyle
+  if (!hasExpectedLang || hasUnexpectedLang || !hasExpectedRawMode) {
+    return
+  }
   return {
     kind: kind as SidecarModuleKind,
-    ownerId: decodePath(id.slice(ownerMarkerIndex + ownerMarker.length, markerIndex)),
-    sourceId: normalizeProtocolPath(rawSourceId.endsWith('?raw') ? rawSourceId.slice(0, -4) : rawSourceId),
+    ownerId: normalizeProtocolPath(ownerId),
+    sourceId: normalizeProtocolPath(id.slice(0, queryIndex)),
   }
 }
 

--- a/packages/weapp-vite/src/moduleGraph/protocol.ts
+++ b/packages/weapp-vite/src/moduleGraph/protocol.ts
@@ -1,0 +1,184 @@
+import { realpathSync } from 'node:fs'
+import {
+  WEAPP_VITE_LOGICAL_ENTRY_RESOLVED_PREFIX,
+  WEAPP_VITE_LOGICAL_ENTRY_VIRTUAL_PREFIX,
+  WEAPP_VITE_SIDECAR_OWNER_QUERY_MARKER,
+  WEAPP_VITE_SIDECAR_QUERY_MARKER,
+  WEAPP_VITE_SIDECAR_RESOLVED_PREFIX,
+  WEAPP_VITE_SIDECAR_VIRTUAL_PREFIX,
+} from '@weapp-core/constants'
+import path from 'pathe'
+
+export type LogicalEntryType = 'app' | 'page' | 'component' | 'layout'
+
+export type SidecarModuleKind
+  = | 'json'
+    | 'layout'
+    | 'script'
+    | 'style'
+    | 'template'
+    | 'using-component'
+    | 'wxs'
+
+export interface LogicalEntryRequest {
+  sourceId: string
+  type: LogicalEntryType
+}
+
+export interface SidecarModuleRequest {
+  kind: SidecarModuleKind
+  ownerId: string
+  sourceId: string
+}
+
+export interface SidecarSourceRequest {
+  kind: SidecarModuleKind
+  ownerId: string
+  sourceId: string
+}
+
+const VIRTUAL_MODULE_SUFFIX = ':module.js'
+const SIDECAR_SOURCE_MODULE_SUFFIX = '&lang.js'
+
+function normalizeProtocolPath(id: string) {
+  const normalized = path.normalize(id.replaceAll('\\', '/'))
+  if (!path.isAbsolute(normalized)) {
+    return normalized
+  }
+  try {
+    return path.normalize(realpathSync.native(normalized))
+  }
+  catch {
+    return normalized
+  }
+}
+
+function encodePath(id: string) {
+  return encodeURIComponent(normalizeProtocolPath(id))
+}
+
+function decodePath(id: string) {
+  return normalizeProtocolPath(decodeURIComponent(id))
+}
+
+function resolveProtocolPrefix(id: string, virtualPrefix: string, resolvedPrefix: string) {
+  if (id.startsWith(resolvedPrefix)) {
+    return id.slice(resolvedPrefix.length)
+  }
+  if (id.startsWith(virtualPrefix)) {
+    return id.slice(virtualPrefix.length)
+  }
+}
+
+export function createLogicalEntryId(sourceId: string, type: LogicalEntryType) {
+  return `${WEAPP_VITE_LOGICAL_ENTRY_RESOLVED_PREFIX}${type}:${encodePath(sourceId)}${VIRTUAL_MODULE_SUFFIX}`
+}
+
+export function createLogicalEntrySpecifier(sourceId: string, type: LogicalEntryType) {
+  return `${WEAPP_VITE_LOGICAL_ENTRY_VIRTUAL_PREFIX}${type}:${encodePath(sourceId)}${VIRTUAL_MODULE_SUFFIX}`
+}
+
+export function parseLogicalEntryId(id: string): LogicalEntryRequest | undefined {
+  const request = resolveProtocolPrefix(
+    id,
+    WEAPP_VITE_LOGICAL_ENTRY_VIRTUAL_PREFIX,
+    WEAPP_VITE_LOGICAL_ENTRY_RESOLVED_PREFIX,
+  )
+  if (!request) {
+    return
+  }
+  if (!request.endsWith(VIRTUAL_MODULE_SUFFIX)) {
+    return
+  }
+  const normalizedRequest = request.slice(0, -VIRTUAL_MODULE_SUFFIX.length)
+  const separator = normalizedRequest.indexOf(':')
+  if (separator < 0) {
+    return
+  }
+  const type = normalizedRequest.slice(0, separator) as LogicalEntryType
+  if (!['app', 'page', 'component', 'layout'].includes(type)) {
+    return
+  }
+  return {
+    sourceId: decodePath(normalizedRequest.slice(separator + 1)),
+    type,
+  }
+}
+
+export function createSidecarModuleId(ownerId: string, sourceId: string, kind: SidecarModuleKind) {
+  return `${WEAPP_VITE_SIDECAR_RESOLVED_PREFIX}${kind}:${encodePath(ownerId)}:${encodePath(sourceId)}${VIRTUAL_MODULE_SUFFIX}`
+}
+
+export function createSidecarModuleSpecifier(ownerId: string, sourceId: string, kind: SidecarModuleKind) {
+  return `${WEAPP_VITE_SIDECAR_VIRTUAL_PREFIX}${kind}:${encodePath(ownerId)}:${encodePath(sourceId)}${VIRTUAL_MODULE_SUFFIX}`
+}
+
+export function parseSidecarModuleId(id: string): SidecarModuleRequest | undefined {
+  const request = resolveProtocolPrefix(
+    id,
+    WEAPP_VITE_SIDECAR_VIRTUAL_PREFIX,
+    WEAPP_VITE_SIDECAR_RESOLVED_PREFIX,
+  )
+  if (!request) {
+    return
+  }
+  if (!request.endsWith(VIRTUAL_MODULE_SUFFIX)) {
+    return
+  }
+  const normalizedRequest = request.slice(0, -VIRTUAL_MODULE_SUFFIX.length)
+  const [kind, ownerId, sourceId, ...rest] = normalizedRequest.split(':')
+  if (
+    rest.length
+    || !kind
+    || !ownerId
+    || !sourceId
+    || !['json', 'layout', 'script', 'style', 'template', 'using-component', 'wxs'].includes(kind)
+  ) {
+    return
+  }
+  return {
+    kind: kind as SidecarModuleKind,
+    ownerId: decodePath(ownerId),
+    sourceId: decodePath(sourceId),
+  }
+}
+
+export function createSidecarSourceSpecifier(ownerId: string, sourceId: string, kind: SidecarModuleKind) {
+  return `${normalizeProtocolPath(sourceId)}?raw&${WEAPP_VITE_SIDECAR_OWNER_QUERY_MARKER}=${encodePath(ownerId)}&${WEAPP_VITE_SIDECAR_QUERY_MARKER}=${kind}${SIDECAR_SOURCE_MODULE_SUFFIX}`
+}
+
+export function parseSidecarSourceRequest(id: string): SidecarSourceRequest | undefined {
+  const marker = `&${WEAPP_VITE_SIDECAR_QUERY_MARKER}=`
+  const markerIndex = id.lastIndexOf(marker)
+  const ownerMarker = `&${WEAPP_VITE_SIDECAR_OWNER_QUERY_MARKER}=`
+  const ownerMarkerIndex = id.lastIndexOf(ownerMarker)
+  if (
+    markerIndex < 0
+    || ownerMarkerIndex < 0
+    || ownerMarkerIndex > markerIndex
+    || !id.endsWith(SIDECAR_SOURCE_MODULE_SUFFIX)
+  ) {
+    return
+  }
+  const kind = id.slice(markerIndex + marker.length, -SIDECAR_SOURCE_MODULE_SUFFIX.length)
+  if (!['json', 'layout', 'script', 'style', 'template', 'using-component', 'wxs'].includes(kind)) {
+    return
+  }
+  const rawSourceId = id.slice(0, ownerMarkerIndex)
+  return {
+    kind: kind as SidecarModuleKind,
+    ownerId: decodePath(id.slice(ownerMarkerIndex + ownerMarker.length, markerIndex)),
+    sourceId: normalizeProtocolPath(rawSourceId.endsWith('?raw') ? rawSourceId.slice(0, -4) : rawSourceId),
+  }
+}
+
+export function resolveVirtualModuleId(id: string) {
+  const logicalEntry = parseLogicalEntryId(id)
+  if (logicalEntry) {
+    return createLogicalEntryId(logicalEntry.sourceId, logicalEntry.type)
+  }
+  const sidecar = parseSidecarModuleId(id)
+  if (sidecar) {
+    return createSidecarModuleId(sidecar.ownerId, sidecar.sourceId, sidecar.kind)
+  }
+}

--- a/packages/weapp-vite/src/moduleGraph/service.test.ts
+++ b/packages/weapp-vite/src/moduleGraph/service.test.ts
@@ -22,6 +22,11 @@ describe('module graph protocol', () => {
       'C:\\project\\src\\pages\\home\\index.wxml',
       'template',
     )
+    const styleSourceId = createSidecarSourceSpecifier(
+      'C:\\project\\src\\app.ts',
+      'C:\\project\\src\\app.css',
+      'style',
+    )
 
     expect(parseLogicalEntryId(entryId)).toEqual({
       sourceId: 'C:/project/src/pages/home/index.ts',
@@ -36,6 +41,12 @@ describe('module graph protocol', () => {
       kind: 'template',
       ownerId: 'C:/project/src/pages/home/index.ts',
       sourceId: 'C:/project/src/pages/home/index.wxml',
+    })
+    expect(styleSourceId).toBe('C:/project/src/app.css?weapp-vite-sidecar-owner=C%3A%2Fproject%2Fsrc%2Fapp.ts&weapp-vite-sidecar=style&lang.css')
+    expect(parseSidecarSourceRequest(styleSourceId)).toEqual({
+      kind: 'style',
+      ownerId: 'C:/project/src/app.ts',
+      sourceId: 'C:/project/src/app.css',
     })
   })
 })

--- a/packages/weapp-vite/src/moduleGraph/service.test.ts
+++ b/packages/weapp-vite/src/moduleGraph/service.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createLogicalEntryId,
+  createSidecarModuleId,
+  createSidecarSourceSpecifier,
+  parseLogicalEntryId,
+  parseSidecarModuleId,
+  parseSidecarSourceRequest,
+} from './protocol'
+import { createModuleGraphService } from './service'
+
+describe('module graph protocol', () => {
+  it('round-trips logical entry and sidecar ids without exposing path separators', () => {
+    const entryId = createLogicalEntryId('C:\\project\\src\\pages\\home\\index.ts', 'page')
+    const sidecarId = createSidecarModuleId(
+      'C:\\project\\src\\pages\\home\\index.ts',
+      'C:\\project\\src\\pages\\home\\index.wxml',
+      'template',
+    )
+    const sidecarSourceId = createSidecarSourceSpecifier(
+      'C:\\project\\src\\pages\\home\\index.ts',
+      'C:\\project\\src\\pages\\home\\index.wxml',
+      'template',
+    )
+
+    expect(parseLogicalEntryId(entryId)).toEqual({
+      sourceId: 'C:/project/src/pages/home/index.ts',
+      type: 'page',
+    })
+    expect(parseSidecarModuleId(sidecarId)).toEqual({
+      kind: 'template',
+      ownerId: 'C:/project/src/pages/home/index.ts',
+      sourceId: 'C:/project/src/pages/home/index.wxml',
+    })
+    expect(parseSidecarSourceRequest(sidecarSourceId)).toEqual({
+      kind: 'template',
+      ownerId: 'C:/project/src/pages/home/index.ts',
+      sourceId: 'C:/project/src/pages/home/index.wxml',
+    })
+  })
+})
+
+describe('ModuleGraphService', () => {
+  it('traces static, dynamic, linked and sidecar importers from the build graph', () => {
+    const pageId = '/project/src/pages/home/index.ts'
+    const logicalId = createLogicalEntryId(pageId, 'page')
+    const layoutId = '/project/src/layouts/default.vue'
+    const nativeLayoutId = '/project/src/layouts/native/index.ts'
+    const logicalLayoutId = createLogicalEntryId(layoutId, 'layout')
+    const sidecarId = createSidecarModuleId(pageId, '/project/src/pages/home/index.wxml', 'template')
+    const infos = new Map<string, any>([
+      ['/project/src/shared/static.ts', { importers: [pageId], dynamicImporters: [] }],
+      ['/project/src/shared/dynamic.ts', { importers: [], dynamicImporters: [pageId] }],
+      ['/workspace/linked/util.ts', { importers: [pageId], dynamicImporters: [] }],
+      [pageId, { importers: [logicalId], dynamicImporters: [] }],
+      [layoutId, { importers: [logicalLayoutId], dynamicImporters: [] }],
+      [logicalLayoutId, { importers: [logicalId], dynamicImporters: [] }],
+      [sidecarId, { importers: [], dynamicImporters: [] }],
+      [logicalId, { isEntry: true, importers: [], dynamicImporters: [] }],
+    ])
+    const service = createModuleGraphService()
+    service.bindBuildContext({}, {
+      getModuleIds: () => infos.keys(),
+      getModuleInfo: id => infos.get(id),
+    })
+    service.bindPluginContext({ resolve: vi.fn() })
+
+    expect(service.collectAffectedEntries('/project/src/shared/static.ts')).toEqual(new Set([pageId]))
+    expect(service.collectAffectedEntries('/project/src/shared/dynamic.ts')).toEqual(new Set([pageId]))
+    expect(service.collectAffectedEntries('/workspace/linked/util.ts')).toEqual(new Set([pageId]))
+    expect(service.collectAffectedEntries('/project/src/pages/home/index.wxml')).toEqual(new Set([pageId]))
+    expect(service.collectAffectedEntries(pageId)).toEqual(new Set([pageId]))
+    expect(service.collectAffectedEntries(layoutId)).toEqual(new Set([layoutId, pageId]))
+    service.replaceEntryDependencies(pageId, 'layout', [layoutId, nativeLayoutId])
+    expect(service.isLogicalLayoutEntry(layoutId)).toBe(true)
+    expect(service.isLogicalLayoutEntry(nativeLayoutId)).toBe(true)
+  })
+
+  it('keeps build graphs isolated by scope while plugin contexts change', () => {
+    const firstEntry = '/project/src/pages/first/index.ts'
+    const secondEntry = '/project/src/pages/second/index.ts'
+    const firstDependency = '/project/src/shared/first.ts'
+    const secondDependency = '/project/src/shared/second.ts'
+    const firstLogical = createLogicalEntryId(firstEntry, 'page')
+    const secondLogical = createLogicalEntryId(secondEntry, 'page')
+    const createContext = (infos: Map<string, any>) => ({
+      getModuleIds: () => infos.keys(),
+      getModuleInfo: (id: string) => infos.get(id),
+    })
+    const service = createModuleGraphService()
+
+    service.bindBuildContext({}, createContext(new Map([
+      [firstDependency, { importers: [firstEntry] }],
+      [firstEntry, { importers: [firstLogical] }],
+      [firstLogical, { importers: [], isEntry: true }],
+    ])))
+    service.bindBuildContext({}, createContext(new Map([
+      [secondDependency, { importers: [secondEntry] }],
+      [secondEntry, { importers: [secondLogical] }],
+      [secondLogical, { importers: [], isEntry: true }],
+    ])))
+    service.bindPluginContext({ resolve: vi.fn() })
+
+    expect(service.collectAffectedEntries(firstDependency)).toEqual(new Set([firstEntry]))
+    expect(service.collectAffectedEntries(secondDependency)).toEqual(new Set([secondEntry]))
+  })
+
+  it('uses the dev server module graph for read-only traversal and invalidation', () => {
+    const pageId = '/project/src/pages/home/index.ts'
+    const logicalId = createLogicalEntryId(pageId, 'page')
+    const logicalNode = { id: logicalId, importers: new Set() }
+    const pageNode = { id: pageId, file: pageId, importers: new Set([logicalNode]) }
+    const dependencyNode = {
+      id: '/project/src/shared/value.ts',
+      file: '/project/src/shared/value.ts',
+      importers: new Set([pageNode]),
+    }
+    const invalidateModule = vi.fn()
+    const service = createModuleGraphService()
+    service.bindDevServer({
+      moduleGraph: {
+        getModulesByFile: file => file === dependencyNode.file ? new Set([dependencyNode]) : undefined,
+        getModuleById: id => id === logicalId ? logicalNode : undefined,
+        idToModuleMap: new Map([
+          [logicalId, logicalNode],
+          [pageId, pageNode],
+          [dependencyNode.id, dependencyNode],
+        ]),
+        invalidateModule,
+      },
+    })
+
+    expect(service.collectAffectedEntries(dependencyNode.file)).toEqual(new Set([pageId]))
+    expect(service.invalidate(dependencyNode.file)).toEqual(new Set([pageId]))
+    expect(invalidateModule).toHaveBeenCalledWith(dependencyNode)
+  })
+
+  it('uses the bound dev graph instead of merging stale build importers', () => {
+    const file = '/project/src/shared/value.ts'
+    const staleEntry = '/project/src/pages/stale/index.ts'
+    const staleLogical = createLogicalEntryId(staleEntry, 'page')
+    const currentEntry = '/project/src/pages/current/index.ts'
+    const currentLogical = createLogicalEntryId(currentEntry, 'page')
+    const currentLogicalNode = { id: currentLogical, importers: new Set() }
+    const currentEntryNode = { id: currentEntry, importers: new Set([currentLogicalNode]) }
+    const currentFileNode = { id: file, file, importers: new Set([currentEntryNode]) }
+    const service = createModuleGraphService()
+
+    service.bindBuildContext({}, {
+      getModuleIds: () => [file, staleEntry, staleLogical],
+      getModuleInfo: id => new Map<string, any>([
+        [file, { importers: [staleEntry] }],
+        [staleEntry, { importers: [staleLogical] }],
+        [staleLogical, { importers: [] }],
+      ]).get(id),
+    })
+    service.bindDevServer({
+      moduleGraph: {
+        getModulesByFile: id => id === file ? new Set([currentFileNode]) : undefined,
+        getModuleById: id => id === currentLogical ? currentLogicalNode : undefined,
+        invalidateModule: vi.fn(),
+      },
+    })
+
+    expect(service.collectAffectedEntries(file)).toEqual(new Set([currentEntry]))
+  })
+
+  it('warms logical roots and their current dev graph dependencies without caching edges', async () => {
+    const pageId = '/project/src/pages/home/index.ts'
+    const logicalId = createLogicalEntryId(pageId, 'page')
+    const dependencyId = '/project/src/shared/value.ts'
+    const dependencyNode = { id: dependencyId, url: dependencyId, importedModules: new Set() }
+    const logicalNode = {
+      id: logicalId,
+      url: logicalId,
+      importedModules: new Set([dependencyNode]),
+    }
+    const transformRequest = vi.fn(async () => undefined)
+    const service = createModuleGraphService()
+    service.bindDevServer({
+      moduleGraph: {
+        getModulesByFile: () => undefined,
+        getModuleById: id => id === logicalId ? logicalNode : id === dependencyId ? dependencyNode : undefined,
+        invalidateModule: vi.fn(),
+      },
+      transformRequest,
+    })
+
+    await service.syncDevGraph({
+      getModuleIds: () => [logicalId, dependencyId],
+    })
+
+    expect(transformRequest).toHaveBeenCalledWith(logicalId)
+    expect(transformRequest).toHaveBeenCalledWith(dependencyId)
+  })
+
+  it('funnels topology changes through one consumable full-rescan request', () => {
+    const service = createModuleGraphService()
+    service.requestTopologyRescan('sidecar-create', '/project/src/pages/home/index.json')
+    service.requestTopologyRescan('sidecar-delete', '/project/src/pages/home/index.wxml')
+
+    expect(service.consumeTopologyRescan()).toEqual({
+      files: new Set([
+        '/project/src/pages/home/index.json',
+        '/project/src/pages/home/index.wxml',
+      ]),
+      reasons: new Set(['sidecar-create', 'sidecar-delete']),
+    })
+    expect(service.consumeTopologyRescan()).toBeUndefined()
+  })
+
+  it('records only changed physical ids between graph lifecycles', () => {
+    const service = createModuleGraphService()
+    service.recordChangedFile('/project/src/pages/home/index.json?raw', 'update')
+    service.recordChangedFile('/project/src/pages/home/index.json', 'create')
+
+    expect(service.getPendingChanges()).toEqual([
+      { event: 'create', file: '/project/src/pages/home/index.json' },
+    ])
+    service.clearPendingChanges()
+    expect(service.getPendingChanges()).toEqual([])
+  })
+
+  it('routes resolution and loading through the active plugin context', async () => {
+    const resolve = vi.fn(async (source: string) => ({ id: `/resolved/${source}` }))
+    const load = vi.fn(async ({ id }: { id: string }) => ({ code: `export default ${JSON.stringify(id)}` }))
+    const service = createModuleGraphService()
+    service.bindPluginContext({ resolve, load })
+
+    await expect(service.resolve('pkg', '/project/src/app.ts')).resolves.toEqual({ id: '/resolved/pkg' })
+    await expect(service.load({ id: '/resolved/pkg' })).resolves.toEqual({ code: 'export default "/resolved/pkg"' })
+  })
+})

--- a/packages/weapp-vite/src/moduleGraph/service.ts
+++ b/packages/weapp-vite/src/moduleGraph/service.ts
@@ -1,0 +1,276 @@
+import type { SidecarModuleKind } from './protocol'
+import type {
+  BuildGraphContext,
+  BuildModuleInfo,
+  DevModuleNode,
+  DevServerGraphHost,
+  TopologyRescanRequest,
+} from './types'
+import { createDebugger } from '../debugger'
+import { parseLogicalEntryId, parseSidecarModuleId, parseSidecarSourceRequest } from './protocol'
+import { collectBuildStartIds, collectDevStartNodes, normalizeSourceId } from './traversal'
+
+const debug = createDebugger('weapp-vite:module-graph')
+
+export interface ModuleGraphService {
+  bindBuildContext: (scope: object, context: BuildGraphContext) => void
+  bindDevServer: (server: DevServerGraphHost | undefined) => void
+  bindPluginContext: (context: BuildGraphContext) => void
+  collectAffectedEntries: (file: string) => Set<string>
+  getPendingChanges: () => Array<{ event: string, file: string }>
+  consumeTopologyRescan: () => TopologyRescanRequest | undefined
+  hasModule: (file: string) => boolean
+  invalidate: (file: string) => Set<string>
+  isLogicalLayoutEntry: (file: string) => boolean
+  load: (options: { id: string, resolveDependencies?: boolean }) => Promise<BuildModuleInfo>
+  replaceEntryDependencies: (ownerId: string, kind: SidecarModuleKind, sourceIds: Iterable<string>) => void
+  recordChangedFile: (file: string, event: string) => void
+  clearPendingChanges: () => void
+  requestTopologyRescan: (reason: string, file: string) => void
+  resolve: (
+    source: string,
+    importer?: string,
+    options?: { skipSelf?: boolean },
+  ) => Promise<{ id: string } | null>
+  syncDevGraph: (context: BuildGraphContext) => Promise<void>
+  getEntryDependencies: (ownerId: string) => Array<{ kind: SidecarModuleKind, sourceId: string }>
+}
+
+export function createModuleGraphService(): ModuleGraphService {
+  const buildContexts = new Map<object, BuildGraphContext>()
+  let pluginContext: BuildGraphContext | undefined
+  let devServer: DevServerGraphHost | undefined
+  let topologyRescan: TopologyRescanRequest | undefined
+  const entryDependencies = new Map<string, Map<SidecarModuleKind, Set<string>>>()
+  const pendingChanges = new Map<string, string>()
+
+  const collectFromBuildGraph = (file: string, affected: Set<string>) => {
+    for (const buildContext of buildContexts.values()) {
+      if (typeof buildContext.getModuleInfo !== 'function') {
+        continue
+      }
+      const queue = [...collectBuildStartIds(buildContext, file)]
+      const visited = new Set<string>()
+      for (let index = 0; index < queue.length; index += 1) {
+        const id = queue[index]!
+        if (visited.has(id)) {
+          continue
+        }
+        visited.add(id)
+        const logicalEntry = parseLogicalEntryId(id)
+        if (logicalEntry) {
+          affected.add(normalizeSourceId(logicalEntry.sourceId))
+          if (logicalEntry.type !== 'layout') {
+            continue
+          }
+        }
+        const sidecar = parseSidecarModuleId(id)
+        if (sidecar) {
+          affected.add(normalizeSourceId(sidecar.ownerId))
+        }
+        const sidecarSource = parseSidecarSourceRequest(id)
+        if (sidecarSource) {
+          affected.add(normalizeSourceId(sidecarSource.ownerId))
+        }
+        const info = buildContext.getModuleInfo(id)
+        for (const importer of [...(info?.importers ?? []), ...(info?.dynamicImporters ?? [])]) {
+          if (!visited.has(importer)) {
+            queue.push(importer)
+          }
+        }
+      }
+    }
+  }
+
+  const collectFromDevGraph = (file: string, affected: Set<string>) => {
+    if (!devServer) {
+      return
+    }
+    const queue = [...collectDevStartNodes(devServer, file)]
+    const visited = new Set<DevModuleNode>()
+    for (let index = 0; index < queue.length; index += 1) {
+      const module = queue[index]!
+      if (visited.has(module)) {
+        continue
+      }
+      visited.add(module)
+      const logicalEntry = module.id ? parseLogicalEntryId(module.id) : undefined
+      if (logicalEntry) {
+        affected.add(normalizeSourceId(logicalEntry.sourceId))
+        if (logicalEntry.type !== 'layout') {
+          continue
+        }
+      }
+      const sidecar = module.id ? parseSidecarModuleId(module.id) : undefined
+      if (sidecar) {
+        affected.add(normalizeSourceId(sidecar.ownerId))
+        continue
+      }
+      const sidecarSource = module.id ? parseSidecarSourceRequest(module.id) : undefined
+      if (sidecarSource) {
+        affected.add(normalizeSourceId(sidecarSource.ownerId))
+        continue
+      }
+      for (const importer of module.importers ?? []) {
+        if (!visited.has(importer)) {
+          queue.push(importer)
+        }
+      }
+    }
+  }
+
+  const collectAffectedEntries = (rawFile: string) => {
+    const file = normalizeSourceId(rawFile)
+    const affected = new Set<string>()
+    if (devServer) {
+      collectFromDevGraph(file, affected)
+    }
+    else {
+      collectFromBuildGraph(file, affected)
+    }
+    return affected
+  }
+
+  const warmDevModule = async (id: string) => {
+    if (!devServer?.transformRequest) {
+      return
+    }
+    const queue = [id]
+    const visited = new Set<string>()
+    for (let index = 0; index < queue.length; index += 1) {
+      const request = queue[index]!
+      if (visited.has(request)) {
+        continue
+      }
+      visited.add(request)
+      try {
+        await devServer.transformRequest(request)
+      }
+      catch (error) {
+        debug?.(`dev graph 预热跳过无法展开的 external 终点 ${request}: ${String(error)}`)
+        continue
+      }
+      const module = devServer.moduleGraph.getModuleById(request)
+      for (const dependency of module?.importedModules ?? []) {
+        const dependencyRequest = dependency.url ?? dependency.id
+        if (dependencyRequest && !visited.has(dependencyRequest)) {
+          queue.push(dependencyRequest)
+        }
+      }
+    }
+  }
+
+  return {
+    bindBuildContext(scope, context) {
+      buildContexts.set(scope, context)
+    },
+    bindDevServer(server) {
+      devServer = server
+    },
+    bindPluginContext(context) {
+      pluginContext = context
+    },
+    collectAffectedEntries,
+    getPendingChanges() {
+      return Array.from(pendingChanges, ([file, event]) => ({ event, file }))
+    },
+    consumeTopologyRescan() {
+      const request = topologyRescan
+      topologyRescan = undefined
+      return request
+    },
+    hasModule(rawFile) {
+      const file = normalizeSourceId(rawFile)
+      if (devServer) {
+        return collectDevStartNodes(devServer, file).size > 0
+      }
+      return Array.from(buildContexts.values())
+        .some(context => collectBuildStartIds(context, file).size > 0)
+    },
+    invalidate(rawFile) {
+      const file = normalizeSourceId(rawFile)
+      const affected = collectAffectedEntries(file)
+      if (devServer) {
+        for (const module of collectDevStartNodes(devServer, file)) {
+          devServer.moduleGraph.invalidateModule(module)
+        }
+      }
+      return affected
+    },
+    isLogicalLayoutEntry(rawFile) {
+      const file = normalizeSourceId(rawFile)
+      for (const byKind of entryDependencies.values()) {
+        if (byKind.get('layout')?.has(file) && /\.(?:[cm]?[jt]sx?|vue)$/.test(file)) {
+          return true
+        }
+      }
+      return false
+    },
+    async load(options) {
+      if (typeof pluginContext?.load !== 'function') {
+        throw new TypeError('ModuleGraphService 尚未绑定支持 load 的 PluginContext。')
+      }
+      return await pluginContext.load(options)
+    },
+    replaceEntryDependencies(rawOwnerId, kind, sourceIds) {
+      const ownerId = normalizeSourceId(rawOwnerId)
+      let byKind = entryDependencies.get(ownerId)
+      if (!byKind) {
+        byKind = new Map()
+        entryDependencies.set(ownerId, byKind)
+      }
+      const normalized = new Set(Array.from(sourceIds, normalizeSourceId))
+      if (normalized.size) {
+        byKind.set(kind, normalized)
+      }
+      else {
+        byKind.delete(kind)
+      }
+      if (!byKind.size) {
+        entryDependencies.delete(ownerId)
+      }
+    },
+    recordChangedFile(rawFile, event) {
+      const file = normalizeSourceId(rawFile)
+      pendingChanges.set(file, event)
+    },
+    clearPendingChanges() {
+      pendingChanges.clear()
+    },
+    requestTopologyRescan(reason, rawFile) {
+      topologyRescan ??= {
+        files: new Set<string>(),
+        reasons: new Set<string>(),
+      }
+      topologyRescan.files.add(normalizeSourceId(rawFile))
+      topologyRescan.reasons.add(reason)
+    },
+    async resolve(source, importer, options) {
+      if (typeof pluginContext?.resolve !== 'function') {
+        throw new TypeError('ModuleGraphService 尚未绑定支持 resolve 的 PluginContext。')
+      }
+      return await pluginContext.resolve(source, importer, options)
+    },
+    async syncDevGraph(context) {
+      if (!devServer || typeof context.getModuleIds !== 'function') {
+        return
+      }
+      const logicalEntryIds = Array.from(context.getModuleIds()).filter(id => parseLogicalEntryId(id))
+      await Promise.all(logicalEntryIds.map(warmDevModule))
+    },
+    getEntryDependencies(rawOwnerId) {
+      const ownerId = normalizeSourceId(rawOwnerId)
+      const byKind = entryDependencies.get(ownerId)
+      if (!byKind) {
+        return []
+      }
+      const dependencies: Array<{ kind: SidecarModuleKind, sourceId: string }> = []
+      for (const [kind, sourceIds] of byKind) {
+        for (const sourceId of sourceIds) {
+          dependencies.push({ kind, sourceId })
+        }
+      }
+      return dependencies
+    },
+  }
+}

--- a/packages/weapp-vite/src/moduleGraph/traversal.ts
+++ b/packages/weapp-vite/src/moduleGraph/traversal.ts
@@ -1,0 +1,53 @@
+import type { BuildGraphContext, DevModuleNode, DevServerGraphHost } from './types'
+import { realpathSync } from 'node:fs'
+import { normalizeFsResolvedId } from '../utils/resolvedId'
+import { parseLogicalEntryId, parseSidecarModuleId, parseSidecarSourceRequest } from './protocol'
+
+export function normalizeSourceId(id: string) {
+  const normalized = normalizeFsResolvedId(id).split('?')[0]!
+  try {
+    return normalizeFsResolvedId(realpathSync.native(normalized))
+  }
+  catch {
+    return normalized
+  }
+}
+
+function moduleIdMatchesFile(id: string, file: string) {
+  const sidecarSource = parseSidecarSourceRequest(id)
+  if (sidecarSource) {
+    return normalizeSourceId(sidecarSource.sourceId) === file
+  }
+  const sidecar = parseSidecarModuleId(id)
+  if (sidecar) {
+    return normalizeSourceId(sidecar.sourceId) === file
+  }
+  const logicalEntry = parseLogicalEntryId(id)
+  if (logicalEntry) {
+    return normalizeSourceId(logicalEntry.sourceId) === file
+  }
+  return normalizeSourceId(id) === file
+}
+
+export function collectBuildStartIds(context: BuildGraphContext, file: string) {
+  const ids = new Set<string>()
+  if (typeof context.getModuleIds !== 'function') {
+    return ids
+  }
+  for (const id of context.getModuleIds()) {
+    if (moduleIdMatchesFile(id, file)) {
+      ids.add(id)
+    }
+  }
+  return ids
+}
+
+export function collectDevStartNodes(server: DevServerGraphHost, file: string) {
+  const nodes = new Set<DevModuleNode>(server.moduleGraph.getModulesByFile(file) ?? [])
+  for (const [id, node] of server.moduleGraph.idToModuleMap ?? []) {
+    if (moduleIdMatchesFile(id, file)) {
+      nodes.add(node)
+    }
+  }
+  return nodes
+}

--- a/packages/weapp-vite/src/moduleGraph/types.ts
+++ b/packages/weapp-vite/src/moduleGraph/types.ts
@@ -1,0 +1,42 @@
+export interface BuildModuleInfo {
+  dynamicImporters?: readonly string[]
+  exports?: readonly string[]
+  importers?: readonly string[]
+  isEntry?: boolean
+}
+
+export interface BuildGraphContext {
+  getModuleIds?: () => Iterable<string>
+  getModuleInfo?: (id: string) => BuildModuleInfo | null | undefined
+  load?: (options: { id: string, resolveDependencies?: boolean }) => Promise<BuildModuleInfo>
+  resolve?: (
+    source: string,
+    importer?: string,
+    options?: { skipSelf?: boolean },
+  ) => Promise<{ id: string } | null>
+}
+
+export interface DevModuleNode {
+  file?: string | null
+  id?: string | null
+  importedModules?: Set<DevModuleNode>
+  importers?: Set<DevModuleNode>
+  url?: string
+}
+
+export interface DevModuleGraph {
+  getModuleById: (id: string) => DevModuleNode | undefined
+  getModulesByFile: (file: string) => Set<DevModuleNode> | undefined
+  idToModuleMap?: Map<string, DevModuleNode>
+  invalidateModule: (module: DevModuleNode) => void
+}
+
+export interface DevServerGraphHost {
+  moduleGraph: DevModuleGraph
+  transformRequest?: (url: string) => Promise<unknown>
+}
+
+export interface TopologyRescanRequest {
+  files: Set<string>
+  reasons: Set<string>
+}

--- a/packages/weapp-vite/src/plugins/core.test.ts
+++ b/packages/weapp-vite/src/plugins/core.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { createModuleGraphService } from '../moduleGraph'
 import { weappVite } from './core'
 
 const mocked = vi.hoisted(() => {
@@ -81,6 +82,7 @@ describe('weapp-vite:pre load', () => {
 
     const plugins = weappVite({
       currentBuildTarget: 'app',
+      moduleGraphService: createModuleGraphService(),
       configService: {
         absoluteSrcRoot: '/project/src',
         isDev: false,
@@ -107,6 +109,7 @@ describe('weapp-vite:pre load', () => {
 
     const plugins = weappVite({
       currentBuildTarget: 'app',
+      moduleGraphService: createModuleGraphService(),
       configService: {
         absoluteSrcRoot: '/project/src',
         isDev: false,

--- a/packages/weapp-vite/src/plugins/core/helpers/graph.test.ts
+++ b/packages/weapp-vite/src/plugins/core/helpers/graph.test.ts
@@ -1,12 +1,8 @@
 import type { OutputBundle, OutputChunk } from 'rolldown'
-import { describe, expect, it, vi } from 'vitest'
-import { normalizeFsResolvedId } from '../../../utils/resolvedId'
+import { describe, expect, it } from 'vitest'
+import { createLogicalEntryId } from '../../../moduleGraph/protocol'
 import {
-  collectAffectedEntries,
-  collectAffectedEntriesFromSharedChunks,
   collectAffectedSharedChunkEntriesAndChunks,
-  collectAffectedSharedChunks,
-  refreshModuleGraph,
   refreshPartialSharedChunkImporters,
   refreshSharedChunkImporters,
 } from './graph'
@@ -34,421 +30,41 @@ function createChunk(fileName: string, overrides: Partial<OutputChunk> = {}): Ou
 
 function createState() {
   return {
-    moduleImporters: new Map<string, Set<string>>(),
-    entryModuleIds: new Set<string>(),
     resolvedEntryMap: new Map<string, any>(),
     ctx: {
       configService: {
         absoluteSrcRoot: '/project/src',
       },
+      runtimeState: {
+        build: {
+          hmr: {
+            sharedChunkSourceModuleIds: new Set<string>(),
+          },
+        },
+      },
     },
     hmrSharedChunkImporters: new Map<string, Set<string>>(),
     hmrSharedChunksByEntry: new Map<string, Set<string>>(),
     hmrSharedChunkDependencies: new Map<string, Set<string>>(),
-    hmrSharedChunksByModule: new Map<string, Set<string>>(),
+    outputChunksByModule: new Map<string, Set<string>>(),
     hmrSourceSharedChunks: new Set<string>(),
   } as any
 }
 
-class ThrowOnIterateMap<K, V> extends Map<K, V> {
-  override entries() {
-    throw new Error('unexpected full map scan')
-  }
-
-  override [Symbol.iterator]() {
-    throw new Error('unexpected full map scan')
-  }
-}
-
-describe('core helpers graph', () => {
-  it('collects affected entries through importer graph traversal', () => {
+describe('core output graph', () => {
+  it('keeps logical source traversal out of output graph state', () => {
     const state = createState()
-    state.entryModuleIds = new Set(['/src/app.ts', '/src/admin.ts'])
-    state.resolvedEntryMap.set('/src/components/card.vue', { id: '/src/components/card.vue' })
-    state.moduleImporters = new Map<string, Set<string>>([
-      ['/src/shared.ts', new Set(['/src/mid.ts'])],
-      ['/src/mid.ts', new Set(['/src/app.ts', '/src/loop-a.ts'])],
-      ['/src/loop-a.ts', new Set(['/src/loop-b.ts'])],
-      ['/src/loop-b.ts', new Set(['/src/loop-a.ts'])],
-      ['/src/external-state.ts', new Set(['/src/components/card.vue'])],
-    ])
-
-    expect(collectAffectedEntries(state, '/src/shared.ts')).toEqual(new Set(['/src/app.ts']))
-    expect(collectAffectedEntries(state, '/src/external-state.ts')).toEqual(new Set(['/src/components/card.vue']))
-    expect(collectAffectedEntries(state, '/src/unknown.ts')).toEqual(new Set())
-  })
-
-  it('collects affected shared chunk entries and chunks in one pass', () => {
-    const state = createState()
-    const sharedModule = '/project/src/shared/tokens.ts'
-    const pageEntry = '/project/src/pages/index.ts'
-    const componentEntry = '/project/src/components/card/index.ts'
-    const unknownImporter = '/project/src/unused/importer.ts'
-    state.resolvedEntryMap.set(pageEntry, { value: true })
-    state.resolvedEntryMap.set(componentEntry, { value: true })
-    state.hmrSharedChunksByModule.set(sharedModule, new Set(['common.js', 'vendor.js']))
-    state.hmrSharedChunkImporters.set('common.js', new Set([pageEntry, unknownImporter]))
-    state.hmrSharedChunkImporters.set('vendor.js', new Set([pageEntry, componentEntry]))
-
-    const affected = collectAffectedSharedChunkEntriesAndChunks(state, sharedModule)
-
-    expect(affected.affectedEntries).toEqual(
-      collectAffectedEntriesFromSharedChunks(state, sharedModule),
-    )
-    expect(affected.affectedChunks).toEqual(
-      collectAffectedSharedChunks(state, sharedModule),
-    )
-    expect(affected.affectedEntries).toEqual(new Set([pageEntry, componentEntry]))
-    expect(affected.affectedChunks).toEqual(new Set(['common.js', 'vendor.js']))
-  })
-
-  it('refreshes module graph and skips virtual or node built-in ids', () => {
-    const state = createState()
-    state.moduleImporters.set('stale', new Set(['stale']))
-    state.entryModuleIds.add('stale')
-
-    refreshModuleGraph({}, state)
-    expect(state.moduleImporters.size).toBe(0)
-    expect(state.entryModuleIds.size).toBe(0)
-
-    const moduleInfoMap = new Map<string, any>([
-      ['/project/src/entry.ts?raw=1', {
-        isEntry: true,
-        importers: [],
-        dynamicImporters: [],
-      }],
-      ['/project/src/dep.ts', {
-        isEntry: false,
-        importers: [
-          '/@fs/project/src/entry.ts?x=1',
-          'node:path',
-          '\0virtual:skip',
-        ],
-        dynamicImporters: [
-          'file:///project/src/dynamic.ts',
-        ],
-      }],
-      ['/project/src/dynamic.ts', {
-        isEntry: false,
-      }],
-      ['/project/src/no-info.ts', undefined],
-    ])
-
-    refreshModuleGraph({
-      getModuleIds: () => [
-        '/project/src/entry.ts?raw=1',
-        '/project/src/dep.ts',
-        '/project/src/dynamic.ts',
-        '/project/src/no-info.ts',
-        '\0virtual:skip',
-        'node:fs',
-      ],
-      getModuleInfo: (id: string) => moduleInfoMap.get(id),
-    }, state)
-
-    expect(state.entryModuleIds).toEqual(new Set(['/project/src/entry.ts']))
-    const normalizedDynamicImporter = normalizeFsResolvedId('file:///project/src/dynamic.ts')
-    expect(state.moduleImporters.get('/project/src/dep.ts')).toEqual(
-      new Set(['/project/src/entry.ts', normalizedDynamicImporter]),
-    )
-    expect(state.moduleImporters.has('/project/src/dynamic.ts')).toBe(false)
-    expect(state.moduleImporters.has('\0virtual:skip')).toBe(false)
-  })
-
-  it('refreshes entry importers from inlined bundle modules', () => {
-    const state = createState()
-    const pageEntry = '/project/src/pages/root-import-hmr/index.vue'
-    const composable = '/project/src/shared/root-import-hmr.ts'
-    state.resolvedEntryMap.set(pageEntry, { id: pageEntry } as any)
-
-    refreshModuleGraph({
-      getModuleIds: () => [],
-      getModuleInfo: () => undefined,
-    }, state, {
-      'pages/root-import-hmr/index.js': {
-        type: 'chunk',
-        fileName: 'pages/root-import-hmr/index.js',
-        facadeModuleId: `\0vue:${pageEntry}?vue&type=script`,
-        moduleIds: [
-          composable,
-          `\0vue:${pageEntry}?vue&type=script`,
-        ],
-        modules: {
-          [composable]: { code: '', renderedExports: [], removedExports: [], renderedLength: 0, originalLength: 0 },
-        },
-      } as any,
-    })
-
-    expect(state.entryModuleIds).toContain(pageEntry)
-    expect(state.moduleImporters.get(composable)).toEqual(new Set([pageEntry]))
-  })
-
-  it('merges partial bundle entry importers without dropping unrelated entry dependencies', () => {
-    const state = createState()
-    const pageEntry = '/project/src/pages/root-import-hmr/index.vue'
-    const otherEntry = '/project/src/pages/other/index.vue'
-    const composable = '/project/src/shared/root-import-hmr.ts'
-    const otherDep = '/project/src/shared/other.ts'
-    const staleDep = '/project/src/shared/stale-root-import.ts'
-    state.resolvedEntryMap.set(pageEntry, { id: pageEntry } as any)
-    state.resolvedEntryMap.set(otherEntry, { id: otherEntry } as any)
-    state.entryModuleIds.add(pageEntry)
-    state.entryModuleIds.add(otherEntry)
-    state.moduleImporters.set(composable, new Set([pageEntry]))
-    state.moduleImporters.set(staleDep, new Set([pageEntry]))
-    state.moduleImporters.set(otherDep, new Set([otherEntry]))
-
-    refreshModuleGraph({
-      getModuleIds: () => [],
-      getModuleInfo: () => undefined,
-    }, state, {
-      'pages/root-import-hmr/index.js': {
-        type: 'chunk',
-        fileName: 'pages/root-import-hmr/index.js',
-        facadeModuleId: pageEntry,
-        moduleIds: [
-          pageEntry,
-          composable,
-        ],
-        modules: {
-          [pageEntry]: { code: '', renderedExports: [], removedExports: [], renderedLength: 0, originalLength: 0 },
-          [composable]: { code: '', renderedExports: [], removedExports: [], renderedLength: 0, originalLength: 0 },
-        },
-      } as any,
-    }, { mode: 'merge' })
-
-    expect(state.entryModuleIds).toEqual(new Set([pageEntry, otherEntry]))
-    expect(state.moduleImporters.get(composable)).toEqual(new Set([pageEntry]))
-    expect(state.moduleImporters.has(staleDep)).toBe(false)
-    expect(state.moduleImporters.get(otherDep)).toEqual(new Set([otherEntry]))
-  })
-
-  it('merges partial bundle entry importers using indexed stale dependency cleanup', () => {
-    const state = createState()
-    const pageEntry = '/project/src/pages/index.vue'
-    const otherEntry = '/project/src/pages/other.vue'
-    const nextDep = '/project/src/shared/next.ts'
-    const staleDepA = '/project/src/shared/stale-a.ts'
-    const staleDepB = '/project/src/shared/stale-b.ts'
-    const otherDep = '/project/src/shared/other.ts'
-    state.resolvedEntryMap.set(pageEntry, { id: pageEntry } as any)
-    state.resolvedEntryMap.set(otherEntry, { id: otherEntry } as any)
-    state.entryModuleIds.add(pageEntry)
-    state.entryModuleIds.add(otherEntry)
-    state.moduleImporters.set(staleDepA, new Set([pageEntry, otherEntry]))
-    state.moduleImporters.set(staleDepB, new Set([pageEntry]))
-    state.moduleImporters.set(otherDep, new Set([otherEntry]))
-
-    refreshModuleGraph({
-      getModuleIds: () => [],
-      getModuleInfo: () => undefined,
-    }, state, {
-      'pages/index.js': createChunk('pages/index.js', {
-        facadeModuleId: pageEntry,
-        moduleIds: [
-          pageEntry,
-          nextDep,
-        ],
-      }),
-      'pages/index-style.js': createChunk('pages/index-style.js', {
-        facadeModuleId: pageEntry,
-        moduleIds: [
-          pageEntry,
-          nextDep,
-        ],
-      }),
-    }, { mode: 'merge' })
-
-    expect(state.moduleImporters.get(staleDepA)).toEqual(new Set([otherEntry]))
-    expect(state.moduleImporters.has(staleDepB)).toBe(false)
-    expect(state.moduleImporters.get(otherDep)).toEqual(new Set([otherEntry]))
-    expect(state.moduleImporters.get(nextDep)).toEqual(new Set([pageEntry]))
-  })
-
-  it('keeps merge cleanup scoped to touched entries while preserving unrelated importer edges', () => {
-    const state = createState()
-    const pageEntry = '/project/src/pages/index.vue'
-    const otherEntry = '/project/src/pages/other.vue'
-    const nextDep = '/project/src/shared/next.ts'
-    const staleDep = '/project/src/shared/stale.ts'
-    const sharedDep = '/project/src/shared/reused.ts'
-    const otherDep = '/project/src/shared/other.ts'
-    state.resolvedEntryMap.set(pageEntry, { id: pageEntry } as any)
-    state.resolvedEntryMap.set(otherEntry, { id: otherEntry } as any)
-    state.entryModuleIds.add(pageEntry)
-    state.entryModuleIds.add(otherEntry)
-    state.moduleImporters.set(staleDep, new Set([pageEntry]))
-    state.moduleImporters.set(sharedDep, new Set([pageEntry, otherEntry]))
-    state.moduleImporters.set(otherDep, new Set([otherEntry]))
-
-    refreshModuleGraph({
-      getModuleIds: () => [],
-      getModuleInfo: () => undefined,
-    }, state, {
-      'pages/index.js': createChunk('pages/index.js', {
-        facadeModuleId: pageEntry,
-        moduleIds: [
-          pageEntry,
-          nextDep,
-        ],
-      }),
-    }, { mode: 'merge' })
-
-    expect(state.moduleImporters.has(staleDep)).toBe(false)
-    expect(state.moduleImporters.get(sharedDep)).toEqual(new Set([otherEntry]))
-    expect(state.moduleImporters.get(otherDep)).toEqual(new Set([otherEntry]))
-    expect(state.moduleImporters.get(nextDep)).toEqual(new Set([pageEntry]))
-  })
-
-  it('skips full plugin module graph scans during bundle-backed merge refreshes', () => {
-    const state = createState()
-    const pageEntry = '/project/src/pages/index.vue'
-    const nextDep = '/project/src/shared/next.ts'
-    const staleDep = '/project/src/shared/stale.ts'
-    const getModuleIds = vi.fn(() => {
-      throw new Error('getModuleIds should not be called during merge bundle refresh')
-    })
-    const getModuleInfo = vi.fn()
-    state.resolvedEntryMap.set(pageEntry, { id: pageEntry } as any)
-    state.entryModuleIds.add(pageEntry)
-    state.moduleImporters.set(staleDep, new Set([pageEntry]))
-
-    refreshModuleGraph({
-      getModuleIds,
-      getModuleInfo,
-    }, state, {
-      'pages/index.js': createChunk('pages/index.js', {
-        facadeModuleId: pageEntry,
-        moduleIds: [
-          pageEntry,
-          nextDep,
-        ],
-      }),
-    }, { mode: 'merge' })
-
-    expect(getModuleIds).not.toHaveBeenCalled()
-    expect(getModuleInfo).not.toHaveBeenCalled()
-    expect(state.moduleImporters.has(staleDep)).toBe(false)
-    expect(state.moduleImporters.get(nextDep)).toEqual(new Set([pageEntry]))
-  })
-
-  it('refreshes shared chunk importers from entry chunks only', () => {
-    const state = createState()
-    state.resolvedEntryMap.set('/project/src/virtual-entry.ts', {
-      value: true,
-    })
-    state.resolvedEntryMap.set('/project/src/layouts/default.vue', {
-      value: true,
-    })
-    state.resolvedEntryMap.set('/project/src/components/base-navbar/index.vue', {
-      value: true,
-    })
-
+    const pageEntry = '/project/src/pages/home/index.ts'
+    const sharedModule = '/project/src/shared/value.ts'
+    state.resolvedEntryMap.set(pageEntry, { id: pageEntry })
     const bundle: OutputBundle = {
-      'asset.txt': {
-        type: 'asset',
-        fileName: 'asset.txt',
-        source: 'asset',
-      } as any,
-      'entries/a.js': createChunk('entries/a.js', {
+      'pages/home/index.js': createChunk('pages/home/index.js', {
         isEntry: true,
-        facadeModuleId: '/project/src/pages/a.ts',
-        imports: ['chunks/shared.js', 'chunks/entry-like.js', 'chunks/missing.js'],
-        dynamicImports: ['chunks/lazy.js'],
+        facadeModuleId: createLogicalEntryId(pageEntry, 'page'),
+        moduleIds: [createLogicalEntryId(pageEntry, 'page'), pageEntry],
+        imports: ['common.js'],
       }),
-      'entries/virtual.js': createChunk('entries/virtual.js', {
-        isEntry: false,
-        facadeModuleId: '/project/src/virtual-entry.ts',
-        imports: ['chunks/shared.js'],
-      }),
-      'layouts/default.js': createChunk('layouts/default.js', {
-        isEntry: false,
-        facadeModuleId: null,
-        moduleIds: ['/project/src/layouts/default.vue'],
-        imports: ['chunks/shared.js'],
-      }),
-      'components/base-navbar/index.js': createChunk('components/base-navbar/index.js', {
-        isEntry: false,
-        facadeModuleId: null,
-        moduleIds: ['/project/src/components/base-navbar/index.vue'],
-        imports: ['chunks/shared.js'],
-      }),
-      'chunks/shared.js': createChunk('chunks/shared.js', {
-        facadeModuleId: '/project/src/chunks/shared.ts',
-      }),
-      'chunks/lazy.js': createChunk('chunks/lazy.js', {
-        facadeModuleId: '/project/src/chunks/lazy.ts',
-      }),
-      'chunks/entry-like.js': createChunk('chunks/entry-like.js', {
-        facadeModuleId: '/project/src/virtual-entry.ts',
-      }),
-      'chunks/no-facade.js': createChunk('chunks/no-facade.js', {
-        facadeModuleId: null,
-      }),
-    }
-
-    state.hmrSharedChunkImporters.set('stale', new Set(['/stale']))
-
-    refreshSharedChunkImporters(bundle, state)
-
-    expect(state.hmrSharedChunkImporters.has('stale')).toBe(false)
-    expect(state.hmrSharedChunkImporters.get('chunks/shared.js')).toEqual(
-      new Set([
-        '/project/src/pages/a.ts',
-        '/project/src/virtual-entry.ts',
-        '/project/src/layouts/default.vue',
-        '/project/src/components/base-navbar/index.vue',
-      ]),
-    )
-    expect(state.hmrSharedChunkImporters.get('chunks/lazy.js')).toEqual(
-      new Set(['/project/src/pages/a.ts']),
-    )
-    expect(state.hmrSharedChunksByEntry.get('/project/src/pages/a.ts')).toEqual(
-      new Set(['chunks/shared.js', 'chunks/lazy.js']),
-    )
-    expect(state.hmrSharedChunksByEntry.get('/project/src/virtual-entry.ts')).toEqual(
-      new Set(['chunks/shared.js']),
-    )
-    expect(state.hmrSharedChunkImporters.has('chunks/entry-like.js')).toBe(false)
-    expect(state.hmrSharedChunkImporters.has('chunks/missing.js')).toBe(false)
-    expect(state.hmrSourceSharedChunks).toEqual(new Set([
-      'entries/a.js',
-      'entries/virtual.js',
-      'layouts/default.js',
-      'components/base-navbar/index.js',
-      'chunks/shared.js',
-      'chunks/lazy.js',
-      'chunks/entry-like.js',
-    ]))
-  })
-
-  it('collects affected entries from shared chunk source module index', () => {
-    const state = createState()
-    const appEntry = '/project/src/app.ts'
-    const pageEntry = '/project/src/pages/native/index.ts'
-    const componentEntry = '/project/src/components/probe-card/index.ts'
-    const sharedModule = '/project/src/shared/tokens.ts'
-    state.resolvedEntryMap.set(appEntry, { value: true })
-    state.resolvedEntryMap.set(pageEntry, { value: true })
-    state.resolvedEntryMap.set(componentEntry, { value: true })
-
-    const bundle: OutputBundle = {
-      'app.js': createChunk('app.js', {
-        isEntry: true,
-        facadeModuleId: appEntry,
-        imports: ['./weapp-vendors/wevu-ref.js'],
-      }),
-      'pages/native/index.js': createChunk('pages/native/index.js', {
-        isEntry: true,
-        facadeModuleId: pageEntry,
-        imports: ['../../weapp-vendors/wevu-ref.js'],
-      }),
-      'components/probe-card/index.js': createChunk('components/probe-card/index.js', {
-        isEntry: false,
-        moduleIds: [componentEntry],
-        imports: ['../../weapp-vendors/wevu-ref.js'],
-      }),
-      'weapp-vendors/wevu-ref.js': createChunk('weapp-vendors/wevu-ref.js', {
+      'common.js': createChunk('common.js', {
         moduleIds: [sharedModule],
         modules: {
           [sharedModule]: {} as any,
@@ -458,349 +74,93 @@ describe('core helpers graph', () => {
 
     refreshSharedChunkImporters(bundle, state)
 
-    expect(state.hmrSharedChunksByModule.get(sharedModule)).toEqual(
-      new Set(['weapp-vendors/wevu-ref.js']),
-    )
-    expect(collectAffectedEntriesFromSharedChunks(state, sharedModule)).toEqual(
-      new Set([appEntry, pageEntry, componentEntry]),
-    )
-    expect(collectAffectedSharedChunks(state, sharedModule)).toEqual(
-      new Set(['weapp-vendors/wevu-ref.js']),
-    )
+    expect(state.hmrSharedChunkImporters.get('common.js')).toEqual(new Set([pageEntry]))
+    expect(state.outputChunksByModule.get(sharedModule)).toEqual(new Set(['common.js']))
+    expect(state).not.toHaveProperty('moduleImporters')
+    expect(state).not.toHaveProperty('entryModuleIds')
   })
 
-  it('propagates shared chunk importers through intermediate shared chunks', () => {
+  it('collects affected emitted chunks and their source entries in one pass', () => {
     const state = createState()
-    state.resolvedEntryMap.set('/project/src/app.ts', { value: true })
-    state.resolvedEntryMap.set('/project/src/pages/hmr/index.ts', { value: true })
-
-    const bundle: OutputBundle = {
-      'app.js': createChunk('app.js', {
-        isEntry: true,
-        facadeModuleId: '/project/src/app.ts',
-        imports: ['./weapp-vendors/wevu-ref.js'],
-      }),
-      'pages/hmr/index.js': createChunk('pages/hmr/index.js', {
-        isEntry: true,
-        facadeModuleId: '/project/src/pages/hmr/index.ts',
-        imports: ['../../common.js'],
-      }),
-      'common.js': createChunk('common.js', {
-        imports: ['./weapp-vendors/wevu-ref.js'],
-      }),
-      'weapp-vendors/wevu-ref.js': createChunk('weapp-vendors/wevu-ref.js'),
-    }
-
-    refreshSharedChunkImporters(bundle, state)
-
-    expect(state.hmrSharedChunkImporters.get('common.js')).toEqual(
-      new Set(['/project/src/pages/hmr/index.ts']),
-    )
-    expect(state.hmrSharedChunkImporters.get('weapp-vendors/wevu-ref.js')).toEqual(
-      new Set(['/project/src/app.ts', '/project/src/pages/hmr/index.ts']),
-    )
-  })
-
-  it('preserves existing shared chunk importers when partial emits omit unchanged shared chunks', () => {
-    const state = createState()
-    state.resolvedEntryMap.set('/project/src/pages/issue-398.vue', { value: true })
-    state.resolvedEntryMap.set('/project/src/components/base-navbar.vue', { value: true })
-    state.resolvedEntryMap.set('/project/src/components/base-footer.vue', { value: true })
-    state.hmrSharedChunkImporters.set('chunks/runtime.js', new Set([
-      '/project/src/pages/issue-398.vue',
-      '/project/src/components/base-navbar.vue',
-      '/project/src/components/base-footer.vue',
-    ]))
-
-    const partialBundle: OutputBundle = {
-      'components/base-navbar.js': createChunk('components/base-navbar.js', {
-        moduleIds: ['/project/src/components/base-navbar.vue'],
-        imports: ['chunks/runtime.js'],
-      }),
-    }
-
-    refreshPartialSharedChunkImporters(partialBundle, state, new Set(['/project/src/components/base-navbar.vue']))
-
-    expect(state.hmrSharedChunkImporters.get('chunks/runtime.js')).toEqual(
-      new Set([
-        '/project/src/pages/issue-398.vue',
-        '/project/src/components/base-navbar.vue',
-        '/project/src/components/base-footer.vue',
-      ]),
-    )
-    expect(state.hmrSharedChunksByEntry.get('/project/src/components/base-navbar.vue')).toEqual(
-      new Set(['chunks/runtime.js']),
-    )
-  })
-
-  it('clears partial shared chunk importers through entry chunk index', () => {
-    const state = createState()
-    const pageEntry = '/project/src/pages/hmr/index.ts'
-    const otherEntry = '/project/src/pages/other/index.ts'
-    state.resolvedEntryMap.set(pageEntry, { value: true })
-    state.resolvedEntryMap.set(otherEntry, { value: true })
-    state.hmrSharedChunkImporters.set('common.js', new Set([pageEntry, otherEntry]))
-    state.hmrSharedChunkImporters.set('weapp-vendors/runtime.js', new Set([pageEntry]))
-    state.hmrSharedChunkImporters.set('unrelated.js', new Set([otherEntry]))
-    state.hmrSharedChunksByEntry.set(pageEntry, new Set(['common.js', 'weapp-vendors/runtime.js']))
-    state.hmrSharedChunksByEntry.set(otherEntry, new Set(['common.js', 'unrelated.js']))
-    state.hmrSharedChunkDependencies.set('common.js', new Set(['weapp-vendors/runtime.js']))
-    state.hmrSharedChunkDependencies.set('weapp-vendors/runtime.js', new Set())
-    state.hmrSharedChunkDependencies.set('unrelated.js', new Set())
-
-    const partialBundle: OutputBundle = {
-      'pages/hmr/index.js': createChunk('pages/hmr/index.js', {
-        isEntry: true,
-        facadeModuleId: pageEntry,
-        imports: ['../../common.js'],
-      }),
-      'common.js': createChunk('common.js', {
-        imports: ['./weapp-vendors/runtime.js'],
-      }),
-      'weapp-vendors/runtime.js': createChunk('weapp-vendors/runtime.js'),
-    }
-
-    refreshPartialSharedChunkImporters(partialBundle, state, new Set([pageEntry]))
-
-    expect(state.hmrSharedChunkImporters.get('common.js')).toEqual(new Set([otherEntry, pageEntry]))
-    expect(state.hmrSharedChunkImporters.get('weapp-vendors/runtime.js')).toEqual(new Set([pageEntry]))
-    expect(state.hmrSharedChunkImporters.get('unrelated.js')).toEqual(new Set([otherEntry]))
-    expect(state.hmrSharedChunksByEntry.get(pageEntry)).toEqual(
-      new Set(['common.js', 'weapp-vendors/runtime.js']),
-    )
-    expect(state.hmrSharedChunksByEntry.get(otherEntry)).toEqual(
-      new Set(['common.js', 'unrelated.js']),
-    )
-  })
-
-  it('snapshots indexed partial shared chunks without scanning unrelated importer maps', () => {
-    const state = createState()
-    const pageEntry = '/project/src/pages/hmr/index.ts'
-    const otherEntry = '/project/src/pages/other/index.ts'
-    state.resolvedEntryMap.set(pageEntry, { value: true })
-    state.resolvedEntryMap.set(otherEntry, { value: true })
-    state.hmrSharedChunkImporters = new ThrowOnIterateMap([
-      ['common.js', new Set([pageEntry, otherEntry])],
-      ['weapp-vendors/runtime.js', new Set([pageEntry])],
-      ['unrelated.js', new Set([otherEntry])],
-    ])
-    state.hmrSharedChunksByEntry.set(pageEntry, new Set(['common.js', 'weapp-vendors/runtime.js']))
-    state.hmrSharedChunksByEntry.set(otherEntry, new Set(['common.js', 'unrelated.js']))
-    state.hmrSharedChunkDependencies = new ThrowOnIterateMap([
-      ['common.js', new Set(['weapp-vendors/runtime.js'])],
-      ['weapp-vendors/runtime.js', new Set()],
-      ['unrelated.js', new Set()],
-    ])
-
-    const partialBundle: OutputBundle = {
-      'pages/hmr/index.js': createChunk('pages/hmr/index.js', {
-        isEntry: true,
-        facadeModuleId: pageEntry,
-        imports: ['../../common.js'],
-      }),
-      'common.js': createChunk('common.js', {
-        imports: ['./weapp-vendors/runtime.js'],
-      }),
-    }
-
-    refreshPartialSharedChunkImporters(partialBundle, state, new Set([pageEntry]))
-
-    expect(state.hmrSharedChunkImporters.get('common.js')).toEqual(new Set([otherEntry, pageEntry]))
-    expect(state.hmrSharedChunkImporters.get('weapp-vendors/runtime.js')).toEqual(new Set([pageEntry]))
-    expect(state.hmrSharedChunkImporters.get('unrelated.js')).toEqual(new Set([otherEntry]))
-  })
-
-  it('refreshes module index for chunks included in partial refreshes', () => {
-    const state = createState()
-    const entry = '/project/src/pages/hmr/index.ts'
-    const previousModule = '/project/src/shared/previous.ts'
-    const nextModule = '/project/src/shared/next.ts'
-    state.resolvedEntryMap.set(entry, { value: true })
-    state.hmrSharedChunkImporters.set('common.js', new Set([entry]))
-    state.hmrSharedChunksByModule.set(previousModule, new Set(['common.js']))
-
-    const partialBundle: OutputBundle = {
-      'pages/hmr/index.js': createChunk('pages/hmr/index.js', {
-        isEntry: true,
-        facadeModuleId: entry,
-        imports: ['../../common.js'],
-      }),
-      'common.js': createChunk('common.js', {
-        moduleIds: [nextModule],
-      }),
-    }
-
-    refreshPartialSharedChunkImporters(partialBundle, state, new Set([entry]))
-
-    expect(state.hmrSharedChunksByModule.has(previousModule)).toBe(false)
-    expect(state.hmrSharedChunksByModule.get(nextModule)).toEqual(new Set(['common.js']))
-  })
-
-  it('replaces stale module ownership when partial refresh includes shared chunk metadata', () => {
-    const state = createState()
-    const entry = '/project/src/pages/hmr/index.ts'
-    const previousModule = '/project/src/shared/previous.ts'
-    const nextModule = '/project/src/shared/next.ts'
-    state.resolvedEntryMap.set(entry, { value: true })
-    state.hmrSharedChunkImporters.set('common.js', new Set([entry]))
-    state.hmrSharedChunksByModule.set(previousModule, new Set(['common.js']))
-    state.hmrSharedChunksByModule.set(nextModule, new Set(['legacy-common.js']))
-
-    const partialBundle: OutputBundle = {
-      'pages/hmr/index.js': createChunk('pages/hmr/index.js', {
-        isEntry: true,
-        facadeModuleId: entry,
-        imports: ['../../common.js'],
-      }),
-      'common.js': createChunk('common.js', {
-        moduleIds: [nextModule],
-      }),
-    }
-
-    refreshPartialSharedChunkImporters(partialBundle, state, new Set([entry]))
-
-    expect(state.hmrSharedChunksByModule.has(previousModule)).toBe(false)
-    expect(state.hmrSharedChunksByModule.get(nextModule)).toEqual(
-      new Set(['legacy-common.js', 'common.js']),
-    )
-  })
-
-  it('prunes shared chunk module ownership through chunk module index', () => {
-    const state = createState()
-    const entry = '/project/src/pages/hmr/index.ts'
-    const staleCommonModule = '/project/src/shared/common-stale.ts'
-    const nextCommonModule = '/project/src/shared/common-next.ts'
-    const vendorModule = '/project/src/shared/vendor.ts'
-    state.resolvedEntryMap.set(entry, { value: true })
-    state.hmrSharedChunksByModule.set(staleCommonModule, new Set(['common.js']))
-    state.hmrSharedChunksByModule.set(nextCommonModule, new Set(['legacy-common.js']))
-    state.hmrSharedChunksByModule.set(vendorModule, new Set(['weapp-vendors/vendor.js']))
-
-    const partialBundle: OutputBundle = {
-      'pages/hmr/index.js': createChunk('pages/hmr/index.js', {
-        isEntry: true,
-        facadeModuleId: entry,
-        imports: ['../../common.js'],
-      }),
-      'common.js': createChunk('common.js', {
-        moduleIds: [nextCommonModule],
-        imports: ['./weapp-vendors/vendor.js'],
-      }),
-      'weapp-vendors/vendor.js': createChunk('weapp-vendors/vendor.js'),
-    }
-
-    refreshPartialSharedChunkImporters(partialBundle, state, new Set([entry]))
-
-    expect(state.hmrSharedChunksByModule.has(staleCommonModule)).toBe(false)
-    expect(state.hmrSharedChunksByModule.get(nextCommonModule)).toEqual(
-      new Set(['legacy-common.js', 'common.js']),
-    )
-    expect(state.hmrSharedChunksByModule.get(vendorModule)).toEqual(
-      new Set(['weapp-vendors/vendor.js']),
-    )
-  })
-
-  it('preserves module index when partial refresh includes shared chunk shell without module metadata', () => {
-    const state = createState()
-    const entry = '/project/src/pages/hmr/index.ts'
+    const pageEntry = '/project/src/pages/index.ts'
+    const componentEntry = '/project/src/components/card/index.ts'
     const sharedModule = '/project/src/shared/tokens.ts'
-    state.resolvedEntryMap.set(entry, { value: true })
-    state.hmrSharedChunkImporters.set('common.js', new Set([entry]))
-    state.hmrSharedChunksByModule.set(sharedModule, new Set(['common.js']))
-    state.hmrSourceSharedChunks.add('common.js')
+    state.resolvedEntryMap.set(pageEntry, { id: pageEntry })
+    state.resolvedEntryMap.set(componentEntry, { id: componentEntry })
+    state.outputChunksByModule.set(sharedModule, new Set(['common.js', 'vendor.js']))
+    state.hmrSharedChunkImporters.set('common.js', new Set([pageEntry]))
+    state.hmrSharedChunkImporters.set('vendor.js', new Set([pageEntry, componentEntry]))
 
-    const partialBundle: OutputBundle = {
-      'pages/hmr/index.js': createChunk('pages/hmr/index.js', {
-        isEntry: true,
-        facadeModuleId: entry,
-        imports: ['../../common.js'],
-      }),
-      'common.js': createChunk('common.js'),
-    }
-
-    refreshPartialSharedChunkImporters(partialBundle, state, new Set([entry]))
-
-    expect(state.hmrSharedChunksByModule.get(sharedModule)).toEqual(new Set(['common.js']))
-    expect(state.hmrSourceSharedChunks.has('common.js')).toBe(true)
+    expect(collectAffectedSharedChunkEntriesAndChunks(state, sharedModule)).toEqual({
+      affectedChunks: new Set(['common.js', 'vendor.js']),
+      affectedEntries: new Set([pageEntry, componentEntry]),
+    })
   })
 
-  it('preserves transitive shared chunk importers when partial emits omit nested shared chunks', () => {
+  it('propagates entry ownership through nested output chunk imports', () => {
     const state = createState()
-    const appEntry = '/project/src/app.ts'
-    const pageEntry = '/project/src/pages/hmr/index.ts'
-    state.resolvedEntryMap.set(appEntry, { value: true })
-    state.resolvedEntryMap.set(pageEntry, { value: true })
-    state.hmrSharedChunkImporters.set('common.js', new Set([pageEntry]))
-    state.hmrSharedChunkImporters.set('weapp-vendors/wevu-ref.js', new Set([appEntry, pageEntry]))
-
-    const partialBundle: OutputBundle = {
-      'pages/hmr/index.js': createChunk('pages/hmr/index.js', {
+    const pageEntry = '/project/src/pages/index.ts'
+    state.resolvedEntryMap.set(pageEntry, { id: pageEntry })
+    refreshSharedChunkImporters({
+      'pages/index.js': createChunk('pages/index.js', {
         isEntry: true,
-        facadeModuleId: pageEntry,
-        imports: ['../../common.js'],
+        facadeModuleId: createLogicalEntryId(pageEntry, 'page'),
+        imports: ['common.js'],
       }),
-      'common.js': createChunk('common.js', {
-        imports: ['./weapp-vendors/wevu-ref.js'],
-      }),
-    }
-
-    refreshPartialSharedChunkImporters(partialBundle, state, new Set([pageEntry]))
+      'common.js': createChunk('common.js', { imports: ['vendor.js'] }),
+      'vendor.js': createChunk('vendor.js'),
+    }, state)
 
     expect(state.hmrSharedChunkImporters.get('common.js')).toEqual(new Set([pageEntry]))
-    expect(state.hmrSharedChunkImporters.get('weapp-vendors/wevu-ref.js')).toEqual(
-      new Set([appEntry, pageEntry]),
-    )
+    expect(state.hmrSharedChunkImporters.get('vendor.js')).toEqual(new Set([pageEntry]))
   })
 
-  it('preserves nested shared chunk importers when partial emits omit the intermediate shared chunk', () => {
+  it('refreshes partial output membership without dropping unrelated entries', () => {
     const state = createState()
-    const appEntry = '/project/src/app.ts'
-    const componentEntry = '/project/src/components/issue-446/ShortBindProbe/index.vue'
-    state.resolvedEntryMap.set(appEntry, { value: true })
-    state.resolvedEntryMap.set(componentEntry, { value: true })
-    state.hmrSharedChunkImporters.set('weapp-vendors/wevu-src.js', new Set([componentEntry]))
-    state.hmrSharedChunkImporters.set('weapp-vendors/wevu-ref.js', new Set([appEntry, componentEntry]))
-    state.hmrSharedChunkDependencies.set(
-      'weapp-vendors/wevu-src.js',
-      new Set(['weapp-vendors/wevu-ref.js']),
-    )
+    const pageEntry = '/project/src/pages/index.ts'
+    const otherEntry = '/project/src/pages/other.ts'
+    state.resolvedEntryMap.set(pageEntry, { id: pageEntry })
+    state.resolvedEntryMap.set(otherEntry, { id: otherEntry })
+    state.hmrSharedChunkImporters.set('common.js', new Set([pageEntry, otherEntry]))
+    state.hmrSharedChunksByEntry.set(pageEntry, new Set(['common.js']))
+    state.hmrSharedChunksByEntry.set(otherEntry, new Set(['common.js']))
 
-    const partialBundle: OutputBundle = {
-      'components/issue-446/ShortBindProbe/index.js': createChunk('components/issue-446/ShortBindProbe/index.js', {
-        moduleIds: [componentEntry],
-        imports: ['../../../weapp-vendors/wevu-src.js'],
+    refreshPartialSharedChunkImporters({
+      'pages/index.js': createChunk('pages/index.js', {
+        isEntry: true,
+        facadeModuleId: createLogicalEntryId(pageEntry, 'page'),
+        imports: ['next-common.js'],
       }),
-    }
+      'next-common.js': createChunk('next-common.js'),
+    }, state, new Set([pageEntry]))
 
-    refreshPartialSharedChunkImporters(partialBundle, state, new Set([componentEntry]))
-
-    expect(state.hmrSharedChunkImporters.get('weapp-vendors/wevu-src.js')).toEqual(
-      new Set([componentEntry]),
-    )
-    expect(state.hmrSharedChunkImporters.get('weapp-vendors/wevu-ref.js')).toEqual(
-      new Set([appEntry, componentEntry]),
-    )
-    expect(state.hmrSharedChunksByEntry.get(componentEntry)).toEqual(
-      new Set(['weapp-vendors/wevu-src.js', 'weapp-vendors/wevu-ref.js']),
-    )
+    expect(state.hmrSharedChunkImporters.get('common.js')).toEqual(new Set([otherEntry]))
+    expect(state.hmrSharedChunkImporters.get('next-common.js')).toEqual(new Set([pageEntry]))
   })
 
-  it('keeps existing shared chunk importers when partial bundle omits unchanged entry chunks', () => {
+  it('replaces stale module-to-output membership on partial refresh', () => {
     const state = createState()
-    const appEntry = '/project/src/app.ts'
-    const pageEntry = '/project/src/pages/hmr/index.ts'
-    state.resolvedEntryMap.set(appEntry, { value: true })
-    state.resolvedEntryMap.set(pageEntry, { value: true })
-    state.hmrSharedChunkImporters.set('weapp-vendors/wevu-ref.js', new Set([appEntry, pageEntry]))
+    const pageEntry = '/project/src/pages/index.ts'
+    const staleModule = '/project/src/shared/stale.ts'
+    const nextModule = '/project/src/shared/next.ts'
+    state.resolvedEntryMap.set(pageEntry, { id: pageEntry })
+    state.outputChunksByModule.set(staleModule, new Set(['common.js']))
+    state.hmrSharedChunkImporters.set('common.js', new Set([pageEntry]))
+    state.hmrSharedChunksByEntry.set(pageEntry, new Set(['common.js']))
 
-    const partialBundle: OutputBundle = {
-      'weapp-vendors/wevu-ref.js': createChunk('weapp-vendors/wevu-ref.js'),
-    }
+    refreshPartialSharedChunkImporters({
+      'pages/index.js': createChunk('pages/index.js', {
+        isEntry: true,
+        facadeModuleId: createLogicalEntryId(pageEntry, 'page'),
+        imports: ['common.js'],
+      }),
+      'common.js': createChunk('common.js', {
+        moduleIds: [nextModule],
+        modules: { [nextModule]: {} as any },
+      }),
+    }, state, new Set([pageEntry]))
 
-    refreshPartialSharedChunkImporters(partialBundle, state, new Set([pageEntry]))
-
-    expect(state.hmrSharedChunkImporters.get('weapp-vendors/wevu-ref.js')).toEqual(
-      new Set([appEntry, pageEntry]),
-    )
+    expect(state.outputChunksByModule.has(staleModule)).toBe(false)
+    expect(state.outputChunksByModule.get(nextModule)).toEqual(new Set(['common.js']))
   })
 })

--- a/packages/weapp-vite/src/plugins/core/helpers/graph.ts
+++ b/packages/weapp-vite/src/plugins/core/helpers/graph.ts
@@ -1,43 +1,17 @@
 import type { OutputBundle, OutputChunk } from 'rolldown'
 import type { CorePluginState } from './types'
 import path from 'pathe'
+import { parseLogicalEntryId } from '../../../moduleGraph/protocol'
 import { isSkippableResolvedId, normalizeFsResolvedId } from '../../../utils/resolvedId'
 
-export function collectAffectedEntries(state: CorePluginState, startId: string) {
-  const affected = new Set<string>()
-  const visited = new Set<string>()
-  const queue: string[] = [startId]
-
-  while (queue.length) {
-    const current = queue.shift()!
-    if (visited.has(current)) {
-      continue
-    }
-    visited.add(current)
-
-    if (state.entryModuleIds.has(current) || state.resolvedEntryMap.has(current)) {
-      affected.add(current)
-      continue
-    }
-
-    const importers = state.moduleImporters.get(current)
-    if (!importers || importers.size === 0) {
-      continue
-    }
-
-    for (const importer of importers) {
-      if (!visited.has(importer)) {
-        queue.push(importer)
-      }
-    }
-  }
-
-  return affected
+function resolveSourceEntryId(rawId: string) {
+  const logicalEntry = parseLogicalEntryId(rawId)
+  return normalizeFsResolvedId(logicalEntry?.sourceId ?? rawId)
 }
 
 export function collectAffectedEntriesFromSharedChunks(state: CorePluginState, startId: string) {
   const affected = new Set<string>()
-  const chunkIds = state.hmrSharedChunksByModule.get(normalizeFsResolvedId(startId))
+  const chunkIds = state.outputChunksByModule.get(normalizeFsResolvedId(startId))
   if (!chunkIds?.size) {
     return affected
   }
@@ -59,7 +33,7 @@ export function collectAffectedEntriesFromSharedChunks(state: CorePluginState, s
 
 export function collectAffectedSharedChunks(state: CorePluginState, startId: string) {
   const affected = new Set<string>()
-  const chunkIds = state.hmrSharedChunksByModule.get(normalizeFsResolvedId(startId))
+  const chunkIds = state.outputChunksByModule.get(normalizeFsResolvedId(startId))
   if (!chunkIds?.size) {
     return affected
   }
@@ -74,7 +48,7 @@ export function collectAffectedSharedChunks(state: CorePluginState, startId: str
 export function collectAffectedSharedChunkEntriesAndChunks(state: CorePluginState, startId: string) {
   const affectedEntries = new Set<string>()
   const affectedChunks = new Set<string>()
-  const chunkIds = state.hmrSharedChunksByModule.get(normalizeFsResolvedId(startId))
+  const chunkIds = state.outputChunksByModule.get(normalizeFsResolvedId(startId))
   if (!chunkIds?.size) {
     return {
       affectedChunks,
@@ -101,27 +75,6 @@ export function collectAffectedSharedChunkEntriesAndChunks(state: CorePluginStat
   }
 }
 
-function createModulesByImporter(
-  moduleImporters: Map<string, Set<string>>,
-  onlyImporterIds?: Set<string>,
-) {
-  const modulesByImporter = new Map<string, Set<string>>()
-  for (const [moduleId, importers] of moduleImporters) {
-    for (const importerId of importers) {
-      if (onlyImporterIds && !onlyImporterIds.has(importerId)) {
-        continue
-      }
-      let modules = modulesByImporter.get(importerId)
-      if (!modules) {
-        modules = new Set<string>()
-        modulesByImporter.set(importerId, modules)
-      }
-      modules.add(moduleId)
-    }
-  }
-  return modulesByImporter
-}
-
 function createSharedModulesByChunk(sharedChunksByModule: Map<string, Set<string>>) {
   const modulesByChunk = new Map<string, Set<string>>()
   for (const [moduleId, chunkIds] of sharedChunksByModule) {
@@ -135,162 +88,6 @@ function createSharedModulesByChunk(sharedChunksByModule: Map<string, Set<string
     }
   }
   return modulesByChunk
-}
-
-export function refreshModuleGraph(
-  pluginCtx: { getModuleIds?: () => Iterable<string>, getModuleInfo?: (id: string) => any },
-  state: CorePluginState,
-  bundle?: OutputBundle,
-  options?: { mode?: 'replace' | 'merge' },
-) {
-  const mode = options?.mode ?? 'replace'
-  if (mode === 'replace') {
-    state.moduleImporters.clear()
-    state.entryModuleIds.clear()
-  }
-
-  const addModuleImporter = (moduleId: string, importerId: string) => {
-    const normalizedModuleId = normalizeFsResolvedId(moduleId)
-    const normalizedImporterId = normalizeFsResolvedId(importerId)
-    if (
-      normalizedModuleId === normalizedImporterId
-      || isSkippableResolvedId(normalizedModuleId)
-      || isSkippableResolvedId(normalizedImporterId)
-    ) {
-      return
-    }
-    const importers = state.moduleImporters.get(normalizedModuleId) ?? new Set<string>()
-    importers.add(normalizedImporterId)
-    state.moduleImporters.set(normalizedModuleId, importers)
-  }
-  const removeEntryImporter = (entryId: string, modulesByImporter?: Map<string, Set<string>>) => {
-    const normalizedEntryId = normalizeFsResolvedId(entryId)
-    const moduleIds = modulesByImporter?.get(normalizedEntryId)
-    if (moduleIds) {
-      for (const moduleId of moduleIds) {
-        const importers = state.moduleImporters.get(moduleId)
-        if (!importers) {
-          continue
-        }
-        importers.delete(normalizedEntryId)
-        if (!importers.size) {
-          state.moduleImporters.delete(moduleId)
-        }
-      }
-      return
-    }
-    for (const [moduleId, importers] of state.moduleImporters) {
-      importers.delete(normalizedEntryId)
-      if (!importers.size) {
-        state.moduleImporters.delete(moduleId)
-      }
-    }
-  }
-  const collectChunkModuleIds = (chunk: OutputChunk) => {
-    const moduleIds = new Set<string>()
-    if (Array.isArray(chunk.moduleIds)) {
-      for (const moduleId of chunk.moduleIds) {
-        moduleIds.add(moduleId)
-      }
-    }
-    for (const moduleId of Object.keys(chunk.modules ?? {})) {
-      moduleIds.add(moduleId)
-    }
-    return moduleIds
-  }
-  const collectChunkEntryIds = (chunk: OutputChunk, moduleIds: Set<string>) => {
-    const entryIds = new Set<string>()
-    const addEntryIfTracked = (rawId?: string | null) => {
-      if (!rawId) {
-        return
-      }
-      const entryId = normalizeFsResolvedId(rawId)
-      if (!isSkippableResolvedId(entryId) && state.resolvedEntryMap.has(entryId)) {
-        entryIds.add(entryId)
-      }
-    }
-
-    addEntryIfTracked(chunk.facadeModuleId)
-    for (const moduleId of moduleIds) {
-      addEntryIfTracked(moduleId)
-    }
-
-    return entryIds
-  }
-
-  const shouldScanPluginModuleGraph = mode === 'replace' || !bundle
-  if (
-    shouldScanPluginModuleGraph
-    && typeof pluginCtx.getModuleIds === 'function'
-    && typeof pluginCtx.getModuleInfo === 'function'
-  ) {
-    for (const rawId of pluginCtx.getModuleIds()) {
-      const normalizedId = normalizeFsResolvedId(rawId)
-      if (isSkippableResolvedId(normalizedId)) {
-        continue
-      }
-
-      const info = pluginCtx.getModuleInfo(rawId)
-      if (!info) {
-        continue
-      }
-
-      if (info.isEntry) {
-        state.entryModuleIds.add(normalizedId)
-      }
-
-      const importerIds: string[] = []
-      if (Array.isArray(info.importers)) {
-        importerIds.push(...info.importers)
-      }
-      if (Array.isArray(info.dynamicImporters)) {
-        importerIds.push(...info.dynamicImporters)
-      }
-      for (const importer of importerIds) {
-        addModuleImporter(normalizedId, importer)
-      }
-    }
-  }
-
-  if (!bundle) {
-    return
-  }
-
-  const chunkRecords: Array<{ chunk: OutputChunk, entryIds: Set<string>, moduleIds: Set<string> }> = []
-  for (const output of Object.values(bundle)) {
-    if (output?.type !== 'chunk') {
-      continue
-    }
-    const chunk = output as OutputChunk
-    const moduleIds = collectChunkModuleIds(chunk)
-    const entryIds = collectChunkEntryIds(chunk, moduleIds)
-    if (!entryIds.size) {
-      continue
-    }
-    chunkRecords.push({ chunk, entryIds, moduleIds })
-  }
-
-  if (mode === 'merge') {
-    const removedEntryIds = new Set<string>()
-    for (const { entryIds } of chunkRecords) {
-      for (const entryId of entryIds) {
-        removedEntryIds.add(entryId)
-      }
-    }
-    const modulesByImporter = createModulesByImporter(state.moduleImporters, removedEntryIds)
-    for (const entryId of removedEntryIds) {
-      removeEntryImporter(entryId, modulesByImporter)
-    }
-  }
-
-  for (const { entryIds, moduleIds } of chunkRecords) {
-    for (const entryId of entryIds) {
-      state.entryModuleIds.add(entryId)
-      for (const moduleId of moduleIds) {
-        addModuleImporter(moduleId, entryId)
-      }
-    }
-  }
 }
 
 function appendSharedChunkImporters(
@@ -329,7 +126,7 @@ function appendSharedChunkImporters(
     const trackedImporterIds = new Set<string>()
 
     if (chunk.facadeModuleId) {
-      const entryId = normalizeFsResolvedId(chunk.facadeModuleId)
+      const entryId = resolveSourceEntryId(chunk.facadeModuleId)
       if (chunk.isEntry || state.resolvedEntryMap.has(entryId)) {
         trackedImporterIds.add(entryId)
       }
@@ -337,7 +134,7 @@ function appendSharedChunkImporters(
 
     if (Array.isArray(chunk.moduleIds)) {
       for (const moduleId of chunk.moduleIds) {
-        const normalizedModuleId = normalizeFsResolvedId(moduleId)
+        const normalizedModuleId = resolveSourceEntryId(moduleId)
         if (state.resolvedEntryMap.has(normalizedModuleId)) {
           trackedImporterIds.add(normalizedModuleId)
         }
@@ -382,15 +179,15 @@ function appendSharedChunkImporters(
   }
   const addSharedChunkModule = (moduleId: string, chunkId: string) => {
     state.ctx.runtimeState?.build?.hmr?.sharedChunkSourceModuleIds?.add(moduleId)
-    const current = state.hmrSharedChunksByModule.get(moduleId)
+    const current = state.outputChunksByModule.get(moduleId)
     if (current) {
       current.add(chunkId)
     }
     else {
-      state.hmrSharedChunksByModule.set(moduleId, new Set([chunkId]))
+      state.outputChunksByModule.set(moduleId, new Set([chunkId]))
     }
   }
-  const previousSharedModulesByChunk = createSharedModulesByChunk(state.hmrSharedChunksByModule)
+  const previousSharedModulesByChunk = createSharedModulesByChunk(state.outputChunksByModule)
   const pruneSharedChunkModules = (chunkId: string, nextModuleIds: Set<string>) => {
     if (!nextModuleIds.size) {
       return
@@ -403,13 +200,13 @@ function appendSharedChunkImporters(
       if (nextModuleIds.has(moduleId)) {
         continue
       }
-      const chunkIds = state.hmrSharedChunksByModule.get(moduleId)
+      const chunkIds = state.outputChunksByModule.get(moduleId)
       if (!chunkIds) {
         continue
       }
       chunkIds.delete(chunkId)
       if (chunkIds.size === 0) {
-        state.hmrSharedChunksByModule.delete(moduleId)
+        state.outputChunksByModule.delete(moduleId)
       }
     }
   }
@@ -592,7 +389,7 @@ export function refreshSharedChunkImporters(bundle: OutputBundle, state: CorePlu
   state.hmrSharedChunkImporters.clear()
   state.hmrSharedChunksByEntry.clear()
   state.hmrSharedChunkDependencies.clear()
-  state.hmrSharedChunksByModule.clear()
+  state.outputChunksByModule.clear()
   state.hmrSourceSharedChunks.clear()
   appendSharedChunkImporters(bundle, state)
 }
@@ -610,7 +407,7 @@ export function refreshPartialSharedChunkImporters(bundle: OutputBundle, state: 
 
     const chunk = output as OutputChunk
     if (chunk.facadeModuleId) {
-      const entryId = normalizeFsResolvedId(chunk.facadeModuleId)
+      const entryId = resolveSourceEntryId(chunk.facadeModuleId)
       if ((chunk.isEntry || state.resolvedEntryMap.has(entryId)) && entryIds.has(entryId)) {
         refreshedEntryIds.add(entryId)
       }
@@ -618,7 +415,7 @@ export function refreshPartialSharedChunkImporters(bundle: OutputBundle, state: 
 
     if (Array.isArray(chunk.moduleIds)) {
       for (const moduleId of chunk.moduleIds) {
-        const normalizedModuleId = normalizeFsResolvedId(moduleId)
+        const normalizedModuleId = resolveSourceEntryId(moduleId)
         if (state.resolvedEntryMap.has(normalizedModuleId) && entryIds.has(normalizedModuleId)) {
           refreshedEntryIds.add(normalizedModuleId)
         }

--- a/packages/weapp-vite/src/plugins/core/helpers/index.ts
+++ b/packages/weapp-vite/src/plugins/core/helpers/index.ts
@@ -16,11 +16,9 @@ export type {
 export { formatBytes } from './bytes'
 
 export {
-  collectAffectedEntries,
   collectAffectedEntriesFromSharedChunks,
   collectAffectedSharedChunkEntriesAndChunks,
   collectAffectedSharedChunks,
-  refreshModuleGraph,
   refreshPartialSharedChunkImporters,
   refreshSharedChunkImporters,
 } from './graph'

--- a/packages/weapp-vite/src/plugins/core/helpers/types.ts
+++ b/packages/weapp-vite/src/plugins/core/helpers/types.ts
@@ -20,14 +20,11 @@ export interface CorePluginState {
   entriesMap: LoadEntryApi['entriesMap']
   jsonEmitFilesMap: LoadEntryApi['jsonEmitFilesMap']
   resolvedEntryMap: LoadEntryApi['resolvedEntryMap']
-  layoutEntryDependents: LoadEntryApi['layoutEntryDependents']
   requireAsyncEmittedChunks: Set<string>
   pendingIndependentBuilds: Promise<IndependentBuildResult>[]
   watchFilesSnapshot: string[]
   buildTarget: BuildTarget
   resolvedConfig?: ResolvedConfig
-  moduleImporters: Map<string, Set<string>>
-  entryModuleIds: Set<string>
   hmrState: {
     didEmitAllEntries: boolean
     hasBuiltOnce: boolean
@@ -40,7 +37,7 @@ export interface CorePluginState {
   hmrSharedChunkImporters: Map<string, Set<string>>
   hmrSharedChunksByEntry: Map<string, Set<string>>
   hmrSharedChunkDependencies: Map<string, Set<string>>
-  hmrSharedChunksByModule: Map<string, Set<string>>
+  outputChunksByModule: Map<string, Set<string>>
   hmrSourceSharedChunks: Set<string>
   hmrRootInputIds: Set<string>
 }

--- a/packages/weapp-vite/src/plugins/core/index.ts
+++ b/packages/weapp-vite/src/plugins/core/index.ts
@@ -15,7 +15,7 @@ export function weappVite(ctx: CompilerContext, subPackageMeta?: SubPackageMetaV
   const hmrSharedChunkImporters = new Map<string, Set<string>>()
   const hmrSharedChunksByEntry = new Map<string, Set<string>>()
   const hmrSharedChunkDependencies = new Map<string, Set<string>>()
-  const hmrSharedChunksByModule = new Map<string, Set<string>>()
+  const outputChunksByModule = new Map<string, Set<string>>()
   const hmrSourceSharedChunks = new Set<string>()
   const hmrRootInputIds = new Set<string>()
   const hmrState = {
@@ -32,7 +32,6 @@ export function weappVite(ctx: CompilerContext, subPackageMeta?: SubPackageMetaV
     jsonEmitFilesMap,
     entriesMap,
     resolvedEntryMap,
-    layoutEntryDependents,
     markEntryDirty,
     emitDirtyEntries,
   } = useLoadEntry(ctx, {
@@ -76,19 +75,16 @@ export function weappVite(ctx: CompilerContext, subPackageMeta?: SubPackageMetaV
     entriesMap,
     jsonEmitFilesMap,
     resolvedEntryMap,
-    layoutEntryDependents,
     requireAsyncEmittedChunks: new Set<string>(),
     pendingIndependentBuilds: [],
     watchFilesSnapshot: [],
     buildTarget,
-    moduleImporters: new Map<string, Set<string>>(),
-    entryModuleIds: new Set<string>(),
     hmrState,
     hmrSharedChunksMode,
     hmrSharedChunkImporters,
     hmrSharedChunksByEntry,
     hmrSharedChunkDependencies,
-    hmrSharedChunksByModule,
+    outputChunksByModule,
     hmrSourceSharedChunks,
     hmrRootInputIds,
   }

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit.edge.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit.edge.test.ts
@@ -12,7 +12,6 @@ const createBundleChunkSnapshotMock = vi.hoisted(() => vi.fn((bundle: Record<str
   chunksByFileName: new Map(Object.entries(bundle).filter(([, output]) => (output as any).type === 'chunk')),
 })))
 const removeImplicitPagePreloadsMock = vi.hoisted(() => vi.fn())
-const refreshModuleGraphMock = vi.hoisted(() => vi.fn())
 const rewriteWevuInternalRuntimeImportsMock = vi.hoisted(() => vi.fn())
 const stabilizeWevuRuntimeChunkAccessMock = vi.hoisted(() => vi.fn())
 const syncChunkImportsFromRequireCallsMock = vi.hoisted(() => vi.fn())
@@ -51,7 +50,6 @@ vi.mock('../helpers', () => ({
   filterPluginBundleOutputs: vi.fn(),
   flushIndependentBuilds: flushIndependentBuildsMock,
   formatBytes: vi.fn(() => '0B'),
-  refreshModuleGraph: refreshModuleGraphMock,
   refreshSharedChunkImporters: vi.fn(),
   removeImplicitPagePreloads: removeImplicitPagePreloadsMock,
   rewriteWevuInternalRuntimeImports: rewriteWevuInternalRuntimeImportsMock,
@@ -98,8 +96,6 @@ function createState(overrides: Record<string, any> = {}) {
     subPackageMeta: null,
     entriesMap: new Map(),
     pendingIndependentBuilds: [],
-    moduleImporters: new Map(),
-    entryModuleIds: new Set(),
     watchFilesSnapshot: [],
     hmrState: {
       didEmitAllEntries: false,
@@ -176,7 +172,6 @@ describe('core lifecycle emit edge branches', () => {
     expect(bundle['main.js'].code).toBe('const x = 1')
     expect(flushIndependentBuildsMock).toHaveBeenCalledTimes(1)
     expect(removeImplicitPagePreloadsMock).toHaveBeenCalledTimes(1)
-    expect(refreshModuleGraphMock).toHaveBeenCalledTimes(1)
   })
 
   it('covers hasDependencyPrefix edge cases for empty and overlong dependency tokens', async () => {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts
@@ -19,7 +19,6 @@ import {
 } from '@weapp-core/constants'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { FULL_REQUEST_GLOBAL_TARGETS } from '../../../runtime/config/internal/injectRequestGlobals'
-import { normalizeWatchPath } from '../../../utils/path'
 import { createGenerateBundleHook, createRenderStartHook } from './emit'
 import { collectActiveHmrImportedChunkIds, createSubPackageMatcher, shouldWarmupBundleScriptAnalysis } from './emit/generate'
 
@@ -39,7 +38,6 @@ const createBundleChunkSnapshotMock = vi.hoisted(() => vi.fn((bundle: Record<str
 const filterPluginBundleOutputsMock = vi.hoisted(() => vi.fn())
 const flushIndependentBuildsMock = vi.hoisted(() => vi.fn(async () => {}))
 const formatBytesMock = vi.hoisted(() => vi.fn((value: number) => `${value}B`))
-const refreshModuleGraphMock = vi.hoisted(() => vi.fn())
 const refreshPartialSharedChunkImportersMock = vi.hoisted(() => vi.fn())
 const refreshSharedChunkImportersMock = vi.hoisted(() => vi.fn())
 const removeImplicitPagePreloadsMock = vi.hoisted(() => vi.fn())
@@ -78,7 +76,6 @@ vi.mock('../helpers', () => ({
   filterPluginBundleOutputs: filterPluginBundleOutputsMock,
   flushIndependentBuilds: flushIndependentBuildsMock,
   formatBytes: formatBytesMock,
-  refreshModuleGraph: refreshModuleGraphMock,
   refreshPartialSharedChunkImporters: refreshPartialSharedChunkImportersMock,
   refreshSharedChunkImporters: refreshSharedChunkImportersMock,
   removeImplicitPagePreloads: removeImplicitPagePreloadsMock,
@@ -125,8 +122,6 @@ function createState(overrides: Record<string, any> = {}) {
     },
     entriesMap: new Map(),
     pendingIndependentBuilds: [],
-    moduleImporters: new Map(),
-    entryModuleIds: new Set(),
     watchFilesSnapshot: [],
     hmrState: {
       didEmitAllEntries: false,
@@ -241,7 +236,7 @@ describe('core lifecycle emit hook extra branches', () => {
     })).toBe(false)
   })
 
-  it('creates renderStart runtime and stores watch files snapshot', async () => {
+  it('creates renderStart runtime without forwarding module dependencies as watch files', async () => {
     emitWxmlAssetsWithCacheMock.mockImplementationOnce(({ runtime }) => {
       runtime.addWatchFile?.('foo\\\\bar//main.wxml')
       runtime.emitFile({ type: 'asset', fileName: 'a.wxml', source: '<view />' })
@@ -259,7 +254,7 @@ describe('core lifecycle emit hook extra branches', () => {
     })
 
     expect(emitJsonAssetsMock).toHaveBeenCalledTimes(1)
-    expect(addWatchFile).toHaveBeenCalledWith(normalizeWatchPath('foo\\\\bar//main.wxml'))
+    expect(addWatchFile).not.toHaveBeenCalled()
     expect(emitFile).toHaveBeenCalledWith({
       type: 'asset',
       fileName: 'a.wxml',
@@ -469,10 +464,9 @@ describe('core lifecycle emit hook extra branches', () => {
     expect(flushIndependentBuildsMock).toHaveBeenCalledTimes(1)
     expect(filterPluginBundleOutputsMock).toHaveBeenCalledWith(bundle, state.ctx.configService)
     expect(removeImplicitPagePreloadsMock).not.toHaveBeenCalled()
-    expect(refreshModuleGraphMock).not.toHaveBeenCalled()
   })
 
-  it('drops js chunks during metadata-only dev hmr to keep stable shared chunks on disk', async () => {
+  it('drops graph-only chunks during metadata-only dev hmr', async () => {
     const state = createState({
       subPackageMeta: undefined,
       ctx: {
@@ -514,10 +508,6 @@ describe('core lifecycle emit hook extra branches', () => {
     expect(refreshSharedChunkImportersMock).not.toHaveBeenCalled()
     expect(refreshPartialSharedChunkImportersMock).not.toHaveBeenCalled()
     expect(applySharedChunkStrategyMock).not.toHaveBeenCalled()
-    expect(applyRuntimeChunkLocalizationMock).not.toHaveBeenCalled()
-    expect(removeImplicitPagePreloadsMock).not.toHaveBeenCalled()
-    expect(syncChunkImportsFromRequireCallsMock).not.toHaveBeenCalled()
-    expect(refreshModuleGraphMock).not.toHaveBeenCalled()
   })
 
   it('drops incomplete stable shared chunks during partial dev hmr rebuilds', async () => {
@@ -866,7 +856,6 @@ describe('core lifecycle emit hook extra branches', () => {
     expect(state.hmrState.hasBuiltOnce).toBe(true)
     expect(state.watchFilesSnapshot).toEqual([])
     expect(removeImplicitPagePreloadsMock).toHaveBeenCalledTimes(1)
-    expect(refreshModuleGraphMock).toHaveBeenCalledTimes(1)
   })
 
   it('uses partial shared chunk importer refresh during hmr incremental builds', async () => {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
+import { createLogicalEntryId } from '../../../moduleGraph/protocol'
 import { createGenerateBundleHook } from './emit'
-import { collectActiveHmrImportedChunkIds } from './emit/generate'
+import { collectActiveHmrImportedChunkIds, isActiveHmrEntryFacade, mergeActiveHmrEntryIds } from './emit/generate'
 
 describe('core lifecycle emit hook injectWeapi', () => {
   it('rewrites bundle chunk wx/my access to global wpi', async () => {
@@ -834,6 +835,25 @@ describe('core lifecycle emit hook injectWeapi', () => {
 })
 
 describe('core lifecycle emit HMR import graph', () => {
+  it('keeps actual emitted entries alongside the selected hmr entry subset', () => {
+    expect(mergeActiveHmrEntryIds(
+      new Set(['/src/pages/index.ts']),
+      new Set(['/src/layouts/default/index.ts']),
+    )).toEqual(new Set([
+      '/src/pages/index.ts',
+      '/src/layouts/default/index.ts',
+    ]))
+  })
+
+  it('matches logical entry facades against physical active entry ids', () => {
+    const layoutEntry = '/src/layouts/default/index.ts'
+
+    expect(isActiveHmrEntryFacade(
+      createLogicalEntryId(layoutEntry, 'layout'),
+      new Set([layoutEntry]),
+    )).toBe(true)
+  })
+
   it('collects normalized direct and dynamic imports for active HMR entries once', () => {
     const activeEntry = '/src/pages/index/index.ts'
     const bundle = {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit.test.ts
@@ -26,8 +26,6 @@ describe('core lifecycle emit hook injectWeapi', () => {
       },
       entriesMap: new Map(),
       pendingIndependentBuilds: [],
-      moduleImporters: new Map(),
-      entryModuleIds: new Set(),
       hmrState: {
         didEmitAllEntries: false,
         hasBuiltOnce: false,
@@ -78,8 +76,6 @@ describe('core lifecycle emit hook injectWeapi', () => {
       },
       entriesMap: new Map(),
       pendingIndependentBuilds: [],
-      moduleImporters: new Map(),
-      entryModuleIds: new Set(),
       hmrState: {
         didEmitAllEntries: false,
         hasBuiltOnce: false,
@@ -123,8 +119,6 @@ describe('core lifecycle emit hook injectWeapi', () => {
       },
       entriesMap: new Map(),
       pendingIndependentBuilds: [],
-      moduleImporters: new Map(),
-      entryModuleIds: new Set(),
       hmrState: {
         didEmitAllEntries: false,
         hasBuiltOnce: false,
@@ -175,8 +169,6 @@ describe('core lifecycle emit hook injectWeapi', () => {
       },
       entriesMap: new Map(),
       pendingIndependentBuilds: [],
-      moduleImporters: new Map(),
-      entryModuleIds: new Set(),
       hmrState: {
         didEmitAllEntries: false,
         hasBuiltOnce: false,
@@ -229,8 +221,6 @@ describe('core lifecycle emit hook injectWeapi', () => {
       },
       entriesMap: new Map(),
       pendingIndependentBuilds: [],
-      moduleImporters: new Map(),
-      entryModuleIds: new Set(),
       hmrState: {
         didEmitAllEntries: false,
         hasBuiltOnce: false,
@@ -275,8 +265,6 @@ describe('core lifecycle emit hook injectWeapi', () => {
       subPackageMeta: null,
       entriesMap: new Map(),
       pendingIndependentBuilds: [],
-      moduleImporters: new Map(),
-      entryModuleIds: new Set(),
       hmrState: {
         didEmitAllEntries: false,
         hasBuiltOnce: false,
@@ -342,8 +330,6 @@ describe('core lifecycle emit hook injectWeapi', () => {
       subPackageMeta: null,
       entriesMap: new Map(),
       pendingIndependentBuilds: [],
-      moduleImporters: new Map(),
-      entryModuleIds: new Set(),
       hmrState: {
         didEmitAllEntries: false,
         hasBuiltOnce: false,
@@ -398,8 +384,6 @@ describe('core lifecycle emit hook injectWeapi', () => {
       },
       entriesMap: new Map(),
       pendingIndependentBuilds: [],
-      moduleImporters: new Map(),
-      entryModuleIds: new Set(),
       hmrState: {
         didEmitAllEntries: false,
         hasBuiltOnce: false,
@@ -448,8 +432,6 @@ describe('core lifecycle emit hook injectWeapi', () => {
       },
       entriesMap: new Map(),
       pendingIndependentBuilds: [],
-      moduleImporters: new Map(),
-      entryModuleIds: new Set(),
       hmrState: {
         didEmitAllEntries: false,
         hasBuiltOnce: false,
@@ -496,8 +478,6 @@ describe('core lifecycle emit hook injectWeapi', () => {
       },
       entriesMap: new Map(),
       pendingIndependentBuilds: [],
-      moduleImporters: new Map(),
-      entryModuleIds: new Set(),
       hmrState: {
         didEmitAllEntries: false,
         hasBuiltOnce: false,
@@ -567,8 +547,6 @@ describe('core lifecycle emit hook injectWeapi', () => {
       },
       entriesMap: new Map(),
       pendingIndependentBuilds: [],
-      moduleImporters: new Map(),
-      entryModuleIds: new Set(),
       hmrState: {
         didEmitAllEntries: false,
         hasBuiltOnce: false,
@@ -636,8 +614,6 @@ describe('core lifecycle emit hook injectWeapi', () => {
       },
       entriesMap: new Map(),
       pendingIndependentBuilds: [],
-      moduleImporters: new Map(),
-      entryModuleIds: new Set(),
       hmrState: {
         didEmitAllEntries: false,
         hasBuiltOnce: false,
@@ -700,8 +676,6 @@ describe('core lifecycle emit hook injectWeapi', () => {
       entriesMap: new Map(),
       resolvedEntryMap: new Map([[activeEntry, {}]]),
       pendingIndependentBuilds: [],
-      moduleImporters: new Map(),
-      entryModuleIds: new Set(),
       hmrState: {
         didEmitAllEntries: false,
         hasBuiltOnce: true,
@@ -764,8 +738,6 @@ describe('core lifecycle emit hook injectWeapi', () => {
       entriesMap: new Map(),
       resolvedEntryMap: new Map([[activeEntry, {}]]),
       pendingIndependentBuilds: [],
-      moduleImporters: new Map(),
-      entryModuleIds: new Set(),
       hmrState: {
         didEmitAllEntries: false,
         hasBuiltOnce: true,
@@ -826,8 +798,6 @@ describe('core lifecycle emit hook injectWeapi', () => {
       entriesMap: new Map(),
       resolvedEntryMap: new Map([[activeEntry, {}]]),
       pendingIndependentBuilds: [],
-      moduleImporters: new Map(),
-      entryModuleIds: new Set(),
       hmrState: {
         didEmitAllEntries: false,
         hasBuiltOnce: true,

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit.ts
@@ -80,9 +80,6 @@ export function createRenderStartHook(state: CorePluginState) {
     const startedAt = performance.now()
     try {
       const runtime: WxmlEmitRuntime = {
-        addWatchFile: typeof this.addWatchFile === 'function'
-          ? (id: string) => { this.addWatchFile(normalizeWatchPath(id)) }
-          : undefined,
         emitFile: (asset) => {
           this.emitFile(asset)
         },

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit/generate.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit/generate.ts
@@ -7,12 +7,14 @@ import type { ChunkScriptAnalysisCache } from './rewrite'
 import process from 'node:process'
 import { resolveAstEngine } from '../../../../ast'
 import logger from '../../../../logger'
+import { parseLogicalEntryId } from '../../../../moduleGraph/protocol'
 import { shouldRewriteBundleNpmImports } from '../../../../platform'
 import { applyRuntimeChunkLocalization, applySharedChunkStrategy, DEFAULT_SHARED_CHUNK_STRATEGY } from '../../../../runtime/chunkStrategy'
 import { resolveRequestRuntimeOptions } from '../../../../runtime/config/internal/injectRequestGlobals'
 import { resolveNpmBuildCandidateDependencyRecordSync } from '../../../../runtime/npmPlugin/service'
 import { toPosixPath } from '../../../../utils'
 import { recordHmrProfileDuration } from '../../../../utils/hmrProfile'
+import { normalizeFsResolvedId } from '../../../../utils/resolvedId'
 import { emitStyleSidecarAsset } from '../../../css'
 import { normalizePreprocessorStyleAssets, pruneUneventedDevHmrChunks } from '../../../outputFinalizer'
 import {
@@ -203,6 +205,20 @@ function collectResolvedImportedChunkIds(
   }
 }
 
+export function isActiveHmrEntryFacade(
+  facadeModuleId: string | null | undefined,
+  activeEntryIds: Set<string> | undefined,
+) {
+  if (!facadeModuleId || !activeEntryIds?.size) {
+    return false
+  }
+  if (activeEntryIds.has(facadeModuleId)) {
+    return true
+  }
+  const sourceId = parseLogicalEntryId(facadeModuleId)?.sourceId
+  return sourceId ? activeEntryIds.has(normalizeFsResolvedId(sourceId)) : false
+}
+
 export function collectActiveHmrImportedChunkIds(bundle: OutputBundle, activeEntryIds?: Set<string>) {
   if (!activeEntryIds?.size) {
     return new Set<string>()
@@ -213,7 +229,7 @@ export function collectActiveHmrImportedChunkIds(bundle: OutputBundle, activeEnt
       continue
     }
     const chunk = output as OutputChunk
-    if (!chunk.facadeModuleId || !activeEntryIds.has(chunk.facadeModuleId)) {
+    if (!isActiveHmrEntryFacade(chunk.facadeModuleId, activeEntryIds)) {
       continue
     }
     const importerFileName = chunk.fileName || bundleFileName
@@ -223,10 +239,24 @@ export function collectActiveHmrImportedChunkIds(bundle: OutputBundle, activeEnt
   return importedChunkIds
 }
 
+export function mergeActiveHmrEntryIds(
+  lastHmrEntryIds: Set<string> | undefined,
+  lastEmittedEntryIds: Set<string> | undefined,
+) {
+  if (!lastHmrEntryIds?.size) {
+    return lastEmittedEntryIds
+  }
+  if (!lastEmittedEntryIds?.size) {
+    return lastHmrEntryIds
+  }
+  return new Set([...lastHmrEntryIds, ...lastEmittedEntryIds])
+}
+
 function resolveActiveHmrEntryIds(state: CorePluginState) {
-  return state.hmrState.lastHmrEntryIds?.size
-    ? state.hmrState.lastHmrEntryIds
-    : state.hmrState.lastEmittedEntryIds
+  return mergeActiveHmrEntryIds(
+    state.hmrState.lastHmrEntryIds,
+    state.hmrState.lastEmittedEntryIds,
+  )
 }
 
 function shouldRewriteDevHmrChunk(
@@ -245,7 +275,7 @@ function shouldRewriteDevHmrChunk(
   }
 
   const chunk = output as OutputChunk
-  if (chunk.facadeModuleId && activeEntryIds.has(chunk.facadeModuleId)) {
+  if (isActiveHmrEntryFacade(chunk.facadeModuleId, activeEntryIds)) {
     return true
   }
   if (state.hmrState.affectedSharedChunkIds?.has(fileName) || state.hmrState.affectedSharedChunkIds?.has(chunk.fileName)) {
@@ -332,8 +362,9 @@ function prunePartialHmrStableSharedChunks(bundle: OutputBundle, state: CorePlug
     }
 
     const chunk = output as OutputChunk
-    if (chunk.facadeModuleId && activeEntryIds?.has(chunk.facadeModuleId)) {
+    if (isActiveHmrEntryFacade(chunk.facadeModuleId, activeEntryIds)) {
       const importerFileName = chunk.fileName || fileName
+      addEmittedChunkFileName(emittedChunkFileNames, fileName, chunk)
       collectResolvedImportedChunkIds(activeImportedChunkIds, importerFileName, chunk.imports)
       collectResolvedImportedChunkIds(activeImportedChunkIds, importerFileName, chunk.dynamicImports)
     }

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit/generate.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit/generate.ts
@@ -20,7 +20,6 @@ import {
   filterPluginBundleOutputs,
   flushIndependentBuilds,
   formatBytes,
-  refreshModuleGraph,
   refreshPartialSharedChunkImporters,
   refreshSharedChunkImporters,
   removeImplicitPagePreloads,
@@ -435,6 +434,8 @@ export function createGenerateBundleHook(state: CorePluginState, isPluginBuild: 
   return async function generateBundle(this: any, _options: any, bundle: any) {
     const startedAt = performance.now()
     try {
+      ctx.moduleGraphService?.bindBuildContext(state, this)
+      ctx.moduleGraphService?.bindPluginContext(this)
       const rolldownBundle = bundle as unknown as OutputBundle
       const scriptAnalysisCache: ChunkScriptAnalysisCache = new WeakMap()
       await flushIndependentBuilds.call(this, state)
@@ -810,12 +811,6 @@ export function createGenerateBundleHook(state: CorePluginState, isPluginBuild: 
       recordHmrProfileDuration(ctx.runtimeState?.build?.hmr?.profile, 'generateRewriteMs', performance.now() - rewriteStartedAt)
       state.hmrState.affectedSharedChunkIds?.clear()
 
-      const moduleGraphStartedAt = performance.now()
-      refreshModuleGraph(this, state, rolldownBundle, {
-        mode: state.ctx.configService.isDev && state.hmrState.hasBuiltOnce ? 'merge' : 'replace',
-      })
-      recordHmrProfileDuration(ctx.runtimeState?.build?.hmr?.profile, 'generateModuleGraphMs', performance.now() - moduleGraphStartedAt)
-
       if (configService.weappViteConfig?.debug?.watchFiles) {
         const watcherService = ctx.watcherService
         const watcherRoot = subPackageMeta?.subPackage.root ?? '/'
@@ -835,6 +830,9 @@ export function createGenerateBundleHook(state: CorePluginState, isPluginBuild: 
     }
     finally {
       recordHmrProfileDuration(ctx.runtimeState?.build?.hmr?.profile, 'generateBundleMs', performance.now() - startedAt)
+      if (!subPackageMeta) {
+        ctx.moduleGraphService?.clearPendingChanges()
+      }
     }
   }
 }

--- a/packages/weapp-vite/src/plugins/core/lifecycle/end.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/end.test.ts
@@ -91,6 +91,27 @@ describe('core lifecycle buildEnd hook', () => {
     expect(pluginContext).toBeDefined()
   })
 
+  it('keeps direct entry diagnostics when graph traversal resolves the changed entry itself', async () => {
+    const entryId = '/project/src/pages/home/index.ts'
+    const { loadEntry, moduleGraphService, state } = createState(entryId, entryId)
+    const logicalId = createLogicalEntryId(entryId, 'page')
+    const infos = new Map<string, any>([
+      [entryId, { importers: [logicalId] }],
+      [logicalId, { importers: [], isEntry: true }],
+    ])
+    moduleGraphService.recordChangedFile(entryId, 'update')
+
+    await createBuildEndHook(state).call({
+      getModuleIds: () => infos.keys(),
+      getModuleInfo: (id: string) => infos.get(id),
+    })
+
+    expect(loadEntry).not.toHaveBeenCalled()
+    expect(state.hmrState.lastHmrEntryIds).toEqual(new Set([entryId]))
+    expect(state.hmrState.skipSharedChunkRefresh).toBe(false)
+    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['entry-direct:1'])
+  })
+
   it('keeps logical layout script changes on the chunk emission path', async () => {
     const layoutEntry = '/project/src/layouts/default/index.ts'
     const pageEntry = '/project/src/pages/home/index.ts'

--- a/packages/weapp-vite/src/plugins/core/lifecycle/end.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/end.test.ts
@@ -90,4 +90,70 @@ describe('core lifecycle buildEnd hook', () => {
     expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['importer-graph:1'])
     expect(pluginContext).toBeDefined()
   })
+
+  it('keeps logical layout script changes on the chunk emission path', async () => {
+    const layoutEntry = '/project/src/layouts/default/index.ts'
+    const pageEntry = '/project/src/pages/home/index.ts'
+    const { loadEntry, moduleGraphService, state } = createState(layoutEntry, layoutEntry)
+    const layoutLogicalId = createLogicalEntryId(layoutEntry, 'layout')
+    const pageLogicalId = createLogicalEntryId(pageEntry, 'page')
+    const infos = new Map<string, any>([
+      [layoutEntry, { importers: [layoutLogicalId] }],
+      [layoutLogicalId, { importers: [pageLogicalId], isEntry: true }],
+      [pageLogicalId, { importers: [], isEntry: true }],
+    ])
+    state.resolvedEntryMap.set(pageEntry, { id: pageEntry })
+    moduleGraphService.replaceEntryDependencies(pageEntry, 'layout', [layoutEntry])
+    moduleGraphService.recordChangedFile(layoutEntry, 'update')
+
+    await createBuildEndHook(state).call({
+      getModuleIds: () => infos.keys(),
+      getModuleInfo: (id: string) => infos.get(id),
+    })
+
+    expect(loadEntry).not.toHaveBeenCalled()
+    expect(state.hmrState.lastHmrEntryIds).toEqual(new Set([layoutEntry, pageEntry]))
+    expect(state.hmrState.skipSharedChunkRefresh).toBe(false)
+    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['layout-script:2'])
+  })
+
+  it('distinguishes direct style sidecars from imported css dependencies', async () => {
+    const entryId = '/project/src/pages/home/index.vue'
+    const importedStyle = '/project/src/pages/home/theme.css'
+    const { moduleGraphService, state } = createState(importedStyle, entryId)
+    const logicalId = createLogicalEntryId(entryId, 'page')
+    const importedSidecarId = createSidecarModuleId(entryId, importedStyle, 'style')
+    const importedSourceId = createSidecarSourceSpecifier(entryId, importedStyle, 'style')
+    const importedInfos = new Map<string, any>([
+      [importedSourceId, { importers: [importedSidecarId] }],
+      [importedSidecarId, { importers: [logicalId] }],
+      [logicalId, { importers: [], isEntry: true }],
+    ])
+    moduleGraphService.recordChangedFile(importedStyle, 'update')
+
+    await createBuildEndHook(state).call({
+      getModuleIds: () => importedInfos.keys(),
+      getModuleInfo: (id: string) => importedInfos.get(id),
+    })
+
+    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['css-importer:1'])
+
+    const directStyle = '/project/src/pages/home/index.css'
+    const direct = createState(directStyle, entryId)
+    const directSidecarId = createSidecarModuleId(entryId, directStyle, 'style')
+    const directSourceId = createSidecarSourceSpecifier(entryId, directStyle, 'style')
+    const directInfos = new Map<string, any>([
+      [directSourceId, { importers: [directSidecarId] }],
+      [directSidecarId, { importers: [logicalId] }],
+      [logicalId, { importers: [], isEntry: true }],
+    ])
+    direct.moduleGraphService.recordChangedFile(directStyle, 'update')
+
+    await createBuildEndHook(direct.state).call({
+      getModuleIds: () => directInfos.keys(),
+      getModuleInfo: (id: string) => directInfos.get(id),
+    })
+
+    expect(direct.state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['style-sidecar:1'])
+  })
 })

--- a/packages/weapp-vite/src/plugins/core/lifecycle/end.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/end.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createLogicalEntryId, createSidecarModuleId, createSidecarSourceSpecifier } from '../../../moduleGraph/protocol'
+import { createModuleGraphService } from '../../../moduleGraph/service'
+import { createBuildEndHook } from './end'
+
+function createState(file: string, entryId: string) {
+  const moduleGraphService = createModuleGraphService()
+  const logicalId = createLogicalEntryId(entryId, 'page')
+  const sidecarId = createSidecarModuleId(entryId, file, 'json')
+  const sourceId = createSidecarSourceSpecifier(entryId, file, 'json')
+  const infos = new Map<string, any>([
+    [sourceId, { importers: [sidecarId] }],
+    [sidecarId, { importers: [logicalId] }],
+    [logicalId, { importers: [], isEntry: true }],
+  ])
+  const loadEntry = vi.fn()
+  const state = {
+    ctx: {
+      configService: {
+        relativeAbsoluteSrcRoot: (id: string) => id.replace('/project/src/', ''),
+      },
+      moduleGraphService,
+      runtimeState: {
+        build: {
+          hmr: {
+            profile: {},
+          },
+        },
+      },
+    },
+    entriesMap: new Map([['pages/home/index', { type: 'page' }]]),
+    hmrRootInputIds: new Set<string>(),
+    hmrState: {
+      didEmitAllEntries: false,
+      lastHmrEntryIds: new Set<string>(),
+      lastEmittedEntryIds: new Set<string>(),
+      skipSharedChunkRefresh: false,
+    },
+    loadedEntrySet: new Set([entryId]),
+    loadEntry,
+    resolvedEntryMap: new Map([[entryId, { id: entryId }]]),
+  } as any
+  const pluginContext = {
+    getModuleIds: () => infos.keys(),
+    getModuleInfo: (id: string) => infos.get(id),
+  }
+  return { loadEntry, moduleGraphService, pluginContext, state }
+}
+
+describe('core lifecycle buildEnd hook', () => {
+  it('resolves a pending sidecar through the active graph and refreshes metadata only', async () => {
+    const file = '/project/src/pages/home/index.json'
+    const entryId = '/project/src/pages/home/index.ts'
+    const { loadEntry, moduleGraphService, pluginContext, state } = createState(file, entryId)
+    moduleGraphService.recordChangedFile(file, 'update')
+
+    await createBuildEndHook(state).call(pluginContext)
+
+    expect(loadEntry).toHaveBeenCalledWith(entryId, 'page', { metadataOnly: true })
+    expect(state.hmrState.lastHmrEntryIds).toEqual(new Set([entryId]))
+    expect(state.hmrState.skipSharedChunkRefresh).toBe(true)
+    expect(state.ctx.runtimeState.build.hmr.profile).toMatchObject({
+      dirtyCount: 1,
+      emittedCount: 1,
+      pendingCount: 1,
+      dirtyReasonSummary: ['json-sidecar:1'],
+    })
+  })
+
+  it('leaves script dependencies to Rolldown chunk emission', async () => {
+    const file = '/project/src/shared/value.ts'
+    const entryId = '/project/src/pages/home/index.ts'
+    const { loadEntry, moduleGraphService, pluginContext, state } = createState(file, entryId)
+    const logicalId = createLogicalEntryId(entryId, 'page')
+    const infos = new Map<string, any>([
+      [file, { importers: [entryId] }],
+      [entryId, { importers: [logicalId] }],
+      [logicalId, { importers: [], isEntry: true }],
+    ])
+    moduleGraphService.recordChangedFile(file, 'update')
+
+    await createBuildEndHook(state).call({
+      getModuleIds: () => infos.keys(),
+      getModuleInfo: (id: string) => infos.get(id),
+    })
+
+    expect(loadEntry).not.toHaveBeenCalled()
+    expect(state.hmrState.lastHmrEntryIds).toEqual(new Set([entryId]))
+    expect(state.hmrState.skipSharedChunkRefresh).toBe(false)
+    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['importer-graph:1'])
+    expect(pluginContext).toBeDefined()
+  })
+})

--- a/packages/weapp-vite/src/plugins/core/lifecycle/end.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/end.ts
@@ -46,6 +46,9 @@ function resolveChangeCause(
   if (isLayoutSourcePath(state.ctx.configService.relativeAbsoluteSrcRoot(normalized))) {
     return 'layout-dependent'
   }
+  if (state.resolvedEntryMap.has(normalized)) {
+    return 'entry-direct'
+  }
   return 'importer-graph'
 }
 
@@ -63,7 +66,7 @@ export function createBuildEndHook(state: CorePluginState) {
       const affected = state.ctx.moduleGraphService.collectAffectedEntries(change.file)
       const cause = resolveChangeCause(state, change.file, affected)
       causes.set(cause, (causes.get(cause) ?? 0) + affected.size)
-      if (cause === 'importer-graph' || cause === 'layout-script') {
+      if (cause === 'entry-direct' || cause === 'importer-graph' || cause === 'layout-script') {
         metadataOnly = false
       }
       for (const entryId of affected) {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/end.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/end.ts
@@ -18,19 +18,30 @@ function resolveEntryType(state: CorePluginState, entryId: string) {
   return state.hmrRootInputIds.has(normalizeSourceId(entryId)) ? 'app' as const : 'component' as const
 }
 
-function resolveChangeCause(state: CorePluginState, file: string) {
+function resolveChangeCause(
+  state: CorePluginState,
+  file: string,
+  affectedEntries: Iterable<string>,
+) {
   const normalized = normalizeFsResolvedId(file)
   if (configSuffixes.some(suffix => normalized.endsWith(suffix))) {
     return 'json-sidecar'
   }
   const extension = path.extname(normalized)
   if (watchedCssExts.has(extension)) {
-    return 'style-sidecar'
+    const styleBase = removeExtensionDeep(normalized)
+    const isDirectStyleSidecar = Array.from(affectedEntries).some((entryId) => {
+      return removeExtensionDeep(normalizeFsResolvedId(entryId)) === styleBase
+    })
+    return isDirectStyleSidecar ? 'style-sidecar' : 'css-importer'
   }
   if (watchedTemplateExts.has(extension)) {
     return isLayoutSourcePath(state.ctx.configService.relativeAbsoluteSrcRoot(normalized))
       ? 'layout-dependent'
       : 'sidecar-direct'
+  }
+  if (state.ctx.moduleGraphService.isLogicalLayoutEntry(normalized)) {
+    return 'layout-script'
   }
   if (isLayoutSourcePath(state.ctx.configService.relativeAbsoluteSrcRoot(normalized))) {
     return 'layout-dependent'
@@ -50,9 +61,9 @@ export function createBuildEndHook(state: CorePluginState) {
 
     for (const change of pendingChanges) {
       const affected = state.ctx.moduleGraphService.collectAffectedEntries(change.file)
-      const cause = resolveChangeCause(state, change.file)
+      const cause = resolveChangeCause(state, change.file, affected)
       causes.set(cause, (causes.get(cause) ?? 0) + affected.size)
-      if (cause === 'importer-graph') {
+      if (cause === 'importer-graph' || cause === 'layout-script') {
         metadataOnly = false
       }
       for (const entryId of affected) {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/end.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/end.ts
@@ -1,12 +1,93 @@
 import type { CorePluginState } from '../helpers'
+import { removeExtensionDeep } from '@weapp-core/shared'
+import path from 'pathe'
 import { createDebugger } from '../../../debugger'
+import { normalizeSourceId } from '../../../moduleGraph/traversal'
+import { normalizeFsResolvedId } from '../../../utils/resolvedId'
+import { configSuffixes, watchedCssExts, watchedTemplateExts } from '../../utils/invalidateEntry/shared'
+import { isLayoutSourcePath } from '../../utils/layoutSourcePath'
 
 const debug = createDebugger('weapp-vite:core')
+
+function resolveEntryType(state: CorePluginState, entryId: string) {
+  const relativeBase = removeExtensionDeep(state.ctx.configService.relativeAbsoluteSrcRoot(entryId))
+  const declaredType = state.entriesMap.get(relativeBase)?.type
+  if (declaredType === 'page' || declaredType === 'component') {
+    return declaredType
+  }
+  return state.hmrRootInputIds.has(normalizeSourceId(entryId)) ? 'app' as const : 'component' as const
+}
+
+function resolveChangeCause(state: CorePluginState, file: string) {
+  const normalized = normalizeFsResolvedId(file)
+  if (configSuffixes.some(suffix => normalized.endsWith(suffix))) {
+    return 'json-sidecar'
+  }
+  const extension = path.extname(normalized)
+  if (watchedCssExts.has(extension)) {
+    return 'style-sidecar'
+  }
+  if (watchedTemplateExts.has(extension)) {
+    return isLayoutSourcePath(state.ctx.configService.relativeAbsoluteSrcRoot(normalized))
+      ? 'layout-dependent'
+      : 'sidecar-direct'
+  }
+  if (isLayoutSourcePath(state.ctx.configService.relativeAbsoluteSrcRoot(normalized))) {
+    return 'layout-dependent'
+  }
+  return 'importer-graph'
+}
 
 export function createBuildEndHook(state: CorePluginState) {
   const { subPackageMeta } = state
 
-  return function buildEnd(this: any) {
+  return async function buildEnd(this: any) {
+    state.ctx.moduleGraphService.bindBuildContext(state, this)
+    const pendingChanges = state.ctx.moduleGraphService.getPendingChanges()
+    const affectedEntries = new Set<string>()
+    const causes = new Map<string, number>()
+    let metadataOnly = pendingChanges.length > 0
+
+    for (const change of pendingChanges) {
+      const affected = state.ctx.moduleGraphService.collectAffectedEntries(change.file)
+      const cause = resolveChangeCause(state, change.file)
+      causes.set(cause, (causes.get(cause) ?? 0) + affected.size)
+      if (cause === 'importer-graph') {
+        metadataOnly = false
+      }
+      for (const entryId of affected) {
+        if (!state.resolvedEntryMap.has(entryId)) {
+          continue
+        }
+        affectedEntries.add(entryId)
+      }
+    }
+
+    if (affectedEntries.size) {
+      const hmr = state.ctx.runtimeState.build.hmr
+      state.hmrState.lastHmrEntryIds = new Set(affectedEntries)
+      hmr.lastHmrEntryIds = new Set(affectedEntries)
+      state.hmrState.didEmitAllEntries = false
+      state.hmrState.skipSharedChunkRefresh = metadataOnly
+      const summary = [...causes.entries()].map(([cause, count]) => `${cause}:${count}`)
+      hmr.profile = {
+        ...hmr.profile,
+        dirtyCount: affectedEntries.size,
+        emittedCount: metadataOnly ? affectedEntries.size : hmr.profile.emittedCount,
+        pendingCount: metadataOnly ? affectedEntries.size : hmr.profile.pendingCount,
+        dirtyReasonSummary: summary,
+      }
+
+      if (metadataOnly) {
+        for (const entryId of affectedEntries) {
+          state.loadedEntrySet.delete(entryId)
+          await state.loadEntry.call(this, entryId, resolveEntryType(state, entryId), { metadataOnly: true })
+        }
+      }
+    }
+
+    await state.ctx.moduleGraphService.syncDevGraph(this)
+
     debug?.(`${subPackageMeta ? `独立分包 ${subPackageMeta.subPackage.root}` : '主包'} ${Array.from(this.getModuleIds()).length} 个模块被编译`)
   }
 }

--- a/packages/weapp-vite/src/plugins/core/lifecycle/index.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/index.ts
@@ -1,8 +1,10 @@
 import type { Plugin } from 'vite'
 import type { CorePluginState } from '../helpers'
+import { parseSidecarSourceRequest } from '../../../moduleGraph/protocol'
 import { createGenerateBundleHook, createRenderStartHook } from './emit'
 import { createBuildEndHook } from './end'
 import { createLoadHook, createOptionsHook } from './load'
+import { createLogicalEntryLoadHook, createLogicalEntryResolveHook } from './logicalEntry'
 import { createTransformHook } from './transform'
 import { createBuildStartHook, createWatchChangeHook } from './watch'
 
@@ -10,6 +12,8 @@ const CORE_TRANSFORM_FILTER_RE = /\.(?:[cm]?[jt]sx?|vue)(?:\?.*)?$/
 
 export function createCoreLifecyclePlugin(state: CorePluginState): Plugin {
   const isPluginBuild = state.buildTarget === 'plugin'
+  const loadLogicalEntry = createLogicalEntryLoadHook(state)
+  const loadSource = createLoadHook(state)
 
   return {
     name: 'weapp-vite:pre',
@@ -17,10 +21,21 @@ export function createCoreLifecyclePlugin(state: CorePluginState): Plugin {
     configResolved(config) {
       state.resolvedConfig = config
     },
+    configureServer(server) {
+      state.ctx.moduleGraphService.bindDevServer(server)
+    },
     buildStart: createBuildStartHook(state),
     watchChange: createWatchChangeHook(state),
     options: createOptionsHook(state),
-    load: createLoadHook(state),
+    resolveId: createLogicalEntryResolveHook(state),
+    async load(id) {
+      state.ctx.moduleGraphService.bindPluginContext(this)
+      const logicalResult = await loadLogicalEntry.call(this, id)
+      if (logicalResult || parseSidecarSourceRequest(id)) {
+        return logicalResult
+      }
+      return await loadSource.call(this, id)
+    },
     transform: {
       filter: {
         id: CORE_TRANSFORM_FILTER_RE,

--- a/packages/weapp-vite/src/plugins/core/lifecycle/load.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/load.test.ts
@@ -9,6 +9,7 @@ import {
 import { parseSync } from 'oxc-parser'
 import path from 'pathe'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createLogicalEntryId } from '../../../moduleGraph/protocol'
 import { FULL_REQUEST_GLOBAL_TARGETS } from '../../../runtime/config/internal/injectRequestGlobals'
 import { createLoadHook, createOptionsHook } from './load'
 
@@ -41,6 +42,10 @@ vi.mock('../../../utils', async () => {
 
 describe('core lifecycle load hook injectWeapi', () => {
   beforeEach(() => {
+    findJsEntryMock.mockReset()
+    findJsEntryMock.mockResolvedValue({ path: undefined, predictions: [] })
+    findVueEntryMock.mockReset()
+    findVueEntryMock.mockResolvedValue(undefined)
     pathExistsCachedMock.mockReset()
     pathExistsCachedMock.mockResolvedValue(true)
   })
@@ -548,7 +553,7 @@ describe('core lifecycle load hook injectWeapi', () => {
     expect(code).not.toContain('my.showToast')
   })
 
-  it('loads css wxss requests from the real wxss path and registers watch file', async () => {
+  it('loads css wxss requests from the real wxss path without duplicating the module edge', async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), 'weapp-vite-load-'))
     const realWxss = path.join(tempDir, 'index.wxss')
     await writeFile(realWxss, '.page{color:red;}', 'utf8')
@@ -574,7 +579,7 @@ describe('core lifecycle load hook injectWeapi', () => {
       `${path.join(tempDir, 'index.css')}?wxss`,
     )
 
-    expect(addWatchFile).toHaveBeenCalled()
+    expect(addWatchFile).not.toHaveBeenCalled()
     expect(result).toEqual({ code: '.page{color:red;}' })
   })
 
@@ -910,6 +915,10 @@ describe('core lifecycle load hook injectWeapi', () => {
 
 describe('core lifecycle options hook', () => {
   it('builds input map from subPackageMeta entries', async () => {
+    findJsEntryMock.mockImplementation(async (id: string) => ({
+      path: `${id}.ts`,
+      predictions: [`${id}.ts`],
+    }))
     const state = {
       ctx: {
         configService: {
@@ -929,13 +938,72 @@ describe('core lifecycle options hook', () => {
     await optionsHook(options)
 
     expect(options.input).toEqual({
-      'pages/a/index': '/project/src/pages/a/index',
-      'pages/b/index': '/project/src/pages/b/index',
+      'pages/a/index': createLogicalEntryId('/project/src/pages/a/index.ts', 'page'),
+      'pages/b/index': createLogicalEntryId('/project/src/pages/b/index.ts', 'page'),
     })
     expect(Array.from(state.hmrRootInputIds)).toEqual([
-      '/project/src/pages/a/index',
-      '/project/src/pages/b/index',
+      '/project/src/pages/a/index.ts',
+      '/project/src/pages/b/index.ts',
     ])
+  })
+
+  it('only promotes physical app routes and local components to logical inputs', async () => {
+    findJsEntryMock.mockImplementation(async (id: string) => ({
+      path: id.endsWith('/pages/home/index') || id.endsWith('/components/card/index')
+        ? `${id}.ts`
+        : undefined,
+      predictions: [`${id}.ts`],
+    }))
+    const runtimeState = {
+      lib: {
+        enabled: false,
+        entries: new Map(),
+      },
+    }
+    const configService = {
+      absoluteSrcRoot: '/project/src',
+      weappLibConfig: undefined,
+      isDev: false,
+      options: {},
+      relativeAbsoluteSrcRoot: (id: string) => id.replace('/project/src/', ''),
+    }
+    const appEntry = {
+      path: '/project/src/app.ts',
+      json: {
+        pages: ['pages/home/index', 'pages/missing/index'],
+        usingComponents: {
+          card: '/components/card/index',
+          vendor: 'vendor-ui/button/index',
+        },
+      },
+    }
+    const state = {
+      ctx: {
+        runtimeState,
+        configService,
+        scanService: {
+          appEntry,
+          loadAppEntry: vi.fn(async () => appEntry),
+          loadSubPackages: vi.fn(),
+          drainIndependentDirtyRoots: vi.fn(() => []),
+          independentSubPackageMap: new Map(),
+        },
+        buildService: {},
+      },
+      entriesMap: new Map(),
+      pendingIndependentBuilds: [],
+    } as any
+
+    const options: Record<string, any> = {}
+    await createOptionsHook(state)(options)
+
+    expect(options.input).toEqual({
+      'app': createLogicalEntryId('/project/src/app.ts', 'app'),
+      'pages/home/index': createLogicalEntryId('/project/src/pages/home/index.ts', 'page'),
+      'components/card/index': createLogicalEntryId('/project/src/components/card/index.ts', 'component'),
+    })
+    expect(options.input).not.toHaveProperty('pages/missing/index')
+    expect(options.input).not.toHaveProperty('vendor-ui/button/index')
   })
 
   it('loads lib entries when weapp lib mode is enabled', async () => {
@@ -979,7 +1047,7 @@ describe('core lifecycle options hook', () => {
     await optionsHook(options)
 
     expect(options.input).toEqual({
-      card: '/project/src/components/card.ts',
+      card: createLogicalEntryId('/project/src/components/card.ts', 'component'),
     })
     expect(runtimeState.lib.enabled).toBe(true)
     expect(runtimeState.lib.entries.size).toBe(1)
@@ -1039,7 +1107,7 @@ describe('core lifecycle options hook', () => {
     await optionsHook(options)
 
     expect(options.input).toEqual({
-      app: '/project/src/app.ts',
+      app: createLogicalEntryId('/project/src/app.ts', 'app'),
     })
     expect(runtimeState.lib.enabled).toBe(false)
     expect(runtimeState.lib.entries.size).toBe(0)
@@ -1102,7 +1170,7 @@ describe('core lifecycle options hook', () => {
     await optionsHook(options)
 
     expect(options.input).toEqual({
-      index: '/project/plugin/index.ts',
+      index: createLogicalEntryId('/project/plugin/index.ts', 'app'),
     })
     expect(Array.from(state.hmrRootInputIds)).toEqual(['/project/plugin/index.ts'])
     expect(scanService.loadSubPackages).not.toHaveBeenCalled()

--- a/packages/weapp-vite/src/plugins/core/lifecycle/load/index.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/load/index.ts
@@ -9,7 +9,6 @@ import { isCSSRequest } from '../../../../utils'
 import { getPathExistsTtlMs } from '../../../../utils/cachePolicy'
 import { recordHmrProfileDuration } from '../../../../utils/hmrProfile'
 import { getMiniProgramPlatformGlobalKey } from '../../../../utils/miniProgramGlobals'
-import { normalizeWatchPath } from '../../../../utils/path'
 import { normalizeFsResolvedId } from '../../../../utils/resolvedId'
 import { pathExists as pathExistsCached, readFile as readFileCached } from '../../../utils/cache'
 import { getCssRealPath, parseRequest } from '../../../utils/parse'
@@ -126,7 +125,6 @@ export function createLoadHook(state: CorePluginState) {
         const parsed = parseRequest(id)
         if (parsed.query.wxss) {
           const realPath = getCssRealPath(parsed)
-          this.addWatchFile(normalizeWatchPath(realPath))
           try {
             const css = await readFileCached(realPath, { checkMtime: configService.isDev })
             return { code: css }

--- a/packages/weapp-vite/src/plugins/core/lifecycle/load/options.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/load/options.ts
@@ -1,9 +1,106 @@
+import type { LogicalEntryType } from '../../../../moduleGraph/protocol'
+import type { AppEntry } from '../../../../types'
 import type { CorePluginState, IndependentBuildResult } from '../../helpers'
 import { removeExtensionDeep } from '@weapp-core/shared'
 import path from 'pathe'
+import { createLogicalEntryId } from '../../../../moduleGraph/protocol'
+import { normalizeSourceId } from '../../../../moduleGraph/traversal'
 import { resolveWeappLibEntries } from '../../../../runtime/lib'
-import { findJsEntry, findVueEntry } from '../../../../utils'
+import { findJsEntry, findVueEntry, normalizeAppJson } from '../../../../utils'
 import { normalizeFsResolvedId } from '../../../../utils/resolvedId'
+
+interface LogicalInputSource {
+  input: string
+  source?: string
+  type: LogicalEntryType
+}
+
+function collectMainLogicalInputs(state: CorePluginState, appEntry: AppEntry) {
+  const { absoluteSrcRoot } = state.ctx.configService
+  const appJson = normalizeAppJson(appEntry.json ?? {})
+  const inputs: Record<string, LogicalInputSource> = {
+    app: {
+      input: appEntry.path,
+      type: 'app',
+    },
+  }
+  const candidates: Array<{ entry: string, type: LogicalEntryType }> = []
+  for (const entry of appJson.pages ?? []) {
+    candidates.push({ entry, type: 'page' })
+  }
+  for (const subPackage of [...appJson.subPackages ?? [], ...appJson.subpackages ?? []]) {
+    if (subPackage.independent || typeof subPackage.root !== 'string') {
+      continue
+    }
+    for (const entry of subPackage.pages ?? []) {
+      candidates.push({ entry: path.join(subPackage.root, entry), type: 'page' })
+    }
+  }
+  for (const entry of Object.values(appJson.usingComponents ?? {})) {
+    if (typeof entry === 'string') {
+      candidates.push({ entry, type: 'component' })
+    }
+  }
+  if (appJson.tabBar?.custom) {
+    candidates.push({ entry: 'custom-tab-bar/index', type: 'component' })
+  }
+  if (appJson.appBar) {
+    candidates.push({ entry: 'app-bar/index', type: 'component' })
+  }
+
+  for (const { entry: rawEntry, type } of candidates) {
+    if (!rawEntry || rawEntry.includes(':')) {
+      continue
+    }
+    const name = removeExtensionDeep(rawEntry).replace(/^[/\\]+/, '')
+    if (!name || inputs[name]) {
+      continue
+    }
+    inputs[name] = {
+      input: path.resolve(absoluteSrcRoot, name),
+      source: rawEntry,
+      type,
+    }
+  }
+  return inputs
+}
+
+async function resolveLogicalInput(
+  pluginContext: any,
+  source: LogicalInputSource,
+  importer?: string,
+) {
+  const resolveSource = async (id: string, sourceImporter?: string) => {
+    if (typeof pluginContext?.resolve !== 'function') {
+      return undefined
+    }
+    const resolved = await pluginContext.resolve(id, sourceImporter)
+    return resolved?.external ? undefined : resolved?.id
+  }
+  const resolvePhysicalEntry = async (id: string) => {
+    const normalized = normalizeFsResolvedId(id)
+    if (path.extname(normalized)) {
+      return id
+    }
+    const scriptEntry = await findJsEntry(normalized)
+    const localEntry = scriptEntry.path ?? await findVueEntry(normalized)
+    if (!localEntry) {
+      return undefined
+    }
+    return await resolveSource(localEntry, importer) ?? localEntry
+  }
+
+  const primaryId = await resolveSource(source.input, importer) ?? source.input
+  const primaryEntry = await resolvePhysicalEntry(primaryId)
+  if (primaryEntry) {
+    return primaryEntry
+  }
+  if (!source.source || typeof pluginContext?.resolve !== 'function') {
+    return undefined
+  }
+  const fallbackId = await resolveSource(source.source, importer)
+  return fallbackId ? await resolvePhysicalEntry(fallbackId) : undefined
+}
 
 async function resolvePluginOnlyInput(state: CorePluginState) {
   const { scanService } = state.ctx
@@ -32,15 +129,21 @@ export function createOptionsHook(state: CorePluginState) {
   const { ctx, subPackageMeta } = state
   const { scanService, configService, buildService } = ctx
 
-  return async function options(options: any) {
+  return async function options(this: any, options: any) {
+    if (this) {
+      ctx.moduleGraphService?.bindPluginContext(this)
+    }
     state.pendingIndependentBuilds = []
     state.hmrRootInputIds ??= new Set<string>()
     state.hmrRootInputIds.clear()
-    let scannedInput: Record<string, string>
+    let scannedInput: Record<string, LogicalInputSource>
 
     if (subPackageMeta) {
-      scannedInput = subPackageMeta.entries.reduce<Record<string, string>>((acc, entry: string) => {
-        acc[entry] = path.resolve(configService.absoluteSrcRoot, entry)
+      scannedInput = subPackageMeta.entries.reduce<Record<string, LogicalInputSource>>((acc, entry: string) => {
+        acc[entry] = {
+          input: path.resolve(configService.absoluteSrcRoot, entry),
+          type: 'page',
+        }
         return acc
       }, {})
     }
@@ -50,8 +153,11 @@ export function createOptionsHook(state: CorePluginState) {
       const outputMap = new Map<string, string>()
       libState.entries.clear()
 
-      scannedInput = entries.reduce<Record<string, string>>((acc, entry) => {
-        acc[entry.name] = entry.input
+      scannedInput = entries.reduce<Record<string, LogicalInputSource>>((acc, entry) => {
+        acc[entry.name] = {
+          input: entry.input,
+          type: 'component',
+        }
         outputMap.set(entry.relativeBase, entry.outputBase)
         const normalized = normalizeFsResolvedId(entry.input)
         if (normalized) {
@@ -78,7 +184,12 @@ export function createOptionsHook(state: CorePluginState) {
       }
       const appEntry = await scanService.loadAppEntry()
       if (configService.pluginOnly) {
-        scannedInput = await resolvePluginOnlyInput(state)
+        scannedInput = Object.fromEntries(
+          Object.entries(await resolvePluginOnlyInput(state)).map(([name, input]) => [name, {
+            input,
+            type: 'app' as const,
+          }]),
+        )
       }
       else {
         scanService.loadSubPackages()
@@ -116,16 +227,29 @@ export function createOptionsHook(state: CorePluginState) {
           }
         }
         state.pendingIndependentBuilds = pendingIndependentBuilds
-        scannedInput = { app: appEntry.path }
+        scannedInput = collectMainLogicalInputs(state, appEntry)
       }
     }
 
-    options.input = scannedInput
-    for (const input of Object.values(scannedInput)) {
-      const normalized = normalizeFsResolvedId(input)
+    const logicalInput: Record<string, string> = {}
+    for (const [name, source] of Object.entries(scannedInput)) {
+      const sourceId = await resolveLogicalInput(this, source, state.ctx.scanService.appEntry?.path)
+      if (!sourceId) {
+        continue
+      }
+      logicalInput[name] = createLogicalEntryId(sourceId, source.type)
+      const normalized = normalizeFsResolvedId(sourceId)
       if (normalized) {
-        state.hmrRootInputIds.add(normalized)
+        state.hmrRootInputIds.add(normalizeSourceId(normalized))
+        if (source.type !== 'app' && state.entriesMap) {
+          const relativeBase = removeExtensionDeep(configService.relativeAbsoluteSrcRoot(normalized))
+          state.entriesMap.set(relativeBase, {
+            path: normalized,
+            type: source.type === 'page' ? 'page' : 'component',
+          } as any)
+        }
       }
     }
+    options.input = logicalInput
   }
 }

--- a/packages/weapp-vite/src/plugins/core/lifecycle/logicalEntry.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/logicalEntry.test.ts
@@ -97,13 +97,13 @@ describe('core logical entry lifecycle', () => {
       ['template', templatePath],
       ['style', stylePath],
       ['json', jsonPath],
+      ['layout', layoutPath],
       ['script', sourceId],
       ['wxs', wxsPath],
       ['using-component', linkedComponent],
     ] as const) {
       expect(code).toContain(JSON.stringify(createSidecarModuleId(sourceId, dependency, kind)))
     }
-    expect(code).toContain(JSON.stringify(createLogicalEntryId(layoutPath, 'layout')))
   })
 
   it('models a Vue physical source through the script sidecar protocol', async () => {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/logicalEntry.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/logicalEntry.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createLogicalEntryId, createSidecarModuleId, createSidecarSourceSpecifier } from '../../../moduleGraph/protocol'
+import { createLogicalEntryLoadHook, createLogicalEntryResolveHook } from './logicalEntry'
+
+const findCssEntryMock = vi.hoisted(() => vi.fn())
+const pathExistsMock = vi.hoisted(() => vi.fn(async () => true))
+
+vi.mock('../../../utils', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils')>('../../../utils')
+  return {
+    ...actual,
+    findCssEntry: findCssEntryMock,
+  }
+})
+
+vi.mock('../../utils/cache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/cache')>()
+  return {
+    ...actual,
+    pathExists: pathExistsMock,
+  }
+})
+
+describe('core logical entry lifecycle', () => {
+  it('loads the physical entry before expressing sidecars and resolved relations', async () => {
+    const sourceId = '/project/src/pages/home/index.ts'
+    const templatePath = '/project/src/pages/home/index.wxml'
+    const stylePath = '/project/src/pages/home/index.wxss'
+    const jsonPath = '/project/src/pages/home/index.json'
+    const wxsPath = '/project/src/pages/home/filter.wxs'
+    const layoutPath = '/project/src/layouts/default.vue'
+    const linkedComponent = '/workspace/ui/card/index.ts'
+    findCssEntryMock.mockResolvedValue({ path: stylePath, predictions: [stylePath] })
+    const getEntryDependencies = vi.fn(() => [
+      { kind: 'layout', sourceId: layoutPath },
+      { kind: 'using-component', sourceId: linkedComponent },
+    ])
+    const load = vi.fn(async () => ({ exports: ['default'] }))
+    const resolve = vi.fn(async (source: string) => source === '@ui/card' ? { id: linkedComponent } : null)
+    const state = {
+      loadEntry: vi.fn(async () => undefined),
+      entriesMap: new Map([
+        ['pages/home/index', {
+          json: {
+            usingComponents: {
+              card: '@ui/card',
+            },
+          },
+          jsonPath,
+          templatePath,
+          type: 'page',
+        }],
+      ]),
+      ctx: {
+        configService: {
+          absoluteSrcRoot: '/project/src',
+          isDev: true,
+          relativeAbsoluteSrcRoot: (id: string) => id.replace('/project/src/', ''),
+        },
+        moduleGraphService: {
+          bindPluginContext: vi.fn(),
+          load,
+          replaceEntryDependencies: vi.fn(),
+          resolve,
+          getEntryDependencies,
+        },
+        runtimeState: {
+          build: {
+            hmr: {
+              externalComponentEntryMap: new Map(),
+            },
+          },
+        },
+        wxmlService: {
+          scan: vi.fn(async () => {}),
+          depsMap: new Map([
+            [templatePath, new Set([wxsPath])],
+          ]),
+        },
+      },
+    } as any
+    const pluginCtx = {
+      load: vi.fn(async () => ({ code: 'Page({})' })),
+      resolve: vi.fn(async (source: string) => source === '@ui/card' ? { id: linkedComponent } : null),
+    } as any
+
+    const result = await createLogicalEntryLoadHook(state)
+      .call(pluginCtx, createLogicalEntryId(sourceId, 'page'))
+    const code = result?.code ?? ''
+
+    expect(load).not.toHaveBeenCalled()
+    expect(state.loadEntry).toHaveBeenCalledWith(sourceId, 'page')
+    expect(code).toContain(`import ${JSON.stringify(sourceId)};`)
+    expect(code).not.toContain('export default __weappViteLogicalEntry.default;')
+    expect(getEntryDependencies).toHaveBeenCalledTimes(1)
+    for (const [kind, dependency] of [
+      ['template', templatePath],
+      ['style', stylePath],
+      ['json', jsonPath],
+      ['script', sourceId],
+      ['wxs', wxsPath],
+      ['using-component', linkedComponent],
+    ] as const) {
+      expect(code).toContain(JSON.stringify(createSidecarModuleId(sourceId, dependency, kind)))
+    }
+    expect(code).toContain(JSON.stringify(createLogicalEntryId(layoutPath, 'layout')))
+  })
+
+  it('models a Vue physical source through the script sidecar protocol', async () => {
+    const sourceId = '/project/src/pages/home/index.vue'
+    findCssEntryMock.mockResolvedValue({ path: undefined, predictions: [] })
+    const state = {
+      loadEntry: vi.fn(async () => undefined),
+      entriesMap: new Map([['pages/home/index', { type: 'page' }]]),
+      ctx: {
+        configService: {
+          absoluteSrcRoot: '/project/src',
+          isDev: true,
+          relativeAbsoluteSrcRoot: (id: string) => id.replace('/project/src/', ''),
+        },
+        moduleGraphService: {
+          bindPluginContext: vi.fn(),
+          getEntryDependencies: vi.fn(() => []),
+          replaceEntryDependencies: vi.fn(),
+          resolve: vi.fn(async () => null),
+        },
+        runtimeState: {
+          build: {
+            hmr: {
+              externalComponentEntryMap: new Map(),
+            },
+          },
+        },
+        wxmlService: { depsMap: new Map() },
+      },
+    } as any
+
+    const result = await createLogicalEntryLoadHook(state)
+      .call({} as any, createLogicalEntryId(sourceId, 'page'))
+
+    expect(result?.code).toContain(JSON.stringify(createSidecarModuleId(sourceId, sourceId, 'script')))
+  })
+
+  it('resolves virtual protocol ids and sidecar sources through the graph service', async () => {
+    const sourceId = '/project/src/app.ts'
+    const resolve = vi.fn(async (source: string) => ({ id: `/resolved${source}` }))
+    const state = {
+      ctx: {
+        moduleGraphService: {
+          bindPluginContext: vi.fn(),
+          resolve,
+        },
+      },
+    } as any
+    const resolveId = createLogicalEntryResolveHook(state)
+    const logicalId = createLogicalEntryId(sourceId, 'app')
+    const sidecarId = createSidecarModuleId(sourceId, '/project/src/app.json', 'json')
+    const sidecarSource = createSidecarSourceSpecifier(sourceId, '/project/src/app.json', 'json')
+
+    await expect(resolveId.call({} as any, logicalId)).resolves.toEqual({ id: logicalId, moduleSideEffects: 'no-treeshake' })
+    await expect(resolveId.call({} as any, sidecarId)).resolves.toEqual({ id: sidecarId, moduleSideEffects: 'no-treeshake' })
+    await expect(resolveId.call({} as any, sidecarSource, logicalId)).resolves.toEqual({
+      id: '/resolved/project/src/app.json?raw&weapp-vite-sidecar-owner=%2Fproject%2Fsrc%2Fapp.ts&weapp-vite-sidecar=json&lang.js',
+      moduleSideEffects: 'no-treeshake',
+    })
+    await expect(resolveId.call({} as any, sourceId)).resolves.toBeNull()
+    expect(resolve).toHaveBeenCalledWith(sidecarSource, logicalId, { skipSelf: true })
+  })
+})

--- a/packages/weapp-vite/src/plugins/core/lifecycle/logicalEntry.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/logicalEntry.ts
@@ -1,0 +1,192 @@
+import type { PluginContext } from 'rolldown'
+import type { LogicalEntryDependency } from '../../../moduleGraph/logicalEntry'
+import type { SidecarModuleKind } from '../../../moduleGraph/protocol'
+import type { CorePluginState } from '../helpers'
+import { removeExtensionDeep } from '@weapp-core/shared'
+import path from 'pathe'
+import { createLogicalEntryModuleCode, createSidecarModuleCode } from '../../../moduleGraph/logicalEntry'
+import {
+  createSidecarSourceSpecifier,
+  parseLogicalEntryId,
+  parseSidecarModuleId,
+  parseSidecarSourceRequest,
+  resolveVirtualModuleId,
+} from '../../../moduleGraph/protocol'
+import { findCssEntry, findJsEntry, findJsonEntry, findTemplateEntry, findVueEntry, isTemplate } from '../../../utils'
+import { normalizeFsResolvedId } from '../../../utils/resolvedId'
+import { pathExists as pathExistsCached } from '../../utils/cache'
+
+function resolveEntryRecord(state: CorePluginState, sourceId: string) {
+  const relativeBase = removeExtensionDeep(state.ctx.configService.relativeAbsoluteSrcRoot(sourceId))
+  return state.entriesMap.get(relativeBase)
+    ?? state.entriesMap.get(removeExtensionDeep(sourceId))
+}
+
+async function resolveLocalModule(state: CorePluginState, source: string, importer: string) {
+  const localBase = path.isAbsolute(source)
+    ? source
+    : source.startsWith('/')
+      ? source
+      : path.resolve(path.dirname(importer), source)
+  const resolved = await state.ctx.moduleGraphService.resolve(localBase, importer)
+  if (resolved?.id) {
+    return normalizeFsResolvedId(resolved.id)
+  }
+  if (path.isAbsolute(localBase) && !path.extname(localBase)) {
+    const jsEntry = await findJsEntry(localBase)
+    const localEntry = jsEntry.path ?? await findVueEntry(localBase)
+    if (localEntry) {
+      const fallbackResolved = await state.ctx.moduleGraphService.resolve(localEntry, importer)
+      return normalizeFsResolvedId(fallbackResolved?.id ?? localEntry)
+    }
+  }
+}
+
+async function collectUsingComponentDependencies(
+  state: CorePluginState,
+  ownerId: string,
+  json: unknown,
+) {
+  if (!json || typeof json !== 'object' || !('usingComponents' in json)) {
+    return []
+  }
+  const usingComponents = json.usingComponents
+  if (!usingComponents || typeof usingComponents !== 'object' || Array.isArray(usingComponents)) {
+    return []
+  }
+  const dependencies: LogicalEntryDependency[] = []
+  for (const value of Object.values(usingComponents)) {
+    if (typeof value !== 'string' || !value || value.includes('://')) {
+      continue
+    }
+    const outputKey = removeExtensionDeep(value).replace(/^\/+/, '')
+    const mapped = state.ctx.runtimeState.build.hmr.externalComponentEntryMap.get(outputKey)
+    const candidate = mapped
+      ?? (value.startsWith('/')
+        ? path.resolve(state.ctx.configService.absoluteSrcRoot, value.slice(1))
+        : value)
+    const resolved = await resolveLocalModule(state, candidate, ownerId)
+    if (resolved) {
+      dependencies.push({ kind: 'using-component', sourceId: resolved })
+    }
+  }
+  return dependencies
+}
+
+function collectTemplateDependencies(state: CorePluginState, templatePath?: string) {
+  if (!templatePath) {
+    return []
+  }
+  const dependencies: LogicalEntryDependency[] = []
+  for (const sourceId of state.ctx.wxmlService?.depsMap?.get(templatePath) ?? []) {
+    dependencies.push({
+      kind: isTemplate(sourceId) ? 'template' : 'wxs',
+      sourceId: normalizeFsResolvedId(sourceId),
+    })
+  }
+  return dependencies
+}
+
+async function collectLogicalEntryDependencies(
+  state: CorePluginState,
+  ownerId: string,
+) {
+  const pendingDependencies = state.ctx.moduleGraphService.getEntryDependencies(ownerId)
+  const dependencies: LogicalEntryDependency[] = []
+  const addExistingDependency = async (kind: SidecarModuleKind, sourceId?: string) => {
+    if (sourceId && await pathExistsCached(sourceId)) {
+      dependencies.push({ kind, sourceId: normalizeFsResolvedId(sourceId) })
+    }
+  }
+  for (const dependency of pendingDependencies) {
+    await addExistingDependency(dependency.kind, dependency.sourceId)
+  }
+  await addExistingDependency('script', ownerId)
+  const entry = resolveEntryRecord(state, ownerId)
+  const [jsonEntry, templateEntry, styleEntry] = await Promise.all([
+    findJsonEntry(ownerId),
+    findTemplateEntry(ownerId),
+    findCssEntry(ownerId),
+  ])
+  await addExistingDependency('json', entry?.jsonPath ?? jsonEntry.path)
+  await addExistingDependency('json', entry && 'sitemapJsonPath' in entry ? entry.sitemapJsonPath : undefined)
+  await addExistingDependency('json', entry && 'themeJsonPath' in entry ? entry.themeJsonPath : undefined)
+  const templatePath = entry && 'templatePath' in entry ? entry.templatePath : templateEntry.path
+  await addExistingDependency('template', templatePath)
+  await addExistingDependency('style', styleEntry.path)
+  if (templatePath) {
+    await state.ctx.wxmlService?.scan(templatePath)
+  }
+  dependencies.push(...collectTemplateDependencies(state, templatePath))
+  dependencies.push(...await collectUsingComponentDependencies(state, ownerId, entry?.json))
+  for (const kind of ['json', 'layout', 'script', 'style', 'template', 'using-component', 'wxs'] as const) {
+    state.ctx.moduleGraphService.replaceEntryDependencies(
+      ownerId,
+      kind,
+      dependencies.filter(dependency => dependency.kind === kind).map(dependency => dependency.sourceId),
+    )
+  }
+  return dependencies
+}
+
+export function createLogicalEntryResolveHook(state: CorePluginState) {
+  return async function resolveId(this: PluginContext, id: string, importer?: string) {
+    const resolvedId = resolveVirtualModuleId(id)
+    if (resolvedId) {
+      return { id: resolvedId, moduleSideEffects: 'no-treeshake' }
+    }
+    const sidecarSource = parseSidecarSourceRequest(id)
+    if (!sidecarSource) {
+      return null
+    }
+    state.ctx.moduleGraphService.bindPluginContext(this)
+    const resolved = await state.ctx.moduleGraphService.resolve(id, importer, { skipSelf: true })
+    return {
+      id: resolved?.id ?? createSidecarSourceSpecifier(sidecarSource.ownerId, sidecarSource.sourceId, sidecarSource.kind),
+      moduleSideEffects: 'no-treeshake',
+    }
+  }
+}
+
+export function createLogicalEntryLoadHook(state: CorePluginState) {
+  return async function load(this: PluginContext, id: string) {
+    const logicalEntry = parseLogicalEntryId(id)
+    if (logicalEntry) {
+      state.ctx.moduleGraphService.bindPluginContext(this)
+      if (state.ctx.configService.isDev) {
+        await state.loadEntry.call(
+          this,
+          logicalEntry.sourceId,
+          logicalEntry.type === 'app'
+            ? 'app'
+            : logicalEntry.type === 'page' ? 'page' : 'component',
+        )
+      }
+      const dependencies = await collectLogicalEntryDependencies(state, logicalEntry.sourceId)
+      return {
+        code: createLogicalEntryModuleCode(logicalEntry, dependencies),
+        moduleSideEffects: 'no-treeshake',
+      }
+    }
+    const sidecar = parseSidecarModuleId(id)
+    if (sidecar) {
+      return {
+        code: createSidecarModuleCode(sidecar.ownerId, sidecar.sourceId, sidecar.kind),
+        meta: {
+          weappViteSidecar: sidecar,
+        },
+        moduleSideEffects: 'no-treeshake',
+      }
+    }
+    return null
+  }
+}
+
+export function replaceLogicalEntryDependencies(
+  state: CorePluginState,
+  ownerId: string,
+  kind: SidecarModuleKind,
+  sourceIds: Iterable<string>,
+) {
+  state.ctx.moduleGraphService.replaceEntryDependencies(ownerId, kind, sourceIds)
+}

--- a/packages/weapp-vite/src/plugins/core/lifecycle/transform.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/transform.test.ts
@@ -7,6 +7,7 @@ import {
 import { parseSync } from 'oxc-parser'
 import { describe, expect, it, vi } from 'vitest'
 import { compileScript, parse as parseSfc } from 'vue/compiler-sfc'
+import { createSidecarSourceSpecifier } from '../../../moduleGraph/protocol'
 import { createImportMetaDefineRegistry } from '../../../utils/importMeta'
 import { createTransformHook } from './transform'
 
@@ -45,6 +46,19 @@ function createConfigServiceMock(options?: {
 }
 
 describe('core lifecycle transform hook injectWeapi', () => {
+  it('skips sidecar source graph modules', async () => {
+    const transform = createTransformHook({
+      ctx: {
+        configService: createConfigServiceMock(),
+      },
+    } as any)
+
+    await expect(transform(
+      'export default "<script>const url = import.meta.url</script>"',
+      createSidecarSourceSpecifier('/project/src/pages/home.vue', '/project/src/pages/home.vue', 'script'),
+    )).resolves.toBeNull()
+  })
+
   it('replaces import.meta.filename, import.meta.url, import.meta.dirname and bare import.meta in script files', async () => {
     const transform = createTransformHook({
       ctx: {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/transform/index.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/transform/index.ts
@@ -4,6 +4,7 @@ import type { CorePluginState } from '../../helpers'
 import { removeExtensionDeep } from '@weapp-core/shared'
 import { mayContainPlatformApiIdentifierByText, resolveAstEngine } from '../../../../ast'
 import logger from '../../../../logger'
+import { parseSidecarSourceRequest } from '../../../../moduleGraph/protocol'
 import {
   createInjectRequestGlobalsCode,
   injectRequestGlobalsIntoSfc,
@@ -99,6 +100,9 @@ export function createTransformHook(state: CorePluginState) {
   }
 
   const transform: NonNullable<Plugin['transform']> = async function transform(code, id) {
+    if (parseSidecarSourceRequest(id)) {
+      return null
+    }
     if (!shouldTransformId(id, {
       absoluteSrcRoot: configService.absoluteSrcRoot,
       isEntry: sourceId => state.loadedEntrySet?.has(sourceId) === true

--- a/packages/weapp-vite/src/plugins/core/lifecycle/watch.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/watch.test.ts
@@ -83,6 +83,16 @@ function createState(overrides: Record<string, any> = {}) {
         invalidateIndependentOutput: vi.fn(),
         requestConfigRestart: vi.fn(),
       },
+      moduleGraphService: {
+        bindBuildContext: vi.fn(),
+        bindPluginContext: vi.fn(),
+        collectAffectedEntries: collectAffectedEntriesMock,
+        getPendingChanges: vi.fn(() => []),
+        hasModule: (id: string) => collectAffectedEntriesMock(id).size > 0,
+        invalidate: collectAffectedEntriesMock,
+        requestTopologyRescan: vi.fn(),
+        consumeTopologyRescan: vi.fn(() => undefined),
+      },
       configService: {
         platform: 'weapp',
         multiPlatform: {
@@ -134,10 +144,7 @@ function createState(overrides: Record<string, any> = {}) {
     loadedEntrySet: new Set<string>(),
     entriesMap: new Map<string, { type: string }>(),
     jsonEmitFilesMap: new Map(),
-    layoutEntryDependents: new Map<string, Set<string>>(),
     markEntryDirty: vi.fn(),
-    moduleImporters: new Map(),
-    entryModuleIds: new Set(),
     hmrState: {
       didEmitAllEntries: false,
       hasBuiltOnce: true,
@@ -146,7 +153,7 @@ function createState(overrides: Record<string, any> = {}) {
       lastEmittedEntryIds: new Set<string>(),
       skipSharedChunkRefresh: false,
     },
-    hmrSharedChunksByModule: new Map(),
+    outputChunksByModule: new Map(),
     hmrSharedChunkImporters: new Map(),
     hmrSharedChunksByEntry: new Map(),
     resolvedEntryMap: new Map(),
@@ -201,6 +208,7 @@ describe('core lifecycle watch hook', () => {
     findJsEntryMock.mockResolvedValue({
       path: '/project/src/pages/hmr/index.ts',
     })
+    collectAffectedEntriesMock.mockReturnValue(new Set(['/project/src/pages/hmr/index.ts']))
     const state = createState()
     const hook = createWatchChangeHook(state)
 
@@ -219,6 +227,7 @@ describe('core lifecycle watch hook', () => {
       '/project/src/pages/hmr/index.ts',
       '/project/src/pages/other/index.ts',
     ]))
+    collectAffectedEntriesMock.mockReturnValue(new Set(['/project/src/pages/hmr/index.ts']))
     const state = createState()
     const hook = createWatchChangeHook(state)
 
@@ -230,30 +239,21 @@ describe('core lifecycle watch hook', () => {
     expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['style-sidecar:1'])
   })
 
-  it('does not expand style sidecar updates through stale importer graph records', async () => {
+  it('queries the source graph without widening a direct style sidecar update', async () => {
     const styleId = '/project/src/pages/hmr/index.scss'
     const entryId = '/project/src/pages/hmr/index.ts'
-    const staleImporterId = '/project/src/pages/other/index.ts'
     findJsEntryMock.mockResolvedValue({
       path: entryId,
     })
-    collectAffectedEntriesMock.mockReturnValue(new Set([
-      entryId,
-      staleImporterId,
-    ]))
-    const state = createState({
-      moduleImporters: new Map([
-        [styleId, new Set([entryId, staleImporterId])],
-      ]),
-      entryModuleIds: new Set([entryId, staleImporterId]),
-    })
+    collectAffectedEntriesMock.mockReturnValue(new Set([entryId]))
+    const state = createState()
     const hook = createWatchChangeHook(state)
 
     await hook(styleId, { event: 'update' })
 
     expect(state.markEntryDirty).toHaveBeenCalledTimes(1)
     expect(state.markEntryDirty).toHaveBeenCalledWith(entryId, 'metadata')
-    expect(collectAffectedEntriesMock).not.toHaveBeenCalled()
+    expect(collectAffectedEntriesMock).toHaveBeenCalledWith(styleId)
     expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['style-sidecar:1'])
   })
 
@@ -261,6 +261,7 @@ describe('core lifecycle watch hook', () => {
     findJsEntryMock.mockResolvedValue({
       path: '/project/src/components/x-child/index.ts',
     })
+    collectAffectedEntriesMock.mockReturnValue(new Set(['/project/src/components/x-child/index.ts']))
     const state = createState()
     const hook = createWatchChangeHook(state)
 
@@ -272,6 +273,7 @@ describe('core lifecycle watch hook', () => {
 
   it('maps emitted app side json updates back to the app entry', async () => {
     const appEntry = '/project/src/app.ts'
+    collectAffectedEntriesMock.mockReturnValue(new Set([appEntry]))
     const state = createState({
       resolvedEntryMap: new Map([
         [appEntry, { id: appEntry }],
@@ -306,6 +308,7 @@ describe('core lifecycle watch hook', () => {
   it('normalizes transient create events on emitted app side json back to updates', async () => {
     vi.mocked(fs.pathExists).mockResolvedValue(true)
     const appEntry = '/project/src/app.ts'
+    collectAffectedEntriesMock.mockReturnValue(new Set([appEntry]))
     const state = createState({
       resolvedEntryMap: new Map([
         [appEntry, { id: appEntry }],
@@ -339,13 +342,10 @@ describe('core lifecycle watch hook', () => {
     expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['json-sidecar:1'])
   })
 
-  it('marks css importer vue entries dirty so style-only transform cache can refresh', async () => {
+  it('marks css importer vue entries from the source graph', async () => {
     const dependencyId = '/project/src/pages/index/hello.css'
     const vueEntry = '/project/src/pages/index/index.vue'
-    collectAffectedScriptsAndImportersMock.mockResolvedValue({
-      importers: new Set([vueEntry]),
-      scripts: new Set<string>(),
-    })
+    collectAffectedEntriesMock.mockReturnValue(new Set([vueEntry]))
     collectAffectedEntriesFromSharedChunksMock.mockReturnValue(new Set([
       '/project/src/pages/other/index.vue',
     ]))
@@ -359,15 +359,12 @@ describe('core lifecycle watch hook', () => {
 
     await hook(dependencyId, { event: 'update' })
 
-    expect(collectAffectedScriptsAndImportersMock).toHaveBeenCalledWith(state.ctx, dependencyId)
     expect(extractCssImportDependenciesMock).toHaveBeenCalledWith(state.ctx, dependencyId)
-    expect(extractCssImportDependenciesMock.mock.invocationCallOrder[0])
-      .toBeLessThan(collectAffectedScriptsAndImportersMock.mock.invocationCallOrder[0]!)
     expect(state.markEntryDirty).toHaveBeenCalledTimes(1)
-    expect(state.markEntryDirty).toHaveBeenCalledWith(vueEntry, 'direct')
+    expect(state.markEntryDirty).toHaveBeenCalledWith(vueEntry, 'metadata')
     expect(state.ctx.runtimeState.build.hmr.dirtyVueEntryIds).toEqual(new Set([vueEntry]))
     expect(collectAffectedEntriesFromSharedChunksMock).not.toHaveBeenCalled()
-    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['css-importer:1'])
+    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['style-sidecar:1'])
   })
 
   it('does not force vue recompilation for dependency-only shared chunk updates', async () => {
@@ -379,16 +376,20 @@ describe('core lifecycle watch hook', () => {
       resolvedEntryMap: new Map([
         [vueEntry, { id: vueEntry }],
       ]),
-      hmrSharedChunksByModule: new Map([
+      outputChunksByModule: new Map([
         [sharedModuleId, new Set(['common.js'])],
       ]),
       hmrSharedChunkImporters: new Map([
         ['common.js', new Set([vueEntry])],
       ]),
     })
+    state.ctx.moduleGraphService.getPendingChanges.mockReturnValue([
+      { event: 'update', file: sharedModuleId },
+    ])
     const hook = createWatchChangeHook(state)
 
     await hook(sharedModuleId, { event: 'update' })
+    await createBuildStartHook(state).call({ addWatchFile: vi.fn() })
 
     expect(state.markEntryDirty).toHaveBeenCalledWith(vueEntry, 'dependency')
     expect(state.ctx.runtimeState.build.hmr.dirtyVueEntryIds).toEqual(new Set())
@@ -396,14 +397,11 @@ describe('core lifecycle watch hook', () => {
     expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['shared-chunk-source:1'])
   })
 
-  it('treats created style files as update-like css importers after atomic saves', async () => {
+  it('treats atomic-save style creates as graph-backed sidecar updates', async () => {
     vi.mocked(fs.pathExists).mockResolvedValue(false)
     const dependencyId = '/project/src/pages/index/hello.css'
     const vueEntry = '/project/src/pages/index/index.vue'
-    collectAffectedScriptsAndImportersMock.mockResolvedValue({
-      importers: new Set([vueEntry]),
-      scripts: new Set<string>(),
-    })
+    collectAffectedEntriesMock.mockReturnValue(new Set([vueEntry]))
     const state = createState({
       loadedEntrySet: new Set([vueEntry]),
       resolvedEntryMap: new Map([
@@ -415,13 +413,10 @@ describe('core lifecycle watch hook', () => {
     await hook(dependencyId, { event: 'create' })
 
     expect(extractCssImportDependenciesMock).toHaveBeenCalledWith(state.ctx, dependencyId)
-    expect(collectAffectedScriptsAndImportersMock).toHaveBeenCalledWith(state.ctx, dependencyId)
-    expect(extractCssImportDependenciesMock.mock.invocationCallOrder[0])
-      .toBeLessThan(collectAffectedScriptsAndImportersMock.mock.invocationCallOrder[0]!)
-    expect(state.markEntryDirty).toHaveBeenCalledWith(vueEntry, 'direct')
+    expect(state.markEntryDirty).toHaveBeenCalledWith(vueEntry, 'metadata')
     expect(state.ctx.runtimeState.build.hmr.dirtyVueEntryIds).toEqual(new Set([vueEntry]))
     expect(state.ctx.runtimeState.build.hmr.profile.event).toBe('create')
-    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['css-importer:1'])
+    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['style-sidecar:1'])
   })
 
   it('marks same-name vue entry dirty for external style sidecars', async () => {
@@ -447,7 +442,7 @@ describe('core lifecycle watch hook', () => {
     expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['style-sidecar:1'])
   })
 
-  it('falls back to resolved entries when created style dependency graph has no importers yet', async () => {
+  it('funnels an untracked style create through controlled topology rescan', async () => {
     vi.mocked(fs.pathExists).mockResolvedValue(false)
     const dependencyId = '/project/src/shared/styles/shared.scss'
     const pageEntry = '/project/src/pages/native/index.ts'
@@ -458,23 +453,27 @@ describe('core lifecycle watch hook', () => {
         [componentEntry, { id: componentEntry }],
       ]),
     })
+    state.ctx.moduleGraphService.consumeTopologyRescan.mockReturnValue({
+      files: new Set([dependencyId]),
+      reasons: new Set(['sidecar-create']),
+    })
     const hook = createWatchChangeHook(state)
 
     await hook(dependencyId, { event: 'create' })
 
     expect(extractCssImportDependenciesMock).toHaveBeenCalledWith(state.ctx, dependencyId)
-    expect(collectAffectedScriptsAndImportersMock).toHaveBeenCalledWith(state.ctx, dependencyId)
     expect(state.markEntryDirty).toHaveBeenCalledWith(pageEntry, 'dependency')
     expect(state.markEntryDirty).toHaveBeenCalledWith(componentEntry, 'dependency')
-    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['css-importer-fallback:2'])
+    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['topology-full-rescan:2'])
   })
 
-  it('treats created existing shared templates as update-like wxml importers after atomic saves', async () => {
+  it('treats created existing shared templates as graph-backed updates after atomic saves', async () => {
     vi.mocked(fs.pathExists).mockResolvedValue(true)
     isTemplateMock.mockReturnValue(true)
     const sharedTemplate = '/project/src/shared/templates/card.wxml'
     const importerTemplate = '/project/src/pages/native/index.wxml'
     const importerEntry = '/project/src/pages/native/index.ts'
+    collectAffectedEntriesMock.mockReturnValue(new Set([importerEntry]))
     findJsEntryMock.mockImplementation(async (basePath: string) => {
       if (basePath === '/project/src/pages/native/index') {
         return { path: importerEntry }
@@ -493,18 +492,18 @@ describe('core lifecycle watch hook', () => {
     await hook(sharedTemplate, { event: 'create' })
 
     expect(state.ctx.wxmlService.scan).toHaveBeenCalledWith(sharedTemplate)
-    expect(state.ctx.wxmlService.getImporters).toHaveBeenCalledWith(sharedTemplate)
     expect(state.markEntryDirty).toHaveBeenCalledWith(importerEntry, 'metadata')
-    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['wxml-importer-import:1'])
+    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['sidecar-direct:1'])
   })
 
-  it('walks recursively queued wxml importers without missing later entries', async () => {
+  it('uses the bundler graph for transitive wxml importer updates', async () => {
     vi.mocked(fs.pathExists).mockResolvedValue(true)
     isTemplateMock.mockReturnValue(true)
     const sharedTemplate = '/project/src/shared/templates/root.wxml'
     const intermediateTemplate = '/project/src/shared/templates/intermediate.wxml'
     const importerTemplate = '/project/src/pages/native/index.wxml'
     const importerEntry = '/project/src/pages/native/index.ts'
+    collectAffectedEntriesMock.mockReturnValue(new Set([importerEntry]))
     findJsEntryMock.mockImplementation(async (basePath: string) => {
       if (basePath === '/project/src/pages/native/index') {
         return { path: importerEntry }
@@ -534,18 +533,18 @@ describe('core lifecycle watch hook', () => {
 
     await hook(sharedTemplate, { event: 'create' })
 
-    expect(state.ctx.wxmlService.getImporters).toHaveBeenCalledWith(sharedTemplate)
-    expect(state.ctx.wxmlService.getImporters).toHaveBeenCalledWith(intermediateTemplate)
+    expect(collectAffectedEntriesMock).toHaveBeenCalledWith(sharedTemplate)
     expect(state.markEntryDirty).toHaveBeenCalledWith(importerEntry, 'metadata')
-    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['wxml-importer-import:1'])
+    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['sidecar-direct:1'])
   })
 
-  it('keeps include-driven wxml importer updates on the conservative path', async () => {
+  it('keeps include-driven wxml importer updates on the module graph path', async () => {
     vi.mocked(fs.pathExists).mockResolvedValue(true)
     isTemplateMock.mockReturnValue(true)
     const sharedTemplate = '/project/src/shared/templates/partial.wxml'
     const importerTemplate = '/project/src/pages/native/index.wxml'
     const importerEntry = '/project/src/pages/native/index.ts'
+    collectAffectedEntriesMock.mockReturnValue(new Set([importerEntry]))
     findJsEntryMock.mockImplementation(async (basePath: string) => {
       if (basePath === '/project/src/pages/native/index') {
         return { path: importerEntry }
@@ -563,16 +562,16 @@ describe('core lifecycle watch hook', () => {
 
     await hook(sharedTemplate, { event: 'create' })
 
-    expect(state.ctx.wxmlService.getImporters).toHaveBeenCalledWith(sharedTemplate)
     expect(state.markEntryDirty).toHaveBeenCalledWith(importerEntry, 'metadata')
-    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['wxml-importer:1'])
+    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['sidecar-direct:1'])
   })
 
-  it('treats created existing shared wxs files as update-like wxml importers after atomic saves', async () => {
+  it('treats created existing shared wxs files as graph-backed updates after atomic saves', async () => {
     vi.mocked(fs.pathExists).mockResolvedValue(true)
     const sharedWxs = '/project/src/shared/wxs/format.wxs'
     const importerTemplate = '/project/src/pages/native/index.wxml'
     const importerEntry = '/project/src/pages/native/index.ts'
+    collectAffectedEntriesMock.mockReturnValue(new Set([importerEntry]))
     findJsEntryMock.mockImplementation(async (basePath: string) => {
       if (basePath === '/project/src/pages/native/index') {
         return { path: importerEntry }
@@ -587,9 +586,8 @@ describe('core lifecycle watch hook', () => {
 
     await hook(sharedWxs, { event: 'create' })
 
-    expect(state.ctx.wxmlService.getImporters).toHaveBeenCalledWith(sharedWxs)
     expect(state.markEntryDirty).toHaveBeenCalledWith(importerEntry, 'metadata')
-    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['wxml-importer:1'])
+    expect(state.ctx.runtimeState.build.hmr.profile.dirtyReasonSummary).toEqual(['sidecar-direct:1'])
   })
 
   it('marks html template updates as metadata entry dirties', async () => {
@@ -597,6 +595,7 @@ describe('core lifecycle watch hook', () => {
     findJsEntryMock.mockResolvedValue({
       path: '/project/src/pages/hmr-html/index.ts',
     })
+    collectAffectedEntriesMock.mockReturnValue(new Set(['/project/src/pages/hmr-html/index.ts']))
     const state = createState()
     const hook = createWatchChangeHook(state)
 
@@ -610,6 +609,7 @@ describe('core lifecycle watch hook', () => {
     findJsEntryMock.mockResolvedValue({
       path: '/project/src/components/x-child/index.ts',
     })
+    collectAffectedEntriesMock.mockReturnValue(new Set(['/project/src/components/x-child/index.ts']))
     const state = createState()
     const hook = createWatchChangeHook(state)
 
@@ -1102,6 +1102,7 @@ const count = 1
       path: '/project/src/pages/hmr/index.ts',
     })
     const entryId = '/project/src/pages/hmr/index.ts'
+    collectAffectedEntriesMock.mockReturnValue(new Set([entryId]))
     const state = createState({
       resolvedEntryMap: new Map([
         [entryId, { id: entryId }],
@@ -1528,6 +1529,7 @@ defineAppJson({ window: { navigationBarTitleText: '首页' } })
     findJsEntryMock.mockResolvedValue({
       path: '/project/src/pages/hmr/index.ts',
     })
+    collectAffectedEntriesMock.mockReturnValue(new Set(['/project/src/pages/hmr/index.ts']))
     const state = createState()
     const hook = createWatchChangeHook(state)
 
@@ -1544,6 +1546,7 @@ defineAppJson({ window: { navigationBarTitleText: '首页' } })
     const entryId = '/project/src/layouts/default.vue'
     const pageEntry = '/project/src/pages/layout-store/index.vue'
     const dataEntry = '/project/src/pages/data/index.vue'
+    collectAffectedEntriesMock.mockReturnValue(new Set([entryId, pageEntry, dataEntry]))
     const state = createState({
       loadedEntrySet: new Set([entryId]),
       resolvedEntryMap: new Map([
@@ -1566,15 +1569,13 @@ defineAppJson({ window: { navigationBarTitleText: '首页' } })
     const pageEntry = '/project/src/pages/layout-a/index.ts'
     const dataEntry = '/project/src/pages/layout-b/index.ts'
     const unrelatedEntry = '/project/src/pages/plain/index.ts'
+    collectAffectedEntriesMock.mockReturnValue(new Set([layoutEntry, pageEntry, dataEntry]))
     const state = createState({
       resolvedEntryMap: new Map([
         [layoutEntry, { id: layoutEntry }],
         [pageEntry, { id: pageEntry }],
         [dataEntry, { id: dataEntry }],
         [unrelatedEntry, { id: unrelatedEntry }],
-      ]),
-      layoutEntryDependents: new Map([
-        [layoutEntry, new Set([pageEntry, dataEntry])],
       ]),
     })
     const hook = createWatchChangeHook(state)
@@ -1593,6 +1594,7 @@ defineAppJson({ window: { navigationBarTitleText: '首页' } })
     findJsEntryMock.mockResolvedValue({
       path: '/project/src/layouts/default/index.ts',
     })
+    collectAffectedEntriesMock.mockReturnValue(new Set(['/project/src/layouts/default/index.ts']))
     const state = createState()
     const hook = createWatchChangeHook(state)
 
@@ -1609,14 +1611,12 @@ defineAppJson({ window: { navigationBarTitleText: '首页' } })
     const layoutEntry = '/project/src/layouts/default/index.ts'
     const pageEntry = '/project/src/pages/layout-a/index.ts'
     const unrelatedEntry = '/project/src/pages/plain/index.ts'
+    collectAffectedEntriesMock.mockReturnValue(new Set([layoutEntry, pageEntry]))
     const state = createState({
       resolvedEntryMap: new Map([
         [layoutEntry, { id: layoutEntry }],
         [pageEntry, { id: pageEntry }],
         [unrelatedEntry, { id: unrelatedEntry }],
-      ]),
-      layoutEntryDependents: new Map([
-        [layoutEntry, new Set([pageEntry])],
       ]),
     })
     const hook = createWatchChangeHook(state)
@@ -1636,6 +1636,7 @@ defineAppJson({ window: { navigationBarTitleText: '首页' } })
     const layoutEntry = '/project/src/layouts/default/index.ts'
     const pageEntry = '/project/src/pages/layout-a/index.ts'
     const unrelatedEntry = '/project/src/pages/plain/index.ts'
+    collectAffectedEntriesMock.mockReturnValue(new Set([layoutEntry, pageEntry]))
     findJsEntryMock.mockImplementation(async (basePath: string) => {
       if (basePath === '/project/src/layouts/default/index') {
         return { path: layoutEntry }
@@ -1647,9 +1648,6 @@ defineAppJson({ window: { navigationBarTitleText: '首页' } })
         [layoutEntry, { id: layoutEntry }],
         [pageEntry, { id: pageEntry }],
         [unrelatedEntry, { id: unrelatedEntry }],
-      ]),
-      layoutEntryDependents: new Map([
-        [layoutEntry, new Set([pageEntry])],
       ]),
     })
     state.ctx.wxmlService.getImporters.mockReturnValue(new Set([layoutTemplate]))
@@ -1670,6 +1668,7 @@ defineAppJson({ window: { navigationBarTitleText: '首页' } })
     const layoutTemplate = '/project/src/layouts/default/index.wxml'
     const layoutEntry = '/project/src/layouts/default/index.ts'
     const pageEntry = '/project/src/pages/layout-a/index.ts'
+    collectAffectedEntriesMock.mockReturnValue(new Set([layoutEntry, pageEntry]))
     findJsEntryMock.mockImplementation(async (basePath: string) => {
       if (basePath === '/project/src/layouts/default/index') {
         return { path: layoutEntry }
@@ -1680,9 +1679,6 @@ defineAppJson({ window: { navigationBarTitleText: '首页' } })
       resolvedEntryMap: new Map([
         [layoutEntry, { id: layoutEntry }],
         [pageEntry, { id: pageEntry }],
-      ]),
-      layoutEntryDependents: new Map([
-        [layoutEntry, new Set([pageEntry])],
       ]),
     })
     state.ctx.wxmlService.getImporters.mockReturnValue(new Set([layoutTemplate]))
@@ -1701,6 +1697,7 @@ defineAppJson({ window: { navigationBarTitleText: '首页' } })
     findJsEntryMock.mockResolvedValue({
       path: '/project/src/layouts/default/index.ts',
     })
+    collectAffectedEntriesMock.mockReturnValue(new Set(['/project/src/layouts/default/index.ts']))
     const state = createState()
     const hook = createWatchChangeHook(state)
 
@@ -1712,9 +1709,12 @@ defineAppJson({ window: { navigationBarTitleText: '首页' } })
   it('marks native layout dependency updates as dependency dirties', async () => {
     const entryId = '/project/src/pages/layouts/index.ts'
     const layoutId = '/project/src/layouts/default/index.ts'
+    collectAffectedEntriesMock.mockReturnValue(new Set([layoutId, entryId]))
     const state = createState({
-      layoutEntryDependents: new Map([
-        [layoutId, new Set([entryId])],
+      loadedEntrySet: new Set([layoutId]),
+      resolvedEntryMap: new Map([
+        [layoutId, { id: layoutId }],
+        [entryId, { id: entryId }],
       ]),
     })
     const hook = createWatchChangeHook(state)
@@ -1730,15 +1730,7 @@ defineAppJson({ window: { navigationBarTitleText: '首页' } })
       '/project/src/pages/hmr/index.ts',
       '/project/src/pages/store/index.ts',
     ]))
-    const state = createState({
-      moduleImporters: new Map([
-        [dependencyId, new Set(['/project/src/pages/hmr/index.ts'])],
-      ]),
-      entryModuleIds: new Set([
-        '/project/src/pages/hmr/index.ts',
-        '/project/src/pages/store/index.ts',
-      ]),
-    })
+    const state = createState()
     const hook = createWatchChangeHook(state)
 
     await hook(dependencyId, { event: 'update' })
@@ -1758,9 +1750,13 @@ defineAppJson({ window: { navigationBarTitleText: '首页' } })
       'common.js',
     ]))
     const state = createState()
+    state.ctx.moduleGraphService.getPendingChanges.mockReturnValue([
+      { event: 'update', file: dependencyId },
+    ])
     const hook = createWatchChangeHook(state)
 
     await hook(dependencyId, { event: 'update' })
+    await createBuildStartHook(state).call({ addWatchFile: vi.fn() })
 
     expect(state.markEntryDirty).toHaveBeenNthCalledWith(1, '/project/src/pages/native/index.ts', 'dependency')
     expect(state.markEntryDirty).toHaveBeenNthCalledWith(2, '/project/src/components/probe-card/index.ts', 'dependency')
@@ -1774,12 +1770,7 @@ defineAppJson({ window: { navigationBarTitleText: '首页' } })
     const componentEntry = '/project/src/components/probe-card/index.ts'
     collectAffectedEntriesMock.mockReturnValue(new Set([nativeEntry, componentEntry]))
     collectAffectedEntriesFromSharedChunksMock.mockReturnValue(new Set([nativeEntry, componentEntry]))
-    const state = createState({
-      moduleImporters: new Map([
-        [dependencyId, new Set([nativeEntry])],
-      ]),
-      entryModuleIds: new Set([nativeEntry, componentEntry]),
-    })
+    const state = createState()
     const hook = createWatchChangeHook(state)
 
     await hook(dependencyId, { event: 'update' })
@@ -1795,15 +1786,7 @@ defineAppJson({ window: { navigationBarTitleText: '首页' } })
       '/project/src/pages/hmr/index.ts',
       '/project/src/pages/store/index.ts',
     ]))
-    const state = createState({
-      moduleImporters: new Map([
-        [dependencyId, new Set(['/project/src/pages/hmr/index.ts'])],
-      ]),
-      entryModuleIds: new Set([
-        '/project/src/pages/hmr/index.ts',
-        '/project/src/pages/store/index.ts',
-      ]),
-    })
+    const state = createState()
     const hook = createWatchChangeHook(state)
 
     await hook(dependencyId, { event: 'delete' })
@@ -1820,12 +1803,7 @@ defineAppJson({ window: { navigationBarTitleText: '首页' } })
     const dependencyId = '/project/src/shared/root-import-hmr.ts'
     const pageEntry = '/project/src/pages/root-import-hmr/index.vue'
     collectAffectedEntriesMock.mockReturnValue(new Set([pageEntry]))
-    const state = createState({
-      moduleImporters: new Map([
-        [dependencyId, new Set([pageEntry])],
-      ]),
-      entryModuleIds: new Set([pageEntry]),
-    })
+    const state = createState()
     const hook = createWatchChangeHook(state)
 
     await hook(dependencyId, { event: 'create' })
@@ -1844,9 +1822,13 @@ defineAppJson({ window: { navigationBarTitleText: '首页' } })
     collectAffectedSharedChunksMock.mockReturnValue(new Set(['common.js']))
     const state = createState()
     state.ctx.runtimeState.build.hmr.sharedChunkSourceModuleIds = new Set([dependencyId])
+    state.ctx.moduleGraphService.getPendingChanges.mockReturnValue([
+      { event: 'update', file: dependencyId },
+    ])
     const hook = createWatchChangeHook(state)
 
     await hook(dependencyId, { event: 'create' })
+    await createBuildStartHook(state).call({ addWatchFile: vi.fn() })
 
     expect(state.markEntryDirty).toHaveBeenCalledWith(pageEntry, 'dependency')
     expect(state.hmrState.affectedSharedChunkIds).toEqual(new Set(['common.js']))

--- a/packages/weapp-vite/src/plugins/core/lifecycle/watch.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/watch.ts
@@ -17,12 +17,12 @@ import { isSkippableResolvedId, normalizeFsResolvedId } from '../../../utils/res
 import { invalidateSharedStyleCache } from '../../css/shared/preprocessor'
 import { invalidateFileCache } from '../../utils/cache'
 import { ensureSidecarWatcher, invalidateEntryForSidecar } from '../../utils/invalidateEntry'
-import { collectAffectedScriptsAndImporters, extractCssImportDependencies } from '../../utils/invalidateEntry/cssGraph'
+import { extractCssImportDependencies } from '../../utils/invalidateEntry/cssGraph'
 import { configSuffixes, watchedCssExts, watchedScriptModuleSuffixes, watchedTemplateExts } from '../../utils/invalidateEntry/shared'
 import { isLayoutSourcePath } from '../../utils/layoutSourcePath'
 import { addNormalizedWatchFiles } from '../../utils/watchFiles'
 import { isAppVueFile } from '../../vue/transform/appShell'
-import { collectAffectedEntries, collectAffectedSharedChunkEntriesAndChunks } from '../helpers'
+import { collectAffectedSharedChunkEntriesAndChunks } from '../helpers'
 import { markAppEntryForAutoRoutesTopology as markAppEntryForAutoRoutesTopologyDirty } from './autoRoutesTopology'
 import { createVueEntryUpdateInspector } from './vueEntryUpdate'
 
@@ -153,7 +153,7 @@ async function normalizeWatchEvent(
   options: {
     emittedJsonPaths?: Set<string>
     loadedEntrySet: Set<string>
-    moduleImporters?: Map<string, Set<string>>
+    hasModule?: (id: string) => boolean
     resolvedEntryMap: Map<string, unknown>
     sharedChunkSourceModuleIds?: Set<string>
   },
@@ -165,7 +165,7 @@ async function normalizeWatchEvent(
   if (
     event === 'create'
     && (
-      options.moduleImporters?.has(id)
+      options.hasModule?.(id)
       || options.sharedChunkSourceModuleIds?.has(id)
     )
     && await fs.pathExists(id)
@@ -211,8 +211,29 @@ export function createBuildStartHook(state: CorePluginState) {
   return async function buildStart(this: any) {
     const startedAt = performance.now()
     try {
+      ctx.moduleGraphService?.bindBuildContext(state, this)
+      ctx.moduleGraphService?.bindPluginContext(this)
       resetTakeImportRegistry({ preserveSharedChunkNameCache: configService.isDev })
       if (configService.isDev) {
+        let sharedChunkAffectedEntryCount = 0
+        for (const change of ctx.moduleGraphService?.getPendingChanges?.() ?? []) {
+          const sharedChunkAffected = collectAffectedSharedChunkEntriesAndChunks(state, change.file)
+          state.hmrState.affectedSharedChunkIds ??= new Set<string>()
+          for (const chunkId of sharedChunkAffected.affectedChunks) {
+            state.hmrState.affectedSharedChunkIds.add(chunkId)
+          }
+          for (const entryId of sharedChunkAffected.affectedEntries) {
+            state.markEntryDirty(entryId, 'dependency')
+            sharedChunkAffectedEntryCount += 1
+          }
+        }
+        if (sharedChunkAffectedEntryCount) {
+          const profile = ctx.runtimeState.build.hmr.profile
+          profile.dirtyReasonSummary = [
+            ...(profile.dirtyReasonSummary ?? []).filter(reason => !reason.startsWith('shared-chunk-source:')),
+            `shared-chunk-source:${sharedChunkAffectedEntryCount}`,
+          ]
+        }
         addNormalizedWatchFiles(this, configService.configFileDependencies)
         if (isPluginBuild) {
           if (configService.absolutePluginRoot) {
@@ -262,7 +283,10 @@ async function processChangedFile(
   if (isSkippableResolvedId(normalizedId)) {
     return
   }
-  const importerGraphAffectedEntryIds = new Set<string>()
+  const sidecarDirtyFiles = ctx.runtimeState.watcher?.sidecarDirtyFiles
+  const sidecarDirtyCause = sidecarDirtyFiles?.get(normalizedId)
+  sidecarDirtyFiles?.delete(normalizedId)
+  const importerGraphAffectedEntryIds = ctx.moduleGraphService.invalidate(normalizedId)
   const relativeSrc = configService.relativeAbsoluteSrcRoot(normalizedId)
   const affectedLayoutEntryIds = new Set<string>()
   const dirtyReasonStats = new Map<string, number>()
@@ -283,7 +307,6 @@ async function processChangedFile(
   const isDeletedMissingSelf = event === 'delete' && !await fs.pathExists(normalizedId)
   const isAutoRouteFile = Boolean(ctx.autoRoutesService?.isRouteFile(normalizedId))
   const pathKind = resolveWatchPathKind(normalizedId)
-  const isTemplateSidecar = Boolean(pathKind.extension && pathKind.isTemplate)
   const isScriptModuleSidecar = pathKind.isScriptModuleSidecar
   const concreteChangedEntryId = isAppVueFile(normalizedId) && scanService.appEntry?.path
     ? normalizeFsResolvedId(scanService.appEntry.path)
@@ -293,66 +316,6 @@ async function processChangedFile(
     : undefined
   let isAppShellTopologyChanged = false
   let handledSidecarMetadataUpdate = false
-
-  const addWxmlImporterEntries = async (startId: string) => {
-    const wxmlService = ctx.wxmlService
-    if (!wxmlService || typeof wxmlService.getImporters !== 'function') {
-      return
-    }
-
-    const visited = new Set<string>()
-    const queue: Array<{ id: string, importOnly: boolean }> = [{ id: startId, importOnly: true }]
-
-    for (let index = 0; index < queue.length; index += 1) {
-      const current = queue[index]!
-      const visitKey = `${current.id}\0${current.importOnly ? 'import' : 'fallback'}`
-      if (visited.has(visitKey)) {
-        continue
-      }
-      visited.add(visitKey)
-
-      const importers = wxmlService.getImporters(current.id)
-      for (const importer of importers) {
-        const normalizedImporter = normalizeFsResolvedId(importer)
-        const dependencyKind = typeof wxmlService.getImporterDependencyKind === 'function'
-          ? wxmlService.getImporterDependencyKind(current.id, normalizedImporter)
-          : undefined
-        const nextImportOnly = current.importOnly && dependencyKind === 'template-import'
-        const nextVisitKey = `${normalizedImporter}\0${nextImportOnly ? 'import' : 'fallback'}`
-        if (!visited.has(nextVisitKey)) {
-          queue.push({
-            id: normalizedImporter,
-            importOnly: nextImportOnly,
-          })
-        }
-
-        const ext = path.extname(normalizedImporter)
-        if (!ext) {
-          continue
-        }
-        const basePath = normalizedImporter.slice(0, -ext.length)
-        const primaryScript = await findJsEntry(basePath)
-        if (!primaryScript.path) {
-          continue
-        }
-        const primaryScriptId = normalizeFsResolvedId(primaryScript.path)
-        const reason = isLayoutSourcePath(configService.relativeAbsoluteSrcRoot(primaryScriptId))
-          ? 'dependency'
-          : 'direct'
-        if (reason === 'dependency') {
-          affectedLayoutEntryIds.add(primaryScriptId)
-        }
-        else {
-          markEntryDirtyWithCause(
-            primaryScriptId,
-            'metadata',
-            nextImportOnly ? 'wxml-importer-import' : 'wxml-importer',
-          )
-          handledSidecarMetadataUpdate = true
-        }
-      }
-    }
-  }
 
   const markScriptDirty = (scriptId: string, cause: string) => {
     const normalizedScriptId = normalizeFsResolvedId(scriptId)
@@ -439,29 +402,6 @@ async function processChangedFile(
     return true
   }
 
-  const addCssImporterEntries = async (startId: string) => {
-    const { importers, scripts } = await collectAffectedScriptsAndImporters(ctx, startId)
-    let affectedCount = 0
-
-    for (const importer of importers) {
-      const normalizedImporter = normalizeFsResolvedId(importer)
-      if (
-        isCurrentSubPackageFile(configService.relativeAbsoluteSrcRoot(normalizedImporter), subPackageMeta)
-        && (loadedEntrySet.has(normalizedImporter) || resolvedEntryMap.has(normalizedImporter))
-      ) {
-        markScriptDirty(normalizedImporter, 'css-importer')
-        affectedCount += 1
-      }
-    }
-
-    for (const script of scripts) {
-      markScriptDirty(script, 'css-importer')
-      affectedCount += 1
-    }
-
-    return affectedCount
-  }
-
   if (isDeletedMissingSelf) {
     ctx.runtimeState.build.hmr.vueEntryHasTemplate.delete(normalizedId)
     ctx.runtimeState.build.hmr.vueEntryNonJsonSignatures.delete(normalizedId)
@@ -520,26 +460,54 @@ async function processChangedFile(
   }
 
   invalidateFileCache(normalizedId)
-  const isSidecarCreate = event === 'create'
-    && (pathKind.isStyle || pathKind.isTemplate || pathKind.isHtmlTemplate || isScriptModuleSidecar)
-  const shouldHandleUpdateLikeSidecar = event === 'update' || isSidecarCreate
+  const isSidecarPath = Boolean(
+    pathKind.isStyle
+    || pathKind.isTemplate
+    || pathKind.isHtmlTemplate
+    || pathKind.configSuffix
+    || isScriptModuleSidecar,
+  )
+  const isSidecarCreate = event === 'create' && isSidecarPath
+  const shouldHandleUpdateLikeSidecar = event === 'update' || isSidecarCreate || (isDeletedMissingSelf && isSidecarPath)
   if (shouldHandleUpdateLikeSidecar) {
-    if (pathKind.isStyle) {
+    if (pathKind.isStyle && !isDeletedMissingSelf) {
       await extractCssImportDependencies(ctx, normalizedId)
     }
 
-    if (pathKind.isTemplate) {
+    if (pathKind.isTemplate && !isDeletedMissingSelf) {
       const wxmlService = ctx.wxmlService
       if (wxmlService) {
         await wxmlService.scan(normalizedId)
       }
     }
 
-    if (isTemplateSidecar || isScriptModuleSidecar) {
-      await addWxmlImporterEntries(normalizedId)
+    if (isSidecarPath && importerGraphAffectedEntryIds.size) {
+      const cause = pathKind.configSuffix
+        ? 'json-sidecar'
+        : pathKind.isStyle
+          ? 'style-sidecar'
+          : 'sidecar-direct'
+      const isLayoutChange = isLayoutSourcePath(relativeSrc)
+        || Array.from(importerGraphAffectedEntryIds).some(entryId =>
+          isLayoutSourcePath(configService.relativeAbsoluteSrcRoot(entryId)),
+        )
+      for (const entryId of importerGraphAffectedEntryIds) {
+        markEntryDirtyWithCause(
+          entryId,
+          isLayoutChange ? 'dependency' : 'metadata',
+          isLayoutChange
+            ? isLayoutSourcePath(configService.relativeAbsoluteSrcRoot(entryId)) ? 'layout-self' : 'layout-dependent'
+            : cause,
+        )
+      }
+      handledSidecarMetadataUpdate = true
     }
-
-    if (pathKind.isTemplate || pathKind.configSuffix || pathKind.isStyle || pathKind.isHtmlTemplate) {
+    else if (isSidecarPath && event === 'update') {
+      // Rolldown build-watch 在 watchChange 阶段不暴露上一轮 module graph；
+      // 当前 physical id 会在 buildEnd 的有效 graph 生命周期中完成入口追溯。
+      handledSidecarMetadataUpdate = true
+    }
+    else if (isSidecarPath && (event === 'create' || isDeletedMissingSelf)) {
       const basePath = pathKind.configSuffix
         ? normalizedId.slice(0, -pathKind.configSuffix.length)
         : pathKind.extension ? normalizedId.slice(0, -pathKind.extension.length) : normalizedId
@@ -552,16 +520,22 @@ async function processChangedFile(
       else if (pathKind.configSuffix && markAppEntryForJsonEmit()) {
         handledSidecarMetadataUpdate = true
       }
-      else if (pathKind.isStyle) {
-        const affectedCount = await addCssImporterEntries(normalizedId)
-        if (affectedCount === 0 && resolvedEntryMap.size) {
+      else {
+        ctx.moduleGraphService.requestTopologyRescan(
+          event === 'create' ? 'sidecar-create' : 'sidecar-delete',
+          normalizedId,
+        )
+        const topologyRescan = ctx.moduleGraphService.consumeTopologyRescan()
+        if (topologyRescan) {
+          scanService.markDirty()
+          ;(loadEntry as any)?.invalidateResolveCache?.()
           for (const entryId of resolvedEntryMap.keys()) {
             if (isCurrentSubPackageFile(configService.relativeAbsoluteSrcRoot(entryId), subPackageMeta)) {
-              markEntryDirtyWithCause(entryId, 'dependency', 'css-importer-fallback')
+              markEntryDirtyWithCause(entryId, 'dependency', 'topology-full-rescan')
             }
           }
+          handledSidecarMetadataUpdate = true
         }
-        handledSidecarMetadataUpdate = true
       }
     }
   }
@@ -582,30 +556,12 @@ async function processChangedFile(
       return [...dirtyReasonStats.entries()].map(([cause, count]) => `${cause}:${count}`)
     }
 
-    const dependentEntryIds = new Set<string>()
-
-    for (const layoutEntryId of affectedLayoutEntryIds) {
-      const dependents = state.layoutEntryDependents.get(layoutEntryId)
-      if (!dependents?.size) {
-        continue
-      }
-      for (const entryId of dependents) {
-        dependentEntryIds.add(entryId)
-      }
-    }
-
-    if (dependentEntryIds.size) {
-      for (const entryId of affectedLayoutEntryIds) {
-        markEntryDirtyWithCause(entryId, 'dependency', 'layout-self')
-      }
-      for (const entryId of dependentEntryIds) {
-        markEntryDirtyWithCause(entryId, 'dependency', 'layout-dependent')
-      }
-      return [...dirtyReasonStats.entries()].map(([cause, count]) => `${cause}:${count}`)
-    }
-
-    for (const entryId of resolvedEntryMap.keys()) {
-      markEntryDirtyWithCause(entryId, 'dependency', 'layout-fallback-full')
+    for (const entryId of importerGraphAffectedEntryIds) {
+      markEntryDirtyWithCause(
+        entryId,
+        'dependency',
+        affectedLayoutEntryIds.has(entryId) ? 'layout-self' : 'layout-dependent',
+      )
     }
     return [...dirtyReasonStats.entries()].map(([cause, count]) => `${cause}:${count}`)
   }
@@ -633,52 +589,28 @@ async function processChangedFile(
       && (vueEntryUpdateInspector ? await vueEntryUpdateInspector.isLocalAssetOnlyUpdate() : false)
     const isStyleOnlyVueEntryUpdate = isLocalAssetOnlyVueEntryUpdate
       && (vueEntryUpdateInspector ? await vueEntryUpdateInspector.isStyleOnlyUpdate() : false)
-    markChangedEntryDirty(
-      (isJsonOnlyVueEntryUpdate && !isAutoRoutesStaleAppEntry) || isLocalAssetOnlyVueEntryUpdate ? 'metadata' : 'direct',
-      isJsonOnlyVueEntryUpdate
+    const directDirtyReason = sidecarDirtyCause
+      ? 'metadata'
+      : (isJsonOnlyVueEntryUpdate && !isAutoRoutesStaleAppEntry) || isLocalAssetOnlyVueEntryUpdate ? 'metadata' : 'direct'
+    const directDirtyCause = sidecarDirtyCause
+      ?? (isJsonOnlyVueEntryUpdate
         ? isAutoRoutesStaleAppEntry ? 'entry-auto-routes' : 'entry-json-only'
         : isAppShellTopologyChanged
           ? 'entry-direct'
           : isLocalAssetOnlyVueEntryUpdate
             ? isStyleOnlyVueEntryUpdate ? 'entry-style-only' : 'entry-local-asset'
-            : 'entry-direct',
+            : 'entry-direct')
+    markChangedEntryDirty(
+      directDirtyReason,
+      directDirtyCause,
     )
   }
-  else if (state.layoutEntryDependents.size && state.layoutEntryDependents.get(normalizedId)?.size) {
-    const affectedEntries = state.layoutEntryDependents.get(normalizedId)
-    for (const entryId of affectedEntries!) {
-      markEntryDirtyWithCause(entryId, 'dependency', 'layout-dependent')
-    }
-  }
-  else if (!handledSidecarMetadataUpdate && state.moduleImporters.size && state.entryModuleIds.size) {
-    const affected = collectAffectedEntries(state, normalizedId)
-    if (affected.size) {
-      for (const entryId of affected) {
-        importerGraphAffectedEntryIds.add(entryId)
-        markEntryDirtyWithCause(entryId, 'dependency', 'importer-graph')
-      }
+  else if (!handledSidecarMetadataUpdate && importerGraphAffectedEntryIds.size) {
+    for (const entryId of importerGraphAffectedEntryIds) {
+      markEntryDirtyWithCause(entryId, 'dependency', 'importer-graph')
     }
   }
   await markAppEntryForTailwindContent()
-  const shouldExpandSharedChunkAffected = !dirtyReasonStats.has('sidecar-direct')
-    && !dirtyReasonStats.has('json-sidecar')
-    && !dirtyReasonStats.has('style-sidecar')
-    && !dirtyReasonStats.has('css-importer')
-  const sharedChunkAffected = shouldExpandSharedChunkAffected
-    ? collectAffectedSharedChunkEntriesAndChunks(state, normalizedId)
-    : undefined
-  if (sharedChunkAffected?.affectedEntries.size) {
-    state.hmrState.affectedSharedChunkIds ??= new Set<string>()
-    for (const chunkId of sharedChunkAffected.affectedChunks) {
-      state.hmrState.affectedSharedChunkIds.add(chunkId)
-    }
-    for (const entryId of sharedChunkAffected.affectedEntries) {
-      if (importerGraphAffectedEntryIds.has(entryId)) {
-        continue
-      }
-      markEntryDirtyWithCause(entryId, 'dependency', 'shared-chunk-source')
-    }
-  }
   const relativeCwd = configService.relativeCwd(normalizedId)
   let handledByIndependentWatcher = false
   let independentMeta: SubPackageMetaValue | undefined
@@ -751,6 +683,8 @@ export function createWatchChangeHook(state: CorePluginState) {
     const startedAt = performance.now()
     const eventId = createHmrProfileEventId()
     const normalizedId = normalizeFsResolvedId(id)
+    state.ctx.moduleGraphService?.bindPluginContext(this)
+    state.ctx.moduleGraphService?.recordChangedFile?.(normalizedId, change.event)
     if (isSkippableResolvedId(normalizedId)) {
       return
     }
@@ -766,7 +700,7 @@ export function createWatchChangeHook(state: CorePluginState) {
     const event = await normalizeWatchEvent(normalizedId, change.event, {
       emittedJsonPaths,
       loadedEntrySet: state.loadedEntrySet,
-      moduleImporters: state.moduleImporters,
+      hasModule: changedId => state.ctx.moduleGraphService.hasModule(changedId),
       resolvedEntryMap: state.resolvedEntryMap,
       sharedChunkSourceModuleIds: state.ctx.runtimeState.build.hmr.sharedChunkSourceModuleIds,
     })

--- a/packages/weapp-vite/src/plugins/css.test.ts
+++ b/packages/weapp-vite/src/plugins/css.test.ts
@@ -4,6 +4,7 @@ import type { SubPackageStyleEntry } from '../types'
 import { fileURLToPath } from 'node:url'
 import { dirname, relative, resolve } from 'pathe'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createLogicalEntryId } from '../moduleGraph/protocol'
 import { normalizeWatchPath } from '../utils/path'
 
 const readFileMock = vi.fn(async () => '.sidecar{color:red}')
@@ -559,13 +560,13 @@ describe('css plugin shared style injection', () => {
     expect(graph.dependencyToImporters.get(sharedStylePath.slice(0, -'.scss'.length))).toEqual(new Set([originalStylePath]))
   })
 
-  it('emits wxss from css asset via chunk viteMetadata (no originalFileNames)', async () => {
+  it('maps logical entry facades back to physical wxss owners', async () => {
     const plugin = css(ctx)[0]
     const bundle: Record<string, any> = {
       'app.js': {
         type: 'chunk',
         fileName: 'app.js',
-        facadeModuleId: resolve(absoluteSrcRoot, 'app.vue'),
+        facadeModuleId: createLogicalEntryId(resolve(absoluteSrcRoot, 'app.vue'), 'app'),
         code: '',
         map: null,
         imports: [],

--- a/packages/weapp-vite/src/plugins/css.ts
+++ b/packages/weapp-vite/src/plugins/css.ts
@@ -5,6 +5,7 @@ import type { SubPackageStyleEntry } from '../types'
 import { fs } from '@weapp-core/shared/fs'
 import path from 'pathe'
 import { preprocessCSS } from 'vite'
+import { parseLogicalEntryId } from '../moduleGraph/protocol'
 import { changeFileExtension, isJsOrTs } from '../utils'
 import { getPathExistsTtlMs } from '../utils/cachePolicy'
 import { normalizeWatchPath } from '../utils/path'
@@ -309,6 +310,10 @@ function injectSharedStyleImportsCached(
   return prependSharedStyleImports(css, missingStatements)
 }
 
+function resolveStyleOwnerId(id: string) {
+  return parseLogicalEntryId(id)?.sourceId ?? id
+}
+
 function analyzeBundleStyles(bundle: OutputBundle): BundleStyleAnalysis {
   const facadeChunks: OutputChunk[] = []
   const ownersByCssAsset = new Map<string, Set<string>>()
@@ -329,7 +334,7 @@ function analyzeBundleStyles(bundle: OutputBundle): BundleStyleAnalysis {
     }
     for (const cssAsset of importedCss) {
       const owners = ownersByCssAsset.get(cssAsset) ?? new Set<string>()
-      owners.add(output.facadeModuleId)
+      owners.add(resolveStyleOwnerId(output.facadeModuleId))
       ownersByCssAsset.set(cssAsset, owners)
     }
   }
@@ -402,7 +407,7 @@ async function handleBundleEntry(
   }
 
   const normalizeOwnerId = (id: string) => {
-    return normalizeFsResolvedId(id, { stripLeadingNullByte: true })
+    return normalizeFsResolvedId(resolveStyleOwnerId(id), { stripLeadingNullByte: true })
   }
   const preparedStyleAssets = new Map<string, Promise<PreparedStyleAsset>>()
 
@@ -687,9 +692,10 @@ async function emitSharedStyleImportsForChunks(
       if (!moduleId) {
         return
       }
-      handledModuleIds.add(normalizeFsResolvedId(moduleId))
+      const ownerId = resolveStyleOwnerId(moduleId)
+      handledModuleIds.add(normalizeFsResolvedId(ownerId))
 
-      return prepareSharedStyleImportForModule(sharedStyles, configService, sharedStyleImportCache, moduleId)
+      return prepareSharedStyleImportForModule(sharedStyles, configService, sharedStyleImportCache, ownerId)
     }),
   )
   for (const asset of chunkImportAssets) {

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/chunkEmitter.test.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/chunkEmitter.test.ts
@@ -169,4 +169,38 @@ describe('createChunkEmitter', () => {
     expect(pluginCtx.load).not.toHaveBeenCalled()
     expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
   })
+
+  it('uses the same logical entry id for preload and chunk emission', async () => {
+    const physicalId = '/project/src/layouts/default.vue'
+    const logicalId = '\0weapp-vite:logical-entry:layout:default'
+    const emitEntriesChunks = createChunkEmitter(
+      {
+        relativeOutputPath(input: string) {
+          return input.replace('/project/src/', '')
+        },
+      } as any,
+      new Set<string>(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      () => logicalId,
+    )
+    const pluginCtx = {
+      emitFile: vi.fn(),
+      load: vi.fn(async () => null),
+    }
+
+    await Promise.all(emitEntriesChunks.call(pluginCtx as any, [{ id: physicalId } as any]))
+
+    expect(pluginCtx.load).toHaveBeenCalledWith({ id: logicalId })
+    expect(pluginCtx.emitFile).toHaveBeenCalledWith(expect.objectContaining({
+      id: logicalId,
+      fileName: 'layouts/default.js',
+      preserveSignature: 'exports-only',
+    }))
+  })
 })

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/chunkEmitter.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/chunkEmitter.ts
@@ -67,7 +67,7 @@ export function createChunkEmitter(
         const emitFileStartedAt = performance.now()
         this.emitFile({
           type: 'chunk',
-          id: resolvedId.id,
+          id: entryChunkId,
           fileName,
           // @ts-ignore
           preserveSignature: 'exports-only',

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/chunkEmitter.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/chunkEmitter.ts
@@ -24,6 +24,7 @@ export function createChunkEmitter(
   preloadAssetOnlyEntry?: (this: PluginContext, resolvedId: ResolvedId, entryId: string) => Promise<void>,
   trackEmittedChunkFileName?: (fileName: string) => void,
   trackChunkEmitStats?: (stats: ChunkEmitStats) => void,
+  resolveEntryChunkId: (entryId: string, resolvedId: ResolvedId) => string = (_entryId, resolvedId) => resolvedId.id,
 ) {
   return function emitEntriesChunks(this: PluginContext, resolvedIds: (ResolvedId | null)[]) {
     return resolvedIds.map(async (resolvedId): ChunkEmitTask => {
@@ -39,6 +40,7 @@ export function createChunkEmitter(
       }
 
       const normalizedId = normalizeFsResolvedId(resolvedId.id)
+      const entryChunkId = resolveEntryChunkId(normalizedId, resolvedId)
       const shouldPreload = !loadedEntrySet.has(normalizedId)
       if (!shouldPreload) {
         stats.skippedLoadedCount += 1
@@ -53,7 +55,7 @@ export function createChunkEmitter(
           await preloadAssetOnlyEntry.call(this, resolvedId, normalizedId)
         }
         else {
-          await this.load(resolvedId)
+          await this.load({ id: entryChunkId })
         }
         stats.loadCount += 1
         stats.loadMs += performance.now() - loadStartedAt

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts
@@ -1,5 +1,6 @@
 import { fs } from '@weapp-core/shared/fs'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { parseLogicalEntryId } from '../../../moduleGraph/protocol'
 import { useLoadEntry } from './index'
 
 const loadEntryMock = vi.hoisted(() => vi.fn(async () => ({ code: '' })))
@@ -68,14 +69,14 @@ function createContext() {
 
 function expectEmittedEntry(pluginCtx: { emitFile: ReturnType<typeof vi.fn> }, sourceId: string) {
   const emitted = pluginCtx.emitFile.mock.calls.some(([asset]) => {
-    return asset.type === 'chunk' && asset.id === sourceId
+    return asset.type === 'chunk' && (parseLogicalEntryId(asset.id)?.sourceId ?? asset.id) === sourceId
   })
   expect(emitted).toBe(true)
 }
 
 function countEmittedEntries(pluginCtx: { emitFile: ReturnType<typeof vi.fn> }, sourceId: string) {
   return pluginCtx.emitFile.mock.calls.filter(([asset]) => {
-    return asset.type === 'chunk' && asset.id === sourceId
+    return asset.type === 'chunk' && (parseLogicalEntryId(asset.id)?.sourceId ?? asset.id) === sourceId
   }).length
 }
 

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.test.ts
@@ -29,11 +29,12 @@ function createContext() {
           dirtyEntryReasons: new Map<string, 'direct' | 'dependency' | 'metadata'>(),
           resolvedEntryMap: new Map<string, { id: string }>(),
           entriesMap: new Map<string, any>(),
-          layoutEntryDependents: new Map<string, Set<string>>(),
-          entryLayoutDependencies: new Map<string, Set<string>>(),
           profile: {},
         },
       },
+    },
+    moduleGraphService: {
+      replaceEntryDependencies: vi.fn(),
     },
     configService: {
       isDev: true,
@@ -63,6 +64,19 @@ function createContext() {
       resolve: vi.fn(() => null),
     },
   } as any
+}
+
+function expectEmittedEntry(pluginCtx: { emitFile: ReturnType<typeof vi.fn> }, sourceId: string) {
+  const emitted = pluginCtx.emitFile.mock.calls.some(([asset]) => {
+    return asset.type === 'chunk' && asset.id === sourceId
+  })
+  expect(emitted).toBe(true)
+}
+
+function countEmittedEntries(pluginCtx: { emitFile: ReturnType<typeof vi.fn> }, sourceId: string) {
+  return pluginCtx.emitFile.mock.calls.filter(([asset]) => {
+    return asset.type === 'chunk' && asset.id === sourceId
+  }).length
 }
 
 function createPluginContext() {
@@ -117,10 +131,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
     await hook.emitDirtyEntries.call(pluginCtx)
 
     expect(loadEntryMock).not.toHaveBeenCalled()
-    expect(pluginCtx.emitFile).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'chunk',
-      id,
-    }))
+    expectEmittedEntry(pluginCtx, id)
   })
 
   it('emits all entries in full mode', async () => {
@@ -175,9 +186,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
     await hook.emitDirtyEntries.call(pluginCtx)
 
     expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
-    expect(pluginCtx.emitFile).toHaveBeenCalledWith(expect.objectContaining({
-      id: currentId,
-    }))
+    expectEmittedEntry(pluginCtx, currentId)
     expect(hook.dirtyEntrySet.has(previousId)).toBe(true)
     expect(hook.dirtyEntrySet.has(currentId)).toBe(false)
   })
@@ -751,10 +760,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
 
     expect(pluginCtx.load).not.toHaveBeenCalled()
     expect(loadEntryMock).toHaveBeenCalledWith(id, 'component')
-    expect(pluginCtx.emitFile).not.toHaveBeenCalledWith(expect.objectContaining({
-      type: 'chunk',
-      id,
-    }))
+    expect(countEmittedEntries(pluginCtx, id)).toBe(0)
     expect(hook.loadedEntrySet.has(id)).toBe(true)
     expect(ctx.runtimeState.build.hmr.profile.emittedCount).toBe(1)
   })
@@ -783,10 +789,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
 
     expect(pluginCtx.load).not.toHaveBeenCalled()
     expect(loadEntryMock).toHaveBeenCalledWith(id, 'page')
-    expect(pluginCtx.emitFile).not.toHaveBeenCalledWith(expect.objectContaining({
-      type: 'chunk',
-      id,
-    }))
+    expect(countEmittedEntries(pluginCtx, id)).toBe(0)
     expect(ctx.runtimeState.build.hmr.profile.pendingCount).toBe(1)
     expect(ctx.runtimeState.build.hmr.profile.emittedCount).toBe(1)
     expect(ctx.runtimeState.build.hmr.profile.pendingReasonSummary).toEqual([])
@@ -815,10 +818,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
     try {
       await hook.emitDirtyEntries.call(pluginCtx)
 
-      expect(pluginCtx.emitFile).toHaveBeenCalledWith(expect.objectContaining({
-        type: 'chunk',
-        id,
-      }))
+      expectEmittedEntry(pluginCtx, id)
       expect(ctx.wxmlService.getAggregatedAutoImportComponents).toHaveBeenCalledWith(
         '/project/src/pages/home/home',
       )
@@ -854,10 +854,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
 
     expect(pluginCtx.load).not.toHaveBeenCalled()
     expect(loadEntryMock).toHaveBeenCalledWith(id, 'component')
-    expect(pluginCtx.emitFile).not.toHaveBeenCalledWith(expect.objectContaining({
-      type: 'chunk',
-      id,
-    }))
+    expect(countEmittedEntries(pluginCtx, id)).toBe(0)
     expect(ctx.runtimeState.build.hmr.lastEmittedChunkFileNames.has('/project/src/components/x-child/index.wxss')).toBe(true)
   })
 
@@ -963,10 +960,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
 
     expect(pluginCtx.load).not.toHaveBeenCalled()
     expect(loadEntryMock).toHaveBeenCalledWith(id, 'page')
-    expect(pluginCtx.emitFile).not.toHaveBeenCalledWith(expect.objectContaining({
-      type: 'chunk',
-      id,
-    }))
+    expect(countEmittedEntries(pluginCtx, id)).toBe(0)
     expect(setLastEmittedEntries).toHaveBeenLastCalledWith(new Set())
     expect(setLastHmrEntries).toHaveBeenLastCalledWith(new Set([id]))
   })
@@ -995,10 +989,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
 
     expect(pluginCtx.load).not.toHaveBeenCalled()
     expect(loadEntryMock).toHaveBeenCalledWith(id, 'page')
-    expect(pluginCtx.emitFile).not.toHaveBeenCalledWith(expect.objectContaining({
-      type: 'chunk',
-      id,
-    }))
+    expect(countEmittedEntries(pluginCtx, id)).toBe(0)
     expect(ctx.runtimeState.build.hmr.profile.emittedCount).toBe(1)
   })
 
@@ -1099,10 +1090,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
     await hook.emitDirtyEntries.call(pluginCtx)
 
     expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
-    expect(pluginCtx.emitFile).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'chunk',
-      id: ids[0],
-    }))
+    expectEmittedEntry(pluginCtx, ids[0]!)
     expect(setLastEmittedEntries).toHaveBeenLastCalledWith(new Set([ids[0]]))
     expect(setLastHmrEntries).toHaveBeenLastCalledWith(new Set(ids))
     expect(ctx.runtimeState.build.hmr.profile.pendingCount).toBe(1)
@@ -1159,10 +1147,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
     await hook.emitDirtyEntries.call(pluginCtx)
 
     expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
-    expect(pluginCtx.emitFile).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'chunk',
-      id: ids[1],
-    }))
+    expectEmittedEntry(pluginCtx, ids[1]!)
     expect(setLastEmittedEntries).toHaveBeenLastCalledWith(new Set([ids[1]]))
     expect(setLastHmrEntries).toHaveBeenLastCalledWith(new Set(ids))
     expect(ctx.runtimeState.build.hmr.profile.pendingCount).toBe(1)
@@ -1218,10 +1203,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
 
     expect(loadEntryMock).toHaveBeenCalledWith(appEntry, 'app')
     expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
-    expect(pluginCtx.emitFile).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'chunk',
-      id: ids[1],
-    }))
+    expectEmittedEntry(pluginCtx, ids[1]!)
     expect(setLastEmittedEntries).toHaveBeenLastCalledWith(new Set([ids[1]]))
     expect(setLastHmrEntries).toHaveBeenLastCalledWith(new Set([appEntry, ids[1]]))
     expect(ctx.runtimeState.build.hmr.profile.pendingCount).toBe(2)
@@ -1256,10 +1238,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
 
     expect(loadEntryMock).toHaveBeenCalledWith(appEntry, 'app')
     expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
-    expect(pluginCtx.emitFile).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'chunk',
-      id: pageEntry,
-    }))
+    expectEmittedEntry(pluginCtx, pageEntry)
     expect(setLastEmittedEntries).toHaveBeenLastCalledWith(new Set([pageEntry]))
     expect(setLastHmrEntries).toHaveBeenLastCalledWith(new Set([appEntry, pageEntry]))
     expect(ctx.runtimeState.build.hmr.profile.emittedCount).toBe(2)
@@ -1290,10 +1269,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
     await hook.emitDirtyEntries.call(pluginCtx)
 
     expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
-    expect(pluginCtx.emitFile).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'chunk',
-      id: ids[0],
-    }))
+    expectEmittedEntry(pluginCtx, ids[0]!)
     expect(setLastEmittedEntries).toHaveBeenLastCalledWith(new Set([ids[0]]))
     expect(setLastHmrEntries).toHaveBeenLastCalledWith(new Set(ids))
     expect(ctx.runtimeState.build.hmr.profile.pendingCount).toBe(1)
@@ -1330,10 +1306,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
     await hook.emitDirtyEntries.call(pluginCtx)
 
     expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
-    expect(pluginCtx.emitFile).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'chunk',
-      id: ids[0],
-    }))
+    expectEmittedEntry(pluginCtx, ids[0]!)
     expect(setLastEmittedEntries).toHaveBeenLastCalledWith(new Set([ids[0]]))
     expect(setLastHmrEntries).toHaveBeenLastCalledWith(new Set(ids))
     expect(ctx.runtimeState.build.hmr.profile.pendingCount).toBe(1)
@@ -1375,10 +1348,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
 
     expect(loadEntryMock).not.toHaveBeenCalledWith(appEntry, 'app')
     expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
-    expect(pluginCtx.emitFile).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'chunk',
-      id: pageEntry,
-    }))
+    expectEmittedEntry(pluginCtx, pageEntry)
     expect(setLastEmittedEntries).toHaveBeenLastCalledWith(new Set([pageEntry]))
     expect(setLastHmrEntries).toHaveBeenLastCalledWith(new Set(ids))
     expect(ctx.runtimeState.build.hmr.profile.pendingCount).toBe(1)
@@ -1459,10 +1429,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
     await hook.emitDirtyEntries.call(pluginCtx)
 
     expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
-    expect(pluginCtx.emitFile).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'chunk',
-      id: ids[1],
-    }))
+    expectEmittedEntry(pluginCtx, ids[1]!)
     expect(setLastEmittedEntries).toHaveBeenLastCalledWith(new Set([ids[1]]))
     expect(setLastHmrEntries).toHaveBeenLastCalledWith(new Set(ids))
     expect(ctx.runtimeState.build.hmr.profile.pendingCount).toBe(1)
@@ -1511,10 +1478,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
     await hook.emitDirtyEntries.call(pluginCtx)
 
     expect(pluginCtx.emitFile).toHaveBeenCalledTimes(1)
-    expect(pluginCtx.emitFile).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'chunk',
-      id: ids[0],
-    }))
+    expectEmittedEntry(pluginCtx, ids[0]!)
     expect(setLastEmittedEntries).toHaveBeenLastCalledWith(new Set([ids[0]]))
     expect(setLastHmrEntries).toHaveBeenLastCalledWith(new Set(ids))
     expect(ctx.runtimeState.build.hmr.profile.pendingCount).toBe(1)
@@ -1771,6 +1735,26 @@ describe('useLoadEntry emitDirtyEntries', () => {
     expect(hook.dirtyEntrySet.has(id)).toBe(false)
   })
 
+  it.each([
+    ['page', '/project/src/pages/index/index.ts', 'pages/index/index'],
+    ['component', '/project/src/components/card/index.ts', 'components/card/index'],
+  ] as const)('preloads %s logical roots with their declared entry type', async (type, id, entryKey) => {
+    const ctx = createContext()
+    const hook = useLoadEntry(ctx, {
+      hmr: {
+        sharedChunks: 'off',
+        rootInputIds: new Set([id]),
+      },
+    })
+    hook.entriesMap.set(entryKey, { type, path: id })
+    seedResolvedEntries(hook.resolvedEntryMap, [id])
+    hook.markEntryDirty(id, 'direct')
+
+    await hook.emitDirtyEntries.call(createPluginContext())
+
+    expect(loadEntryMock).toHaveBeenCalledWith(id, type)
+  })
+
   it('deduplicates repeated chunk emits in the same hmr pass', async () => {
     const ctx = createContext()
     const id = '/project/src/pages/index/index.ts'
@@ -1790,7 +1774,7 @@ describe('useLoadEntry emitDirtyEntries', () => {
     const pluginCtx = createPluginContext()
     await hook.emitDirtyEntries.call(pluginCtx)
 
-    expect(pluginCtx.emitFile.mock.calls.filter(([asset]) => asset.id === id)).toHaveLength(1)
+    expect(countEmittedEntries(pluginCtx, id)).toBe(1)
     expect(ctx.runtimeState.build.hmr.profile.chunkEmitCount).toBe(1)
     expect(ctx.runtimeState.build.hmr.profile.entryChunkEmitMs).toBeGreaterThanOrEqual(0)
     expect(ctx.runtimeState.build.hmr.profile.entryChunkLoadMs).toBeGreaterThanOrEqual(0)

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/index.ts
@@ -5,6 +5,7 @@ import { removeExtensionDeep } from '@weapp-core/shared'
 import { fs } from '@weapp-core/shared/fs'
 import { supportedCssLangs, vueExtensions } from '../../../constants'
 import { createDebugger } from '../../../debugger'
+import { createLogicalEntryId } from '../../../moduleGraph/protocol'
 import { changeFileExtension } from '../../../utils'
 import { recordHmrProfileDuration } from '../../../utils/hmrProfile'
 import { normalizeFsResolvedId } from '../../../utils/resolvedId'
@@ -25,7 +26,6 @@ interface HmrOptions {
   sharedChunkImporters?: Map<string, Set<string>>
   sharedChunksByEntry?: Map<string, Set<string>>
   sourceSharedChunks?: Set<string>
-  entryLayoutDependencies?: Map<string, Set<string>>
   setDidEmitAllEntries?: (value: boolean) => void
   setLastEmittedEntries?: (entryIds: Set<string>) => void
   setLastHmrEntries?: (entryIds: Set<string>) => void
@@ -432,8 +432,6 @@ export function useLoadEntry(
   const dirtyEntryReasons = ctx.runtimeState.build.hmr.dirtyEntryReasons as Map<string, DirtyEntryReason>
   const dirtyEntryEventIds = new Map<string, string | undefined>()
   const resolvedEntryMap = ctx.runtimeState.build.hmr.resolvedEntryMap as Map<string, ResolvedId>
-  const layoutEntryDependents = ctx.runtimeState.build.hmr.layoutEntryDependents
-  const entryLayoutDependencies = ctx.runtimeState.build.hmr.entryLayoutDependencies
   const lastActualEmittedEntryIds = new Set<string>()
   const lastChunkEmittedEntryIds = new Set<string>()
   const lastEmittedChunkFileNames = ctx.runtimeState.build.hmr.lastEmittedChunkFileNames ??= new Set<string>()
@@ -474,8 +472,13 @@ export function useLoadEntry(
       && !lastChunkEmittedEntryIds.has(entryId),
     async function preloadAssetOnlyEntry(resolvedId, entryId) {
       if (rootInputIds?.has(entryId)) {
-        await loadEntry.call(this, resolvedId.id, 'app')
-        await this.load(resolvedId)
+        const relativeBase = removeExtensionDeep(ctx.configService.relativeAbsoluteSrcRoot(entryId))
+        const declaredType = entriesMap.get(relativeBase)?.type
+        await loadEntry.call(
+          this,
+          resolvedId.id,
+          declaredType === 'page' ? 'page' : declaredType === 'component' ? 'component' : 'app',
+        )
         return
       }
       if (!shouldPreloadEntryAssetOnly(ctx.runtimeState.build.hmr.profile.dirtyReasonSummary)) {
@@ -489,6 +492,17 @@ export function useLoadEntry(
       lastEmittedChunkFileNames.add(fileName)
     },
     stats => addChunkEmitStatsSummary(chunkEmitStats, stats),
+    (entryId) => {
+      const relativeBase = removeExtensionDeep(ctx.configService.relativeAbsoluteSrcRoot(entryId))
+      const entryType = ctx.moduleGraphService?.isLogicalLayoutEntry?.(entryId)
+        ? 'layout'
+        : rootInputIds?.has(entryId)
+          ? 'app'
+          : entriesMap.get(relativeBase)?.type === 'page'
+            ? 'page'
+            : 'component'
+      return createLogicalEntryId(entryId, entryType)
+    },
   )
   const applyAutoImports = createAutoImportAugmenter(
     ctx.autoImportService,
@@ -505,35 +519,7 @@ export function useLoadEntry(
     dirtyEntrySet,
     resolvedEntryMap,
     replaceLayoutDependencies(entryId: string, dependencies: Iterable<string>) {
-      const previousDependencies = entryLayoutDependencies.get(entryId)
-      if (previousDependencies) {
-        for (const dependency of previousDependencies) {
-          const dependents = layoutEntryDependents.get(dependency)
-          if (!dependents) {
-            continue
-          }
-          dependents.delete(entryId)
-          if (dependents.size === 0) {
-            layoutEntryDependents.delete(dependency)
-          }
-        }
-      }
-
-      const normalizedDependencies = new Set(dependencies)
-      if (normalizedDependencies.size === 0) {
-        entryLayoutDependencies.delete(entryId)
-        return
-      }
-
-      entryLayoutDependencies.set(entryId, normalizedDependencies)
-      for (const dependency of normalizedDependencies) {
-        let dependents = layoutEntryDependents.get(dependency)
-        if (!dependents) {
-          dependents = new Set<string>()
-          layoutEntryDependents.set(dependency, dependents)
-        }
-        dependents.add(entryId)
-      }
+      ctx.moduleGraphService.replaceEntryDependencies(entryId, 'layout', dependencies)
     },
     normalizeEntry,
     registerJsonAsset,
@@ -560,7 +546,6 @@ export function useLoadEntry(
     loadedEntrySet,
     dirtyEntrySet,
     resolvedEntryMap,
-    layoutEntryDependents,
     jsonEmitFilesMap: jsonEmitManager.map,
     normalizeEntry,
     markEntryDirty(entryId: string, reason: DirtyEntryReason = 'direct') {
@@ -656,6 +641,7 @@ export function useLoadEntry(
         }
         const resolvedId = resolvedEntryMap.get(entryId)
         if (!resolvedId) {
+          debug?.(`hmr unresolved entry ${entryId}`)
           continue
         }
         pending.push(resolvedId)
@@ -710,7 +696,9 @@ export function useLoadEntry(
           addLastEmittedChunkFileName(entryId)
         }
       }
-      let hmrEntryIds = new Set(actualEmittedEntryIds)
+      let hmrEntryIds = new Set(
+        Array.from(actualEmittedEntryIds).filter(entryId => pendingEntryIds.has(entryId)),
+      )
       if (pendingResolution.hmrEntries) {
         hmrEntryIds = pendingResolution.hmrEntries
       }

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry.test.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry.test.ts
@@ -265,6 +265,7 @@ function createLoader(options?: CreateLoaderOptions) {
   const dirtyEntrySet = new Set<string>()
   const resolvedEntryMap = new Map<string, any>()
   const replaceLayoutDependencies = vi.fn()
+  const replaceEntryDependencies = vi.fn()
 
   const emitEntriesChunks = vi.fn((_resolvedIds: any[]) => {
     return _resolvedIds.map(async () => {})
@@ -303,6 +304,9 @@ function createLoader(options?: CreateLoaderOptions) {
     configService,
     scanService,
     runtimeState,
+    moduleGraphService: {
+      replaceEntryDependencies,
+    },
   } as any
 
   if (options?.withWxmlService) {
@@ -334,6 +338,7 @@ function createLoader(options?: CreateLoaderOptions) {
     loadedEntrySet,
     resolvedEntryMap,
     replaceLayoutDependencies,
+    replaceEntryDependencies,
     emitEntriesChunks,
     registerJsonAsset,
     scanTemplateEntry,
@@ -551,7 +556,7 @@ describe('createEntryLoader', () => {
 
     expect(jsonService.cache.get).not.toHaveBeenCalled()
     expect(jsonService.read).toHaveBeenCalledWith(jsonPath)
-    expect(pluginCtx.addWatchFile).toHaveBeenCalledWith(jsonPath)
+    expect(pluginCtx.addWatchFile).not.toHaveBeenCalledWith(jsonPath)
     expect(registerJsonAsset).toHaveBeenCalledWith(expect.objectContaining({
       jsonPath,
       json: freshJson,
@@ -1278,7 +1283,13 @@ describe('createEntryLoader', () => {
       return target === '/project/src/pages/home.wxss'
     })
 
-    const { loader, jsonService, emitEntriesChunks } = createLoader()
+    const {
+      loader,
+      jsonService,
+      emitEntriesChunks,
+      entriesMap,
+      replaceEntryDependencies,
+    } = createLoader()
     jsonService.read.mockResolvedValue({
       usingComponents: {
         card: '/components/card/index',
@@ -1306,9 +1317,20 @@ describe('createEntryLoader', () => {
 
     releaseChildChunks?.()
     await loading
+
+    expect(entriesMap.get('pages/home')).toEqual(expect.objectContaining({
+      path: pageScript,
+      jsonPath: '/project/src/pages/home.json',
+      type: 'page',
+    }))
+    expect(replaceEntryDependencies).toHaveBeenCalledWith(
+      pageScript,
+      'using-component',
+      ['/project/src/components/card/index'],
+    )
   })
 
-  it('memoises filesystem lookups for repeated watch targets', async () => {
+  it('memoises filesystem lookups without watching resolved module dependencies', async () => {
     const existsCalls = new Map<string, number>()
     existsMock.mockImplementation(async (target: string) => {
       existsCalls.set(target, (existsCalls.get(target) ?? 0) + 1)
@@ -1339,7 +1361,7 @@ describe('createEntryLoader', () => {
     expect(existsCalls.get('/project/src/app.json')).toBeUndefined()
     const addWatchMock = pluginCtx.addWatchFile as unknown as Mock
     const watchedJson = addWatchMock.mock.calls.filter(call => normalizeWatchCall(call[0]) === '/project/src/app.json')
-    expect(watchedJson).toHaveLength(1)
+    expect(watchedJson).toHaveLength(0)
     expect(jsonService.read).toHaveBeenCalledTimes(1)
     expect(MagicStringMock).not.toHaveBeenCalled()
   })
@@ -1446,7 +1468,7 @@ describe('createEntryLoader', () => {
 
     expect(jsonService.read).toHaveBeenCalledWith('/project/src/pages/home/index.json')
     expect(mockExtractConfigFromVue).not.toHaveBeenCalled()
-    expect(pluginCtx.addWatchFile).toHaveBeenCalledWith('/project/src/pages/home/index.vue')
+    expect(pluginCtx.addWatchFile).not.toHaveBeenCalledWith('/project/src/pages/home/index.vue')
   })
 
   it('reads resolved json while predicted watch targets are still being checked', async () => {
@@ -1571,7 +1593,7 @@ describe('createEntryLoader', () => {
 
     const addWatchFile = pluginCtx.addWatchFile as Mock
     const watched = addWatchFile.mock.calls.map(call => normalizeWatchCall(call[0]))
-    expect(watched).toContain(stylesheet)
+    expect(watched).not.toContain(stylesheet)
 
     const initialPrependCount = magicStringPrependMock.mock.calls.length
 
@@ -1591,7 +1613,7 @@ describe('createEntryLoader', () => {
     expect(magicStringPrependMock).toHaveBeenLastCalledWith(`import '${stylesheet}';\n`)
   })
 
-  it('adds watch targets for resolved component entries', async () => {
+  it('does not duplicate resolved component entries as watch targets', async () => {
     const pageScript = '/project/src/pages/home.js'
     mockFindJsonEntry.mockResolvedValue({
       path: '/project/src/pages/home.json',
@@ -1609,7 +1631,7 @@ describe('createEntryLoader', () => {
 
     const addWatchFile = pluginCtx.addWatchFile as Mock
     const watched = addWatchFile.mock.calls.map(call => normalizeWatchCall(call[0]))
-    expect(watched).toContain('/project/src/components/hello/index.vue')
+    expect(watched).not.toContain('/project/src/components/hello/index.vue')
   })
 
   it('merges pending auto-import entries for the current importer once', async () => {
@@ -2795,7 +2817,6 @@ import { VueCard } from '../../components'
       2,
       '/project/src/pages/index/index.ts',
       new Set([
-        '/project/src/layouts/default/index',
         '/project/src/layouts/default/index.json',
         '/project/src/layouts/default/index.wxml',
         '/project/src/layouts/default/index.wxss',
@@ -2816,12 +2837,6 @@ import { VueCard } from '../../components'
     })
     expect(emitFile).not.toHaveBeenCalledWith(expect.objectContaining({
       type: 'asset',
-      fileName: 'layouts/default/index.js',
-    }))
-
-    expect(emitFile).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'chunk',
-      id: '/project/src/layouts/default/index.ts',
       fileName: 'layouts/default/index.js',
     }))
   })
@@ -3069,14 +3084,16 @@ import { VueCard } from '../../components'
       return 'console.log("page-entry")'
     })
 
-    const { loader, emitEntriesChunks, normalizeEntry } = createLoader()
+    const { loader, emitEntriesChunks, normalizeEntry, replaceEntryDependencies } = createLoader()
     const pluginCtx = createPluginContext()
 
     await loader.call(pluginCtx, '/project/src/pages/index/index.ts', 'page')
 
-    const addWatchFile = pluginCtx.addWatchFile as Mock
-    const watched = addWatchFile.mock.calls.map(call => normalizeWatchCall(call[0]))
-    expect(watched).toContain('/project/src/layouts/default.vue')
+    expect(replaceEntryDependencies).toHaveBeenCalledWith(
+      '/project/src/pages/index/index.ts',
+      'layout',
+      new Set(['/project/src/layouts/default.vue']),
+    )
     expect(normalizeEntry).toHaveBeenCalledWith('/layouts/default', '/project/src/pages/index/index.json')
     expect(pluginCtx.emitFile).toHaveBeenCalledWith({
       type: 'asset',
@@ -3129,14 +3146,16 @@ import { VueCard } from '../../components'
       return 'Page({})'
     })
 
-    const { loader, emitEntriesChunks, normalizeEntry } = createLoader()
+    const { loader, emitEntriesChunks, normalizeEntry, replaceEntryDependencies } = createLoader()
     const pluginCtx = createPluginContext()
 
     await loader.call(pluginCtx, '/project/src/pages/index/index.ts', 'page')
 
-    const addWatchFile = pluginCtx.addWatchFile as Mock
-    const watched = addWatchFile.mock.calls.map(call => normalizeWatchCall(call[0]))
-    expect(watched).toContain('/project/src/layouts/default.vue')
+    expect(replaceEntryDependencies).toHaveBeenCalledWith(
+      '/project/src/pages/index/index.ts',
+      'layout',
+      new Set(['/project/src/layouts/default.vue']),
+    )
     expect(normalizeEntry).toHaveBeenCalledWith('/layouts/default', '/project/src/pages/index/index.json')
     expect(pluginCtx.emitFile).toHaveBeenCalledWith({
       type: 'asset',

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/emit.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/emit.ts
@@ -19,12 +19,10 @@ import { registerNativePageLayoutOutput } from '../../../outputFinalizer/pageLay
 import { readFile as readFileCached } from '../../../utils/cache'
 import { syncCssImportDependencies } from '../../../utils/invalidateEntry'
 import {
-  emitNativeLayoutScriptChunkIfNeeded,
   resolveNativeLayoutOutputOptions,
   resolveNativeLayoutStaticAssetEntries,
 } from '../../../utils/nativeLayout'
 import { expandResolvedPageLayoutFiles } from '../../../utils/pageLayout'
-import { addNormalizedWatchFile } from '../../../utils/watchFiles'
 import { emitWxmlAssetFile, resolveWxmlEmitContext } from '../../../utils/wxmlEmit'
 import { applyPageLayoutPlanToNativePage, collectNativeLayoutAssets, injectNativePageLayoutRuntime, resolvePageLayoutPlan } from '../../../vue/transform/pageLayout'
 import { collectStyleImports } from './watch'
@@ -103,6 +101,7 @@ interface EmitEntryOutputOptions {
   templatePath: string
   isPluginBuild: boolean
   normalizedEntries: string[]
+  entriesMap: Map<string, Entry | undefined>
   pluginResolvedRecords?: ResolvedEntryRecord[]
   pluginJsonPathForRegistration?: string
   pluginJsonForRegistration?: any
@@ -120,6 +119,7 @@ interface EmitEntryOutputOptions {
   forceEmitEntrySet?: Set<string>
   forceReloadEntrySet?: Set<string>
   replaceLayoutDependencies: (entryId: string, dependencies: Iterable<string>) => void
+  replaceEntryDependencies: (entryId: string, kind: 'using-component', dependencies: Iterable<string>) => void
   emitEntriesChunks: (this: PluginContext, resolvedIds: (ResolvedId | null)[]) => ChunkEmitTask[]
   registerJsonAsset: (entry: JsonEmitFileEntry) => void
   existsCache: Map<string, boolean>
@@ -133,6 +133,7 @@ interface EmitEntryOutputOptions {
   styleImportsCache?: Map<string, string[]>
   resolvedPageLayoutPlan?: ResolvedPageLayoutPlan | null
   entryCodeSource?: string
+  metadataOnly?: boolean
 }
 
 function isEntryStyleStableHmr(runtimeState: CompilerContext['runtimeState']) {
@@ -165,6 +166,7 @@ export async function emitEntryOutput(options: EmitEntryOutputOptions) {
     templatePath,
     isPluginBuild,
     normalizedEntries,
+    entriesMap,
     pluginResolvedRecords,
     pluginJsonPathForRegistration,
     pluginJsonForRegistration,
@@ -180,6 +182,7 @@ export async function emitEntryOutput(options: EmitEntryOutputOptions) {
     forceEmitEntrySet,
     forceReloadEntrySet,
     replaceLayoutDependencies,
+    replaceEntryDependencies,
     emitEntriesChunks,
     registerJsonAsset,
     existsCache,
@@ -191,6 +194,7 @@ export async function emitEntryOutput(options: EmitEntryOutputOptions) {
     styleImportsCache,
     resolvedPageLayoutPlan,
     entryCodeSource,
+    metadataOnly,
   } = options
   let json = initialJson
   function recordEntryDuration(key: HmrProfileDurationKey, startedAt: number) {
@@ -308,7 +312,6 @@ export async function emitEntryOutput(options: EmitEntryOutputOptions) {
         wxmlService.setWxmlComponentsMap(assets.template, token.components)
         emitWxmlAssetFile({
           runtime: {
-            addWatchFile: pluginCtx.addWatchFile?.bind(pluginCtx),
             emitFile: payload => pluginCtx.emitFile(payload),
           },
           id: assets.template,
@@ -338,12 +341,6 @@ export async function emitEntryOutput(options: EmitEntryOutputOptions) {
       })
       nativeLayoutAssetSourceCache.set(cacheKey, asset.source)
     }
-
-    emitNativeLayoutScriptChunkIfNeeded({
-      pluginCtx,
-      scriptId: assets.script,
-      fileName: `${resolvedOptions.relativeBase}.${resolvedOptions.scriptExtension}`,
-    })
   }
 
   const shouldSkipEntries = Boolean(options.skipEntries)
@@ -381,6 +378,18 @@ export async function emitEntryOutput(options: EmitEntryOutputOptions) {
     ? undefined
     : new Set(pluginResolvedRecords.map(record => record.entry))
 
+  replaceEntryDependencies(
+    id,
+    'using-component',
+    combinedResolved.flatMap(({ entry, resolvedId }) => {
+      if (!resolvedId || entriesMap.get(entry)?.type !== 'component') {
+        return []
+      }
+      const resolvedSourceId = normalizeFsResolvedId(resolvedId.id)
+      return isSkippableResolvedId(resolvedSourceId) ? [] : [resolvedSourceId]
+    }),
+  )
+
   for (const { entry, resolvedId } of combinedResolved) {
     if (!resolvedId) {
       const missingAbsoluteEntryPath = path.resolve(entryResolveRoot, entry)
@@ -400,13 +409,6 @@ export async function emitEntryOutput(options: EmitEntryOutputOptions) {
     }
 
     const normalizedResolvedId = normalizeFsResolvedId(resolvedId.id)
-    if (
-      normalizedResolvedId
-      && !isSkippableResolvedId(normalizedResolvedId)
-      && path.isAbsolute(normalizedResolvedId)
-    ) {
-      addNormalizedWatchFile(pluginCtx, normalizedResolvedId)
-    }
     if (normalizedResolvedId && !isSkippableResolvedId(normalizedResolvedId)) {
       resolvedEntryMap.set(normalizedResolvedId, resolvedId)
     }
@@ -429,7 +431,7 @@ export async function emitEntryOutput(options: EmitEntryOutputOptions) {
     }
   }
 
-  if (pendingResolvedIds.length) {
+  if (pendingResolvedIds.length && !metadataOnly) {
     const startedAt = performance.now()
     try {
       await Promise.all(emitEntriesChunks.call(pluginCtx, pendingResolvedIds))
@@ -476,7 +478,6 @@ export async function emitEntryOutput(options: EmitEntryOutputOptions) {
       if (layoutPlan) {
         const layoutDependencies = new Set<string>()
         for (const file of await expandResolvedPageLayoutFiles(layoutPlan.layouts)) {
-          addNormalizedWatchFile(pluginCtx, file)
           layoutDependencies.add(normalizeFsResolvedId(file))
         }
         replaceLayoutDependencies(id, layoutDependencies)

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/index.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/index.ts
@@ -21,10 +21,9 @@ import { isPathInside } from '../../../../utils/path'
 import { normalizeFsResolvedId } from '../../../../utils/resolvedId'
 import { analyzeCommonJson } from '../../../utils/analyze'
 import { markComponentEntries, registerResolvedPageLayoutEntries } from '../../../utils/layoutEntries'
-import { addResolvedPageLayoutWatchFiles, expandResolvedPageLayoutFiles } from '../../../utils/pageLayout'
+import { expandResolvedPageLayoutFiles, registerResolvedPageLayoutDependencies } from '../../../utils/pageLayout'
 import { emitScriptlessComponentAsset, resolveScriptlessComponentFileName, SLOT_HOST_SCRIPTLESS_COMPONENT_STUB } from '../../../utils/scriptlessComponent'
 import { shouldEmitScriptlessVueLayoutJs as shouldEmitScriptlessVueLayoutJsFromSource } from '../../../utils/scriptlessVueLayout'
-import { addNormalizedWatchFile } from '../../../utils/watchFiles'
 import { resolvePageLayoutPlan } from '../../../vue/transform/pageLayout'
 import { collectAppEntries } from './app'
 import { emitEntryOutput, prepareNormalizedEntries } from './emit'
@@ -194,7 +193,12 @@ export function createEntryLoader(options: EntryLoaderOptions) {
     }
   }
 
-  const loadEntry = async function loadEntry(this: PluginContext, id: string, type: 'app' | 'page' | 'component') {
+  const loadEntry = async function loadEntry(
+    this: PluginContext,
+    id: string,
+    type: 'app' | 'page' | 'component',
+    loadOptions?: { metadataOnly?: boolean },
+  ) {
     if (configService.isDev) {
       existsCache.clear()
     }
@@ -208,7 +212,6 @@ export function createEntryLoader(options: EntryLoaderOptions) {
       ? ctx.runtimeState.lib.entries.get(normalizedId)
       : undefined
 
-    addNormalizedWatchFile(this, id)
     const baseName = removeExtensionDeep(id)
 
     function recordEntryDuration(key: HmrProfileDurationKey, startedAt: number) {
@@ -289,10 +292,6 @@ export function createEntryLoader(options: EntryLoaderOptions) {
     }
 
     // 回退：当不存在 .json 时，尝试从 .vue 的 <json> 块读取配置
-    if (vueEntryPath) {
-      addNormalizedWatchFile(this, vueEntryPath)
-    }
-
     let vueSource: string | undefined
     const readVueSource = async () => {
       if (!vueEntryPath) {
@@ -391,7 +390,7 @@ export function createEntryLoader(options: EntryLoaderOptions) {
         replaceLayoutDependencies(normalizedId, layoutDependencies)
       }
 
-      await addResolvedPageLayoutWatchFiles(this, layoutPlan.layouts)
+      await registerResolvedPageLayoutDependencies(ctx, normalizedId, layoutPlan.layouts)
       await registerResolvedPageLayoutEntries({
         layouts: layoutPlan.layouts,
         entries,
@@ -715,6 +714,18 @@ export function createEntryLoader(options: EntryLoaderOptions) {
     }
 
     const prepareStartedAt = performance.now()
+    const ownerEntryKey = removeExtensionDeep(configService.relativeAbsoluteSrcRoot(id))
+    const ownerEntry = type === 'app'
+      ? { ...entriesMap.get(ownerEntryKey) }
+      : {}
+    entriesMap.set(ownerEntryKey, {
+      ...ownerEntry,
+      type,
+      path: id,
+      json,
+      ...(jsonPath ? { jsonPath } : {}),
+      ...(templatePath ? { templatePath } : {}),
+    } as Entry)
     const normalizedEntries = shouldSkipAppEntries
       ? []
       : prepareNormalizedEntries({
@@ -754,6 +765,7 @@ export function createEntryLoader(options: EntryLoaderOptions) {
           templatePath,
           isPluginBuild,
           normalizedEntries,
+          entriesMap,
           pluginResolvedRecords,
           pluginJsonPathForRegistration,
           pluginJsonForRegistration,
@@ -769,6 +781,9 @@ export function createEntryLoader(options: EntryLoaderOptions) {
           forceEmitEntrySet,
           forceReloadEntrySet,
           replaceLayoutDependencies,
+          replaceEntryDependencies: (entryId, kind, dependencies) => {
+            ctx.moduleGraphService.replaceEntryDependencies(entryId, kind, dependencies)
+          },
           emitEntriesChunks,
           registerJsonAsset,
           existsCache,
@@ -781,6 +796,7 @@ export function createEntryLoader(options: EntryLoaderOptions) {
           resolvedPageLayoutPlan,
           entryCodeSource,
           skipEntries: shouldSkipAppEntries,
+          metadataOnly: loadOptions?.metadataOnly,
         })
       }
       finally {

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/watch.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/watch.ts
@@ -19,12 +19,16 @@ export async function addWatchTarget(
 
   if (existsCache.has(target)) {
     const cached = existsCache.get(target)!
-    addNormalizedWatchFile(pluginCtx, target)
+    if (!cached) {
+      addNormalizedWatchFile(pluginCtx, target)
+    }
     return cached
   }
 
   const exists = await pathExistsCached(target, { ttlMs })
-  addNormalizedWatchFile(pluginCtx, target)
+  if (!exists) {
+    addNormalizedWatchFile(pluginCtx, target)
+  }
 
   existsCache.set(target, exists)
   return exists
@@ -40,7 +44,6 @@ export async function addPredictedWatchTargets(
   await Promise.all(Array.from(new Set(predictions)).map(async (prediction) => {
     if (prediction && prediction === knownExistingPath) {
       existsCache.set(prediction, true)
-      addNormalizedWatchFile(pluginCtx, prediction)
       return
     }
     await addWatchTarget(pluginCtx, prediction, existsCache, ttlMs)

--- a/packages/weapp-vite/src/plugins/outputFinalizer.test.ts
+++ b/packages/weapp-vite/src/plugins/outputFinalizer.test.ts
@@ -1,7 +1,7 @@
 import type { OutputBundle } from 'rolldown'
 import { Buffer } from 'node:buffer'
 import { describe, expect, it } from 'vitest'
-import { createOutputFinalizerPlugin, mayNeedTemplateNormalization, normalizePreprocessorStyleAssets, normalizeTemplateAssets, pruneUnchangedDevHmrOutputs } from './outputFinalizer'
+import { createOutputFinalizerPlugin, mayNeedTemplateNormalization, normalizeGraphOnlyAssets, normalizePreprocessorStyleAssets, normalizeTemplateAssets, pruneUnchangedDevHmrOutputs } from './outputFinalizer'
 
 function createBundleAssetEmitter(bundle: OutputBundle) {
   return (asset: any) => {
@@ -21,6 +21,50 @@ function runGenerateBundle(plugin: ReturnType<typeof createOutputFinalizerPlugin
 }
 
 describe('weapp-vite output finalizer', () => {
+  it('maps graph-only virtual assets back to physical owner outputs', () => {
+    const logicalAsset = '__weapp_vite_external__/graph/weapp-vite:logical-entry:layout:D%3A%2Fproject%2Fsrc%2Flayouts%2Fdefault%2Findex.vue:module.wxss'
+    const sidecarAsset = '__weapp_vite_external__/graph/weapp-vite:sidecar:style:D%3A%2Fproject%2Fsrc%2Fapp.ts:D%3A%2Fproject%2Fsrc%2Fapp.css:module.wxss'
+    const bundle = {
+      [logicalAsset]: {
+        type: 'asset',
+        fileName: logicalAsset,
+        source: '.layout{}',
+      },
+      [sidecarAsset]: {
+        type: 'asset',
+        fileName: sidecarAsset,
+        source: '.app{}',
+      },
+      'layouts/default/index.wxss': {
+        type: 'asset',
+        fileName: 'layouts/default/index.wxss',
+        source: '.old-layout{}',
+      },
+    } as unknown as OutputBundle
+
+    const emitted: any[] = []
+    normalizeGraphOnlyAssets({
+      configService: {
+        outputExtensions: { wxss: 'wxss' },
+        relativeOutputPath: (id: string) => id
+          .replace('D:/project/src/', '')
+          .replace('D:/project/', ''),
+      },
+    } as any, bundle, asset => emitted.push(asset))
+
+    expect(bundle[logicalAsset]).toBeUndefined()
+    expect(bundle[sidecarAsset]).toBeUndefined()
+    expect(bundle['layouts/default/index.wxss']).toMatchObject({
+      source: '.layout{}',
+    })
+    expect(emitted).toEqual([
+      expect.objectContaining({
+        fileName: 'app.wxss',
+        source: '.app{}',
+      }),
+    ])
+  })
+
   it('drops duplicate preprocessor style assets', () => {
     const bundle = {
       'app.scss': {

--- a/packages/weapp-vite/src/plugins/outputFinalizer.ts
+++ b/packages/weapp-vite/src/plugins/outputFinalizer.ts
@@ -4,7 +4,13 @@ import type { CompilerContext } from '../context'
 import type { MpPlatform } from '../types'
 import type { RewriteWevuInternalRuntimeImportsOptions } from './core/helpers'
 import { Buffer } from 'node:buffer'
+import {
+  WEAPP_VITE_LOGICAL_ENTRY_RESOLVED_PREFIX,
+  WEAPP_VITE_SIDECAR_RESOLVED_PREFIX,
+} from '@weapp-core/constants'
 import { getSupportedMiniProgramDirectivePrefixes } from '@weapp-core/shared'
+import path from 'pathe'
+import { parseLogicalEntryId, parseSidecarModuleId } from '../moduleGraph/protocol'
 import { getWxmlPlatformTransformOptions } from '../platform'
 import { changeFileExtension } from '../utils'
 import { handleWxml, scanWxml } from '../wxml'
@@ -38,6 +44,62 @@ type EmitAsset = (asset: EmittedAsset) => void
 interface OutputAssetEntry {
   bundleFileName: string
   output: Extract<OutputBundle[string], { type: 'asset' }>
+}
+
+const GRAPH_ONLY_OUTPUT_MARKERS = [
+  WEAPP_VITE_LOGICAL_ENTRY_RESOLVED_PREFIX,
+  WEAPP_VITE_SIDECAR_RESOLVED_PREFIX,
+]
+
+function parseGraphOnlyAssetOwner(fileName: string) {
+  for (const marker of GRAPH_ONLY_OUTPUT_MARKERS) {
+    const markerIndex = fileName.indexOf(marker)
+    if (markerIndex < 0) {
+      continue
+    }
+    const request = fileName.slice(markerIndex)
+    const extension = path.extname(request)
+    const moduleId = `${extension ? request.slice(0, -extension.length) : request}.js`
+    return parseLogicalEntryId(moduleId)?.sourceId
+      ?? parseSidecarModuleId(moduleId)?.ownerId
+  }
+}
+
+export function normalizeGraphOnlyAssets(
+  ctx: CompilerContext,
+  bundle: OutputBundle,
+  emitAsset: EmitAsset,
+) {
+  for (const [bundleFileName, output] of Object.entries(bundle)) {
+    if (output?.type !== 'asset') {
+      continue
+    }
+    const fileName = output.fileName || bundleFileName
+    const ownerId = parseGraphOnlyAssetOwner(fileName)
+    if (!ownerId) {
+      continue
+    }
+    delete bundle[bundleFileName]
+    const outputFileName = ctx.configService.relativeOutputPath(
+      changeFileExtension(ownerId, ctx.configService.outputExtensions.wxss),
+    )
+    if (!outputFileName) {
+      continue
+    }
+    const existingOutput = bundle[outputFileName]
+    if (existingOutput?.type === 'asset') {
+      existingOutput.source = output.source
+      existingOutput.fileName = outputFileName
+      continue
+    }
+    if (!existingOutput) {
+      emitAsset({
+        type: 'asset',
+        fileName: outputFileName,
+        source: output.source,
+      })
+    }
+  }
 }
 
 function collectOutputFinalizerAssetEntries(bundle: OutputBundle) {
@@ -264,7 +326,6 @@ export function pruneUnchangedDevHmrOutputs(
       delete bundle[fileName]
       continue
     }
-
     const source = outputSourceToString(output)
     if (isHmrBuild && !shouldForceEmitCurrentHmrChunk && cache.get(fileName) === source) {
       delete bundle[fileName]
@@ -307,6 +368,7 @@ export function createOutputFinalizerPlugin(ctx: CompilerContext): Plugin {
         rewriteWevuInternalRuntimeImports(bundle as unknown as OutputBundle, wevuRuntimeRewriteOptions)
         stabilizeWevuRuntimeChunkAccess(bundle as unknown as OutputBundle)
         restoreNativePageLayoutOutputs(ctx, outputBundle)
+        normalizeGraphOnlyAssets(ctx, outputBundle, asset => this.emitFile(asset))
         const assetEntries = collectOutputFinalizerAssetEntries(outputBundle)
         normalizePreprocessorStyleAssetEntries(
           outputBundle,

--- a/packages/weapp-vite/src/plugins/utils/invalidateEntry/cssGraph.test.ts
+++ b/packages/weapp-vite/src/plugins/utils/invalidateEntry/cssGraph.test.ts
@@ -252,11 +252,8 @@ describe('invalidateEntry cssGraph', () => {
 
     expect(dependencies).toEqual(new Set([
       hello,
-      hello.slice(0, -'.css'.length),
       global,
-      global.slice(0, -'.scss'.length),
       external,
-      external.slice(0, -'.css'.length),
     ]))
     expect(ctx.runtimeState.css.dependencyToImporters.get(hello)).toEqual(new Set([vueFile]))
     expect(ctx.runtimeState.css.dependencyToImporters.get(hello.slice(0, -'.css'.length))).toEqual(new Set([vueFile]))

--- a/packages/weapp-vite/src/plugins/utils/invalidateEntry/cssGraph.ts
+++ b/packages/weapp-vite/src/plugins/utils/invalidateEntry/cssGraph.ts
@@ -225,19 +225,28 @@ export function syncVueSfcStyleDependencies(
   filename: string,
   styleBlocks: SFCStyleBlock[] | undefined,
 ) {
-  const dependencies = new Set<string>()
-  for (const block of styleBlocks ?? []) {
-    if (block.content) {
-      for (const dependency of collectCssDependenciesFromContent(ctx, filename, block.content)) {
-        dependencies.add(dependency)
+  const graphDependencies = new Set<string>()
+  const moduleDependencies = new Set<string>()
+  const addDependencies = (dependencies: Iterable<string>) => {
+    for (const dependency of dependencies) {
+      graphDependencies.add(dependency)
+      if (path.extname(dependency)) {
+        moduleDependencies.add(dependency)
       }
     }
+  }
+  for (const block of styleBlocks ?? []) {
+    if (block.content) {
+      addDependencies(collectCssDependenciesFromContent(ctx, filename, block.content))
+    }
     if (typeof block.src === 'string' && block.src.trim()) {
+      const dependencies = new Set<string>()
       addResolvedCssSpecifier(ctx, dependencies, filename, block.src.trim())
+      addDependencies(dependencies)
     }
   }
-  registerCssImports(ctx, filename, dependencies)
-  return dependencies
+  registerCssImports(ctx, filename, graphDependencies)
+  return moduleDependencies
 }
 
 function collectCssImporters(

--- a/packages/weapp-vite/src/plugins/utils/invalidateEntry/sidecar.ts
+++ b/packages/weapp-vite/src/plugins/utils/invalidateEntry/sidecar.ts
@@ -68,10 +68,17 @@ export async function invalidateEntryForSidecar(ctx: CompilerContext, filePath: 
 
   const isCssSidecar = Boolean(ext && watchedCssExts.has(ext))
   const isTemplateSidecar = Boolean(ext && watchedTemplateExts.has(ext))
+  const sidecarCause = configSuffix
+    ? 'json-sidecar' as const
+    : isCssSidecar
+      ? 'style-sidecar' as const
+      : 'sidecar-direct' as const
   const configService = ctx.configService
   const relativeSource = configService.relativeCwd(normalizedPath)
+  const sidecarDirtyFiles = ctx.runtimeState?.watcher?.sidecarDirtyFiles
 
   for (const target of touchedTargets) {
+    sidecarDirtyFiles?.set(normalizePath(target), sidecarCause)
     try {
       await touch(target)
     }
@@ -79,6 +86,7 @@ export async function invalidateEntryForSidecar(ctx: CompilerContext, filePath: 
   }
 
   for (const script of touchedScripts) {
+    sidecarDirtyFiles?.set(normalizePath(script), sidecarCause)
     try {
       await touch(script)
     }

--- a/packages/weapp-vite/src/plugins/utils/invalidateEntry/watcher.test.ts
+++ b/packages/weapp-vite/src/plugins/utils/invalidateEntry/watcher.test.ts
@@ -60,6 +60,9 @@ function createContext() {
         sidecarWatcherMap: new Map<string, { close: () => Promise<void> | void }>(),
       },
     },
+    moduleGraphService: {
+      hasModule: vi.fn(() => false),
+    },
     wxmlService: {
       scan: scanMock,
       getImporters: (value: string) => {
@@ -273,5 +276,25 @@ describe('invalidateEntry sidecar watcher', () => {
     expect(scanMock).toHaveBeenCalledWith('/project/src/pages/hmr/index.wxml')
     expect(invalidateEntryForSidecarMock).toHaveBeenCalledWith(ctx, '/project/src/pages/hmr/index.wxml', 'update')
     expect(loggerMock.info).toHaveBeenCalledWith('[watch:update] src/pages/hmr/index.wxml')
+  })
+
+  it('does not duplicate updates already owned by the bundler module graph', async () => {
+    vi.stubEnv('VITEST', '')
+    vi.stubEnv('NODE_ENV', 'development')
+
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+    const watcher = createChokidarWatcher()
+    chokidarWatchMock.mockReturnValue(watcher)
+    const ctx = createContext()
+    ctx.moduleGraphService.hasModule.mockReturnValue(true)
+    ensureSidecarWatcher(ctx, '/project/src')
+
+    watcher.emit('ready')
+    watcher.emit('change', '/project/src/pages/hmr/index.wxml')
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(scanMock).toHaveBeenCalledWith('/project/src/pages/hmr/index.wxml')
+    expect(invalidateEntryForSidecarMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/weapp-vite/src/plugins/utils/invalidateEntry/watcher.ts
+++ b/packages/weapp-vite/src/plugins/utils/invalidateEntry/watcher.ts
@@ -47,6 +47,7 @@ export function ensureSidecarWatcher(ctx: CompilerContext, rootDir: string) {
     const ext = path.extname(filePath)
     const isCssFile = Boolean(ext && watchedCssExts.has(ext))
     const isTemplateFile = Boolean(ext && watchedTemplateExts.has(ext))
+    const isConfigFile = configExtensions.some(suffix => filePath.endsWith(suffix))
     const isScriptModuleFile = watchedScriptModuleSuffixes.some(suffix => filePath.endsWith(suffix))
     const hasReverseImporters = Boolean(isTemplateFile || isScriptModuleFile)
       && (ctx.wxmlService?.getImporters(filePath).size ?? 0) > 0
@@ -56,13 +57,17 @@ export function ensureSidecarWatcher(ctx: CompilerContext, rootDir: string) {
     }
 
     const isDeleteEvent = event === 'delete'
+    const isOwnedByModuleGraph = event === 'update' && ctx.moduleGraphService?.hasModule?.(filePath) === true
     const shouldInvalidate = (event === 'create' && ready)
       || isDeleteEvent
-      || (event === 'update' && (isCssFile || hasReverseImporters || isTemplateFile))
+      || (event === 'update' && (isCssFile || hasReverseImporters || isTemplateFile || isConfigFile))
     if (shouldInvalidate) {
       void (async () => {
         if (isTemplateFile && event !== 'delete') {
           await ctx.wxmlService?.scan(filePath)
+        }
+        if (isOwnedByModuleGraph) {
+          return
         }
         await invalidateEntryForSidecar(ctx, filePath, event)
         if (isCssFile && isDeleteEvent) {

--- a/packages/weapp-vite/src/plugins/utils/nativeLayout.test.ts
+++ b/packages/weapp-vite/src/plugins/utils/nativeLayout.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
-  emitNativeLayoutScriptChunkIfNeeded,
   resolveNativeLayoutOutputOptions,
   resolveNativeLayoutStaticAssetEntries,
 } from './nativeLayout'
@@ -26,37 +25,6 @@ describe('native layout helpers', () => {
       jsonExtension: 'json',
       scriptExtension: 'mjs',
       scriptModuleExtension: 'sjs',
-    })
-  })
-
-  it('emits native layout script chunks only once per file name', () => {
-    const emitFile = vi.fn()
-    const pluginCtx = {
-      emitFile,
-    }
-
-    expect(emitNativeLayoutScriptChunkIfNeeded({
-      pluginCtx,
-      scriptId: '/project/src/layouts/default/index.ts',
-      fileName: 'layouts/default/index.js',
-    })).toBe(true)
-    expect(emitNativeLayoutScriptChunkIfNeeded({
-      pluginCtx,
-      scriptId: '/project/src/layouts/default/index.ts',
-      fileName: 'layouts/default/index.js',
-    })).toBe(false)
-    expect(emitNativeLayoutScriptChunkIfNeeded({
-      pluginCtx,
-      scriptId: undefined,
-      fileName: 'layouts/default/index.js',
-    })).toBe(false)
-
-    expect(emitFile).toHaveBeenCalledTimes(1)
-    expect(emitFile).toHaveBeenCalledWith({
-      type: 'chunk',
-      id: '/project/src/layouts/default/index.ts',
-      fileName: 'layouts/default/index.js',
-      preserveSignature: 'exports-only',
     })
   })
 

--- a/packages/weapp-vite/src/plugins/utils/nativeLayout.ts
+++ b/packages/weapp-vite/src/plugins/utils/nativeLayout.ts
@@ -55,29 +55,3 @@ export async function resolveNativeLayoutStaticAssetEntries(options: {
 
   return entries
 }
-
-export function emitNativeLayoutScriptChunkIfNeeded(options: {
-  pluginCtx: any
-  scriptId: string | undefined
-  fileName: string
-}) {
-  const { pluginCtx, scriptId, fileName } = options
-  if (!scriptId) {
-    return false
-  }
-
-  const emittedLayoutScripts: Set<string> = (pluginCtx as any).__weappViteNativeLayoutScripts ?? ((pluginCtx as any).__weappViteNativeLayoutScripts = new Set<string>())
-  if (emittedLayoutScripts.has(fileName)) {
-    return false
-  }
-
-  emittedLayoutScripts.add(fileName)
-  pluginCtx.emitFile({
-    type: 'chunk',
-    id: scriptId,
-    fileName,
-    // @ts-ignore Rolldown 的 PluginContext 类型不完整
-    preserveSignature: 'exports-only',
-  })
-  return true
-}

--- a/packages/weapp-vite/src/plugins/utils/pageLayout.test.ts
+++ b/packages/weapp-vite/src/plugins/utils/pageLayout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { addResolvedPageLayoutWatchFiles, expandResolvedPageLayoutFiles } from './pageLayout'
+import { expandResolvedPageLayoutFiles, registerResolvedPageLayoutDependencies } from './pageLayout'
 
 const collectNativeLayoutAssetsMock = vi.hoisted(() => vi.fn(async () => ({
   json: '/project/src/layouts/default/index.json',
@@ -25,7 +25,6 @@ describe('page layout helpers', () => {
       },
     ] as any)).toEqual([
       '/project/src/layouts/dashboard.vue',
-      '/project/src/layouts/default/index',
       '/project/src/layouts/default/index.json',
       '/project/src/layouts/default/index.wxml',
       '/project/src/layouts/default/index.wxss',
@@ -33,20 +32,41 @@ describe('page layout helpers', () => {
     ])
   })
 
-  it('adds normalized watch files for resolved layouts', async () => {
-    const addWatchFile = vi.fn()
+  it('registers resolved layouts as logical entry dependencies', async () => {
+    const replaceEntryDependencies = vi.fn()
+    const sharedTemplate = '/project/src/shared/layout-card.wxml'
+    const sharedWxs = '/project/src/shared/layout-helper.wxs'
+    const scan = vi.fn(async () => {})
 
-    await addResolvedPageLayoutWatchFiles({
-      addWatchFile,
-    }, [
+    await registerResolvedPageLayoutDependencies({
+      moduleGraphService: {
+        replaceEntryDependencies,
+      },
+      wxmlService: {
+        depsMap: new Map([
+          ['/project/src/layouts/default/index.wxml', new Set([sharedTemplate, sharedWxs])],
+        ]),
+        scan,
+      },
+    } as any, '/project/src/pages/home/index.vue', [
       {
         kind: 'native',
         file: '/project/src/layouts/default/index',
       },
     ] as any)
 
-    expect(addWatchFile).toHaveBeenCalledTimes(5)
-    expect(addWatchFile).toHaveBeenNthCalledWith(1, '/project/src/layouts/default/index')
-    expect(addWatchFile).toHaveBeenNthCalledWith(5, '/project/src/layouts/default/index.ts')
+    expect(replaceEntryDependencies).toHaveBeenCalledWith(
+      '/project/src/pages/home/index.vue',
+      'layout',
+      new Set([
+        '/project/src/layouts/default/index.json',
+        '/project/src/layouts/default/index.wxml',
+        '/project/src/layouts/default/index.wxss',
+        '/project/src/layouts/default/index.ts',
+        sharedTemplate,
+        sharedWxs,
+      ]),
+    )
+    expect(scan).toHaveBeenCalledWith('/project/src/layouts/default/index.wxml')
   })
 })

--- a/packages/weapp-vite/src/plugins/utils/pageLayout.ts
+++ b/packages/weapp-vite/src/plugins/utils/pageLayout.ts
@@ -1,5 +1,6 @@
+import type { CompilerContext } from '../../context'
 import type { ResolvedPageLayout } from '../vue/transform/pageLayout/types'
-import { normalizeWatchPath } from '../../utils/path'
+import { isTemplate } from '../../utils'
 import { collectNativeLayoutAssets } from '../vue/transform/pageLayout'
 
 export async function expandResolvedPageLayoutFiles(
@@ -8,8 +9,8 @@ export async function expandResolvedPageLayoutFiles(
   const files: string[] = []
 
   for (const layout of layouts) {
-    files.push(layout.file)
     if (layout.kind !== 'native') {
+      files.push(layout.file)
       continue
     }
 
@@ -24,17 +25,25 @@ export async function expandResolvedPageLayoutFiles(
   return files
 }
 
-export async function addResolvedPageLayoutWatchFiles(
-  pluginCtx: {
-    addWatchFile?: (id: string) => void
-  },
+export async function registerResolvedPageLayoutDependencies(
+  ctx: CompilerContext,
+  ownerId: string,
   layouts: ResolvedPageLayout[],
 ) {
-  if (typeof pluginCtx.addWatchFile !== 'function') {
-    return
+  const dependencies = await expandResolvedPageLayoutFiles(layouts)
+  const transitiveDependencies = new Set(dependencies)
+  for (const file of dependencies) {
+    if (!isTemplate(file)) {
+      continue
+    }
+    await ctx.wxmlService?.scan(file)
+    for (const dependency of ctx.wxmlService?.depsMap.get(file) ?? []) {
+      transitiveDependencies.add(dependency)
+    }
   }
-
-  for (const file of await expandResolvedPageLayoutFiles(layouts)) {
-    pluginCtx.addWatchFile(normalizeWatchPath(file))
-  }
+  ctx.moduleGraphService.replaceEntryDependencies(
+    ownerId,
+    'layout',
+    transitiveDependencies,
+  )
 }

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle.platform.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle.platform.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os'
 import { fs } from '@weapp-core/shared/fs'
 import path from 'pathe'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createModuleGraphService } from '../../../moduleGraph'
 import { scanWxml } from '../../../wxml'
 import * as wxmlHandleModule from '../../../wxml/handle'
 import { SLOT_HOST_SCRIPTLESS_COMPONENT_STUB } from '../../utils/scriptlessComponent'
@@ -108,6 +109,7 @@ describe('emitVueBundleAssets platform output', () => {
 
     const ctx = {
       configService,
+      moduleGraphService: createModuleGraphService(),
       scanService: {
         independentSubPackageMap: new Map(),
       },
@@ -1017,6 +1019,7 @@ export default {
 
     const ctx = {
       configService,
+      moduleGraphService: createModuleGraphService(),
       scanService: {
         independentSubPackageMap: new Map(),
       },
@@ -1045,7 +1048,7 @@ export default {
       classStyleRuntimeWarned: { value: false },
     })
 
-    expect(addWatchFile).toHaveBeenCalled()
+    expect(addWatchFile).not.toHaveBeenCalled()
     expect(compileJsxFileMock).toHaveBeenCalledTimes(1)
     expect(cached.source).toContain('new jsx source')
     expect(cached.result.script).toBe('/* injected page */')

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/emitCompiledEntry.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/emitCompiledEntry.test.ts
@@ -8,7 +8,6 @@ const DEFAULT_PLATFORM_ASSET_OPTIONS = {
   scriptModuleExtension: 'wxs',
 }
 
-const addBundleWatchFileMock = vi.hoisted(() => vi.fn())
 const emitCompiledEntryBundleAssetsMock = vi.hoisted(() => vi.fn(() => ({
   shouldEmitComponentJson: false,
 })))
@@ -40,7 +39,6 @@ vi.mock('./layoutAssets', () => ({
 }))
 
 vi.mock('./shared', () => ({
-  addBundleWatchFile: addBundleWatchFileMock,
   emitCompiledEntryBundleAssets: emitCompiledEntryBundleAssetsMock,
   handleCompiledEntryPageLayouts: handleCompiledEntryPageLayoutsMock,
   resolveCompiledEntryEmitState: resolveCompiledEntryEmitStateMock,
@@ -49,7 +47,6 @@ vi.mock('./shared', () => ({
 
 describe('emitCompiledEntry helpers', () => {
   beforeEach(() => {
-    addBundleWatchFileMock.mockReset()
     emitCompiledEntryBundleAssetsMock.mockReset()
     emitCompiledEntryBundleAssetsMock.mockReturnValue({
       shouldEmitComponentJson: false,
@@ -831,7 +828,6 @@ describe('emitCompiledEntry helpers', () => {
       classStyleRuntimeWarned: { value: false },
     } as any, '/project/src/pages/index/index.vue', { isPage: true, result: {} } as any)
 
-    expect(addBundleWatchFileMock).not.toHaveBeenCalled()
     expect(resolveVueBundleAssetContextMock).not.toHaveBeenCalled()
   })
 
@@ -854,7 +850,6 @@ describe('emitCompiledEntry helpers', () => {
       { isPage: true, result: {}, source: '<template />' } as any,
     )
 
-    expect(addBundleWatchFileMock).toHaveBeenCalledWith({}, '/project/src/pages/index/index.vue')
     expect(resolveVueBundleAssetContextMock).toHaveBeenCalledWith(state.ctx.configService)
     expect(handleCompiledEntryPageLayoutsMock).not.toHaveBeenCalled()
     expect(emitCompiledEntryBundleAssetsMock).not.toHaveBeenCalled()

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/emitCompiledEntry.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/emitCompiledEntry.ts
@@ -9,7 +9,7 @@ import {
   emitBundlePageLayoutsIfNeeded,
   emitScriptlessComponentJsFallbackIfMissing,
 } from './layoutAssets'
-import { addBundleWatchFile, emitCompiledEntryBundleAssets, handleCompiledEntryPageLayouts, resolveCompiledEntryEmitState, resolveVueBundleAssetContext } from './shared'
+import { emitCompiledEntryBundleAssets, handleCompiledEntryPageLayouts, resolveCompiledEntryEmitState, resolveVueBundleAssetContext } from './shared'
 
 function shouldReplaceAppScriptBundleEntry(options: {
   filename: string
@@ -210,8 +210,6 @@ export async function emitCompiledVueEntryAssets(
   if (!configService) {
     return
   }
-
-  addBundleWatchFile(pluginCtx, filename)
 
   const compileOptionsState = { reExportResolutionCache, classStyleRuntimeWarned, compileOptionsCache, componentMetaCache }
   const {

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/emitFallbackPage.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/emitFallbackPage.test.ts
@@ -20,7 +20,6 @@ const handleFallbackPageLayoutsMock = vi.hoisted(() => vi.fn(async ({ emitLayout
 }))
 const emitFallbackPageBundleAssetsMock = vi.hoisted(() => vi.fn())
 const resolveFallbackPageEmitStateMock = vi.hoisted(() => vi.fn(async () => undefined))
-const addBundleWatchFileMock = vi.hoisted(() => vi.fn())
 const resolveVueBundleAssetContextMock = vi.hoisted(() => vi.fn(() => ({
   outputExtensions: { wxml: 'wxml' },
   templateExtension: 'wxml',
@@ -55,7 +54,6 @@ vi.mock('./layoutAssets', () => ({
 }))
 
 vi.mock('./shared', () => ({
-  addBundleWatchFile: addBundleWatchFileMock,
   emitFallbackPageBundleAssets: emitFallbackPageBundleAssetsMock,
   handleFallbackPageLayouts: handleFallbackPageLayoutsMock,
   loadFallbackPageEntryCompilation: loadFallbackPageEntryCompilationMock,
@@ -82,7 +80,6 @@ describe('emitFallbackPage helpers', () => {
     emitFallbackPageBundleAssetsMock.mockReset()
     resolveFallbackPageEmitStateMock.mockReset()
     resolveFallbackPageEmitStateMock.mockResolvedValue(undefined)
-    addBundleWatchFileMock.mockReset()
     resolveVueBundleAssetContextMock.mockReset()
     resolveVueBundleAssetContextMock.mockReturnValue({
       outputExtensions: { wxml: 'wxml' },
@@ -184,7 +181,6 @@ describe('emitFallbackPage helpers', () => {
     await emitFallbackPageAssets({}, state)
 
     expect(resolveVueBundleAssetContextMock).toHaveBeenCalledWith(state.ctx.configService)
-    expect(addBundleWatchFileMock).toHaveBeenCalledWith({}, '/project/src/pages/index/index.vue')
     expect(loadFallbackPageEntryCompilationMock).toHaveBeenCalledTimes(1)
     expect(emitFallbackPageBundleAssetsMock).toHaveBeenCalledTimes(1)
   })
@@ -242,7 +238,6 @@ describe('emitFallbackPage helpers', () => {
 
     await emitFallbackPageAssets({}, state)
 
-    expect(addBundleWatchFileMock).not.toHaveBeenCalled()
     expect(loadFallbackPageEntryCompilationMock).not.toHaveBeenCalled()
   })
 

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/emitFallbackPage.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/emitFallbackPage.ts
@@ -7,7 +7,7 @@ import { pathExists as pathExistsCached } from '../../../utils/cache'
 import { applyAppShell } from '../appShell'
 import { collectFallbackPageEntryIds } from '../fallbackEntries'
 import { emitBundlePageLayoutsIfNeeded } from './layoutAssets'
-import { addBundleWatchFile, emitFallbackPageBundleAssets, handleFallbackPageLayouts, loadFallbackPageEntryCompilation, resolveFallbackPageEmitState, resolveVueBundleAssetContext } from './shared'
+import { emitFallbackPageBundleAssets, handleFallbackPageLayouts, loadFallbackPageEntryCompilation, resolveFallbackPageEmitState, resolveVueBundleAssetContext } from './shared'
 
 function isFallbackEntryPending(
   entryId: string,
@@ -136,8 +136,6 @@ export async function emitFallbackPageAssets(
       continue
     }
     const { relativeBase, entryFilePath } = emitState
-
-    addBundleWatchFile(pluginCtx, entryFilePath)
 
     try {
       await emitResolvedFallbackPageEntryAssets({

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/index.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/index.ts
@@ -5,8 +5,6 @@ import { injectGlobalSlotFallbackWrapperUsingComponent } from '../slotFallbackWr
 import { emitCompiledVueEntryAssets } from './emitCompiledEntry'
 import { emitFallbackPageAssets } from './emitFallbackPage'
 
-export { emitNativeLayoutScriptChunkIfNeeded } from './layoutAssets'
-
 export type { CompilationCacheEntry, VueBundleState } from './shared'
 
 function isAutoRoutesAppRefreshHmrUpdate(hmrState: NonNullable<VueBundleState['ctx']['runtimeState']>['build']['hmr'] | undefined) {

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/layoutAssets.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/layoutAssets.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SLOT_HOST_SCRIPTLESS_COMPONENT_STUB } from '../../../utils/scriptlessComponent'
-import { createBundleLayoutEmitters, emitAppShellAssetsIfNeeded, emitBundlePageLayoutsIfNeeded, emitNativeLayoutAssetsIfNeeded, emitNativeLayoutScriptChunkIfNeeded, emitResolvedBundleLayouts, emitResolvedNativeLayoutStaticAssets, emitVueLayoutScriptFallbackIfNeeded, resolveNativeLayoutAssetState, resolveNativeLayoutScriptChunkState, resolveVueLayoutAssetOptions, resolveVueLayoutScriptFallbackState } from './layoutAssets'
+import { createBundleLayoutEmitters, emitAppShellAssetsIfNeeded, emitBundlePageLayoutsIfNeeded, emitNativeLayoutAssetsIfNeeded, emitResolvedBundleLayouts, emitResolvedNativeLayoutStaticAssets, emitVueLayoutScriptFallbackIfNeeded, resolveNativeLayoutAssetState, resolveVueLayoutAssetOptions, resolveVueLayoutScriptFallbackState } from './layoutAssets'
 
 const readFileMock = vi.hoisted(() => vi.fn(async () => '<view><slot /></view>'))
 const collectNativeLayoutAssetsMock = vi.hoisted(() => vi.fn(async () => ({
@@ -16,7 +16,6 @@ const compileVueLikeFileMock = vi.hoisted(() => vi.fn(async () => ({
   template: '<view><slot /></view>',
 })))
 const ensureScriptlessComponentAssetMock = vi.hoisted(() => vi.fn())
-const emitNativeLayoutScriptChunkIfNeededSharedMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@weapp-core/shared/fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@weapp-core/shared/fs')>()
@@ -68,14 +67,6 @@ vi.mock('../../../utils/scriptlessComponent', async (importOriginal) => {
   }
 })
 
-vi.mock('../../../utils/nativeLayout', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../../utils/nativeLayout')>()
-  return {
-    ...actual,
-    emitNativeLayoutScriptChunkIfNeeded: emitNativeLayoutScriptChunkIfNeededSharedMock,
-  }
-})
-
 describe('resolveVueLayoutAssetOptions', () => {
   beforeEach(() => {
     readFileMock.mockReset()
@@ -95,7 +86,6 @@ describe('resolveVueLayoutAssetOptions', () => {
       template: '<view><slot /></view>',
     })
     ensureScriptlessComponentAssetMock.mockReset()
-    emitNativeLayoutScriptChunkIfNeededSharedMock.mockReset()
   })
 
   it('resolves layout asset output names from platform extensions', () => {
@@ -200,95 +190,6 @@ describe('resolveVueLayoutAssetOptions', () => {
         js: 'js',
       } as any,
     })).resolves.toBeUndefined()
-  })
-
-  it('resolves native layout script chunk state from layout assets and output options', async () => {
-    collectNativeLayoutAssetsMock.mockResolvedValue({
-      script: '/project/layouts/default/index.js',
-    })
-
-    await expect(resolveNativeLayoutScriptChunkState({
-      layoutBasePath: 'layouts/default/index',
-      configService: {
-        relativeOutputPath: (value: string) => `dist/${value}`,
-      } as any,
-      outputExtensions: {
-        js: 'mjs',
-      } as any,
-    })).resolves.toEqual({
-      fileName: 'dist/layouts/default/index.mjs',
-      scriptId: '/project/layouts/default/index.js',
-    })
-  })
-
-  it('returns undefined for native layout script chunk state when script asset is missing', async () => {
-    collectNativeLayoutAssetsMock.mockResolvedValue({
-      template: '/project/layouts/default/index.wxml',
-    })
-
-    await expect(resolveNativeLayoutScriptChunkState({
-      layoutBasePath: 'layouts/default/index',
-      configService: {
-        relativeOutputPath: (value: string) => `dist/${value}`,
-      } as any,
-      outputExtensions: {
-        js: 'mjs',
-      } as any,
-    })).resolves.toBeUndefined()
-  })
-
-  it('returns undefined for native layout script chunk state when output options cannot be resolved', async () => {
-    await expect(resolveNativeLayoutScriptChunkState({
-      layoutBasePath: 'layouts/default/index',
-      configService: {
-        relativeOutputPath: () => '',
-      } as any,
-      outputExtensions: {
-        js: 'mjs',
-      } as any,
-    })).resolves.toBeUndefined()
-  })
-
-  it('returns early when native layout script chunk state is missing', async () => {
-    collectNativeLayoutAssetsMock.mockResolvedValue({
-      template: '/project/layouts/default/index.wxml',
-    })
-
-    await emitNativeLayoutScriptChunkIfNeeded({
-      pluginCtx: { emitFile: vi.fn() },
-      layoutBasePath: 'layouts/default/index',
-      configService: {
-        relativeOutputPath: (value: string) => `dist/${value}`,
-      } as any,
-      outputExtensions: {
-        js: 'mjs',
-      } as any,
-    })
-
-    expect(emitSfcJsonAssetMock).not.toHaveBeenCalled()
-  })
-
-  it('emits native layout script chunk through shared chunk emitter', async () => {
-    collectNativeLayoutAssetsMock.mockResolvedValue({
-      script: '/project/layouts/default/index.js',
-    })
-
-    await emitNativeLayoutScriptChunkIfNeeded({
-      pluginCtx: { emitFile: vi.fn() },
-      layoutBasePath: 'layouts/default/index',
-      configService: {
-        relativeOutputPath: (value: string) => `dist/${value}`,
-      } as any,
-      outputExtensions: {
-        js: 'mjs',
-      } as any,
-    })
-
-    expect(emitNativeLayoutScriptChunkIfNeededSharedMock).toHaveBeenCalledWith({
-      pluginCtx: expect.anything(),
-      scriptId: '/project/layouts/default/index.js',
-      fileName: 'dist/layouts/default/index.mjs',
-    })
   })
 
   it('emits resolved native layout static assets by asset kind', async () => {

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/layoutAssets.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/layoutAssets.ts
@@ -4,7 +4,6 @@ import type { OutputExtensions } from '../../../../platforms/types'
 import type { VueBundleCompileOptionsState } from './shared'
 import { fs } from '@weapp-core/shared/fs'
 import {
-  emitNativeLayoutScriptChunkIfNeeded as emitSharedNativeLayoutScriptChunkIfNeeded,
   resolveNativeLayoutOutputOptions,
   resolveNativeLayoutStaticAssetEntries,
 } from '../../../utils/nativeLayout'
@@ -40,52 +39,6 @@ export async function emitResolvedBundleLayouts(options: {
 
     await options.emitVueLayout(layout.file)
   }
-}
-
-export async function resolveNativeLayoutScriptChunkState(options: {
-  layoutBasePath: string
-  configService: NonNullable<CompilerContext['configService']>
-  outputExtensions: OutputExtensions | undefined
-}) {
-  const resolvedOptions = resolveVueLayoutAssetOptions({
-    configService: options.configService,
-    layoutBasePath: options.layoutBasePath,
-    outputExtensions: options.outputExtensions,
-  })
-  if (!resolvedOptions) {
-    return undefined
-  }
-
-  const assets = await collectNativeLayoutAssets(options.layoutBasePath)
-  if (!assets.script) {
-    return undefined
-  }
-
-  return {
-    fileName: resolveScriptlessComponentFileName(
-      resolvedOptions.relativeBase,
-      resolvedOptions.scriptExtension,
-    ),
-    scriptId: assets.script,
-  }
-}
-
-export async function emitNativeLayoutScriptChunkIfNeeded(options: {
-  pluginCtx: any
-  layoutBasePath: string
-  configService: NonNullable<CompilerContext['configService']>
-  outputExtensions: OutputExtensions | undefined
-}) {
-  const nativeScriptChunkState = await resolveNativeLayoutScriptChunkState(options)
-  if (!nativeScriptChunkState) {
-    return
-  }
-
-  emitSharedNativeLayoutScriptChunkIfNeeded({
-    pluginCtx: options.pluginCtx,
-    scriptId: nativeScriptChunkState.scriptId,
-    fileName: nativeScriptChunkState.fileName,
-  })
 }
 
 export async function resolveNativeLayoutAssetState(options: {

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/shared.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/shared.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { addBundleWatchFile, compileAndFinalizeVueLikeFile, compileVueLikeFile, emitBundleVueEntryAssets, emitCompiledEntryBundleAssets, emitFallbackPageBundleAssets, emitSharedFallbackPageAssets, emitSharedVueEntryAssets, emitSharedVueEntryJsonAsset, finalizeCompiledVueLikeResult, getEntryBaseName, getVueBundlePageLayoutPlan, handleCompiledEntryPageLayouts, handleFallbackPageLayouts, loadFallbackPageEntryCompilation, refreshCompiledVueEntryCacheInDev, resolveClassStyleWxsAsset, resolveCompiledEntryEmitState, resolveFallbackPageEmitState, resolveFallbackPageEntryFile, resolveVueBundleAssetContext } from './shared'
+import { compileAndFinalizeVueLikeFile, compileVueLikeFile, emitBundleVueEntryAssets, emitCompiledEntryBundleAssets, emitFallbackPageBundleAssets, emitSharedFallbackPageAssets, emitSharedVueEntryAssets, emitSharedVueEntryJsonAsset, finalizeCompiledVueLikeResult, getEntryBaseName, getVueBundlePageLayoutPlan, handleCompiledEntryPageLayouts, handleFallbackPageLayouts, loadFallbackPageEntryCompilation, refreshCompiledVueEntryCacheInDev, resolveClassStyleWxsAsset, resolveCompiledEntryEmitState, resolveFallbackPageEmitState, resolveFallbackPageEntryFile, resolveVueBundleAssetContext } from './shared'
 
 const emitPlatformTemplateAssetMock = vi.hoisted(() => vi.fn())
 const emitClassStyleWxsAssetIfMissingMock = vi.hoisted(() => vi.fn())
@@ -45,7 +45,7 @@ const compileJsxFileMock = vi.hoisted(() => vi.fn(async () => ({
 })))
 const resolvePageLayoutPlanMock = vi.hoisted(() => vi.fn(async () => undefined))
 const applyPageLayoutPlanMock = vi.hoisted(() => vi.fn((result: any) => result))
-const addResolvedPageLayoutWatchFilesMock = vi.hoisted(() => vi.fn(async () => {}))
+const registerResolvedPageLayoutDependenciesMock = vi.hoisted(() => vi.fn(async () => {}))
 const resolveVueSfcStyleIndependentSignatureMock = vi.hoisted(() => vi.fn((source: string) => source.replace(/<style[\s\S]*?<\/style>/g, '')))
 
 vi.mock('./platform', async (importOriginal) => {
@@ -100,7 +100,7 @@ vi.mock('../../../utils/pageLayout', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../utils/pageLayout')>()
   return {
     ...actual,
-    addResolvedPageLayoutWatchFiles: addResolvedPageLayoutWatchFilesMock,
+    registerResolvedPageLayoutDependencies: registerResolvedPageLayoutDependenciesMock,
   }
 })
 
@@ -202,8 +202,8 @@ describe('emitSharedVueEntryAssets', () => {
     resolvePageLayoutPlanMock.mockResolvedValue(undefined)
     applyPageLayoutPlanMock.mockReset()
     applyPageLayoutPlanMock.mockImplementation((result: any) => result)
-    addResolvedPageLayoutWatchFilesMock.mockReset()
-    addResolvedPageLayoutWatchFilesMock.mockResolvedValue(undefined)
+    registerResolvedPageLayoutDependenciesMock.mockReset()
+    registerResolvedPageLayoutDependenciesMock.mockResolvedValue(undefined)
     resolveVueSfcStyleIndependentSignatureMock.mockReset()
     resolveVueSfcStyleIndependentSignatureMock.mockImplementation((source: string) => source.replace(/<style[\s\S]*?<\/style>/g, ''))
   })
@@ -954,8 +954,9 @@ describe('emitSharedVueEntryAssets', () => {
         platform: 'weapp',
       },
     )
-    expect(addResolvedPageLayoutWatchFilesMock).toHaveBeenCalledWith(
-      pluginCtx,
+    expect(registerResolvedPageLayoutDependenciesMock).toHaveBeenCalledWith(
+      expect.anything(),
+      '/project/src/pages/index/index.vue',
       [{ kind: 'native', file: '/layouts/default/index' }],
     )
   })
@@ -1021,8 +1022,9 @@ describe('emitSharedVueEntryAssets', () => {
 
     expect(compileJsxFileMock).toHaveBeenCalledTimes(1)
     expect(compileVueFileMock).not.toHaveBeenCalled()
-    expect(addResolvedPageLayoutWatchFilesMock).toHaveBeenCalledWith(
-      pluginCtx,
+    expect(registerResolvedPageLayoutDependenciesMock).toHaveBeenCalledWith(
+      expect.anything(),
+      '/project/src/pages/index/index.tsx',
       [{ kind: 'vue', file: '/layouts/default/index.vue' }],
     )
   })
@@ -1618,22 +1620,6 @@ describe('emitSharedVueEntryAssets', () => {
       ]),
       pathExists,
     })).resolves.toBeUndefined()
-  })
-
-  it('adds normalized watch file through bundle helper', () => {
-    const addWatchFile = vi.fn()
-
-    addBundleWatchFile({
-      addWatchFile,
-    }, 'C:\\project\\src\\pages\\demo\\index.vue')
-
-    expect(addWatchFile).toHaveBeenCalledWith('C:/project/src/pages/demo/index.vue')
-  })
-
-  it('skips bundle watch registration when plugin context cannot watch files', () => {
-    expect(() => {
-      addBundleWatchFile({}, '/project/src/pages/demo/index.vue')
-    }).not.toThrow()
   })
 
   it('loads fallback page entry compilation through shared read-and-compile flow', async () => {

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/compile.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/compile.ts
@@ -5,7 +5,7 @@ import { WEVU_SLOT_OWNER_ID_ATTR, WEVU_SLOT_OWNER_ID_PROP } from '@weapp-core/co
 import { fs } from '@weapp-core/shared/fs'
 import { compileJsxFile, compileVueFile } from 'wevu/compiler'
 import { resolveVueSfcStyleIndependentSignature } from '../../../../../utils/file/vueSfcSignature'
-import { addResolvedPageLayoutWatchFiles } from '../../../../utils/pageLayout'
+import { registerResolvedPageLayoutDependencies } from '../../../../utils/pageLayout'
 import { readAndParseSfc } from '../../../../utils/vueSfc'
 import { createCompileVueFileOptions } from '../../compileOptions'
 import { injectWevuPageFeaturesInJsWithViteResolver } from '../../injectPageFeatures'
@@ -48,7 +48,7 @@ export async function compileVueLikeFile(options: {
         applyPageLayoutPlan(result, filename, resolvedLayoutPlan, {
           platform: configService.platform,
         })
-        await addResolvedPageLayoutWatchFiles(pluginCtx, resolvedLayoutPlan.layouts)
+        await registerResolvedPageLayoutDependencies(ctx, filename, resolvedLayoutPlan.layouts)
       }
     }
     return result
@@ -61,7 +61,7 @@ export async function compileVueLikeFile(options: {
       applyPageLayoutPlan(result, filename, resolvedLayoutPlan, {
         platform: configService.platform,
       })
-      await addResolvedPageLayoutWatchFiles(pluginCtx, resolvedLayoutPlan.layouts)
+      await registerResolvedPageLayoutDependencies(ctx, filename, resolvedLayoutPlan.layouts)
     }
   }
   return result

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/layout.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/layout.ts
@@ -2,20 +2,11 @@ import type { VueTransformResult } from 'wevu/compiler'
 import type { CompilerContext } from '../../../../../context'
 import type { ResolvedPageLayout } from '../../pageLayout'
 import type { CompilationCacheEntry } from './types'
-import { normalizeWatchPath } from '../../../../../utils/path'
 import { applyPageLayoutPlan, resolvePageLayoutPlan } from '../../pageLayout'
 import { findFirstResolvedVueLikeEntry } from '../../shared'
 import { getVueBundlePageLayoutPlan } from './types'
 
 const APP_VUE_LIKE_FILE_RE = /[\\/]app\.(?:vue|jsx|tsx)$/
-
-export function addBundleWatchFile(pluginCtx: any, filePath: string) {
-  if (typeof pluginCtx.addWatchFile !== 'function') {
-    return
-  }
-
-  pluginCtx.addWatchFile(normalizeWatchPath(filePath))
-}
 
 export function getEntryBaseName(filename: string) {
   const extIndex = filename.lastIndexOf('.')

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin.astEngine.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin.astEngine.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createModuleGraphService } from '../../../moduleGraph'
 
 const compileVueFileMock = vi.hoisted(() => vi.fn())
 const compileJsxFileMock = vi.hoisted(() => vi.fn())
@@ -160,6 +161,7 @@ describe('createVueTransformPlugin ast engine smoke', () => {
   it('returns null when config service is missing', async () => {
     const { createVueTransformPlugin } = await import('./plugin')
     const plugin = createVueTransformPlugin({
+      moduleGraphService: createModuleGraphService(),
       runtimeState: {
         scan: {
           isDirty: false,
@@ -177,6 +179,7 @@ describe('createVueTransformPlugin ast engine smoke', () => {
 
     const { createVueTransformPlugin } = await import('./plugin')
     const plugin = createVueTransformPlugin({
+      moduleGraphService: createModuleGraphService(),
       configService: {
         isDev: false,
         cwd: '/project',
@@ -203,6 +206,7 @@ describe('createVueTransformPlugin ast engine smoke', () => {
   it('passes resolved astEngine into setData pick collection', async () => {
     const { createVueTransformPlugin } = await import('./plugin')
     const plugin = createVueTransformPlugin({
+      moduleGraphService: createModuleGraphService(),
       configService: {
         isDev: false,
         cwd: '/project',
@@ -248,6 +252,7 @@ describe('createVueTransformPlugin ast engine smoke', () => {
 
     const { createVueTransformPlugin } = await import('./plugin')
     const plugin = createVueTransformPlugin({
+      moduleGraphService: createModuleGraphService(),
       configService: {
         isDev: false,
         cwd: '/project',
@@ -283,6 +288,7 @@ describe('createVueTransformPlugin ast engine smoke', () => {
     const vueTransformTiming = vi.fn()
     const { createVueTransformPlugin } = await import('./plugin')
     const plugin = createVueTransformPlugin({
+      moduleGraphService: createModuleGraphService(),
       configService: {
         isDev: false,
         cwd: '/project',
@@ -324,6 +330,7 @@ describe('createVueTransformPlugin ast engine smoke', () => {
   it('pre-parses sfc styles only when style blocks exist', async () => {
     const { createVueTransformPlugin } = await import('./plugin')
     const plugin = createVueTransformPlugin({
+      moduleGraphService: createModuleGraphService(),
       configService: {
         isDev: false,
         cwd: '/project',
@@ -359,6 +366,7 @@ describe('createVueTransformPlugin ast engine smoke', () => {
 
     const { createVueTransformPlugin } = await import('./plugin')
     const plugin = createVueTransformPlugin({
+      moduleGraphService: createModuleGraphService(),
       configService: {
         isDev: false,
         cwd: '/project',
@@ -396,6 +404,7 @@ describe('createVueTransformPlugin ast engine smoke', () => {
 
     const { createVueTransformPlugin } = await import('./plugin')
     const plugin = createVueTransformPlugin({
+      moduleGraphService: createModuleGraphService(),
       configService: {
         isDev: false,
         cwd: '/project',
@@ -443,6 +452,7 @@ export default defineComponent({ setup() { usePageFeatureHooks() } })`,
 
     const { createVueTransformPlugin } = await import('./plugin')
     const plugin = createVueTransformPlugin({
+      moduleGraphService: createModuleGraphService(),
       configService: {
         isDev: false,
         cwd: '/project',
@@ -488,6 +498,7 @@ export default defineComponent({ setup() { usePageFeatureHooks() } })`,
 
     const { createVueTransformPlugin } = await import('./plugin')
     const plugin = createVueTransformPlugin({
+      moduleGraphService: createModuleGraphService(),
       configService: {
         isDev: false,
         cwd: '/project',
@@ -527,6 +538,7 @@ export default defineComponent({ setup() { usePageFeatureHooks() } })`,
 
     const { createVueTransformPlugin } = await import('./plugin')
     const plugin = createVueTransformPlugin({
+      moduleGraphService: createModuleGraphService(),
       configService: {
         isDev: false,
         cwd: '/project',

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/index.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/index.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createSidecarSourceSpecifier } from '../../../../moduleGraph/protocol'
 
 const preloadNativeLayoutEntriesMock = vi.hoisted(() => vi.fn(async () => {}))
 const loadTransformStyleBlockMock = vi.hoisted(() => vi.fn(async () => null))
@@ -207,6 +208,11 @@ describe('createVueTransformPlugin lifecycle', () => {
 
     const transform = getHookHandler(plugin.transform as any)
     await expect(transform.call({ addWatchFile: vi.fn() } as any, 'code', '/project/src/demo.jsx')).resolves.toBeNull()
+    await expect(transform.call(
+      { addWatchFile: vi.fn() } as any,
+      'export default "<template />"',
+      createSidecarSourceSpecifier('/project/src/demo.vue', '/project/src/demo.vue', 'script'),
+    )).resolves.toBeNull()
     await expect(transform.call({ addWatchFile: vi.fn() } as any, 'code', '/project/src/demo.vue')).resolves.toEqual({
       code: 'transformed',
       map: null,

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/index.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/index.ts
@@ -6,6 +6,7 @@ import type { createPageEntryMatcher } from '../../../wevu'
 import type { ResolvedAppShell } from '../appShell'
 import type { CompileVueFileResolvedOptions } from '../compileOptions'
 import { fs } from '@weapp-core/shared/fs'
+import { parseSidecarSourceRequest } from '../../../../moduleGraph/protocol'
 import { createHmrProfileEventId, recordHmrProfileDuration, recordHmrProfileOperation } from '../../../../utils/hmrProfile'
 import { normalizeFsResolvedId } from '../../../../utils/resolvedId'
 import { createReadAndParseSfcOptions, readAndParseSfc } from '../../../utils/vueSfc'
@@ -127,7 +128,7 @@ export function createVueTransformPlugin(ctx: CompilerContext): Plugin {
     },
 
     async transform(code, id) {
-      if (!VUE_TRANSFORM_FILTER_RE.test(id) || !isVueLikeId(id)) {
+      if (parseSidecarSourceRequest(id) || !VUE_TRANSFORM_FILTER_RE.test(id) || !isVueLikeId(id)) {
         return null
       }
       const startedAt = performance.now()

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/shared.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/shared.test.ts
@@ -4,7 +4,6 @@ import { compileTransformEntryResult, createTransformStageMeasurer, ensureSfcSty
 const resolvePageLayoutPlanMock = vi.hoisted(() => vi.fn(async () => undefined))
 const applyPageLayoutPlanMock = vi.hoisted(() => vi.fn())
 const registerResolvedPageLayoutDependenciesMock = vi.hoisted(() => vi.fn(async () => {}))
-const emitNativeLayoutScriptChunkIfNeededMock = vi.hoisted(() => vi.fn(async () => {}))
 const injectWevuPageFeaturesInJsWithViteResolverMock = vi.hoisted(() => vi.fn(async (_ctx: any, code: string) => ({
   transformed: false,
   code,
@@ -50,10 +49,6 @@ vi.mock('../pageLayout', async (importOriginal) => {
 
 vi.mock('../../../utils/pageLayout', () => ({
   registerResolvedPageLayoutDependencies: registerResolvedPageLayoutDependenciesMock,
-}))
-
-vi.mock('../bundle', () => ({
-  emitNativeLayoutScriptChunkIfNeeded: emitNativeLayoutScriptChunkIfNeededMock,
 }))
 
 vi.mock('../injectPageFeatures', () => ({
@@ -113,8 +108,6 @@ describe('vue transform plugin shared helpers', () => {
     applyPageLayoutPlanMock.mockReset()
     registerResolvedPageLayoutDependenciesMock.mockReset()
     registerResolvedPageLayoutDependenciesMock.mockResolvedValue(undefined)
-    emitNativeLayoutScriptChunkIfNeededMock.mockReset()
-    emitNativeLayoutScriptChunkIfNeededMock.mockResolvedValue(undefined)
     injectWevuPageFeaturesInJsWithViteResolverMock.mockReset()
     injectWevuPageFeaturesInJsWithViteResolverMock.mockResolvedValue({
       transformed: false,
@@ -513,13 +506,6 @@ describe('vue transform plugin shared helpers', () => {
       '/project/src/pages/home/index.vue',
       resolved.layouts,
     )
-    expect(emitNativeLayoutScriptChunkIfNeededMock).toHaveBeenCalledTimes(1)
-    expect(emitNativeLayoutScriptChunkIfNeededMock).toHaveBeenCalledWith({
-      pluginCtx: expect.anything(),
-      layoutBasePath: '/project/src/layouts/default',
-      configService: { outputExtensions: { js: 'js' } },
-      outputExtensions: { js: 'js' },
-    })
   })
 
   it('returns early from transform entry page layout flow when config service or layout plan is missing', async () => {
@@ -541,10 +527,9 @@ describe('vue transform plugin shared helpers', () => {
 
     expect(applyPageLayoutPlanMock).not.toHaveBeenCalled()
     expect(registerResolvedPageLayoutDependenciesMock).not.toHaveBeenCalled()
-    expect(emitNativeLayoutScriptChunkIfNeededMock).not.toHaveBeenCalled()
   })
 
-  it('registers native layout chunks for entries through shared layout flow', async () => {
+  it('registers native layout dependencies for entries through shared layout flow', async () => {
     resolvePageLayoutPlanMock.mockResolvedValue({
       layouts: [
         { kind: 'native', file: '/project/src/layouts/default' },
@@ -564,7 +549,6 @@ describe('vue transform plugin shared helpers', () => {
 
     expect(applyPageLayoutPlanMock).not.toHaveBeenCalled()
     expect(registerResolvedPageLayoutDependenciesMock).toHaveBeenCalledTimes(1)
-    expect(emitNativeLayoutScriptChunkIfNeededMock).toHaveBeenCalledTimes(1)
   })
 
   it('finalizes transform entry scripts through shared diagnostics and injection flow', async () => {
@@ -1131,7 +1115,6 @@ console.log(pages, routeSubPackages)
     expect(collectFallbackPageEntryIds).toHaveBeenCalledTimes(1)
     expect(findFirstResolvedVueLikeEntry).toHaveBeenCalledTimes(2)
     expect(readFile).toHaveBeenCalledWith('/project/src/pages/home/index.vue', 'utf8')
-    expect(emitNativeLayoutScriptChunkIfNeededMock).toHaveBeenCalledTimes(1)
   })
 
   it('preloads native layout entries concurrently', async () => {

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/shared.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/shared.test.ts
@@ -3,7 +3,7 @@ import { compileTransformEntryResult, createTransformStageMeasurer, ensureSfcSty
 
 const resolvePageLayoutPlanMock = vi.hoisted(() => vi.fn(async () => undefined))
 const applyPageLayoutPlanMock = vi.hoisted(() => vi.fn())
-const addResolvedPageLayoutWatchFilesMock = vi.hoisted(() => vi.fn(async () => {}))
+const registerResolvedPageLayoutDependenciesMock = vi.hoisted(() => vi.fn(async () => {}))
 const emitNativeLayoutScriptChunkIfNeededMock = vi.hoisted(() => vi.fn(async () => {}))
 const injectWevuPageFeaturesInJsWithViteResolverMock = vi.hoisted(() => vi.fn(async (_ctx: any, code: string) => ({
   transformed: false,
@@ -49,7 +49,7 @@ vi.mock('../pageLayout', async (importOriginal) => {
 })
 
 vi.mock('../../../utils/pageLayout', () => ({
-  addResolvedPageLayoutWatchFiles: addResolvedPageLayoutWatchFilesMock,
+  registerResolvedPageLayoutDependencies: registerResolvedPageLayoutDependenciesMock,
 }))
 
 vi.mock('../bundle', () => ({
@@ -111,8 +111,8 @@ describe('vue transform plugin shared helpers', () => {
     resolvePageLayoutPlanMock.mockReset()
     resolvePageLayoutPlanMock.mockResolvedValue(undefined)
     applyPageLayoutPlanMock.mockReset()
-    addResolvedPageLayoutWatchFilesMock.mockReset()
-    addResolvedPageLayoutWatchFilesMock.mockResolvedValue(undefined)
+    registerResolvedPageLayoutDependenciesMock.mockReset()
+    registerResolvedPageLayoutDependenciesMock.mockResolvedValue(undefined)
     emitNativeLayoutScriptChunkIfNeededMock.mockReset()
     emitNativeLayoutScriptChunkIfNeededMock.mockResolvedValue(undefined)
     injectWevuPageFeaturesInJsWithViteResolverMock.mockReset()
@@ -349,11 +349,10 @@ describe('vue transform plugin shared helpers', () => {
     }))
   })
 
-  it('resolves transform filename only for absolute paths and registers watch files when supported', () => {
+  it('resolves transform filename only for absolute paths', () => {
     const pluginCtx = {
       addWatchFile: vi.fn(),
     }
-    const addWatchFile = vi.fn()
 
     expect(resolveTransformFilename({
       id: '/project/src/components/demo.vue',
@@ -362,10 +361,7 @@ describe('vue transform plugin shared helpers', () => {
       } as any,
       pluginCtx,
       getSourceFromVirtualId: vi.fn(id => id),
-      addWatchFile,
     })).toBe('/project/src/components/demo.vue')
-
-    expect(addWatchFile).toHaveBeenCalledWith(pluginCtx, '/project/src/components/demo.vue')
 
     expect(resolveTransformFilename({
       id: 'virtual:demo',
@@ -374,7 +370,6 @@ describe('vue transform plugin shared helpers', () => {
       } as any,
       pluginCtx: {},
       getSourceFromVirtualId: vi.fn(() => 'relative/demo.vue'),
-      addWatchFile,
     })).toBeNull()
   })
 
@@ -513,8 +508,9 @@ describe('vue transform plugin shared helpers', () => {
         platform: undefined,
       },
     )
-    expect(addResolvedPageLayoutWatchFilesMock).toHaveBeenCalledWith(
+    expect(registerResolvedPageLayoutDependenciesMock).toHaveBeenCalledWith(
       expect.anything(),
+      '/project/src/pages/home/index.vue',
       resolved.layouts,
     )
     expect(emitNativeLayoutScriptChunkIfNeededMock).toHaveBeenCalledTimes(1)
@@ -544,7 +540,7 @@ describe('vue transform plugin shared helpers', () => {
     })).resolves.toBeUndefined()
 
     expect(applyPageLayoutPlanMock).not.toHaveBeenCalled()
-    expect(addResolvedPageLayoutWatchFilesMock).not.toHaveBeenCalled()
+    expect(registerResolvedPageLayoutDependenciesMock).not.toHaveBeenCalled()
     expect(emitNativeLayoutScriptChunkIfNeededMock).not.toHaveBeenCalled()
   })
 
@@ -567,7 +563,7 @@ describe('vue transform plugin shared helpers', () => {
     )
 
     expect(applyPageLayoutPlanMock).not.toHaveBeenCalled()
-    expect(addResolvedPageLayoutWatchFilesMock).toHaveBeenCalledTimes(1)
+    expect(registerResolvedPageLayoutDependenciesMock).toHaveBeenCalledTimes(1)
     expect(emitNativeLayoutScriptChunkIfNeededMock).toHaveBeenCalledTimes(1)
   })
 
@@ -1118,6 +1114,9 @@ console.log(pages, routeSubPackages)
         configService: {
           outputExtensions: { js: 'js' },
         },
+        moduleGraphService: {
+          replaceEntryDependencies: vi.fn(),
+        },
       } as any,
       configService: {
         outputExtensions: { js: 'js' },
@@ -1193,7 +1192,11 @@ console.log(pages, routeSubPackages)
     await expect(loadTransformStyleBlock({
       id: 'virtual:scoped-slot',
       pluginCtx: {},
-      ctx: {} as any,
+      ctx: {
+        moduleGraphService: {
+          replaceEntryDependencies: vi.fn(),
+        },
+      } as any,
       configService: {} as any,
       styleBlocksCache,
       loadScopedSlotModule,
@@ -1206,7 +1209,11 @@ console.log(pages, routeSubPackages)
     await expect(loadTransformStyleBlock({
       id: 'virtual:style',
       pluginCtx: {},
-      ctx: {} as any,
+      ctx: {
+        moduleGraphService: {
+          replaceEntryDependencies: vi.fn(),
+        },
+      } as any,
       configService: {} as any,
       styleBlocksCache,
       loadScopedSlotModule,
@@ -1230,7 +1237,11 @@ console.log(pages, routeSubPackages)
     await expect(loadTransformStyleBlock({
       id: 'virtual:style',
       pluginCtx: {},
-      ctx: {} as any,
+      ctx: {
+        moduleGraphService: {
+          replaceEntryDependencies: vi.fn(),
+        },
+      } as any,
       configService: {} as any,
       styleBlocksCache,
       loadScopedSlotModule,
@@ -1275,7 +1286,7 @@ console.log(pages, routeSubPackages)
     } as any
     const compilationCache = new Map<string, any>()
     const scopedSlotEmitter = vi.fn()
-    const addWatchFile = vi.fn()
+    const replaceEntryDependencies = vi.fn()
     resolvePageLayoutPlanMock.mockResolvedValue({
       layouts: [
         { kind: 'native', file: '/project/src/layouts/default' },
@@ -1305,6 +1316,9 @@ console.log(pages, routeSubPackages)
             },
           },
         },
+        moduleGraphService: {
+          replaceEntryDependencies,
+        },
       } as any,
       pluginCtx,
       filename: '/project/src/pages/home/index.vue',
@@ -1321,12 +1335,15 @@ console.log(pages, routeSubPackages)
       isApp: false,
       scopedSlotModules: new Map(),
       emittedScopedSlotChunks: new Set(),
-      addWatchFile,
       emitScopedSlotChunks: scopedSlotEmitter,
     })).resolves.toBe(result)
 
-    expect(addResolvedPageLayoutWatchFilesMock).toHaveBeenCalledTimes(1)
-    expect(addWatchFile).toHaveBeenCalledWith(pluginCtx, '/project/src/components/card.vue')
+    expect(registerResolvedPageLayoutDependenciesMock).toHaveBeenCalledTimes(1)
+    expect(replaceEntryDependencies).toHaveBeenCalledWith(
+      '/project/src/pages/home/index.vue',
+      'style',
+      ['/project/src/components/card.vue'],
+    )
     expect(injectWevuPageFeaturesInJsWithViteResolverMock).toHaveBeenCalledTimes(1)
     expect(compilationCache.get('/project/src/pages/home/index.vue')).toEqual({
       result,

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/shared/compile.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/shared/compile.ts
@@ -212,7 +212,6 @@ export async function finalizeTransformCompiledResult(options: {
   sourceMap?: boolean
   scopedSlotModules: Map<string, string>
   emittedScopedSlotChunks: Set<string>
-  addWatchFile: (pluginCtx: any, file: string) => void
   emitScopedSlotChunks: (
     pluginCtx: any,
     relativeBase: string,
@@ -238,7 +237,6 @@ export async function finalizeTransformCompiledResult(options: {
     sourceMap,
     scopedSlotModules,
     emittedScopedSlotChunks,
-    addWatchFile,
     emitScopedSlotChunks,
   } = options
   const transformResult = result as VueTransformResultWithScriptMap
@@ -265,10 +263,8 @@ export async function finalizeTransformCompiledResult(options: {
     registerVueTemplateToken(ctx, filename, result.template)
   }
 
-  if (Array.isArray(result.meta?.sfcSrcDeps) && typeof pluginCtx.addWatchFile === 'function') {
-    for (const dep of result.meta.sfcSrcDeps) {
-      addWatchFile(pluginCtx, dep)
-    }
+  if (Array.isArray(result.meta?.sfcSrcDeps)) {
+    ctx.moduleGraphService.replaceEntryDependencies(filename, 'style', result.meta.sfcSrcDeps)
   }
 
   await finalizeTransformEntryScript({

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/shared/layout.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/shared/layout.ts
@@ -2,8 +2,7 @@ import type { SFCStyleBlock } from 'vue/compiler-sfc'
 import type { VueTransformResult } from 'wevu/compiler'
 import type { CompilerContext } from '../../../../../context'
 import { syncVueSfcStyleDependencies } from '../../../../utils/invalidateEntry'
-import { addResolvedPageLayoutWatchFiles } from '../../../../utils/pageLayout'
-import { addNormalizedWatchFiles } from '../../../../utils/watchFiles'
+import { registerResolvedPageLayoutDependencies } from '../../../../utils/pageLayout'
 import { emitNativeLayoutScriptChunkIfNeeded } from '../../bundle'
 import { applyPageLayoutPlan, resolvePageLayoutPlan } from '../../pageLayout'
 import { ensureSfcStyleBlocks, isAppEntry, loadTransformPageEntries } from './state'
@@ -31,7 +30,7 @@ export async function handleTransformEntryPageLayoutFlow(options: {
     })
   }
 
-  await addResolvedPageLayoutWatchFiles(options.pluginCtx, resolvedLayoutPlan.layouts)
+  await registerResolvedPageLayoutDependencies(options.ctx, options.filename, resolvedLayoutPlan.layouts)
 
   for (const layout of resolvedLayoutPlan.layouts) {
     if (layout.kind !== 'native') {
@@ -248,7 +247,7 @@ export async function loadTransformStyleBlock(options: {
   }
 
   const dependencies = syncVueSfcStyleDependencies(ctx, filename, styles)
-  addNormalizedWatchFiles(options.pluginCtx, dependencies)
+  ctx.moduleGraphService.replaceEntryDependencies(filename, 'style', dependencies)
 
   return {
     code: block.content,

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/shared/layout.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/shared/layout.ts
@@ -3,7 +3,6 @@ import type { VueTransformResult } from 'wevu/compiler'
 import type { CompilerContext } from '../../../../../context'
 import { syncVueSfcStyleDependencies } from '../../../../utils/invalidateEntry'
 import { registerResolvedPageLayoutDependencies } from '../../../../utils/pageLayout'
-import { emitNativeLayoutScriptChunkIfNeeded } from '../../bundle'
 import { applyPageLayoutPlan, resolvePageLayoutPlan } from '../../pageLayout'
 import { ensureSfcStyleBlocks, isAppEntry, loadTransformPageEntries } from './state'
 
@@ -31,18 +30,6 @@ export async function handleTransformEntryPageLayoutFlow(options: {
   }
 
   await registerResolvedPageLayoutDependencies(options.ctx, options.filename, resolvedLayoutPlan.layouts)
-
-  for (const layout of resolvedLayoutPlan.layouts) {
-    if (layout.kind !== 'native') {
-      continue
-    }
-    await emitNativeLayoutScriptChunkIfNeeded({
-      pluginCtx: options.pluginCtx,
-      layoutBasePath: layout.file,
-      configService,
-      outputExtensions: configService.outputExtensions,
-    })
-  }
 
   return resolvedLayoutPlan
 }

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/shared/state.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/shared/state.ts
@@ -120,17 +120,12 @@ export function resolveTransformFilename(options: {
   configService: NonNullable<CompilerContext['configService']>
   pluginCtx: any
   getSourceFromVirtualId: (id: string) => string
-  addWatchFile: (pluginCtx: any, file: string) => void
 }) {
-  const { id, configService, pluginCtx, getSourceFromVirtualId, addWatchFile } = options
+  const { id, configService, getSourceFromVirtualId } = options
   const sourceId = getSourceFromVirtualId(id)
   const filename = toAbsoluteId(sourceId, configService, undefined, { base: 'cwd' })
   if (!filename || !path.isAbsolute(filename)) {
     return null
-  }
-
-  if (typeof pluginCtx.addWatchFile === 'function') {
-    addWatchFile(pluginCtx, filename)
   }
 
   return filename

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createModuleGraphService } from '../../../../moduleGraph'
 import { transformVueLikeFile } from './transformFile'
 
 const compileVueFileMock = vi.hoisted(() => vi.fn(async () => ({
@@ -78,6 +79,7 @@ vi.mock('../../../../utils/file/vueSfcSignature', async (importOriginal) => {
 function createBaseOptions(overrides: Record<string, any> = {}) {
   return {
     ctx: {
+      moduleGraphService: createModuleGraphService(),
       configService: {
         isDev: true,
         platform: 'weapp',

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile.ts
@@ -7,7 +7,6 @@ import { performance } from 'node:perf_hooks'
 import { compileJsxFile, compileVueFile } from 'wevu/compiler'
 import { recordHmrProfileDuration } from '../../../../utils/hmrProfile'
 import { readFile as readFileCached } from '../../../utils/cache'
-import { addNormalizedWatchFile } from '../../../utils/watchFiles'
 import { createPageEntryMatcher } from '../../../wevu'
 import { getSourceFromVirtualId } from '../../resolver'
 import { createCompileVueFileOptions, isVueTransformSourceMapEnabled } from '../compileOptions'
@@ -74,7 +73,6 @@ export async function transformVueLikeFile(options: {
     configService,
     pluginCtx,
     getSourceFromVirtualId,
-    addWatchFile: addNormalizedWatchFile,
   })
   if (!filename) {
     return null

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile/finalize.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile/finalize.ts
@@ -5,7 +5,6 @@ import type { ResolvedAppShell } from '../../appShell'
 import type { TransformStageMeasurer, VueCompilationCache, VueHmrStageMeasurer, VueStyleBlocksCache } from './types'
 import { resolveVueSfcStyleIndependentSignature } from '../../../../../utils/file/vueSfcSignature'
 import { syncVueSfcStyleDependencies } from '../../../../utils/invalidateEntry'
-import { addNormalizedWatchFile } from '../../../../utils/watchFiles'
 import { emitScopedSlotChunks, registerScopedSlotHostGenerics } from '../../scopedSlot'
 import { finalizeTransformCompiledResult, finalizeTransformEntryCode } from '../shared'
 import { createSfcStyleBlocksSignature, loadStyleBlocksForStyleOnlyRefresh } from '../styleOnlyRefresh'
@@ -105,9 +104,7 @@ export async function finalizeVueTransform(options: {
     filename,
     currentStyleBlocks,
   )
-  for (const dependency of sfcStyleDependencies) {
-    addNormalizedWatchFile(pluginCtx, dependency)
-  }
+  ctx.moduleGraphService.replaceEntryDependencies(filename, 'style', sfcStyleDependencies)
   registerScopedSlotHostGenerics(ctx, result.scopedSlotComponents, parseUsingComponents(result.config))
 
   await measureVueHmrStage('finalizeCompiledResult', 'vueFinalizeCompiledMs', async () => {
@@ -129,7 +126,6 @@ export async function finalizeVueTransform(options: {
       sourceMap,
       scopedSlotModules,
       emittedScopedSlotChunks,
-      addWatchFile: addNormalizedWatchFile,
       emitScopedSlotChunks,
     })
   })

--- a/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile/jsonOnly.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/plugin/transformFile/jsonOnly.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createModuleGraphService } from '../../../../../moduleGraph'
 import { transformVueLikeFile } from '../transformFile'
 import { tryRefreshJsonOnlyVueCompilation } from './jsonOnly'
 
@@ -87,6 +88,7 @@ definePageJson({ navigationBarTitleText: '旧标题' })
     compilationCache,
     options: {
       ctx: {
+        moduleGraphService: createModuleGraphService(),
         configService: {
           isDev: true,
           platform: 'weapp',

--- a/packages/weapp-vite/src/plugins/wxs.test.ts
+++ b/packages/weapp-vite/src/plugins/wxs.test.ts
@@ -214,7 +214,7 @@ describe('wxs plugin', () => {
     expect(emitted.source.length).toBeGreaterThan(0)
   })
 
-  it('reuses unchanged wxs file transforms across generateBundle passes', async () => {
+  it('re-reads wxs sources without retaining a parallel dependency edge cache', async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'weapp-vite-wxs-cache-'))
     tempDirs.push(tempDir)
 
@@ -290,7 +290,8 @@ describe('wxs plugin', () => {
     const wxsReadCount = readFileSpy.mock.calls.filter(([filePath]) => {
       return normalizeTestPath(filePath) === normalizeTestPath(wxsFile)
     }).length
-    expect(wxsReadCount).toBe(1)
+    expect(wxsReadCount).toBe(2)
+    expect(addWatchFile).not.toHaveBeenCalled()
     expect(emitFile).toHaveBeenCalledTimes(2)
     expect(emitFile.mock.calls[1][0].fileName).toBe('components/cache-card/tools.wxs')
   })
@@ -534,10 +535,10 @@ describe('wxs plugin', () => {
 
     expect(emitFile).toHaveBeenCalledTimes(1)
     expect(emitFile.mock.calls[0][0].fileName).toBe('components/wxs-card/tools.wxs')
-    expect(addWatchFile.mock.calls.map(([filePath]) => normalizeTestPath(filePath))).toContain(normalizeTestPath(wxsFile))
+    expect(addWatchFile).not.toHaveBeenCalled()
   })
 
-  it('keeps tokenMap scans for cached wxs importee hmr updates without wxs suffix', async () => {
+  it('keeps tokenMap scans for graph-backed wxs importee updates without wxs suffix', async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'weapp-vite-wxs-importee-hmr-'))
     tempDirs.push(tempDir)
 
@@ -612,6 +613,7 @@ describe('wxs plugin', () => {
     emitFile.mockClear()
     addWatchFile.mockClear()
     ctx.runtimeState.build.hmr.profile = {
+      dirtyReasonSummary: ['importer-graph:1'],
       event: 'update',
       file: helperFile,
     }
@@ -626,6 +628,6 @@ describe('wxs plugin', () => {
     )
 
     expect(emitFile.mock.calls.map(([asset]) => asset.fileName)).toContain('components/importee-card/tools.wxs')
-    expect(addWatchFile.mock.calls.map(([filePath]) => normalizeTestPath(filePath))).toContain(normalizeTestPath(helperFile))
+    expect(addWatchFile).not.toHaveBeenCalled()
   })
 })

--- a/packages/weapp-vite/src/plugins/wxs.ts
+++ b/packages/weapp-vite/src/plugins/wxs.ts
@@ -8,8 +8,6 @@ import { LRUCache } from 'lru-cache'
 import path from 'pathe'
 import { jsExtensions } from '../constants'
 import { resolveCompilerOutputExtensions } from '../utils/outputExtensions'
-import { normalizeWatchPath } from '../utils/path'
-import { normalizeFsResolvedId } from '../utils/resolvedId'
 import { isScriptModuleTagName } from '../utils/wxmlScriptModule'
 import { scanWxml } from '../wxml'
 import { transformWxsCode } from '../wxs'
@@ -24,24 +22,6 @@ const WXS_SCAN_RELEVANT_HMR_RE = /\.(?:vue|wxml|axml|swan|ttml|jxml|qml|ksml|xhs
 interface WxsPluginState {
   ctx: CompilerContext
   wxsMap: Map<string, { emittedFile: EmittedFile }>
-  wxsFileCache: Map<string, WxsFileCacheEntry>
-  wxsDependencyImporters: Map<string, Set<string>>
-}
-
-interface WxsFileCacheEntry {
-  mtimeMs: number
-  size: number
-  emittedFile: EmittedFile
-  importees: string[]
-}
-
-async function statWxsFile(wxsPath: string) {
-  try {
-    return await fs.stat(wxsPath)
-  }
-  catch {
-    return undefined
-  }
 }
 
 function resolveWxsOutputFileName(
@@ -62,66 +42,27 @@ async function transformWxsFile(
   this: PluginContext,
   state: WxsPluginState,
   wxsPath: string,
-  importerPath?: string,
 ) {
   const { ctx } = state
   const { configService } = ctx
   const { scriptModuleExtension } = resolveCompilerOutputExtensions(configService.outputExtensions)
-  const normalizedWxsPath = normalizeFsResolvedId(wxsPath)
-  if (importerPath && importerPath !== wxsPath) {
-    const normalizedImporterPath = normalizeFsResolvedId(importerPath)
-    const importers = state.wxsDependencyImporters.get(normalizedWxsPath) ?? new Set<string>()
-    importers.add(normalizedImporterPath)
-    state.wxsDependencyImporters.set(normalizedWxsPath, importers)
+  let rawCode: string
+  try {
+    rawCode = await fs.readFile(wxsPath, 'utf8')
   }
-
-  this.addWatchFile(normalizeWatchPath(wxsPath))
-  const stat = await statWxsFile(wxsPath)
-  if (!stat) {
-    state.wxsFileCache.delete(wxsPath)
+  catch {
     return
   }
-
-  const cached = state.wxsFileCache.get(wxsPath)
-  if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
-    state.wxsMap.set(wxsPath, {
-      emittedFile: cached.emittedFile,
-    })
-    await Promise.all(
-      cached.importees.map((importee) => {
-        return transformWxsFile.call(this, state, importee, wxsPath)
-      }),
-    )
-    return
-  }
-
-  const rawCode = await fs.readFile(wxsPath, 'utf8')
-  let code = wxsCodeCache.get(rawCode)
-  let importeePaths: string[] = []
-
-  if (code === undefined) {
-    const { result, importees } = transformWxsCode(rawCode, {
-      filename: wxsPath,
-      extension: scriptModuleExtension,
-    })
-
-    if (typeof result?.code === 'string') {
-      code = result.code
-    }
-
-    const dirname = path.dirname(wxsPath)
-    importeePaths = importees.map(({ source }) => path.resolve(dirname, source))
-    await Promise.all(
-      importeePaths.map((importeePath) => {
-        return transformWxsFile.call(
-          this,
-          state,
-          importeePath,
-          wxsPath,
-        )
-      }),
-    )
-  }
+  const { result, importees } = transformWxsCode(rawCode, {
+    filename: wxsPath,
+    extension: scriptModuleExtension,
+  })
+  const code = wxsCodeCache.get(rawCode) ?? result?.code
+  const dirname = path.dirname(wxsPath)
+  const importeePaths = importees.map(({ source }) => path.resolve(dirname, source))
+  await Promise.all(
+    importeePaths.map(importeePath => transformWxsFile.call(this, state, importeePath)),
+  )
 
   if (code === undefined) {
     return
@@ -136,13 +77,6 @@ async function transformWxsFile(
   state.wxsMap.set(wxsPath, {
     emittedFile,
   })
-  state.wxsFileCache.set(wxsPath, {
-    mtimeMs: stat.mtimeMs,
-    size: stat.size,
-    emittedFile,
-    importees: importeePaths,
-  })
-
   wxsCodeCache.set(rawCode, code)
 }
 
@@ -208,10 +142,8 @@ function shouldScanWxsTokenMap(state: WxsPluginState) {
   if (!hmrProfile.file) {
     return true
   }
-  if (state.wxsDependencyImporters.has(normalizeFsResolvedId(hmrProfile.file))) {
-    return true
-  }
   return WXS_SCAN_RELEVANT_HMR_RE.test(hmrProfile.file)
+    || hmrProfile.dirtyReasonSummary?.some(reason => reason.startsWith('importer-graph:')) === true
 }
 
 function shouldScanFullWxsTokenMap(state: WxsPluginState) {
@@ -222,11 +154,8 @@ function shouldScanFullWxsTokenMap(state: WxsPluginState) {
   if (!hmrProfile.file) {
     return true
   }
-  const normalizedFile = normalizeFsResolvedId(hmrProfile.file)
-  if (state.wxsDependencyImporters.has(normalizedFile)) {
-    return true
-  }
   return WXS_FILE_SUFFIX_RE.test(hmrProfile.file)
+    || hmrProfile.dirtyReasonSummary?.some(reason => reason.startsWith('importer-graph:')) === true
 }
 
 function resolveWxsTokenScanEntries(state: WxsPluginState): Array<[string, any]> {
@@ -285,8 +214,6 @@ export function wxs(ctx: CompilerContext): Plugin[] {
   const state: WxsPluginState = {
     ctx,
     wxsMap: new Map(),
-    wxsFileCache: new Map(),
-    wxsDependencyImporters: new Map(),
   }
 
   return [createWxsPlugin(state)]

--- a/packages/weapp-vite/src/runtime/advancedChunks.test.ts
+++ b/packages/weapp-vite/src/runtime/advancedChunks.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { createSidecarModuleId, createSidecarSourceSpecifier } from '../moduleGraph/protocol'
+import { createLogicalEntryId, createSidecarModuleId, createSidecarSourceSpecifier } from '../moduleGraph/protocol'
 import { createAdvancedChunkNameResolver } from './advancedChunks'
 import { __clearSharedChunkDiagnosticsForTest, DEFAULT_SHARED_CHUNK_STRATEGY, SHARED_CHUNK_VIRTUAL_PREFIX } from './chunkStrategy'
 
@@ -174,5 +174,23 @@ describe('advanced chunk resolvers', () => {
     })
 
     expect(resolveAdvancedChunkName(sidecarSourceId, ctx)).toBeUndefined()
+  })
+
+  it('leaves logical entry physical sources inside their facade chunks', () => {
+    const resolveAdvancedChunkName = createAdvancedChunkNameResolver({
+      vendorsMatchers: [[/[\\/]node_modules[\\/]/gi]],
+      relativeAbsoluteSrcRoot,
+      getSubPackageRoots: () => [],
+      strategy: DEFAULT_SHARED_CHUNK_STRATEGY,
+      sharedMode: 'path',
+      resolveSharedPath: () => 'layouts/default/index.ts',
+    })
+    const sourceId = `${ROOT}/layouts/default/index.ts`
+    const logicalEntryId = createLogicalEntryId(sourceId, 'layout')
+    const ctx = createCtx({
+      [sourceId]: [logicalEntryId, `${ROOT}/pages/layouts/index.ts`],
+    })
+
+    expect(resolveAdvancedChunkName(sourceId, ctx)).toBeUndefined()
   })
 })

--- a/packages/weapp-vite/src/runtime/advancedChunks.test.ts
+++ b/packages/weapp-vite/src/runtime/advancedChunks.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest'
+import { createSidecarModuleId, createSidecarSourceSpecifier } from '../moduleGraph/protocol'
 import { createAdvancedChunkNameResolver } from './advancedChunks'
 import { __clearSharedChunkDiagnosticsForTest, DEFAULT_SHARED_CHUNK_STRATEGY, SHARED_CHUNK_VIRTUAL_PREFIX } from './chunkStrategy'
 
@@ -154,5 +155,24 @@ describe('advanced chunk resolvers', () => {
 
     expect(resolveAdvancedChunkName(`${ROOT}/utils/feature.ts`, ctx)).toBe('utils/feature')
     expect(resolveAdvancedChunkName(`${ROOT}/shared.ts`, ctx)).toBe('common')
+  })
+
+  it('keeps source-graph-only sidecars out of output chunk naming', () => {
+    const resolveAdvancedChunkName = createAdvancedChunkNameResolver({
+      vendorsMatchers: [[/[\\/]node_modules[\\/]/gi]],
+      relativeAbsoluteSrcRoot,
+      getSubPackageRoots: () => ['packageA'],
+      strategy: DEFAULT_SHARED_CHUNK_STRATEGY,
+      sharedMode: 'path',
+    })
+    const ownerId = `${ROOT}/components/card.ts`
+    const targetId = `${ROOT}/packageA/components/location.ts`
+    const sidecarId = createSidecarModuleId(ownerId, targetId, 'using-component')
+    const sidecarSourceId = createSidecarSourceSpecifier(ownerId, targetId, 'using-component')
+    const ctx = createCtx({
+      [sidecarSourceId]: [sidecarId, `${sidecarId}:duplicate-importer`],
+    })
+
+    expect(resolveAdvancedChunkName(sidecarSourceId, ctx)).toBeUndefined()
   })
 })

--- a/packages/weapp-vite/src/runtime/advancedChunks.ts
+++ b/packages/weapp-vite/src/runtime/advancedChunks.ts
@@ -1,4 +1,5 @@
 import type { ResolveSharedChunkNameOptions } from './chunkStrategy'
+import { parseSidecarSourceRequest } from '../moduleGraph/protocol'
 import { resolveSharedChunkName } from './chunkStrategy'
 
 export type AdvancedChunkNameResolver = (
@@ -40,6 +41,9 @@ export function createAdvancedChunkNameResolver(options: AdvancedChunkResolverOp
   const isVendor = testByReg2DExpList(vendorsMatchers)
 
   return (id, ctx) => {
+    if (parseSidecarSourceRequest(id)) {
+      return undefined
+    }
     const subPackageRoots = Array.from(getSubPackageRoots())
     const relativeId = relativeAbsoluteSrcRoot(id)
     const resolvedMode = resolveSharedMode ? resolveSharedMode(relativeId, id) : sharedMode

--- a/packages/weapp-vite/src/runtime/advancedChunks.ts
+++ b/packages/weapp-vite/src/runtime/advancedChunks.ts
@@ -1,5 +1,5 @@
 import type { ResolveSharedChunkNameOptions } from './chunkStrategy'
-import { parseSidecarSourceRequest } from '../moduleGraph/protocol'
+import { parseLogicalEntryId, parseSidecarSourceRequest } from '../moduleGraph/protocol'
 import { resolveSharedChunkName } from './chunkStrategy'
 
 export type AdvancedChunkNameResolver = (
@@ -42,6 +42,12 @@ export function createAdvancedChunkNameResolver(options: AdvancedChunkResolverOp
 
   return (id, ctx) => {
     if (parseSidecarSourceRequest(id)) {
+      return undefined
+    }
+    const isLogicalEntrySource = ctx.getModuleInfo(id)?.importers?.some((importer) => {
+      return parseLogicalEntryId(importer)?.sourceId === id
+    })
+    if (isLogicalEntrySource) {
       return undefined
     }
     const subPackageRoots = Array.from(getSubPackageRoots())

--- a/packages/weapp-vite/src/runtime/buildPlugin/devBuildWatcher.test.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/devBuildWatcher.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createDevBuildWatcher } from './devBuildWatcher'
+
+describe('devBuildWatcher', () => {
+  it('forwards one-shot build events through the Rolldown watcher contract', () => {
+    const controller = createDevBuildWatcher()
+    const listener = vi.fn()
+
+    controller.emitEvent({ code: 'START' })
+    controller.emitEvent({ code: 'END' })
+    controller.watcher.on('event', listener)
+
+    expect(listener).toHaveBeenNthCalledWith(1, { code: 'START' })
+    expect(listener).toHaveBeenNthCalledWith(2, { code: 'END' })
+  })
+
+  it('supports off, clear and idempotent close', async () => {
+    const controller = createDevBuildWatcher()
+    const eventListener = vi.fn()
+    const closeListener = vi.fn()
+
+    controller.watcher.on('event', eventListener)
+    controller.watcher.off('event', eventListener)
+    controller.emitEvent({ code: 'START' })
+    controller.watcher.on('close', closeListener)
+    await controller.watcher.close()
+    await controller.watcher.close()
+
+    expect(eventListener).not.toHaveBeenCalled()
+    expect(closeListener).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/weapp-vite/src/runtime/buildPlugin/devBuildWatcher.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/devBuildWatcher.ts
@@ -1,0 +1,81 @@
+import type {
+  RolldownWatcher,
+  RolldownWatcherEvent,
+  RolldownWatcherWatcherEventMap,
+} from 'rolldown'
+
+type WatcherEventName = keyof RolldownWatcherWatcherEventMap
+type WatcherListener<E extends WatcherEventName> = (
+  ...args: RolldownWatcherWatcherEventMap[E]
+) => void | Promise<void>
+
+export interface DevBuildWatcherController {
+  watcher: RolldownWatcher
+  emitEvent: (event: RolldownWatcherEvent) => void
+}
+
+/**
+ * 为 provider 驱动的一次性构建提供 Rolldown watcher 兼容事件接口。
+ */
+export function createDevBuildWatcher(): DevBuildWatcherController {
+  const listeners = new Map<WatcherEventName, Set<(...args: any[]) => void | Promise<void>>>()
+  const pendingEvents: RolldownWatcherEvent[] = []
+  let closed = false
+
+  const watcher: RolldownWatcher = {
+    on(event, listener) {
+      let eventListeners = listeners.get(event)
+      if (!eventListeners) {
+        eventListeners = new Set()
+        listeners.set(event, eventListeners)
+      }
+      eventListeners.add(listener)
+      if (event === 'event' && pendingEvents.length) {
+        const queuedEvents = pendingEvents.splice(0)
+        for (const queuedEvent of queuedEvents) {
+          void Promise.resolve((listener as WatcherListener<'event'>)(queuedEvent)).catch(() => {})
+        }
+      }
+      return watcher
+    },
+    off(event, listener) {
+      listeners.get(event)?.delete(listener)
+      return watcher
+    },
+    clear(event) {
+      listeners.delete(event)
+    },
+    async close() {
+      if (closed) {
+        return
+      }
+      closed = true
+      const closeListeners = Array.from(listeners.get('close') ?? [])
+      listeners.clear()
+      await Promise.all(closeListeners.map(listener => listener()))
+    },
+  }
+
+  function emit<E extends WatcherEventName>(
+    event: E,
+    ...args: RolldownWatcherWatcherEventMap[E]
+  ) {
+    if (closed) {
+      return
+    }
+    for (const listener of listeners.get(event) ?? []) {
+      void Promise.resolve((listener as WatcherListener<E>)(...args)).catch(() => {})
+    }
+  }
+
+  return {
+    watcher,
+    emitEvent(event) {
+      if (!listeners.get('event')?.size) {
+        pendingEvents.push(event)
+        return
+      }
+      emit('event', event)
+    },
+  }
+}

--- a/packages/weapp-vite/src/runtime/buildPlugin/layoutBuild.test.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/layoutBuild.test.ts
@@ -14,6 +14,30 @@ async function createTempRoot() {
   return root
 }
 
+function chunkImportsTransitively(
+  outputs: Array<{ type: string, fileName: string, imports?: string[] }>,
+  sourceFileName: string,
+  targetFileName: string,
+) {
+  const chunks = new Map(outputs
+    .filter(output => output.type === 'chunk')
+    .map(output => [output.fileName, output.imports ?? []]))
+  const queue = [...(chunks.get(sourceFileName) ?? [])]
+  const visited = new Set<string>()
+  for (let index = 0; index < queue.length; index += 1) {
+    const fileName = queue[index]!
+    if (fileName === targetFileName) {
+      return true
+    }
+    if (visited.has(fileName)) {
+      continue
+    }
+    visited.add(fileName)
+    queue.push(...(chunks.get(fileName) ?? []))
+  }
+  return false
+}
+
 async function writeJson(file: string, value: unknown) {
   await fs.writeFile(file, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
 }
@@ -230,32 +254,19 @@ describe('layout build regression', () => {
         && output.fileName.endsWith('.js')
         && output.code.includes('LAYOUT-SHARED-MARKER')
     })
-    const candidateSharedWevuChunkNames = new Set([
-      ...(layoutChunk?.type === 'chunk' ? layoutChunk.imports : []),
-      ...(pageChunk?.type === 'chunk' ? pageChunk.imports : []),
-    ])
-    candidateSharedWevuChunkNames.delete(sharedRuntimeChunk?.fileName ?? '')
-    const sharedWevuChunk = outputs.find((output) => {
-      return output.type === 'chunk'
-        && candidateSharedWevuChunkNames.has(output.fileName)
-        && output.imports.includes(sharedRuntimeChunk?.fileName ?? '')
-    })
     const pageJson = outputs.find(output => output.type === 'asset' && output.fileName === 'pages/index/index.json')
 
     expect(layoutChunk).toBeTruthy()
     expect(pageChunk).toBeTruthy()
     expect(sharedRuntimeChunk).toBeTruthy()
-    expect(sharedWevuChunk).toBeTruthy()
     expect(pageJson).toBeTruthy()
 
     expect(sharedRuntimeChunk!.fileName).toMatch(/weapp-vendors\/wevu-[\w-]+\.js$/)
     expect(sharedRuntimeChunk!.code).toContain('LAYOUT-SHARED-MARKER')
     expect(sharedRuntimeChunk!.code).not.toContain('//#region src/layouts/default.vue')
     expect(layoutChunk!.code).not.toContain('Component({})')
-    expect(layoutChunk!.code).toContain('setup(')
-    expect(layoutChunk!.imports).toContain(sharedWevuChunk!.fileName)
-    expect(pageChunk!.imports).toContain(sharedWevuChunk!.fileName)
-    expect(sharedWevuChunk!.imports).toContain(sharedRuntimeChunk!.fileName)
+    expect(chunkImportsTransitively(outputs, layoutChunk!.fileName, sharedRuntimeChunk!.fileName)).toBe(true)
+    expect(chunkImportsTransitively(outputs, pageChunk!.fileName, sharedRuntimeChunk!.fileName)).toBe(true)
     expect(String(pageJson!.source)).toContain('"weapp-layout-default": "/layouts/default"')
   })
 
@@ -283,12 +294,17 @@ describe('layout build regression', () => {
     const layoutJson = outputs.find(output => output.fileName === 'layouts/default.json')
     const layoutWxml = outputs.find(output => output.fileName === 'layouts/default.wxml')
     const layoutScript = layoutJs!.type === 'asset' ? String(layoutJs!.source) : layoutJs!.code
+    const combinedChunkCode = outputs
+      .filter(output => output.type === 'chunk')
+      .map(output => output.code)
+      .join('\n')
 
     expect(layoutJs).toBeTruthy()
     expect(layoutScript.length).toBeGreaterThan(0)
-    expect(layoutScript).toContain('vueSlots')
-    expect(layoutScript).toContain('__wvSlotOwnerId')
-    expect(layoutScript).toContain('__wvSlotScope')
+    expect(layoutScript).toContain('exports.default')
+    expect(combinedChunkCode).toContain('vueSlots')
+    expect(combinedChunkCode).toContain('__wvSlotOwnerId')
+    expect(combinedChunkCode).toContain('__wvSlotScope')
     expect(layoutJson).toBeTruthy()
     expect(layoutWxml).toBeTruthy()
   })

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
@@ -33,6 +33,7 @@ const buildWorkersMock = vi.hoisted(() => vi.fn(async () => {}))
 const loggerInfoMock = vi.hoisted(() => vi.fn())
 const loggerSuccessMock = vi.hoisted(() => vi.fn())
 const loggerWarnMock = vi.hoisted(() => vi.fn())
+const loggerErrorMock = vi.hoisted(() => vi.fn())
 const independentBuildMock = vi.hoisted(() => vi.fn(async () => ({ output: [] })))
 const independentGetOutputMock = vi.hoisted(() => vi.fn(() => undefined))
 const independentInvalidateMock = vi.hoisted(() => vi.fn())
@@ -47,12 +48,35 @@ const chokidarWatchMock = vi.hoisted(() => vi.fn(() => ({
   on: vi.fn(),
   close: vi.fn(),
 })))
-const findJsEntryMock = vi.hoisted(() => vi.fn(async () => ({ path: undefined })))
 const syncProjectSupportFilesMock = vi.hoisted(() => vi.fn(async () => ({
   managedTsconfigChanged: false,
   managedTsconfigWarnings: [],
 })))
 const runStatefulHmrDevMock = vi.hoisted(() => vi.fn())
+const devBuildWatcherQueue = vi.hoisted(() => [] as Array<{
+  watcher: any
+  emitEvent: ReturnType<typeof vi.fn>
+}>)
+const createDevBuildWatcherMock = vi.hoisted(() => vi.fn(() => {
+  const queued = devBuildWatcherQueue.shift()
+  if (queued) {
+    return queued
+  }
+  const watcher = {
+    on: vi.fn(() => watcher),
+    off: vi.fn(() => watcher),
+    clear: vi.fn(),
+    close: vi.fn(async () => {}),
+  }
+  return { watcher, emitEvent: vi.fn() }
+}))
+const moduleGraphProviderChange = vi.hoisted(() => ({
+  handler: undefined as undefined | ((file: string) => void),
+}))
+const createDevModuleGraphProviderMock = vi.hoisted(() => vi.fn(async (_ctx, _config, onChange) => {
+  moduleGraphProviderChange.handler = onChange
+  return { close: vi.fn(async () => {}) }
+}))
 
 vi.mock('node:fs/promises', () => ({
   appendFile: appendFileMock,
@@ -91,6 +115,14 @@ vi.mock('../statefulHmr/session', () => ({
   runStatefulHmrDev: runStatefulHmrDevMock,
 }))
 
+vi.mock('../../moduleGraph/devProvider', () => ({
+  createDevModuleGraphProvider: createDevModuleGraphProviderMock,
+}))
+
+vi.mock('./devBuildWatcher', () => ({
+  createDevBuildWatcher: createDevBuildWatcherMock,
+}))
+
 vi.mock('../libDts', () => ({
   generateLibDts: generateLibDtsMock,
 }))
@@ -111,13 +143,13 @@ vi.mock('./workers', () => ({
 }))
 
 vi.mock('../../utils/file', () => ({
-  findJsEntry: findJsEntryMock,
   touch: touchMock,
 }))
 
 vi.mock('../../context/shared', () => ({
   debug: vi.fn(),
   logger: {
+    error: loggerErrorMock,
     info: loggerInfoMock,
     success: loggerSuccessMock,
     warn: loggerWarnMock,
@@ -172,6 +204,10 @@ function createManualWatcher() {
     subscribed,
     close: vi.fn(),
   }
+  devBuildWatcherQueue.push({
+    watcher,
+    emitEvent: vi.fn(event => watcher.emitPayload(event)),
+  })
   return watcher
 }
 
@@ -243,6 +279,12 @@ function createMockContext(overrides: Record<string, unknown> = {}) {
       loadAppEntry: vi.fn(async () => {}),
       loadSubPackages: vi.fn(() => []),
     },
+    moduleGraphService: {
+      collectAffectedEntries: vi.fn(() => new Set<string>()),
+      hasModule: vi.fn(() => true),
+      isLogicalLayoutEntry: vi.fn(() => false),
+      recordChangedFile: vi.fn(),
+    },
   } as any
 
   if (Object.keys(overrides).length > 0) {
@@ -275,6 +317,7 @@ async function waitForMockCalls(mock: { mock: { calls: unknown[] } }, count: num
 
 describe('runtime buildPlugin service', () => {
   beforeEach(() => {
+    devBuildWatcherQueue.length = 0
     vi.clearAllMocks()
     buildMock.mockReset()
     runStatefulHmrDevMock.mockReset()
@@ -288,7 +331,6 @@ describe('runtime buildPlugin service', () => {
       hasWorkersDir: false,
       workersDir: undefined,
     })
-    findJsEntryMock.mockResolvedValue({ path: undefined })
     syncProjectSupportFilesMock.mockResolvedValue({
       managedTsconfigChanged: false,
       managedTsconfigWarnings: [],
@@ -538,6 +580,12 @@ describe('runtime buildPlugin service', () => {
       .mockResolvedValueOnce(watcher)
       .mockResolvedValue({ output: [] })
     const ctx = createMockContext()
+    ctx.runtimeState.build.hmr.resolvedEntryMap.set('/project/src/pages/logs/index.ts', {
+      id: '/project/src/pages/logs/index.ts',
+    })
+    ctx.moduleGraphService.collectAffectedEntries.mockReturnValue(new Set([
+      '/project/src/pages/logs/index.ts',
+    ]))
     const service = createBuildService(ctx)
 
     const firstBuild = service.build({ skipNpm: true })
@@ -549,7 +597,7 @@ describe('runtime buildPlugin service', () => {
     await firstBuild
 
     nowValue = 20
-    sidecarWatcher.emit('change', '/project/src/pages/logs/index.wxml')
+    moduleGraphProviderChange.handler?.('/project/src/pages/logs/index.wxml')
     nowValue = 28
     await waitForMockCalls(loggerSuccessMock, 1)
 
@@ -572,7 +620,6 @@ describe('runtime buildPlugin service', () => {
         dirtySummaries.push(ctx.runtimeState.build.hmr.profile.dirtyReasonSummary)
         return { output: [] }
       })
-    findJsEntryMock.mockResolvedValue({ path: '/project/src/pages/logs/index.ts' })
     ctx.runtimeState.build.hmr.resolvedEntryMap.set('/project/src/pages/logs/index.ts', {
       id: '/project/src/pages/logs/index.ts',
     })
@@ -581,6 +628,9 @@ describe('runtime buildPlugin service', () => {
     })
     ctx.runtimeState.build.hmr.loadedEntrySet.add('/project/src/pages/logs/index.ts')
     ctx.runtimeState.build.hmr.loadedEntrySet.add('/project/src/pages/about/index.ts')
+    ctx.moduleGraphService.collectAffectedEntries.mockReturnValue(new Set([
+      '/project/src/pages/logs/index.ts',
+    ]))
     const service = createBuildService(ctx)
 
     const firstBuild = service.build({ skipNpm: true })
@@ -590,10 +640,13 @@ describe('runtime buildPlugin service', () => {
     await firstBuild
     touchMock.mockClear()
 
-    sidecarWatcher.emit('change', '/project/src/pages/logs/index.wxml')
+    moduleGraphProviderChange.handler?.('/project/src/pages/logs/index.wxml')
     await waitForMockCalls(buildMock, 2)
 
     expect(buildMock).toHaveBeenCalledTimes(2)
+    expect(buildMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      build: expect.objectContaining({ emptyOutDir: false }),
+    }))
     expect(ctx.runtimeState.build.hmr.dirtyEntrySet).toEqual(new Set(['/project/src/pages/logs/index.ts']))
     expect(ctx.runtimeState.build.hmr.dirtyEntryReasons.get('/project/src/pages/logs/index.ts')).toBe('metadata')
     expect(dirtySummaries).toEqual([['sidecar-direct:1']])
@@ -617,6 +670,13 @@ describe('runtime buildPlugin service', () => {
     ctx.runtimeState.build.hmr.resolvedEntryMap.set('/project/src/pages/about/index.ts', {
       id: '/project/src/pages/about/index.ts',
     })
+    ctx.moduleGraphService.collectAffectedEntries.mockImplementation((file: string) => {
+      return new Set([
+        file.endsWith('.wxml')
+          ? '/project/src/pages/logs/index.ts'
+          : '/project/src/pages/about/index.ts',
+      ])
+    })
     buildMock
       .mockResolvedValueOnce(watcher)
       .mockImplementation(async () => {
@@ -632,13 +692,17 @@ describe('runtime buildPlugin service', () => {
     watcher.emit('END')
     await firstBuild
 
-    sidecarWatcher.emit('change', '/project/src/pages/logs/index.wxml')
-    sidecarWatcher.emit('change', '/project/src/pages/about/index.wxss')
+    moduleGraphProviderChange.handler?.('/project/src/pages/logs/index.wxml')
+    moduleGraphProviderChange.handler?.('/project/src/pages/about/index.wxss')
     await waitForMockCalls(buildMock, 2)
 
     expect(buildMock).toHaveBeenCalledTimes(2)
-    expect(dirtySummaries).toEqual([['snapshot-full:2']])
-    expect(forceFullValues).toEqual(['1'])
+    expect(ctx.runtimeState.build.hmr.dirtyEntrySet).toEqual(new Set([
+      '/project/src/pages/logs/index.ts',
+      '/project/src/pages/about/index.ts',
+    ]))
+    expect(dirtySummaries).toEqual([['sidecar-direct:1', 'style-sidecar:1']])
+    expect(forceFullValues).toEqual([undefined])
     expect(loggerSuccessMock).toHaveBeenCalledTimes(1)
   })
 
@@ -662,6 +726,9 @@ describe('runtime buildPlugin service', () => {
     })
     ctx.runtimeState.build.hmr.loadedEntrySet.add('/project/src/pages/logs/index.ts')
     ctx.runtimeState.build.hmr.loadedEntrySet.add('/project/src/pages/about/index.ts')
+    ctx.moduleGraphService.collectAffectedEntries.mockReturnValue(new Set([
+      '/project/src/pages/logs/index.ts',
+    ]))
     const service = createBuildService(ctx)
 
     const firstBuild = service.build({ skipNpm: true })
@@ -679,6 +746,9 @@ describe('runtime buildPlugin service', () => {
     ]))
     expect(ctx.runtimeState.build.hmr.loadedEntrySet.size).toBe(0)
     expect(forceFullValues).toEqual(['1'])
+    expect(buildMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      build: expect.objectContaining({ emptyOutDir: true }),
+    }))
   })
 
   it('ignores vue updates in snapshot sidecar watcher', async () => {
@@ -727,7 +797,37 @@ describe('runtime buildPlugin service', () => {
     expect(loggerSuccessMock).not.toHaveBeenCalled()
   })
 
-  it('watches user build.watch.include entries with snapshot sidecar watcher', async () => {
+  it('routes native logical layout scripts through the dev graph provider', async () => {
+    const watcher = createManualWatcher()
+    const sidecarWatcher = createManualSidecarWatcher()
+    chokidarWatchMock.mockReturnValue(sidecarWatcher)
+    buildMock
+      .mockResolvedValueOnce(watcher)
+      .mockResolvedValue({ output: [] })
+    const ctx = createMockContext()
+    const layoutId = '/project/src/layouts/default/index.ts'
+    const pageId = '/project/src/pages/layouts/index.ts'
+    ctx.runtimeState.build.hmr.resolvedEntryMap.set(pageId, { id: pageId })
+    ctx.moduleGraphService.isLogicalLayoutEntry.mockImplementation((id: string) => id === layoutId)
+    ctx.runtimeState.build.hmr.resolvedEntryMap.set(layoutId, { id: layoutId })
+    ctx.moduleGraphService.collectAffectedEntries.mockReturnValue(new Set([layoutId, pageId]))
+    const service = createBuildService(ctx)
+
+    const firstBuild = service.build({ skipNpm: true })
+    await watcher.subscribed
+    watcher.emit('START')
+    watcher.emit('END')
+    await firstBuild
+
+    moduleGraphProviderChange.handler?.(layoutId)
+    await waitForMockCalls(buildMock, 2)
+
+    expect(ctx.runtimeState.build.hmr.dirtyEntrySet).toEqual(new Set([layoutId, pageId]))
+    expect(ctx.runtimeState.build.hmr.dirtyEntryReasons.get(layoutId)).toBe('dependency')
+    expect(ctx.runtimeState.build.hmr.dirtyEntryReasons.get(pageId)).toBe('dependency')
+  })
+
+  it('leaves existing linked script updates to the Rolldown watcher', async () => {
     const watcher = createManualWatcher()
     const sidecarWatcher = createManualSidecarWatcher()
     chokidarWatchMock.mockReturnValue(sidecarWatcher)
@@ -757,11 +857,10 @@ describe('runtime buildPlugin service', () => {
     expect(patterns).toContain('/workspace/packages/shared/**')
 
     sidecarWatcher.emit('change', '/workspace/packages/shared/message.ts')
-    await waitForMockCalls(buildMock, 2)
+    await flushAsyncTasks()
 
-    expect(ctx.runtimeState.build.hmr.dirtyEntrySet).toEqual(new Set([
-      '/project/src/pages/logs/index.ts',
-    ]))
+    expect(buildMock).toHaveBeenCalledTimes(1)
+    expect(ctx.runtimeState.build.hmr.dirtyEntrySet).toEqual(new Set())
   })
 
   it('ignores generated output updates in snapshot sidecar watcher', async () => {
@@ -1664,14 +1763,13 @@ describe('runtime buildPlugin service', () => {
     expect(ctx.npmService.checkDependenciesCacheOutdate).toHaveBeenCalledTimes(1)
   })
 
-  it('rejects dev build when watcher emits error', async () => {
-    buildMock.mockResolvedValueOnce(createWatcher(['ERROR']))
+  it('rejects dev build when the initial one-shot build fails', async () => {
+    const buildError = new Error('initial build failed')
+    buildMock.mockRejectedValueOnce(buildError)
     const ctx = createMockContext()
     const service = createBuildService(ctx)
 
-    await expect(service.build({ skipNpm: true })).rejects.toEqual({
-      code: 'ERROR',
-    })
+    await expect(service.build({ skipNpm: true })).rejects.toBe(buildError)
     expect(ctx.watcherService.setRollupWatcher).not.toHaveBeenCalled()
   })
 

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
@@ -657,6 +657,36 @@ describe('runtime buildPlugin service', () => {
     expect(forceFullValues).toEqual([undefined])
   })
 
+  it('classifies imported style changes through their graph-owned entry', async () => {
+    const watcher = createManualWatcher()
+    const sidecarWatcher = createManualSidecarWatcher()
+    const dirtySummaries: Array<string[] | undefined> = []
+    chokidarWatchMock.mockReturnValue(sidecarWatcher)
+    const ctx = createMockContext()
+    const pageId = '/project/src/pages/logs/index.vue'
+    ctx.runtimeState.build.hmr.resolvedEntryMap.set(pageId, { id: pageId })
+    ctx.moduleGraphService.collectAffectedEntries.mockReturnValue(new Set([pageId]))
+    buildMock
+      .mockResolvedValueOnce(watcher)
+      .mockImplementation(async () => {
+        dirtySummaries.push(ctx.runtimeState.build.hmr.profile.dirtyReasonSummary)
+        return { output: [] }
+      })
+    const service = createBuildService(ctx)
+
+    const firstBuild = service.build({ skipNpm: true })
+    await watcher.subscribed
+    watcher.emit('START')
+    watcher.emit('END')
+    await firstBuild
+
+    moduleGraphProviderChange.handler?.('/project/src/pages/logs/hello.css')
+    await waitForMockCalls(buildMock, 2)
+
+    expect(dirtySummaries).toEqual([['css-importer:1']])
+    expect(ctx.runtimeState.build.hmr.dirtyVueEntryIds).toEqual(new Set([pageId]))
+  })
+
   it('batches consecutive sidecar snapshot events into one build', async () => {
     const watcher = createManualWatcher()
     const sidecarWatcher = createManualSidecarWatcher()
@@ -718,16 +748,16 @@ describe('runtime buildPlugin service', () => {
         return { output: [] }
       })
     const ctx = createMockContext()
-    ctx.runtimeState.build.hmr.resolvedEntryMap.set('/project/src/pages/logs/index.ts', {
-      id: '/project/src/pages/logs/index.ts',
+    ctx.runtimeState.build.hmr.resolvedEntryMap.set('/project/src/pages/logs/index.vue', {
+      id: '/project/src/pages/logs/index.vue',
     })
     ctx.runtimeState.build.hmr.resolvedEntryMap.set('/project/src/pages/about/index.ts', {
       id: '/project/src/pages/about/index.ts',
     })
-    ctx.runtimeState.build.hmr.loadedEntrySet.add('/project/src/pages/logs/index.ts')
+    ctx.runtimeState.build.hmr.loadedEntrySet.add('/project/src/pages/logs/index.vue')
     ctx.runtimeState.build.hmr.loadedEntrySet.add('/project/src/pages/about/index.ts')
     ctx.moduleGraphService.collectAffectedEntries.mockReturnValue(new Set([
-      '/project/src/pages/logs/index.ts',
+      '/project/src/pages/logs/index.vue',
     ]))
     const service = createBuildService(ctx)
 
@@ -741,14 +771,48 @@ describe('runtime buildPlugin service', () => {
     await waitForMockCalls(buildMock, 2)
 
     expect(ctx.runtimeState.build.hmr.dirtyEntrySet).toEqual(new Set([
-      '/project/src/pages/logs/index.ts',
+      '/project/src/pages/logs/index.vue',
       '/project/src/pages/about/index.ts',
+    ]))
+    expect(ctx.runtimeState.build.hmr.dirtyVueEntryIds).toEqual(new Set([
+      '/project/src/pages/logs/index.vue',
     ]))
     expect(ctx.runtimeState.build.hmr.loadedEntrySet.size).toBe(0)
     expect(forceFullValues).toEqual(['1'])
     expect(buildMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
       build: expect.objectContaining({ emptyOutDir: true }),
     }))
+  })
+
+  it('continues snapshot builds after a transient topology build failure', async () => {
+    const watcher = createManualWatcher()
+    const sidecarWatcher = createManualSidecarWatcher()
+    chokidarWatchMock.mockReturnValue(sidecarWatcher)
+    buildMock
+      .mockResolvedValueOnce(watcher)
+      .mockRejectedValueOnce(new Error('transient atomic save'))
+      .mockResolvedValueOnce({ output: [] })
+    const ctx = createMockContext()
+    ctx.runtimeState.build.hmr.resolvedEntryMap.set('/project/src/pages/logs/index.ts', {
+      id: '/project/src/pages/logs/index.ts',
+    })
+    const service = createBuildService(ctx)
+
+    const firstBuild = service.build({ skipNpm: true })
+    await watcher.subscribed
+    watcher.emit('START')
+    watcher.emit('END')
+    await firstBuild
+
+    sidecarWatcher.emit('unlink', '/project/src/pages/logs/index.wxss')
+    await waitForMockCalls(buildMock, 2)
+    await waitForMockCalls(loggerErrorMock, 1)
+
+    sidecarWatcher.emit('add', '/project/src/pages/logs/index.wxss')
+    await waitForMockCalls(buildMock, 3)
+    await waitForMockCalls(loggerSuccessMock, 1)
+
+    expect(buildMock).toHaveBeenCalledTimes(3)
   })
 
   it('ignores vue updates in snapshot sidecar watcher', async () => {

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
@@ -71,7 +71,7 @@ const createDevBuildWatcherMock = vi.hoisted(() => vi.fn(() => {
   return { watcher, emitEvent: vi.fn() }
 }))
 const moduleGraphProviderChange = vi.hoisted(() => ({
-  handler: undefined as undefined | ((file: string) => void),
+  handler: undefined as undefined | ((change: { event: 'create' | 'update', file: string }) => void),
 }))
 const createDevModuleGraphProviderMock = vi.hoisted(() => vi.fn(async (_ctx, _config, onChange) => {
   moduleGraphProviderChange.handler = onChange
@@ -597,7 +597,7 @@ describe('runtime buildPlugin service', () => {
     await firstBuild
 
     nowValue = 20
-    moduleGraphProviderChange.handler?.('/project/src/pages/logs/index.wxml')
+    moduleGraphProviderChange.handler?.({ event: 'update', file: '/project/src/pages/logs/index.wxml' })
     nowValue = 28
     await waitForMockCalls(loggerSuccessMock, 1)
 
@@ -640,7 +640,7 @@ describe('runtime buildPlugin service', () => {
     await firstBuild
     touchMock.mockClear()
 
-    moduleGraphProviderChange.handler?.('/project/src/pages/logs/index.wxml')
+    moduleGraphProviderChange.handler?.({ event: 'update', file: '/project/src/pages/logs/index.wxml' })
     await waitForMockCalls(buildMock, 2)
 
     expect(buildMock).toHaveBeenCalledTimes(2)
@@ -680,7 +680,7 @@ describe('runtime buildPlugin service', () => {
     watcher.emit('END')
     await firstBuild
 
-    moduleGraphProviderChange.handler?.('/project/src/pages/logs/hello.css')
+    moduleGraphProviderChange.handler?.({ event: 'update', file: '/project/src/pages/logs/hello.css' })
     await waitForMockCalls(buildMock, 2)
 
     expect(dirtySummaries).toEqual([['css-importer:1']])
@@ -722,8 +722,8 @@ describe('runtime buildPlugin service', () => {
     watcher.emit('END')
     await firstBuild
 
-    moduleGraphProviderChange.handler?.('/project/src/pages/logs/index.wxml')
-    moduleGraphProviderChange.handler?.('/project/src/pages/about/index.wxss')
+    moduleGraphProviderChange.handler?.({ event: 'update', file: '/project/src/pages/logs/index.wxml' })
+    moduleGraphProviderChange.handler?.({ event: 'update', file: '/project/src/pages/about/index.wxss' })
     await waitForMockCalls(buildMock, 2)
 
     expect(buildMock).toHaveBeenCalledTimes(2)
@@ -759,6 +759,7 @@ describe('runtime buildPlugin service', () => {
     ctx.moduleGraphService.collectAffectedEntries.mockReturnValue(new Set([
       '/project/src/pages/logs/index.vue',
     ]))
+    ctx.moduleGraphService.hasModule.mockReturnValue(false)
     const service = createBuildService(ctx)
 
     const firstBuild = service.build({ skipNpm: true })
@@ -778,6 +779,43 @@ describe('runtime buildPlugin service', () => {
       '/project/src/pages/logs/index.vue',
     ]))
     expect(ctx.runtimeState.build.hmr.loadedEntrySet.size).toBe(0)
+    expect(forceFullValues).toEqual(['1'])
+    expect(buildMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      build: expect.objectContaining({ emptyOutDir: true }),
+    }))
+  })
+
+  it('routes known atomic creates through the module graph provider only once', async () => {
+    const watcher = createManualWatcher()
+    const sidecarWatcher = createManualSidecarWatcher()
+    const forceFullValues: Array<string | undefined> = []
+    chokidarWatchMock.mockReturnValue(sidecarWatcher)
+    buildMock
+      .mockResolvedValueOnce(watcher)
+      .mockImplementation(async () => {
+        forceFullValues.push(process.env.WEAPP_VITE_FORCE_FULL_HMR_SHARED_CHUNKS)
+        return { output: [] }
+      })
+    const ctx = createMockContext()
+    const file = '/project/src/pages/logs/index.wxml'
+    ctx.runtimeState.build.hmr.resolvedEntryMap.set('/project/src/pages/logs/index.ts', {
+      id: '/project/src/pages/logs/index.ts',
+    })
+    const service = createBuildService(ctx)
+
+    const firstBuild = service.build({ skipNpm: true })
+    await watcher.subscribed
+    watcher.emit('START')
+    watcher.emit('END')
+    await firstBuild
+
+    moduleGraphProviderChange.handler?.({ event: 'create', file })
+    sidecarWatcher.emit('add', file)
+    await waitForMockCalls(buildMock, 2)
+
+    expect(buildMock).toHaveBeenCalledTimes(2)
+    expect(ctx.moduleGraphService.recordChangedFile).toHaveBeenCalledOnce()
+    expect(ctx.moduleGraphService.recordChangedFile).toHaveBeenCalledWith(file, 'create')
     expect(forceFullValues).toEqual(['1'])
     expect(buildMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
       build: expect.objectContaining({ emptyOutDir: true }),
@@ -808,7 +846,9 @@ describe('runtime buildPlugin service', () => {
     await waitForMockCalls(buildMock, 2)
     await waitForMockCalls(loggerErrorMock, 1)
 
-    sidecarWatcher.emit('add', '/project/src/pages/logs/index.wxss')
+    const restoredFile = '/project/src/pages/logs/index.wxss'
+    sidecarWatcher.emit('add', restoredFile)
+    moduleGraphProviderChange.handler?.({ event: 'create', file: restoredFile })
     await waitForMockCalls(buildMock, 3)
     await waitForMockCalls(loggerSuccessMock, 1)
 
@@ -883,7 +923,7 @@ describe('runtime buildPlugin service', () => {
     watcher.emit('END')
     await firstBuild
 
-    moduleGraphProviderChange.handler?.(layoutId)
+    moduleGraphProviderChange.handler?.({ event: 'update', file: layoutId })
     await waitForMockCalls(buildMock, 2)
 
     expect(ctx.runtimeState.build.hmr.dirtyEntrySet).toEqual(new Set([layoutId, pageId]))

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.ts
@@ -9,6 +9,7 @@ import type { BuildTarget, MutableCompilerContext } from '../../context'
 import type { ChangeEvent, SubPackageMetaValue } from '../../types'
 import { appendFile, mkdir } from 'node:fs/promises'
 import process from 'node:process'
+import { removeExtensionDeep } from '@weapp-core/shared'
 import chokidar from 'chokidar'
 import path from 'pathe'
 import { build } from 'vite'
@@ -181,7 +182,10 @@ interface SnapshotBuildBatch {
   startedAt: number
 }
 
-function resolveSnapshotSidecarDirtySummary(filePath: string) {
+function resolveSnapshotSidecarDirtySummary(
+  filePath: string,
+  affectedEntries?: Iterable<string>,
+) {
   const normalizedFile = normalizeFsResolvedId(filePath)
   const configSuffix = configSuffixes.find(suffix => normalizedFile.endsWith(suffix))
   if (configSuffix) {
@@ -189,7 +193,13 @@ function resolveSnapshotSidecarDirtySummary(filePath: string) {
   }
   const ext = path.extname(normalizedFile)
   if (ext && watchedCssExts.has(ext)) {
-    return 'style-sidecar:1'
+    const styleBase = removeExtensionDeep(normalizedFile)
+    const isDirectStyleSidecar = affectedEntries
+      ? Array.from(affectedEntries).some((entryId) => {
+          return removeExtensionDeep(normalizeFsResolvedId(entryId)) === styleBase
+        })
+      : true
+    return isDirectStyleSidecar ? 'style-sidecar:1' : 'css-importer:1'
   }
   if (ext && watchedTemplateExts.has(ext)) {
     return 'sidecar-direct:1'
@@ -1218,6 +1228,9 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
         ctx.runtimeState.build.hmr.dirtyEntrySet.add(entryId)
         ctx.runtimeState.build.hmr.dirtyEntryReasons.set(entryId, 'direct')
         ctx.runtimeState.build.hmr.loadedEntrySet.delete(entryId)
+        if (entryId.endsWith('.vue')) {
+          ctx.runtimeState.build.hmr.dirtyVueEntryIds.add(entryId)
+        }
       }
       ctx.runtimeState.build.hmr.profile = {
         ...ctx.runtimeState.build.hmr.profile,
@@ -1234,6 +1247,9 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
       ctx.runtimeState.build.hmr.dirtyEntrySet.add(entryId)
       ctx.runtimeState.build.hmr.dirtyEntryReasons.set(entryId, dirtyReason)
       ctx.runtimeState.build.hmr.loadedEntrySet.delete(entryId)
+      if (entryId.endsWith('.vue') && dirtyReason !== 'dependency') {
+        ctx.runtimeState.build.hmr.dirtyVueEntryIds.add(entryId)
+      }
       ctx.runtimeState.build.hmr.profile = {
         ...ctx.runtimeState.build.hmr.profile,
         dirtyCount: ctx.runtimeState.build.hmr.dirtyEntrySet.size,
@@ -1261,7 +1277,7 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
       if (devWatcherClosed) {
         return snapshotBuildChain
       }
-      snapshotBuildChain = snapshotBuildChain.then(async () => {
+      const currentSnapshotBuild = snapshotBuildChain.then(async () => {
         if (devWatcherClosed) {
           return
         }
@@ -1279,14 +1295,18 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
         }
         const snapshotResolveStartedAt = performance.now()
         const graphAffectedEntries = new Set<string>()
+        const graphAffectedEntriesByFile = new Map<string, Set<string>>()
         for (const batchReason of batchReasons) {
           if (!batchReason.file) {
             continue
           }
-          for (const entryId of ctx.moduleGraphService.collectAffectedEntries(batchReason.file)) {
+          const affectedForFile = ctx.moduleGraphService.collectAffectedEntries(batchReason.file)
+          graphAffectedEntriesByFile.set(normalizeFsResolvedId(batchReason.file), affectedForFile)
+          for (const entryId of affectedForFile) {
             graphAffectedEntries.add(entryId)
           }
         }
+        debug?.(`[module-graph-provider] affected=${graphAffectedEntries.size} files=${batchReasons.length}`)
         recordHmrProfileDuration(ctx.runtimeState.build.hmr.profile, 'snapshotResolveMs', performance.now() - snapshotResolveStartedAt)
         const snapshotBuildStartedAt = performance.now()
         const requiresFullRescan = batchReasons.some(batchReason =>
@@ -1309,7 +1329,10 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
             if (!batchReason.file) {
               continue
             }
-            const summary = resolveSnapshotSidecarDirtySummary(batchReason.file).replace(/:\d+$/, '')
+            const summary = resolveSnapshotSidecarDirtySummary(
+              batchReason.file,
+              graphAffectedEntriesByFile.get(normalizeFsResolvedId(batchReason.file)),
+            ).replace(/:\d+$/, '')
             summaryCounts.set(summary, (summaryCounts.get(summary) ?? 0) + 1)
           }
           ctx.runtimeState.build.hmr.profile.dirtyReasonSummary = Array.from(
@@ -1364,7 +1387,8 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
           delete process.env.WEAPP_VITE_FORCE_FULL_HMR_SHARED_CHUNKS
         }
       })
-      return snapshotBuildChain
+      snapshotBuildChain = currentSnapshotBuild.catch(() => undefined)
+      return currentSnapshotBuild
     }
 
     function resolveSnapshotBatchReason(batch: SnapshotBuildBatch) {
@@ -1421,7 +1445,9 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
           if (isDevOutputFile(id)) {
             return
           }
-          if (!ctx.moduleGraphService.hasModule(id)) {
+          const hasModule = ctx.moduleGraphService.hasModule(id)
+          debug?.(`[module-graph-provider] change=${configService.relativeAbsoluteSrcRoot(id)} module=${hasModule}`)
+          if (!hasModule) {
             return
           }
           const startedAt = performance.now()

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.ts
@@ -14,6 +14,7 @@ import path from 'pathe'
 import { build } from 'vite'
 import { debug, logger } from '../../context/shared'
 import { createCompilerContext } from '../../createContext'
+import { createDevModuleGraphProvider } from '../../moduleGraph/devProvider'
 import { invalidateFileCache } from '../../plugins/utils/cache'
 import {
   configSuffixes,
@@ -26,7 +27,7 @@ import {
   watchedTemplateSuffixes,
 } from '../../plugins/utils/invalidateEntry/shared'
 import { isLayoutSourcePath } from '../../plugins/utils/layoutSourcePath'
-import { findJsEntry, touch } from '../../utils/file'
+import { touch } from '../../utils/file'
 import { createHmrProfileEventId, recordHmrProfileDuration, resolveHmrProfileJsonEnvOption, resolveHmrProfileJsonPath as resolveHmrProfileJsonOutputPath } from '../../utils/hmrProfile'
 import { resolveCompilerOutputExtensions } from '../../utils/outputExtensions'
 import { syncProjectConfigToOutput } from '../../utils/projectConfig'
@@ -37,6 +38,7 @@ import { createSharedBuildConfig } from '../sharedBuildConfig'
 import { runStatefulHmrDev } from '../statefulHmr/session'
 import { syncProjectSupportFiles } from '../supportFiles'
 import { createSidecarWatchOptions } from '../watch/options'
+import { createDevBuildWatcher } from './devBuildWatcher'
 import { createHmrProfileMetricsPlugin } from './hmrProfileMetricsPlugin'
 import { createIndependentBuilder } from './independent'
 import { cleanOutputs, isOutputRootInsideOutDir, resetEmittedOutputCaches } from './outputs'
@@ -171,6 +173,7 @@ interface HmrPhaseRegressionCandidate {
 interface SnapshotBuildReason {
   event?: ChangeEvent
   file?: string
+  forceFullRescan?: boolean
 }
 
 interface SnapshotBuildBatch {
@@ -191,7 +194,7 @@ function resolveSnapshotSidecarDirtySummary(filePath: string) {
   if (ext && watchedTemplateExts.has(ext)) {
     return 'sidecar-direct:1'
   }
-  return 'sidecar-direct:1'
+  return 'importer-graph:1'
 }
 
 type ActiveConfigService = NonNullable<MutableCompilerContext['configService']>
@@ -299,6 +302,7 @@ function createSnapshotSidecarWatchPatterns(configService: ActiveConfigService, 
     ...watchedTemplateSuffixes.map(ext => path.join(root, `**/*${ext}`)),
     ...watchedScriptModuleSuffixes.map(ext => path.join(root, `**/*${ext}`)),
     ...Array.from(watchedSnapshotScriptExts).map(ext => path.join(root, `**/*${ext}`)),
+    ...(configService.configFileDependencies ?? []).map(dependency => path.normalize(dependency)),
   ]
   for (const include of resolveUserBuildWatchInclude(configService, inlineConfig)) {
     patterns.push(include)
@@ -1198,6 +1202,7 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
       ...buildOptions,
       build: {
         ...(buildOptions.build ?? {}),
+        emptyOutDir: false,
       },
     }
     delete snapshotBuildOptions.build?.watch
@@ -1206,36 +1211,7 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
     let devWatcherClosed = false
     let pendingSnapshotBatch: SnapshotBuildBatch | undefined
     let snapshotBatchTimer: ReturnType<typeof setTimeout> | undefined
-
-    async function resolveSnapshotSidecarEntryId(reason?: SnapshotBuildReason) {
-      if (reason?.event !== 'update' || !reason.file) {
-        return undefined
-      }
-      const normalizedFile = normalizeFsResolvedId(reason.file)
-      const configSuffix = configSuffixes.find(suffix => normalizedFile.endsWith(suffix))
-      const ext = path.extname(normalizedFile)
-      if (!configSuffix && !(ext && (watchedCssExts.has(ext) || watchedTemplateExts.has(ext)))) {
-        return undefined
-      }
-      const basePath = configSuffix
-        ? normalizedFile.slice(0, -configSuffix.length)
-        : ext
-          ? normalizedFile.slice(0, -ext.length)
-          : normalizedFile
-      const primaryScript = await findJsEntry(basePath)
-      if (!primaryScript.path) {
-        return undefined
-      }
-      const entryId = normalizeFsResolvedId(primaryScript.path)
-      if (!ctx.runtimeState.build.hmr.resolvedEntryMap.has(entryId)) {
-        return undefined
-      }
-      const relativeSrc = configService.relativeAbsoluteSrcRoot(entryId)
-      if (isLayoutSourcePath(relativeSrc)) {
-        return undefined
-      }
-      return entryId
-    }
+    const devBuildWatcher = target === 'app' ? createDevBuildWatcher() : undefined
 
     function markSnapshotEntriesFullDirty() {
       for (const entryId of ctx.runtimeState.build.hmr.resolvedEntryMap.keys()) {
@@ -1250,9 +1226,13 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
       }
     }
 
-    function markSnapshotEntryDirty(entryId: string, reason?: SnapshotBuildReason) {
+    function markSnapshotEntryDirty(
+      entryId: string,
+      reason?: SnapshotBuildReason,
+      dirtyReason: 'direct' | 'dependency' | 'metadata' = 'metadata',
+    ) {
       ctx.runtimeState.build.hmr.dirtyEntrySet.add(entryId)
-      ctx.runtimeState.build.hmr.dirtyEntryReasons.set(entryId, 'metadata')
+      ctx.runtimeState.build.hmr.dirtyEntryReasons.set(entryId, dirtyReason)
       ctx.runtimeState.build.hmr.loadedEntrySet.delete(entryId)
       ctx.runtimeState.build.hmr.profile = {
         ...ctx.runtimeState.build.hmr.profile,
@@ -1263,11 +1243,24 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
       }
     }
 
-    const runSnapshotBuild = (reason?: SnapshotBuildReason) => {
+    function resolveSnapshotDirtyReason(reason?: SnapshotBuildReason) {
+      if (!reason?.file) {
+        return 'direct' as const
+      }
+      if (isLayoutSourcePath(configService.relativeAbsoluteSrcRoot(reason.file))) {
+        return 'dependency' as const
+      }
+      return isSidecarFile(reason.file) ? 'metadata' as const : 'direct' as const
+    }
+
+    const runSnapshotBuild = (
+      reason?: SnapshotBuildReason,
+      batchReasons: SnapshotBuildReason[] = reason ? [reason] : [],
+      eventStartedAt = reason ? performance.now() : 0,
+    ) => {
       if (devWatcherClosed) {
         return snapshotBuildChain
       }
-      const startedAt = reason ? performance.now() : 0
       snapshotBuildChain = snapshotBuildChain.then(async () => {
         if (devWatcherClosed) {
           return
@@ -1281,28 +1274,90 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
             eventId: createHmrProfileEventId(),
             event: reason.event,
             file: reason.file,
-            watchToDirtyMs: performance.now() - startedAt,
+            watchToDirtyMs: performance.now() - eventStartedAt,
           }
         }
         const snapshotResolveStartedAt = performance.now()
-        const sidecarEntryId = await resolveSnapshotSidecarEntryId(reason)
+        const graphAffectedEntries = new Set<string>()
+        for (const batchReason of batchReasons) {
+          if (!batchReason.file) {
+            continue
+          }
+          for (const entryId of ctx.moduleGraphService.collectAffectedEntries(batchReason.file)) {
+            graphAffectedEntries.add(entryId)
+          }
+        }
         recordHmrProfileDuration(ctx.runtimeState.build.hmr.profile, 'snapshotResolveMs', performance.now() - snapshotResolveStartedAt)
         const snapshotBuildStartedAt = performance.now()
-        if (sidecarEntryId) {
-          markSnapshotEntryDirty(sidecarEntryId, reason)
+        const requiresFullRescan = batchReasons.some(batchReason =>
+          batchReason.forceFullRescan
+          || batchReason.event === 'create'
+          || batchReason.event === 'delete',
+        )
+        if (!requiresFullRescan && graphAffectedEntries.size) {
+          const dirtyReasons = batchReasons.map(resolveSnapshotDirtyReason)
+          const dirtyReason = dirtyReasons.includes('direct')
+            ? 'direct'
+            : dirtyReasons.includes('dependency') ? 'dependency' : 'metadata'
+          for (const entryId of graphAffectedEntries) {
+            if (ctx.runtimeState.build.hmr.resolvedEntryMap.has(entryId)) {
+              markSnapshotEntryDirty(entryId, reason, dirtyReason)
+            }
+          }
+          const summaryCounts = new Map<string, number>()
+          for (const batchReason of batchReasons) {
+            if (!batchReason.file) {
+              continue
+            }
+            const summary = resolveSnapshotSidecarDirtySummary(batchReason.file).replace(/:\d+$/, '')
+            summaryCounts.set(summary, (summaryCounts.get(summary) ?? 0) + 1)
+          }
+          ctx.runtimeState.build.hmr.profile.dirtyReasonSummary = Array.from(
+            summaryCounts,
+            ([summary, count]) => `${summary}:${count}`,
+          )
           try {
+            devBuildWatcher?.emitEvent({ code: 'START' })
             await build(snapshotBuildOptions)
+            devBuildWatcher?.emitEvent({ code: 'END' })
+          }
+          catch (error) {
+            devBuildWatcher?.emitEvent({
+              code: 'ERROR',
+              error: error instanceof Error ? error : new Error(String(error)),
+              result: undefined as never,
+            })
+            throw error
           }
           finally {
             recordHmrProfileDuration(ctx.runtimeState.build.hmr.profile, 'snapshotBuildMs', performance.now() - snapshotBuildStartedAt)
           }
           return 'snapshot'
         }
+        if (!requiresFullRescan && batchReasons.length && batchReasons.every(batchReason => batchReason.event === 'update')) {
+          return
+        }
         markSnapshotEntriesFullDirty()
         process.env.WEAPP_VITE_FORCE_FULL_HMR_SHARED_CHUNKS = '1'
         try {
-          await build(snapshotBuildOptions)
+          devBuildWatcher?.emitEvent({ code: 'START' })
+          await build({
+            ...snapshotBuildOptions,
+            build: {
+              ...(snapshotBuildOptions.build ?? {}),
+              emptyOutDir: true,
+            },
+          })
+          devBuildWatcher?.emitEvent({ code: 'END' })
           return 'snapshot'
+        }
+        catch (error) {
+          devBuildWatcher?.emitEvent({
+            code: 'ERROR',
+            error: error instanceof Error ? error : new Error(String(error)),
+            result: undefined as never,
+          })
+          throw error
         }
         finally {
           recordHmrProfileDuration(ctx.runtimeState.build.hmr.profile, 'snapshotBuildMs', performance.now() - snapshotBuildStartedAt)
@@ -1330,6 +1385,9 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
       if (devWatcherClosed) {
         return
       }
+      if (reason.file) {
+        ctx.moduleGraphService?.recordChangedFile(reason.file, reason.event ?? 'update')
+      }
       if (pendingSnapshotBatch) {
         pendingSnapshotBatch.reasons.push(reason)
         pendingSnapshotBatch.startedAt = Math.min(pendingSnapshotBatch.startedAt, startedAt)
@@ -1351,25 +1409,45 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
           return
         }
         const batchReason = resolveSnapshotBatchReason(batch)
-        void runSnapshotBuild(batchReason).then((result) => {
-          if (result !== 'snapshot') {
-            return
-          }
-          const durationMs = performance.now() - batch.startedAt
-          finalizeHmrProfile(durationMs)
-          recordHmrProfile(durationMs)
-          logger.success(formatHmrLogLine(durationMs))
-          resetHmrProfile()
-        }).catch((error) => {
+        void runSnapshotBuild(batchReason, batch.reasons, batch.startedAt).catch((error) => {
           resetHmrProfile()
           logger.error(error)
         })
       }, SNAPSHOT_BUILD_BATCH_DELAY_MS)
     }
 
-    const watcherPromise = build(
-      buildOptions,
-    ) as unknown as Promise<RolldownWatcher>
+    const moduleGraphProvider = target === 'app'
+      ? await createDevModuleGraphProvider(ctx, buildOptions, (id) => {
+          if (isDevOutputFile(id)) {
+            return
+          }
+          if (!ctx.moduleGraphService.hasModule(id)) {
+            return
+          }
+          const startedAt = performance.now()
+          scheduleSnapshotBuild({ event: 'update', file: id }, startedAt)
+        })
+      : undefined
+
+    const watcherPromise = target === 'app'
+      ? (async () => {
+          devBuildWatcher!.emitEvent({ code: 'START' })
+          try {
+            await build(snapshotBuildOptions)
+            devBuildWatcher!.emitEvent({ code: 'END' })
+            return devBuildWatcher!.watcher
+          }
+          catch (error) {
+            devBuildWatcher!.emitEvent({
+              code: 'ERROR',
+              error: error instanceof Error ? error : new Error(String(error)),
+              result: undefined as never,
+            })
+            await moduleGraphProvider?.close()
+            throw error
+          }
+        })()
+      : build(buildOptions) as unknown as Promise<RolldownWatcher>
     const workerPromise = target === 'app' && hasWorkersDir && workersDir
       ? devWorkers(configService, watcherService, workersDir)
       : Promise.resolve()
@@ -1405,8 +1483,10 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
         startTime = performance.now()
       }
       else if (e.code === 'END') {
-        const durationMs = performance.now() - startTime
-        recordHmrProfileDuration(ctx.runtimeState.build.hmr.profile, 'bundlerMs', durationMs)
+        const bundlerDurationMs = performance.now() - startTime
+        const durationMs = bundlerDurationMs
+          + (target === 'app' ? ctx.runtimeState.build.hmr.profile.watchToDirtyMs ?? 0 : 0)
+        recordHmrProfileDuration(ctx.runtimeState.build.hmr.profile, 'bundlerMs', bundlerDurationMs)
         void (async () => {
           const shouldRestart = shouldRestartDevBuild(target)
           if (shouldRestart) {
@@ -1433,7 +1513,7 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
           }
 
           if (firstBuildCompleted) {
-            finalizeHmrProfile(durationMs)
+            finalizeHmrProfile(bundlerDurationMs)
             recordHmrProfile(durationMs)
             await writeHmrProfileJsonSample(durationMs).catch((error) => {
               debug?.(`write hmr profile json failed: ${String(error)}`)
@@ -1456,10 +1536,14 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
       }
       else if (e.code === 'ERROR') {
         resetHmrProfile()
-        rejectWatcher(e)
+        if (target !== 'app') {
+          rejectWatcher(e)
+        }
       }
     })
-    await promise
+    if (target !== 'app') {
+      await promise
+    }
 
     const watcherRoot = target === 'plugin'
       ? configService.absolutePluginRoot ?? configService.absoluteSrcRoot
@@ -1483,6 +1567,15 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
         if (!shouldHandleSnapshotSidecarFile(id, ctx)) {
           return
         }
+        const normalizedId = normalizeFsResolvedId(id)
+        const isConfigDependency = (configService.configFileDependencies ?? [])
+          .some(dependency => normalizeFsResolvedId(dependency) === normalizedId)
+        if (!event.startsWith('add') && !event.startsWith('unlink') && !isConfigDependency) {
+          return
+        }
+        if (isConfigDependency) {
+          requestedConfigRestartBuilds.add(target)
+        }
         const sidecarStartedAt = performance.now()
         const normalizedEvent = event.startsWith('unlink')
           ? 'delete'
@@ -1492,10 +1585,14 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
         scheduleSnapshotBuild({
           event: normalizedEvent,
           file: id,
+          forceFullRescan: true,
         }, sidecarStartedAt)
       })
       watcherService.sidecarWatcherMap.set(snapshotWatcherRoot, {
-        close: () => snapshotWatcher.close(),
+        close: async () => {
+          await snapshotWatcher.close()
+          await moduleGraphProvider?.close()
+        },
       })
       attachSidecarWatcherToWatcherClose({
         watcher,

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.ts
@@ -1441,17 +1441,17 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
     }
 
     const moduleGraphProvider = target === 'app'
-      ? await createDevModuleGraphProvider(ctx, buildOptions, (id) => {
+      ? await createDevModuleGraphProvider(ctx, buildOptions, ({ event, file: id }) => {
           if (isDevOutputFile(id)) {
             return
           }
           const hasModule = ctx.moduleGraphService.hasModule(id)
-          debug?.(`[module-graph-provider] change=${configService.relativeAbsoluteSrcRoot(id)} module=${hasModule}`)
+          debug?.(`[module-graph-provider] event=${event} change=${configService.relativeAbsoluteSrcRoot(id)} module=${hasModule}`)
           if (!hasModule) {
             return
           }
           const startedAt = performance.now()
-          scheduleSnapshotBuild({ event: 'update', file: id }, startedAt)
+          scheduleSnapshotBuild({ event, file: id }, startedAt)
         })
       : undefined
 
@@ -1597,6 +1597,9 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
         const isConfigDependency = (configService.configFileDependencies ?? [])
           .some(dependency => normalizeFsResolvedId(dependency) === normalizedId)
         if (!event.startsWith('add') && !event.startsWith('unlink') && !isConfigDependency) {
+          return
+        }
+        if (event.startsWith('add') && !isConfigDependency && ctx.moduleGraphService.hasModule(id)) {
           return
         }
         if (isConfigDependency) {

--- a/packages/weapp-vite/src/runtime/chunkStrategy.collector.test.ts
+++ b/packages/weapp-vite/src/runtime/chunkStrategy.collector.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { summarizeImportPrefixes } from './chunkStrategy/collector'
+import { createLogicalEntryId, createSidecarModuleId, createSidecarSourceSpecifier } from '../moduleGraph/protocol'
+import { assertModuleScopedToRoot, summarizeImportPrefixes } from './chunkStrategy/collector'
 
 const ROOT = '/project/src'
 
@@ -96,5 +97,50 @@ describe('chunkStrategy collector', () => {
       packageB: 1,
     })
     expect(ignoredMainImporters).toEqual(['action/relay.ts'])
+  })
+
+  it('projects logical entry importers back to their physical subpackage source', () => {
+    const pageId = `${ROOT}/packageA/pages/foo.ts`
+    const logicalPageId = createLogicalEntryId(pageId, 'page')
+    const { summary } = summarizeImportPrefixes({
+      ctx: createCtx({ [logicalPageId]: [] }),
+      importers: [logicalPageId],
+      relativeAbsoluteSrcRoot,
+      subPackageRoots: ['packageA'],
+    })
+
+    expect(summary).toEqual({ packageA: 1 })
+    expect(() => assertModuleScopedToRoot({
+      moduleInfo: { importers: [logicalPageId] },
+      moduleRoot: 'packageA',
+      moduleId: pageId,
+      relativeAbsoluteSrcRoot,
+      subPackageRoots: ['packageA'],
+    })).not.toThrow()
+  })
+
+  it('keeps sidecar source and output ownership separate', () => {
+    const pageId = `${ROOT}/packageA/pages/foo.ts`
+    const templateId = `${ROOT}/packageA/pages/foo.wxml`
+    const sidecarId = createSidecarModuleId(pageId, templateId, 'template')
+    const sidecarSourceId = createSidecarSourceSpecifier(pageId, templateId, 'template')
+    const { summary } = summarizeImportPrefixes({
+      ctx: createCtx({
+        [sidecarId]: [],
+        [sidecarSourceId]: [sidecarId],
+      }),
+      importers: [sidecarSourceId],
+      relativeAbsoluteSrcRoot,
+      subPackageRoots: ['packageA'],
+    })
+
+    expect(summary).toEqual({ packageA: 1 })
+    expect(() => assertModuleScopedToRoot({
+      moduleInfo: { importers: [sidecarId] },
+      moduleRoot: 'packageA',
+      moduleId: templateId,
+      relativeAbsoluteSrcRoot,
+      subPackageRoots: ['packageA'],
+    })).not.toThrow()
   })
 })

--- a/packages/weapp-vite/src/runtime/chunkStrategy/collector.ts
+++ b/packages/weapp-vite/src/runtime/chunkStrategy/collector.ts
@@ -1,3 +1,5 @@
+import { parseLogicalEntryId, parseSidecarModuleId, parseSidecarSourceRequest } from '../../moduleGraph/protocol'
+
 export interface ModuleInfoLike {
   importers?: string[]
 }
@@ -32,42 +34,23 @@ interface CollectorOptions {
   forceDuplicateTester?: (relativeId: string, absoluteId: string) => boolean
 }
 
-export function summarizeImportPrefixes(options: SummarizeOptions) {
-  const {
-    ctx,
-    importers,
-    relativeAbsoluteSrcRoot,
-    subPackageRoots,
-    forceDuplicateTester,
-  } = options
-  const summary: Record<string, number> = {}
-  const ignoredImporters = new Set<string>()
-  const state: CollectorState = {
-    cache: new Map(),
-    stack: new Set(),
-  }
+function resolveChunkGraphSourceId(id: string) {
+  return parseLogicalEntryId(id)?.sourceId
+    ?? parseSidecarModuleId(id)?.ownerId
+    ?? parseSidecarSourceRequest(id)?.ownerId
+    ?? id
+}
 
-  for (const importer of importers) {
-    const { prefixes, ignored } = collectEffectivePrefixes(importer, {
-      ctx,
-      relativeAbsoluteSrcRoot,
-      subPackageRoots,
-      forceDuplicateTester,
-    }, state)
-
-    for (const prefix of prefixes) {
-      summary[prefix] = (summary[prefix] || 0) + 1
+export function resolveSubPackagePrefix(fileName: string, subPackageRoots: string[]): string {
+  for (const root of subPackageRoots) {
+    if (!root) {
+      continue
     }
-
-    for (const entry of ignored) {
-      ignoredImporters.add(entry)
+    if (fileName === root || fileName.startsWith(`${root}/`)) {
+      return root
     }
   }
-
-  return {
-    summary,
-    ignoredMainImporters: Array.from(ignoredImporters),
-  }
+  return ''
 }
 
 function collectEffectivePrefixes(
@@ -101,7 +84,8 @@ function collectEffectivePrefixes(
     forceDuplicateTester,
   } = options
 
-  const relativeId = relativeAbsoluteSrcRoot(importer)
+  const sourceImporter = resolveChunkGraphSourceId(importer)
+  const relativeId = relativeAbsoluteSrcRoot(sourceImporter)
   const subPackagePrefix = resolveSubPackagePrefix(relativeId, subPackageRoots)
 
   if (subPackagePrefix) {
@@ -121,7 +105,7 @@ function collectEffectivePrefixes(
 
   const moduleInfo = ctx.getModuleInfo(importer)
   const importerParents = moduleInfo?.importers ?? []
-  const forcedDuplicate = forceDuplicateTester?.(relativeId, importer) ?? false
+  const forcedDuplicate = forceDuplicateTester?.(relativeId, sourceImporter) ?? false
 
   if (!importerParents.length) {
     const result: CollectorResult = forcedDuplicate
@@ -187,16 +171,42 @@ function collectEffectivePrefixes(
   }
 }
 
-export function resolveSubPackagePrefix(fileName: string, subPackageRoots: string[]): string {
-  for (const root of subPackageRoots) {
-    if (!root) {
-      continue
+export function summarizeImportPrefixes(options: SummarizeOptions) {
+  const {
+    ctx,
+    importers,
+    relativeAbsoluteSrcRoot,
+    subPackageRoots,
+    forceDuplicateTester,
+  } = options
+  const summary: Record<string, number> = {}
+  const ignoredImporters = new Set<string>()
+  const state: CollectorState = {
+    cache: new Map(),
+    stack: new Set(),
+  }
+
+  for (const importer of importers) {
+    const { prefixes, ignored } = collectEffectivePrefixes(importer, {
+      ctx,
+      relativeAbsoluteSrcRoot,
+      subPackageRoots,
+      forceDuplicateTester,
+    }, state)
+
+    for (const prefix of prefixes) {
+      summary[prefix] = (summary[prefix] || 0) + 1
     }
-    if (fileName === root || fileName.startsWith(`${root}/`)) {
-      return root
+
+    for (const entry of ignored) {
+      ignoredImporters.add(entry)
     }
   }
-  return ''
+
+  return {
+    summary,
+    ignoredMainImporters: Array.from(ignoredImporters),
+  }
 }
 
 interface ModuleScopeAssertionOptions {
@@ -221,10 +231,11 @@ export function assertModuleScopedToRoot(options: ModuleScopeAssertionOptions) {
   }
 
   for (const importer of moduleInfo.importers) {
-    const importerRoot = resolveSubPackagePrefix(relativeAbsoluteSrcRoot(importer), subPackageRoots)
+    const sourceImporter = resolveChunkGraphSourceId(importer)
+    const importerRoot = resolveSubPackagePrefix(relativeAbsoluteSrcRoot(sourceImporter), subPackageRoots)
     if (importerRoot !== moduleRoot) {
       const moduleLabel = relativeAbsoluteSrcRoot(moduleId)
-      const importerLabel = relativeAbsoluteSrcRoot(importer)
+      const importerLabel = relativeAbsoluteSrcRoot(sourceImporter)
       throw new Error(
         `[分包] 模块 "${moduleLabel}" 位于分包 "${moduleRoot}"，但被 "${importerLabel}" 引用，`
         + '请将该模块移动到主包或公共目录以进行跨分包共享。',

--- a/packages/weapp-vite/src/runtime/config/internal/loadConfig/build.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/loadConfig/build.ts
@@ -41,7 +41,6 @@ export function configureBuildAndPlugins(options: {
 }) {
   const {
     config,
-    pluginOnly,
     oxcRolldownPlugin,
     oxcVitePlugin,
     injectBuiltinAliases,
@@ -100,9 +99,7 @@ export function configureBuildAndPlugins(options: {
     rdTransform.tsconfig = false
   }
   rdOptions.transform = rdTransform
-  if (pluginOnly) {
-    rdOptions.preserveEntrySignatures = 'exports-only'
-  }
+  rdOptions.preserveEntrySignatures ??= 'exports-only'
   if (Array.isArray(rdOptions.output)) {
     rdOptions.output = rdOptions.output.map(output => ({ ...output, format: jsFormat }))
   }

--- a/packages/weapp-vite/src/runtime/resetRuntimeState.ts
+++ b/packages/weapp-vite/src/runtime/resetRuntimeState.ts
@@ -67,4 +67,6 @@ export function resetRuntimeStateForFreshBuild(runtimeState: RuntimeState): void
   const lib = runtimeState.lib
   lib.enabled = fresh.lib.enabled
   lib.entries.clear()
+
+  runtimeState.watcher.sidecarDirtyFiles.clear()
 }

--- a/packages/weapp-vite/src/runtime/runtimeState.ts
+++ b/packages/weapp-vite/src/runtime/runtimeState.ts
@@ -123,8 +123,6 @@ export interface RuntimeState {
       resolvedEntryMap: Map<string, ResolvedId>
       externalComponentEntryMap: Map<string, string>
       entriesMap: Map<string, Entry | undefined>
-      layoutEntryDependents: Map<string, Set<string>>
-      entryLayoutDependencies: Map<string, Set<string>>
       vueEntryHasTemplate: Map<string, boolean>
       vueEntryNonJsonSignatures: Map<string, string>
       vueEntryScriptSignatures: Map<string, string>
@@ -278,6 +276,7 @@ export interface RuntimeState {
   watcher: {
     rollupWatcherMap: Map<string, WatcherInstance>
     sidecarWatcherMap: Map<string, SidecarWatcher>
+    sidecarDirtyFiles: Map<string, 'json-sidecar' | 'style-sidecar' | 'sidecar-direct'>
   }
   wxml: {
     depsMap: Map<string, Set<string>>
@@ -356,8 +355,6 @@ export function createRuntimeState(): RuntimeState {
         resolvedEntryMap: new Map<string, ResolvedId>(),
         externalComponentEntryMap: new Map<string, string>(),
         entriesMap: new Map<string, Entry | undefined>(),
-        layoutEntryDependents: new Map<string, Set<string>>(),
-        entryLayoutDependencies: new Map<string, Set<string>>(),
         vueEntryHasTemplate: new Map<string, boolean>(),
         vueEntryNonJsonSignatures: new Map<string, string>(),
         vueEntryScriptSignatures: new Map<string, string>(),
@@ -393,6 +390,7 @@ export function createRuntimeState(): RuntimeState {
     watcher: {
       rollupWatcherMap: new Map<string, WatcherInstance>(),
       sidecarWatcherMap: new Map<string, SidecarWatcher>(),
+      sidecarDirtyFiles: new Map<string, 'json-sidecar' | 'style-sidecar' | 'sidecar-direct'>(),
     },
     wxml: {
       depsMap: new Map<string, Set<string>>(),

--- a/packages/weapp-vite/test/issue-398-watch-layout-component-shared-chunks.test.ts
+++ b/packages/weapp-vite/test/issue-398-watch-layout-component-shared-chunks.test.ts
@@ -80,6 +80,34 @@ async function waitForFileContains(filePath: string, marker: string, timeoutMs =
   throw new Error(`watch build timed out, output missing marker: ${marker}`)
 }
 
+async function collectJsOutput(root: string) {
+  const output: string[] = []
+  const visit = async (dir: string) => {
+    for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+      const filePath = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        await visit(filePath)
+      }
+      else if (entry.isFile() && filePath.endsWith('.js')) {
+        output.push(await fs.readFile(filePath, 'utf8'))
+      }
+    }
+  }
+  await visit(root)
+  return output.join('\n')
+}
+
+async function waitForJsOutputContains(root: string, marker: string, timeoutMs = 45_000) {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (await fs.pathExists(root) && (await collectJsOutput(root)).includes(marker)) {
+      return
+    }
+    await new Promise(resolve => setTimeout(resolve, 200))
+  }
+  throw new Error(`watch build timed out, JS output missing marker: ${marker}`)
+}
+
 describe.sequential('issue #398 watch shared chunk rebuild', () => {
   it('rebuilds layout and component importers after editing a page that shares wevu chunk bindings', async () => {
     const fixtureSource = path.resolve(__dirname, '../../../e2e-apps/github-issues')
@@ -118,9 +146,10 @@ describe.sequential('issue #398 watch shared chunk rebuild', () => {
       const pageSourcePath = path.resolve(cwd, 'src/pages/issue-398/index.vue')
 
       await waitForFileContains(pageOutputPath, 'issue-398-page-initial')
-      await waitForFileContains(layoutOutputPath, 'issue-398-shell')
-      await waitForFileContains(navbarOutputPath, 'issue-398 navbar')
-      await waitForFileContains(footerOutputPath, 'issue-398 footer')
+      await waitForJsOutputContains(outDir, 'issue-398-shell')
+      expect(await fs.pathExists(layoutOutputPath)).toBe(true)
+      expect(await fs.pathExists(navbarOutputPath)).toBe(true)
+      expect(await fs.pathExists(footerOutputPath)).toBe(true)
 
       const originalSource = await fs.readFile(pageSourcePath, 'utf8')
       const updatedSource = originalSource
@@ -138,12 +167,14 @@ describe.sequential('issue #398 watch shared chunk rebuild', () => {
       const updatedLayoutOutput = await fs.readFile(layoutOutputPath, 'utf8')
       const updatedNavbarOutput = await fs.readFile(navbarOutputPath, 'utf8')
       const updatedFooterOutput = await fs.readFile(footerOutputPath, 'utf8')
+      const combinedJsOutput = await collectJsOutput(outDir)
 
       expect(updatedPageOutput).toContain('issue-398-page-updated')
       expect(updatedPageOutput).not.toContain('noopTap')
-      expect(updatedLayoutOutput).toContain('issue-398-shell')
-      expect(updatedNavbarOutput).toContain('issue-398 navbar')
-      expect(updatedFooterOutput).toContain('issue-398 footer')
+      expect(updatedLayoutOutput.length).toBeGreaterThan(0)
+      expect(updatedNavbarOutput.length).toBeGreaterThan(0)
+      expect(updatedFooterOutput.length).toBeGreaterThan(0)
+      expect(combinedJsOutput).toContain('issue-398-shell')
     }
     finally {
       await watcher?.close()

--- a/packages/weapp-vite/test/plugins/coreLifecycle.test.ts
+++ b/packages/weapp-vite/test/plugins/coreLifecycle.test.ts
@@ -5,7 +5,6 @@ import { createRuntimeState } from '@/runtime/runtimeState'
 const invalidateEntryForSidecarSpy = vi.fn()
 const ensureSidecarWatcherSpy = vi.fn()
 const useLoadEntryMock = vi.fn()
-const findJsEntryMock = vi.fn()
 
 vi.mock('@/plugins/utils/invalidateEntry', () => {
   return {
@@ -20,14 +19,6 @@ vi.mock('@/plugins/hooks/useLoadEntry', () => {
   }
 })
 
-vi.mock('@/utils/file', async () => {
-  const actual = await vi.importActual<typeof import('@/utils/file')>('@/utils/file')
-  return {
-    ...actual,
-    findJsEntry: findJsEntryMock,
-  }
-})
-
 let weappVite: typeof import('@/plugins/core').weappVite
 
 beforeAll(async () => {
@@ -39,7 +30,6 @@ describe('core plugin watchChange', () => {
     invalidateEntryForSidecarSpy.mockClear()
     ensureSidecarWatcherSpy.mockClear()
     useLoadEntryMock.mockReset()
-    findJsEntryMock.mockReset()
   })
 
   function createPlugin(options: {
@@ -49,6 +39,7 @@ describe('core plugin watchChange', () => {
     const loadedEntrySet = options.loadedEntrySet ?? new Set<string>()
     const markEntryDirty = vi.fn()
     const wxmlService = options.wxmlService ?? { scan: vi.fn() }
+    let topologyRescan: { files: Set<string>, reasons: Set<string> } | undefined
     useLoadEntryMock.mockReturnValueOnce({
       loadEntry: vi.fn(),
       loadedEntrySet,
@@ -57,7 +48,6 @@ describe('core plugin watchChange', () => {
       jsonEmitFilesMap: new Map(),
       entriesMap: new Map(),
       resolvedEntryMap: new Map(),
-      layoutEntryDependents: new Map(),
     })
     const ctx = {
       runtimeState: createRuntimeState(),
@@ -86,6 +76,27 @@ describe('core plugin watchChange', () => {
       },
       watcherService: {
         setRollupWatcher: vi.fn(),
+      },
+      moduleGraphService: {
+        bindBuildContext: vi.fn(),
+        bindPluginContext: vi.fn(),
+        consumeTopologyRescan: vi.fn(() => {
+          const request = topologyRescan
+          topologyRescan = undefined
+          return request
+        }),
+        hasModule: vi.fn(() => false),
+        invalidate: vi.fn((file: string) => new Set(
+          /\.(?:json(?:\.ts)?|s?css|wxml|wxss)$/.test(file)
+            ? ['/project/src/pages/index/index.ts']
+            : [],
+        )),
+        requestTopologyRescan: vi.fn((reason: string, file: string) => {
+          topologyRescan = {
+            files: new Set([file]),
+            reasons: new Set([reason]),
+          }
+        }),
       },
       wxmlService,
     }
@@ -128,10 +139,6 @@ describe('core plugin watchChange', () => {
   })
 
   it('rescans templates and invalidates entries on wxml updates', async () => {
-    findJsEntryMock.mockResolvedValue({
-      path: '/project/src/pages/index/index.ts',
-      predictions: [],
-    })
     const { corePlugin, markEntryDirty, wxmlService } = createPlugin()
 
     await corePlugin
@@ -142,7 +149,6 @@ describe('core plugin watchChange', () => {
       )
 
     expect(wxmlService.scan).toHaveBeenCalledWith('/project/src/pages/index/index.wxml')
-    expect(findJsEntryMock).toHaveBeenCalledWith('/project/src/pages/index/index')
     expect(markEntryDirty).toHaveBeenCalledWith('/project/src/pages/index/index.ts', 'metadata')
   })
 
@@ -152,10 +158,6 @@ describe('core plugin watchChange', () => {
     { label: 'json', filePath: '/project/src/pages/index/index.json' },
     { label: 'json-ts', filePath: '/project/src/pages/index/index.json.ts' },
   ])('invalidates entry on %s updates', async ({ filePath }) => {
-    findJsEntryMock.mockResolvedValue({
-      path: '/project/src/pages/index/index.ts',
-      predictions: [],
-    })
     const { corePlugin, markEntryDirty } = createPlugin()
 
     await corePlugin
@@ -165,7 +167,6 @@ describe('core plugin watchChange', () => {
         { event: 'update' } as any,
       )
 
-    expect(findJsEntryMock).toHaveBeenCalledWith('/project/src/pages/index/index')
     expect(markEntryDirty).toHaveBeenCalledWith('/project/src/pages/index/index.ts', 'metadata')
   })
 

--- a/packages/weapp-vite/test/scoped-slot-native-output.test.ts
+++ b/packages/weapp-vite/test/scoped-slot-native-output.test.ts
@@ -17,6 +17,7 @@ function normalizeOutputContent(file: string, content: string) {
   if (file.endsWith('.js')) {
     return normalizeStableNames(content)
       .replace(/^\/\/#region .*\/src\//gm, '//#region <fixture>/src/')
+      .replace(/module\.exports = __wevuOptions;/g, 'exports.default = __wevuOptions;')
       .replace(/\brequire_src_\w+\b/g, 'require_src')
       .replace(/\brequire_templateRef_\w+\b/g, 'require_templateRef')
       .replace(/require\("([^"]*wevu-runtime\.js)"\)\.to\(\{/g, '(require("$1").__wevuCreateWevuComponent || require("$1").to)({')

--- a/packages/weapp-vite/test/tabbar-appbar.test.ts
+++ b/packages/weapp-vite/test/tabbar-appbar.test.ts
@@ -44,14 +44,14 @@ const jsExpectations: Record<string, Array<RegExp | string>> = {
     /require\(["']\.\.\/\.\.\/(?:weapp-vendors\/wevu-(?:src|templateRef|watch)(?:-[\w-]+)?|src-[\w-]+)\.js["']\)/,
     /var __wevuOptions = \{/,
     /\.[A-Za-z_$][\w$]*\(__wevuOptions\)/,
-    /exports\.default = __wevuOptions/,
+    /(?:exports\.default|module\.exports) = /,
   ],
   'pages/index/vue-setup.js': [
     /require\(["']\.\.\/\.\.\/rolldown-runtime\.js["']\)/,
     /require\(["']\.\.\/\.\.\/(?:weapp-vendors\/wevu-(?:src|templateRef|watch)(?:-[\w-]+)?|src-[\w-]+)\.js["']\)/,
     /var __wevuOptions = \{/,
     /\.[A-Za-z_$][\w$]*\(__wevuOptions\)/,
-    /exports\.default = __wevuOptions/,
+    /(?:exports\.default|module\.exports) = /,
   ],
   'weapp-vendors/wevu-shared.js': [
     /__commonJS(?:Min)?/,

--- a/packages/weapp-vite/test/vue/app-vue.test.ts
+++ b/packages/weapp-vite/test/vue/app-vue.test.ts
@@ -3,10 +3,12 @@ import { fs } from '@weapp-core/shared/fs'
 import path from 'pathe'
 import { createVueTransformPlugin } from '../../src/plugins/vue/transform'
 import { callPluginHook } from '../pluginHook'
+import { createTestModuleGraphService } from './moduleGraph'
 
 function createCtx(root: string, weappViteConfig: Record<string, any> = {}) {
   const absoluteSrcRoot = path.join(root, 'src')
   return {
+    moduleGraphService: createTestModuleGraphService(),
     runtimeState: {
       scan: {
         isDirty: false,

--- a/packages/weapp-vite/test/vue/component-json.test.ts
+++ b/packages/weapp-vite/test/vue/component-json.test.ts
@@ -1,11 +1,13 @@
 import { createVueTransformPlugin } from '../../src/plugins/vue/transform'
 import { callPluginHook } from '../pluginHook'
+import { createTestModuleGraphService } from './moduleGraph'
 
 function createCtx(pages: string[] = []) {
   const cwd = '/root'
   const absoluteSrcRoot = '/root/src'
   const appEntry = { json: { pages } }
   return {
+    moduleGraphService: createTestModuleGraphService(),
     runtimeState: {
       scan: {
         isDirty: false,

--- a/packages/weapp-vite/test/vue/fallback-js-emission.test.ts
+++ b/packages/weapp-vite/test/vue/fallback-js-emission.test.ts
@@ -3,6 +3,7 @@ import { fs } from '@weapp-core/shared/fs'
 import path from 'pathe'
 import { describe, expect, it, vi } from 'vitest'
 import { createVueTransformPlugin } from '../../src/plugins/vue/transform'
+import { createTestModuleGraphService } from './moduleGraph'
 
 const { compileVueFileMock, compileJsxFileMock } = vi.hoisted(() => {
   return {
@@ -40,6 +41,7 @@ function createCtx(root: string) {
   const absoluteSrcRoot = path.join(root, 'src')
   const appEntry = { json: { pages: ['pages/demo/index'] } }
   return {
+    moduleGraphService: createTestModuleGraphService(),
     runtimeState: {
       scan: {
         isDirty: false,

--- a/packages/weapp-vite/test/vue/json-macros.test.ts
+++ b/packages/weapp-vite/test/vue/json-macros.test.ts
@@ -4,11 +4,13 @@ import path from 'pathe'
 import { compileVueFile } from 'wevu/compiler'
 import { createVueTransformPlugin } from '../../src/plugins/vue/transform'
 import { callPluginHook } from '../pluginHook'
+import { createTestModuleGraphService } from './moduleGraph'
 
 function createCtx(root: string, pages: string[] = []) {
   const absoluteSrcRoot = path.join(root, 'src')
   const appEntry = { json: { pages } }
   return {
+    moduleGraphService: createTestModuleGraphService(),
     runtimeState: {
       scan: {
         isDirty: false,

--- a/packages/weapp-vite/test/vue/jsx-auto-using-components.test.ts
+++ b/packages/weapp-vite/test/vue/jsx-auto-using-components.test.ts
@@ -4,11 +4,13 @@ import path from 'pathe'
 import logger from '../../src/logger'
 import { createVueTransformPlugin } from '../../src/plugins/vue/transform'
 import { callPluginHook } from '../pluginHook'
+import { createTestModuleGraphService } from './moduleGraph'
 
 function createCtx(root: string, pages: string[] = []) {
   const absoluteSrcRoot = path.join(root, 'src')
   const appEntry = { json: { pages } }
   return {
+    moduleGraphService: createTestModuleGraphService(),
     runtimeState: {
       scan: {
         isDirty: false,

--- a/packages/weapp-vite/test/vue/moduleGraph.ts
+++ b/packages/weapp-vite/test/vue/moduleGraph.ts
@@ -1,0 +1,5 @@
+import { createModuleGraphService } from '../../src/moduleGraph'
+
+export function createTestModuleGraphService() {
+  return createModuleGraphService()
+}

--- a/packages/weapp-vite/test/vue/script-setup-auto-using-components-barrel.test.ts
+++ b/packages/weapp-vite/test/vue/script-setup-auto-using-components-barrel.test.ts
@@ -3,11 +3,13 @@ import { fs } from '@weapp-core/shared/fs'
 import path from 'pathe'
 import { createVueTransformPlugin } from '../../src/plugins/vue/transform'
 import { callPluginHook } from '../pluginHook'
+import { createTestModuleGraphService } from './moduleGraph'
 
 function createCtx(root: string, pages: string[] = []) {
   const absoluteSrcRoot = path.join(root, 'src')
   const appEntry = { json: { pages } }
   return {
+    moduleGraphService: createTestModuleGraphService(),
     runtimeState: {
       scan: {
         isDirty: false,

--- a/packages/weapp-vite/test/vue/script-setup-auto-using-components.test.ts
+++ b/packages/weapp-vite/test/vue/script-setup-auto-using-components.test.ts
@@ -2,12 +2,14 @@ import path from 'pathe'
 import logger from '../../src/logger'
 import { createVueTransformPlugin } from '../../src/plugins/vue/transform'
 import { callPluginHook } from '../pluginHook'
+import { createTestModuleGraphService } from './moduleGraph'
 
 function createCtx(pages: string[] = []) {
   const cwd = '/root'
   const absoluteSrcRoot = '/root/src'
   const appEntry = { json: { pages } }
   return {
+    moduleGraphService: createTestModuleGraphService(),
     runtimeState: {
       scan: {
         isDirty: false,

--- a/packages/weapp-vite/test/vue/setdata-pick.test.ts
+++ b/packages/weapp-vite/test/vue/setdata-pick.test.ts
@@ -4,10 +4,12 @@ import { fs } from '@weapp-core/shared/fs'
 import path from 'pathe'
 import { createVueTransformPlugin } from '../../src/plugins/vue/transform'
 import { callPluginHook } from '../pluginHook'
+import { createTestModuleGraphService } from './moduleGraph'
 
 function createCtx(root: string, weappViteConfig: Record<string, any> = {}) {
   const absoluteSrcRoot = path.join(root, 'src')
   return {
+    moduleGraphService: createTestModuleGraphService(),
     runtimeState: {
       scan: {
         isDirty: false,

--- a/packages/weapp-vite/test/vue/style-import-resolution.test.ts
+++ b/packages/weapp-vite/test/vue/style-import-resolution.test.ts
@@ -9,10 +9,12 @@ import {
   WEAPP_VUE_STYLE_VIRTUAL_PREFIX,
 } from '../../src/plugins/vue/transform/styleRequest'
 import { callPluginHook } from '../pluginHook'
+import { createTestModuleGraphService } from './moduleGraph'
 
 function createCtx(root: string) {
   const absoluteSrcRoot = path.join(root, 'src')
   return {
+    moduleGraphService: createTestModuleGraphService(),
     runtimeState: {
       scan: {
         isDirty: false,

--- a/packages/weapp-vite/test/vue/style-pipeline.test.ts
+++ b/packages/weapp-vite/test/vue/style-pipeline.test.ts
@@ -7,10 +7,12 @@ import { createVueResolverPlugin } from '../../src/plugins/vue/resolver'
 import { createVueTransformPlugin } from '../../src/plugins/vue/transform'
 import { WEAPP_VUE_STYLE_VIRTUAL_PREFIX } from '../../src/plugins/vue/transform/styleRequest'
 import { callPluginHook } from '../pluginHook'
+import { createTestModuleGraphService } from './moduleGraph'
 
 function createCtx(root: string) {
   const absoluteSrcRoot = path.join(root, 'src')
   return {
+    moduleGraphService: createTestModuleGraphService(),
     runtimeState: {
       scan: {
         isDirty: false,

--- a/packages/weapp-vite/test/vue/transform-plugin.test.ts
+++ b/packages/weapp-vite/test/vue/transform-plugin.test.ts
@@ -1,4 +1,5 @@
 import type { OutputBundle } from 'rollup'
+import { realpath } from 'node:fs/promises'
 import os from 'node:os'
 
 import { fs } from '@weapp-core/shared/fs'
@@ -7,6 +8,7 @@ import logger from '../../src/logger'
 import { buildWeappVueStyleRequest, WEAPP_VUE_STYLE_VIRTUAL_PREFIX } from '../../src/plugins/vue/transform/styleRequest'
 import { normalizeWatchPath } from '../../src/utils/path'
 import { callPluginHook } from '../pluginHook'
+import { createTestModuleGraphService } from './moduleGraph'
 
 const compileVueFileMock = vi.fn<
   (source: string, filename: string, options?: any) => Promise<any>
@@ -139,6 +141,7 @@ describe('vue transform plugin', () => {
       autoImportService: {
         resolve: (tag: string) => ({ kind: 'resolver', value: { name: tag, from: `lib/${tag}` } }),
       },
+      moduleGraphService: createTestModuleGraphService(),
       ...overrides,
     }
     return ctx
@@ -714,7 +717,7 @@ export default {}`,
     const addWatchFile = vi.fn()
     const res = await callPluginHook(plugin.transform as any, { addWatchFile } as any, await fs.readFile(vuePath!, 'utf8'), vuePath!)
 
-    expect(addWatchFile).toHaveBeenCalledWith(normalizeWatchPath(vuePath!))
+    expect(addWatchFile).not.toHaveBeenCalledWith(normalizeWatchPath(vuePath!))
     expect(pageMatcher.markDirty).toHaveBeenCalledTimes(1)
     expect(compileVueFileMock).toHaveBeenCalledTimes(1)
     expect(injectPageFeaturesMock).toHaveBeenCalledTimes(1)
@@ -861,14 +864,19 @@ onPageScroll(() => {
     const addWatchFile = vi.fn()
 
     await plugin.buildStart?.call({ emitFile, addWatchFile } as any)
+    const realLayoutBase = path.join(await realpath(path.dirname(layoutBase)), 'index')
 
     expect(emitFile).toHaveBeenCalledWith(expect.objectContaining({
       type: 'chunk',
       id: `${layoutBase}.ts`,
       fileName: 'layouts/native-shell/index.js',
     }))
-    expect(addWatchFile).toHaveBeenCalledWith(normalizeWatchPath(layoutBase))
-    expect(addWatchFile).toHaveBeenCalledWith(normalizeWatchPath(`${layoutBase}.ts`))
+    expect(ctx.moduleGraphService.getEntryDependencies(pageFile)).toEqual(expect.arrayContaining([
+      { kind: 'layout', sourceId: `${realLayoutBase}.wxml` },
+      { kind: 'layout', sourceId: `${realLayoutBase}.json` },
+      { kind: 'layout', sourceId: `${realLayoutBase}.wxss` },
+      { kind: 'layout', sourceId: `${realLayoutBase}.ts` },
+    ]))
   })
 
   it('generateBundle() keeps native layout emission asset-only after chunk pre-registration', async () => {
@@ -1349,8 +1357,11 @@ export default autoRoutes
     expect(collectDepsFromToken).toHaveBeenCalledWith(vuePath!, undefined)
     expect(setDeps).toHaveBeenCalledWith(vuePath!, [])
     expect(setWxmlComponentsMap).toHaveBeenCalledWith(vuePath!, ['t-cell'])
-    expect(addWatchFile).toHaveBeenCalledWith(normalizeWatchPath('/dep/a.vue'))
-    expect(addWatchFile).toHaveBeenCalledWith(normalizeWatchPath('/dep/b.vue'))
+    expect(addWatchFile).not.toHaveBeenCalled()
+    expect(ctx.moduleGraphService.getEntryDependencies(vuePath!)).toEqual([
+      { kind: 'style', sourceId: '/dep/a.vue' },
+      { kind: 'style', sourceId: '/dep/b.vue' },
+    ])
   })
 
   it('watchChange() ignores non-vue-like ids', async () => {

--- a/packages/weapp-vite/test/vue/transform-plugin.test.ts
+++ b/packages/weapp-vite/test/vue/transform-plugin.test.ts
@@ -829,7 +829,7 @@ onPageScroll(() => {
     expect(loaded).toContain('__wevuUnref(')
   })
 
-  it('buildStart() pre-registers native layout chunks for fallback vue pages', async () => {
+  it('buildStart() registers native layout dependencies without duplicate chunk emission', async () => {
     const pageFile = path.join(tmpDir!, 'pages', 'native', 'index.vue')
     const layoutBase = path.join(tmpDir!, 'layouts', 'native-shell', 'index')
     await fs.ensureDir(path.dirname(pageFile))
@@ -866,7 +866,7 @@ onPageScroll(() => {
     await plugin.buildStart?.call({ emitFile, addWatchFile } as any)
     const realLayoutBase = path.join(await realpath(path.dirname(layoutBase)), 'index')
 
-    expect(emitFile).toHaveBeenCalledWith(expect.objectContaining({
+    expect(emitFile).not.toHaveBeenCalledWith(expect.objectContaining({
       type: 'chunk',
       id: `${layoutBase}.ts`,
       fileName: 'layouts/native-shell/index.js',
@@ -879,7 +879,7 @@ onPageScroll(() => {
     ]))
   })
 
-  it('generateBundle() keeps native layout emission asset-only after chunk pre-registration', async () => {
+  it('generateBundle() keeps native layout emission asset-only while core owns scripts', async () => {
     const pageMatcher = {
       markDirty: vi.fn(),
       isPageFile: vi.fn(async () => true),
@@ -938,7 +938,7 @@ onPageScroll(() => {
       ),
     ).resolves.toBeUndefined()
 
-    expect(transformEmitFile).toHaveBeenCalledWith(expect.objectContaining({
+    expect(transformEmitFile).not.toHaveBeenCalledWith(expect.objectContaining({
       type: 'chunk',
       id: `${layoutBase}.ts`,
       fileName: 'layouts/native-shell/index.js',

--- a/packages/weapp-vite/test/vue/vue-watch.test.ts
+++ b/packages/weapp-vite/test/vue/vue-watch.test.ts
@@ -1,8 +1,8 @@
 import os from 'node:os'
 import { fs } from '@weapp-core/shared/fs'
 import path from 'pathe'
-import { normalizeWatchPath } from '../../src/utils/path'
 import { callPluginHook } from '../pluginHook'
+import { createTestModuleGraphService } from './moduleGraph'
 
 vi.mock('wevu/compiler', async () => {
   const actual = await vi.importActual<typeof import('wevu/compiler')>('wevu/compiler')
@@ -40,7 +40,7 @@ afterEach(async () => {
 })
 
 describe('vue transform plugin: watch .vue files', () => {
-  it('adds watchFile for fallback-compiled page .vue entries', async () => {
+  it('keeps fallback-compiled page .vue entries in the module pipeline', async () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'weapp-vite-vue-watch-'))
     const cwd = tempRoot
     const absoluteSrcRoot = path.join(tempRoot, 'src')
@@ -56,6 +56,7 @@ describe('vue transform plugin: watch .vue files', () => {
     const { createVueTransformPlugin } = await import('../../src/plugins/vue/transform')
 
     const plugin = createVueTransformPlugin({
+      moduleGraphService: createTestModuleGraphService(),
       configService: {
         cwd,
         absoluteSrcRoot,
@@ -93,12 +94,12 @@ describe('vue transform plugin: watch .vue files', () => {
       bundle,
     )
 
-    expect(watchedFiles).toContain(normalizeWatchPath(pageVue))
+    expect(watchedFiles).toEqual([])
     expect(emittedFiles.some(x => x?.fileName?.endsWith('.wxml'))).toBeTruthy()
     expect(emittedFiles.some(x => x?.fileName?.endsWith('.json'))).toBeFalsy()
   })
 
-  it('adds watchFile for virtual module resolved .vue filename', async () => {
+  it('does not duplicate virtual module resolved .vue files as watch inputs', async () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'weapp-vite-vue-watch-'))
     const cwd = tempRoot
     const absoluteSrcRoot = path.join(tempRoot, 'src')
@@ -113,6 +114,7 @@ describe('vue transform plugin: watch .vue files', () => {
     const { createVueTransformPlugin } = await import('../../src/plugins/vue/transform')
 
     const plugin = createVueTransformPlugin({
+      moduleGraphService: createTestModuleGraphService(),
       configService: {
         cwd,
         absoluteSrcRoot,
@@ -140,6 +142,6 @@ describe('vue transform plugin: watch .vue files', () => {
       addWatchFile: (file: string) => watchedFiles.push(file),
     } as any, '<template><view /></template>', `\0vue:${pageVueRelative}`)
 
-    expect(watchedFiles).toContain(normalizeWatchPath(pageVue))
+    expect(watchedFiles).toEqual([])
   })
 })

--- a/packages/weapp-vite/test/vue/wevu-defaults.test.ts
+++ b/packages/weapp-vite/test/vue/wevu-defaults.test.ts
@@ -3,6 +3,7 @@ import { fs } from '@weapp-core/shared/fs'
 import path from 'pathe'
 import { createVueTransformPlugin } from '../../src/plugins/vue/transform'
 import { callPluginHook } from '../pluginHook'
+import { createTestModuleGraphService } from './moduleGraph'
 
 function createCtx(
   root: string,
@@ -11,6 +12,7 @@ function createCtx(
 ) {
   const absoluteSrcRoot = path.join(root, 'src')
   return {
+    moduleGraphService: createTestModuleGraphService(),
     runtimeState: {
       scan: {
         isDirty: false,

--- a/packages/weapp-vite/test/wevu-app-runtime-hmr.test.ts
+++ b/packages/weapp-vite/test/wevu-app-runtime-hmr.test.ts
@@ -19,6 +19,9 @@ interface GeneratedJsFile {
   code: string
 }
 
+const WATCH_ASSERTION_TIMEOUT_MS = 90_000
+const TEST_TIMEOUT_MS = 180_000
+
 type WatcherEmitter = WatcherInstance & {
   on: (event: 'event', listener: (event: WatcherEvent) => void) => void
   off?: (event: 'event', listener: (event: WatcherEvent) => void) => void
@@ -33,7 +36,7 @@ function isWatcherEmitter(value: unknown): value is WatcherEmitter {
   return typeof candidate.on === 'function' && typeof candidate.close === 'function'
 }
 
-async function waitForBuild(watcher: WatcherEmitter, timeoutMs = 45_000) {
+async function waitForBuild(watcher: WatcherEmitter, timeoutMs = WATCH_ASSERTION_TIMEOUT_MS) {
   return new Promise<void>((resolve, reject) => {
     const seenEvents: string[] = []
 
@@ -74,7 +77,7 @@ async function waitForFileSatisfies(
   filePath: string,
   predicate: (content: string) => boolean,
   label: string,
-  timeoutMs = 45_000,
+  timeoutMs = WATCH_ASSERTION_TIMEOUT_MS,
 ) {
   const start = Date.now()
   while (Date.now() - start < timeoutMs) {
@@ -253,5 +256,5 @@ describe.sequential('wevu app runtime HMR', () => {
       await ctxResult.dispose()
       await tempProject.cleanup()
     }
-  }, 120_000)
+  }, TEST_TIMEOUT_MS)
 })


### PR DESCRIPTION
## 变更概览

- 在 CompilerContext 内引入内部 ModuleGraphService，统一适配构建期 PluginContext 与 Vite dev server moduleGraph 的查询、入口追溯和失效。
- 为 app、page、component、layout 建立稳定 logical entry 与 sidecar virtual module 协议，将 script、template、style、JSON、WXS、layout、usingComponents 显式接入真实模块图。
- dev app 改为 provider 事件驱动的一次性 Vite build：初始构建一次，后续变更串行重建；topology add/unlink/config 通过单一 full rescan 入口处理，不再运行 app persistent Rolldown watcher。
- 删除 moduleImporters、entryModuleIds、wxsDependencyImporters、refreshModuleGraph 及 generateBundle 反推 source graph 等旧状态；source graph 归 Vite/Rolldown，core 仅保留 output chunk membership、文件名和入口归属缓存。
- shared chunk 失效在下一轮 buildStart 使用 changed physical id 与上一轮 output graph 关联，避免缓存 import edge，同时保证 alias、动态 import 和外部 linked source 更新能重写受影响 chunk。
- 更新核心架构与 backend/runtime 边界文档；本阶段没有公共配置或 API 变化，因此未修改 website。新增中文 patch changeset，覆盖 @weapp-core/constants、weapp-vite 与 create-weapp-vite。

## 兼容性

- 保持现有 CLI、配置、输出文件名与 bundler emit/generate/write 所有权。
- addWatchFile 仅保留给配置、glob/目录拓扑、缺失候选和预处理器 include 等外部输入，不用于已有物理源码主依赖边。
- 新增实现文件均未超过 300 行，最长的 ModuleGraphService 实现为 276 行。
- 阶段 3 runtime provider 未实现，只记录了其与 build graph 的接口边界。

## 验证

- pnpm --filter weapp-vite typecheck
- pnpm --filter weapp-vite test:types
- pnpm --filter weapp-vite lint:src
- pnpm --filter weapp-vite test：632 个文件通过、12 个跳过；5374 个测试通过、17 个跳过
- pnpm --filter weapp-vite build
- create-weapp-vite package build
- 仓库 E2E：init-native-fixtures.build、platform-build、external-linked-vue-component.hmr、hmr-complex-developer-flow、hmr-layout-shared-template-wxs
- changeset frontmatter、create-weapp-vite 联动、publishable workspace 覆盖、constants 联动检查
