### PR TITLE
fix(wevu): 修复返回后重复导航失效

### DIFF
--- a/.changeset/fix-wevu-router-back-route-sync.md
+++ b/.changeset/fix-wevu-router-back-route-sync.md
@@ -1,0 +1,6 @@
+---
+"create-weapp-vite": patch
+"wevu": patch
+---
+
+修复小程序返回上一页后 `router.currentRoute` 未恢复的问题；通过 `router.back()`、原生返回或系统返回回到来源页后，可以再次 `router.push()` 进入同一目标页，并保持 `useRoute()` 与导航守卫来源状态一致。

--- a/e2e-apps/github-issues/src/pages/issue-550/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-550/index.vue
@@ -1,16 +1,31 @@
 <script setup lang="ts">
 import { computed } from 'wevu'
-import { useRoute } from 'wevu/router'
+import { useRoute, useRouter } from 'wevu/router'
 
 definePageJson({
   navigationBarTitleText: 'issue-550',
 })
 
 const route = useRoute()
+const router = useRouter()
 const routeName = computed(() => route.name ?? '')
 const routeMatchedName = computed(() => route.matched?.[0]?.name ?? '')
 
-function _runE2E() {
+function routerBack() {
+  return router.back()
+}
+
+function nativeBack() {
+  return wx.navigateBack()
+}
+
+function _runE2E(action?: 'nativeBack' | 'routerBack') {
+  if (action === 'routerBack') {
+    return routerBack()
+  }
+  if (action === 'nativeBack') {
+    return nativeBack()
+  }
   return {
     ok: route.name === 'pages/issue-550/index',
     name: route.name,
@@ -31,6 +46,12 @@ function _runE2E() {
     >
       route name = {{ routeName }}
     </view>
+    <button @tap="routerBack">
+      router back
+    </button>
+    <button @tap="nativeBack">
+      native back
+    </button>
   </view>
 </template>
 

--- a/e2e-apps/github-issues/src/pages/issue-705/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-705/index.vue
@@ -22,6 +22,11 @@ function createSnapshot() {
       fullPath: route.fullPath,
       name: route.name,
     },
+    routerRoute: {
+      path: router.currentRoute.path,
+      fullPath: router.currentRoute.fullPath,
+      name: router.currentRoute.name,
+    },
     hooks: hookCalls.slice(),
     failure: lastFailure,
     ready,
@@ -65,15 +70,19 @@ onReady(() => {
   ready = true
 })
 
+async function pushToTarget() {
+  hookCalls.length = 0
+  lastFailure = null
+  wx.setStorageSync(PUSH_RESULT_STORAGE_KEY, {
+    stage: 'started',
+  })
+  await router.push('/pages/issue-550/index')
+  return createSnapshot()
+}
+
 async function _runE2E(action?: 'push' | 'switchTab') {
   if (action === 'push') {
-    hookCalls.length = 0
-    lastFailure = null
-    wx.setStorageSync(PUSH_RESULT_STORAGE_KEY, {
-      stage: 'started',
-    })
-    await router.push('/pages/issue-550/index')
-    return createSnapshot()
+    return pushToTarget()
   }
 
   if (action === 'switchTab') {
@@ -105,6 +114,12 @@ defineExpose({
     <text class="issue705-title">
       issue-705 router route sync
     </text>
+    <button
+      class="issue705-push"
+      @tap="pushToTarget"
+    >
+      push target
+    </button>
   </view>
 </template>
 
@@ -121,5 +136,9 @@ defineExpose({
   font-size: 30rpx;
   font-weight: 700;
   color: #111827;
+}
+
+.issue705-push {
+  margin-top: 24rpx;
 }
 </style>

--- a/e2e/ide/github-issues.runtime.issue705.test.ts
+++ b/e2e/ide/github-issues.runtime.issue705.test.ts
@@ -13,6 +13,8 @@ const PUSH_RESULT_STORAGE_KEY = '__weapp_vite_issue_705_push_result__'
 const SWITCH_TAB_RESULT_STORAGE_KEY = '__weapp_vite_issue_705_switch_tab_result__'
 const TAB_PUSH_RESULT_STORAGE_KEY = '__weapp_vite_issue_705_tab_push_result__'
 const STORAGE_TIMEOUT = 8_000
+const ISSUE_PAGE_PATH = '/pages/issue-705/index'
+const TARGET_PAGE_PATH = '/pages/issue-550/index'
 
 async function removeStorage(miniProgram: any, key: string) {
   await miniProgram.callWxMethodWithOptions('removeStorageSync', {
@@ -78,6 +80,24 @@ async function waitForIssue705TabReady(page: any) {
     await new Promise(resolve => setTimeout(resolve, 200))
   }
   throw new Error(`Timed out waiting for issue #705 tab readiness: ${JSON.stringify(latest)}`)
+}
+
+async function waitForIssue705Page(miniProgram: any) {
+  const page = await waitForCurrentPagePath(miniProgram, ISSUE_PAGE_PATH, STORAGE_TIMEOUT)
+  if (!page || !(await isIssue705PageReady(page))) {
+    throw new Error('Failed to return to issue-705 page')
+  }
+  return page
+}
+
+async function navigateBackFromHost(miniProgram: any) {
+  if (typeof miniProgram.navigateBack === 'function') {
+    await miniProgram.navigateBack()
+    return
+  }
+  await miniProgram.callWxMethodWithOptions('navigateBack', {
+    timeout: 12_000,
+  })
 }
 
 describe.sequential('e2e app: github-issues / issue #705', () => {
@@ -151,6 +171,68 @@ describe.sequential('e2e app: github-issues / issue #705', () => {
       }, 'push').catch(() => undefined)
       const tabPushResult = await waitForStorage(miniProgram, TAB_PUSH_RESULT_STORAGE_KEY)
       expectNavigationResult(tabPushResult, 'pages/issue-705-tab/index')
+    }
+    finally {
+      await releaseSharedMiniProgram(miniProgram)
+    }
+  })
+
+  it('restores route state after every back path and allows pushing the same target again', async (ctx) => {
+    let miniProgram = await getSharedMiniProgram(ctx)
+    try {
+      for (const backMode of ['router', 'native', 'system'] as const) {
+        await removeStorage(miniProgram, PUSH_RESULT_STORAGE_KEY)
+        const issuePage = await relaunchPage(
+          miniProgram,
+          ISSUE_PAGE_PATH,
+          undefined,
+          30_000,
+          {
+            readiness: isIssue705PageReady,
+          },
+        )
+        if (!issuePage) {
+          throw new Error(`Failed to launch issue-705 page for ${backMode} back`)
+        }
+        miniProgram = await getSharedMiniProgram(ctx)
+
+        await issuePage.callMethodWithOptions('_runE2E', {
+          timeout: 12_000,
+        }, 'push').catch(() => undefined)
+        const firstPushResult = await waitForStorage(miniProgram, PUSH_RESULT_STORAGE_KEY)
+        expect(firstPushResult.failure).toBeNull()
+        expectNavigationResult(firstPushResult, 'pages/issue-705/index')
+
+        const targetPage = await waitForCurrentPagePath(miniProgram, TARGET_PAGE_PATH, STORAGE_TIMEOUT)
+        if (!targetPage) {
+          throw new Error(`Failed to navigate to issue-705 target for ${backMode} back`)
+        }
+
+        if (backMode === 'system') {
+          await navigateBackFromHost(miniProgram)
+        }
+        else {
+          await targetPage.callMethodWithOptions('_runE2E', {
+            timeout: 12_000,
+          }, backMode === 'router' ? 'routerBack' : 'nativeBack').catch(() => undefined)
+        }
+
+        const returnedPage = await waitForIssue705Page(miniProgram)
+        const returnedSnapshot = await returnedPage.callMethodWithOptions('_runE2E', {
+          timeout: 5_000,
+        })
+        expect(returnedSnapshot.route.path).toBe('pages/issue-705/index')
+        expect(returnedSnapshot.routerRoute.path).toBe('pages/issue-705/index')
+
+        await removeStorage(miniProgram, PUSH_RESULT_STORAGE_KEY)
+        await returnedPage.callMethodWithOptions('_runE2E', {
+          timeout: 12_000,
+        }, 'push').catch(() => undefined)
+        const secondPushResult = await waitForStorage(miniProgram, PUSH_RESULT_STORAGE_KEY)
+        expect(secondPushResult.failure).toBeNull()
+        expectNavigationResult(secondPushResult, 'pages/issue-705/index')
+        expect(await waitForCurrentPagePath(miniProgram, TARGET_PAGE_PATH, STORAGE_TIMEOUT)).toBeTruthy()
+      }
     }
     finally {
       await releaseSharedMiniProgram(miniProgram)

--- a/packages-runtime/wevu/src/router/navigationResult.ts
+++ b/packages-runtime/wevu/src/router/navigationResult.ts
@@ -72,8 +72,8 @@ export function createNavigationResultController(options: {
   }
 
   async function settleNavigationResult(result: NavigationRunResult): Promise<void | NavigationFailure> {
-    if (!result.failure && result.to) {
-      notifyRouteStateSync({ route: result.to })
+    if (!result.failure) {
+      notifyRouteStateSync(result.to ? { route: result.to } : undefined)
     }
     await emitNavigationAfterEach(result)
     if (result.failure && shouldRejectNavigationFailure(result.failure)) {

--- a/packages-runtime/wevu/src/router/routeSync.ts
+++ b/packages-runtime/wevu/src/router/routeSync.ts
@@ -1,6 +1,8 @@
+import type { MiniProgramPageLike } from '../routerInternal/shared'
 import type { RouteLocationNormalizedLoaded } from './types'
 
 export interface RouteStateSyncPayload {
+  page?: MiniProgramPageLike
   route?: RouteLocationNormalizedLoaded
   url?: string
 }

--- a/packages-runtime/wevu/src/router/useRoute.ts
+++ b/packages-runtime/wevu/src/router/useRoute.ts
@@ -2,7 +2,7 @@ import type { MiniProgramPageLifetime } from '../runtime/types'
 import type { SetupContextRouter } from '../runtime/types/props'
 import type { LocationQueryRaw, RouteLocationNormalizedLoaded } from './types'
 import { reactive, readonly } from '../reactivity'
-import { cloneLocationQuery, cloneRouteLocationRedirectedFrom, cloneRouteMeta, cloneRouteParams, cloneRouteRecordMatchedList, resolveCurrentRoute } from '../routerInternal/shared'
+import { cloneLocationQuery, cloneRouteLocationRedirectedFrom, cloneRouteMeta, cloneRouteParams, cloneRouteRecordMatchedList, resolveCurrentRoute, resolvePageRoute } from '../routerInternal/shared'
 import { getCurrentSetupContext, onLoad, onReady, onRouteDone, onShow, onUnload } from '../runtime/hooks'
 import {
   useNativePageRouter as useNativePageRouterInternal,
@@ -102,6 +102,10 @@ export function createRouteStateController(options: UseRouteOptions = {}): Route
   const unregisterRouteStateSync = registerRouteStateSyncHandler((payload) => {
     if (payload?.route) {
       syncRoute(undefined, payload.route)
+      return
+    }
+    if (payload?.page) {
+      syncRoute(undefined, resolvePageRoute(payload.page))
       return
     }
     if (payload?.url) {

--- a/packages-runtime/wevu/src/routerInternal/location.ts
+++ b/packages-runtime/wevu/src/routerInternal/location.ts
@@ -85,22 +85,29 @@ function getCurrentMiniProgramPage(fallbackPage?: MiniProgramPageLike): MiniProg
   return hasPageRoute(currentPageInstance) ? currentPageInstance : fallbackPage
 }
 
+export function resolvePageRoute(
+  page: MiniProgramPageLike | undefined,
+  queryOverride?: LocationQueryRaw,
+): RouteLocationNormalizedLoaded {
+  if (!page) {
+    return createRouteLocation('', {})
+  }
+
+  const rawPath = typeof page.route === 'string'
+    ? page.route
+    : typeof page.__route__ === 'string'
+      ? page.__route__
+      : ''
+
+  const querySource = queryOverride ?? ((page.options ?? {}) as LocationQueryRaw)
+  const query = normalizeQuery(querySource)
+  return createRouteLocation(rawPath, query, '', undefined, {})
+}
+
 export function resolveCurrentRoute(
   queryOverride?: LocationQueryRaw,
   fallbackPage?: MiniProgramPageLike,
 ): RouteLocationNormalizedLoaded {
   const currentPage = getCurrentMiniProgramPage(fallbackPage)
-  if (!currentPage) {
-    return createRouteLocation('', {})
-  }
-
-  const rawPath = typeof currentPage.route === 'string'
-    ? currentPage.route
-    : typeof currentPage.__route__ === 'string'
-      ? currentPage.__route__
-      : ''
-
-  const querySource = queryOverride ?? ((currentPage.options ?? {}) as LocationQueryRaw)
-  const query = normalizeQuery(querySource)
-  return createRouteLocation(rawPath, query, '', undefined, {})
+  return resolvePageRoute(currentPage, queryOverride)
 }

--- a/packages-runtime/wevu/src/routerInternal/shared.ts
+++ b/packages-runtime/wevu/src/routerInternal/shared.ts
@@ -2,6 +2,7 @@ export {
   createRouteLocation,
   parsePathInput,
   resolveCurrentRoute,
+  resolvePageRoute,
 } from './location'
 export {
   collectRouteNamesForRemoval,

--- a/packages-runtime/wevu/src/runtime/register/component/lifecycle.ts
+++ b/packages-runtime/wevu/src/runtime/register/component/lifecycle.ts
@@ -5,6 +5,7 @@ import {
   WEVU_READY_CALLED_KEY,
   WEVU_ROUTE_DONE_CALLED_KEY,
 } from '@weapp-core/constants'
+import { notifyRouteStateSync } from '../../../router/routeSync'
 import { callHookList } from '../../hooks'
 import { scheduleTemplateRefUpdate } from '../../templateRefs'
 import { enableDeferredSetData, mountRuntimeInstance, setRuntimeSetDataVisibility, teardownRuntimeInstance } from '../runtimeInstance'
@@ -132,6 +133,9 @@ export function createPageLifecycleHooks<D extends object, C extends ComputedDef
         ;(this as any)[WEVU_ROUTE_DONE_CALLED_KEY] = false
       }
       setRuntimeSetDataVisibility(this, true)
+      if (isPage) {
+        notifyRouteStateSync({ page: this })
+      }
       callHookList(this, 'onShow', args)
       if (typeof userOnShow === 'function') {
         return userOnShow.apply(this, args)

--- a/packages-runtime/wevu/test/router-navigation.test.ts
+++ b/packages-runtime/wevu/test/router-navigation.test.ts
@@ -7,6 +7,7 @@ import {
   NavigationFailureType,
 } from '@/router'
 import { clearActiveRouter } from '@/router/instance'
+import { notifyRouteStateSync } from '@/router/routeSync'
 import { callHookList, setCurrentInstance, setCurrentSetupContext } from '@/runtime/hooks'
 
 describe('router navigation helpers', () => {
@@ -3300,6 +3301,118 @@ describe('router navigation helpers', () => {
         to: { path: 'pages/profile/index' },
       },
     ])
+  })
+
+  it('restores currentRoute after back so the same target can be pushed again', async () => {
+    const pages = [
+      {
+        route: 'pages/page1/index',
+        options: {},
+      },
+    ]
+    const navigateTo = vi.fn((options: any) => {
+      pages.push({
+        route: 'pages/page2/index',
+        options: {},
+      })
+      options.success?.({})
+    })
+    const navigateBack = vi.fn((options: any) => {
+      pages.pop()
+      options.success?.({})
+    })
+    const instance = {
+      __wevu: {},
+      [WEVU_HOOKS_KEY]: {},
+      router: {
+        switchTab: vi.fn(),
+        reLaunch: vi.fn(),
+        redirectTo: vi.fn(),
+        navigateTo,
+        navigateBack,
+      },
+    } as any
+
+    setCurrentInstance(instance)
+    setCurrentSetupContext({ instance, emit: vi.fn(), attrs: {}, slots: {} })
+    ;(globalThis as any).getCurrentPages = vi.fn(() => pages)
+
+    const router = createRouter({
+      routes: [
+        {
+          name: 'page1',
+          path: '/pages/page1/index',
+        },
+        {
+          name: 'page2',
+          path: '/pages/page2/index',
+        },
+      ],
+    })
+
+    await expect(router.push({ name: 'page2' })).resolves.toBeUndefined()
+    expect(router.currentRoute.path).toBe('pages/page2/index')
+
+    await expect(router.back()).resolves.toBeUndefined()
+    expect(router.currentRoute.path).toBe('pages/page1/index')
+
+    await expect(router.push({ name: 'page2' })).resolves.toBeUndefined()
+    expect(navigateTo).toHaveBeenCalledTimes(2)
+  })
+
+  it('restores currentRoute from the activated page when the host performs back navigation', async () => {
+    const page1 = {
+      route: 'pages/page1/index',
+      options: {
+        source: 'host-back',
+      },
+    }
+    const pages = [page1]
+    const navigateTo = vi.fn((options: any) => {
+      pages.push({
+        route: 'pages/page2/index',
+        options: {},
+      })
+      options.success?.({})
+    })
+    const instance = {
+      __wevu: {},
+      [WEVU_HOOKS_KEY]: {},
+      router: {
+        switchTab: vi.fn(),
+        reLaunch: vi.fn(),
+        redirectTo: vi.fn(),
+        navigateTo,
+        navigateBack: vi.fn(),
+      },
+    } as any
+
+    setCurrentInstance(instance)
+    setCurrentSetupContext({ instance, emit: vi.fn(), attrs: {}, slots: {} })
+    ;(globalThis as any).getCurrentPages = vi.fn(() => pages)
+
+    const router = createRouter({
+      routes: [
+        {
+          name: 'page1',
+          path: '/pages/page1/index',
+        },
+        {
+          name: 'page2',
+          path: '/pages/page2/index',
+        },
+      ],
+    })
+
+    await router.push({ name: 'page2' })
+    expect(router.currentRoute.path).toBe('pages/page2/index')
+
+    notifyRouteStateSync({ page: page1 })
+    expect(router.currentRoute.fullPath).toBe('/pages/page1/index?source=host-back')
+    expect(router.currentRoute.name).toBe('page1')
+
+    await expect(router.push({ name: 'page2' })).resolves.toBeUndefined()
+    expect(navigateTo).toHaveBeenCalledTimes(2)
   })
 
   it('syncs currentRoute after native switchTab succeeds', async () => {

--- a/packages-runtime/wevu/test/runtime-register-component-lifecycle-extra.test.ts
+++ b/packages-runtime/wevu/test/runtime-register-component-lifecycle-extra.test.ts
@@ -21,8 +21,13 @@ const mocks = vi.hoisted(() => {
     ensureMiniProgramGlobalPatched: vi.fn(),
     releaseCurrentPageInstance: vi.fn(),
     resolvePageOptions: vi.fn(() => ({ from: 'resolved-options' })),
+    notifyRouteStateSync: vi.fn(),
   }
 })
+
+vi.mock('@/router/routeSync', () => ({
+  notifyRouteStateSync: mocks.notifyRouteStateSync,
+}))
 
 vi.mock('@/runtime/hooks', () => ({
   callHookList: mocks.callHookList,
@@ -115,6 +120,7 @@ describe('runtime: component page lifecycle extra', () => {
     expect(mocks.attachOptionalPageLifecycleHooks).toHaveBeenCalledTimes(1)
     expect(mocks.ensureMiniProgramGlobalPatched).not.toHaveBeenCalled()
     expect(mocks.bindCurrentPageInstance).not.toHaveBeenCalled()
+    expect(mocks.notifyRouteStateSync).not.toHaveBeenCalled()
     expect(mocks.releaseCurrentPageInstance).not.toHaveBeenCalled()
     expect(mocks.setRuntimeSetDataVisibility).toHaveBeenNthCalledWith(1, instance, true)
     expect(mocks.setRuntimeSetDataVisibility).toHaveBeenNthCalledWith(2, instance, false)
@@ -209,6 +215,7 @@ describe('runtime: component page lifecycle extra', () => {
     expect(instance[WEVU_ROUTE_DONE_CALLED_KEY]).toBe(false)
     expect(mocks.ensureMiniProgramGlobalPatched).toHaveBeenCalledTimes(1)
     expect(mocks.bindCurrentPageInstance).toHaveBeenCalledWith(instance)
+    expect(mocks.notifyRouteStateSync).toHaveBeenCalledWith({ page: instance })
     expect(mocks.resolvePageOptions).toHaveBeenCalledWith(instance)
     expect(mocks.mountRuntimeInstance).toHaveBeenCalledTimes(1)
 


### PR DESCRIPTION
## 问题

首次从 A 页 router.push 到 B 页后，共享 currentRoute 会更新为 B；但 router.back、wx.navigateBack 和宿主系统返回没有统一把状态恢复到重新显示的 A 页。再次 push B 时因此被误判为重复导航。

根因是返回导航没有目标路由可直接写入，且宿主返回绕过导航 API；App setup 中创建的 router 也不会自动收到页面 A 的 onShow 状态。

## 修复

- 让成功的 back 结果进入既有 route sync 总线，并从当前页面恢复路由。
- 页面 onShow 完成实例绑定和可见性恢复后，使用明确页面实例同步 route 状态，再执行用户生命周期 hook。
- 新增 resolvePageRoute(page)，保留页面 options/query，避免系统返回时依赖可能暂时滞后的全局页面栈。
- 保持单一状态源：同一总线同步 router.currentRoute 与所有 useRoute() 实例。
- 增加单元测试及 GitHub issue 复现页，覆盖 router.back、wx.navigateBack、宿主返回，以及返回后再次 push 同一目标。
- 增加 wevu 与 create-weapp-vite patch changeset。

## 验证

- pnpm vitest run packages-runtime/wevu/test/router-navigation.test.ts packages-runtime/wevu/test/runtime-register-component-lifecycle-extra.test.ts：79 tests passed
- pnpm --filter wevu test：73 files / 792 tests passed
- pnpm --filter wevu typecheck
- pnpm --filter wevu test:types
- 涉及文件 ESLint 与 Vue stylelint
- pnpm --filter wevu build
- pnpm --filter weapp-vite build
- pnpm --filter e2e-app-github-issues build
- headless 单文件 IDE E2E：2 tests passed，覆盖三种返回路径

本地真实 DevTools 验证在页面启动前持续命中 simulator boot / reLaunch 协议超时，runtime 日志为 0，未进入业务断言；保留完整断言，交由 PR CI 的真实环境继续验证。

关联 #705
目标反馈：https://github.com/weapp-vite/weapp-vite/issues/705#issuecomment-5057176162