### PR TITLE
fix(wevu): 对齐返回导航守卫语义

### DIFF
--- a/.changeset/fix-wevu-native-back-navigation-hooks.md
+++ b/.changeset/fix-wevu-native-back-navigation-hooks.md
@@ -1,0 +1,6 @@
+---
+"create-weapp-vite": patch
+"wevu": patch
+---
+
+修复返回导航与 Vue Router 守卫语义不一致的问题；`router.back()` 现在会从页面栈解析目标路由，原生返回和系统返回也会触发 `beforeEach`、`beforeResolve` 与 `afterEach`，并向 hooks 提供完整的 `to` 和 `from`。

--- a/e2e-apps/github-issues/src/pages/issue-550/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-550/index.vue
@@ -10,21 +10,34 @@ const route = useRoute()
 const router = useRouter()
 const routeName = computed(() => route.name ?? '')
 const routeMatchedName = computed(() => route.matched?.[0]?.name ?? '')
+const BACK_RESULT_STORAGE_KEY = '__weapp_vite_issue_705_back_result__'
+
+function prepareBackProbe() {
+  wx.setStorageSync(BACK_RESULT_STORAGE_KEY, {
+    stage: 'started',
+  })
+}
 
 function routerBack() {
+  prepareBackProbe()
   return router.back()
 }
 
 function nativeBack() {
+  prepareBackProbe()
   return wx.navigateBack()
 }
 
-function _runE2E(action?: 'nativeBack' | 'routerBack') {
+function _runE2E(action?: 'nativeBack' | 'prepareBack' | 'routerBack') {
   if (action === 'routerBack') {
     return routerBack()
   }
   if (action === 'nativeBack') {
     return nativeBack()
+  }
+  if (action === 'prepareBack') {
+    prepareBackProbe()
+    return
   }
   return {
     ok: route.name === 'pages/issue-550/index',

--- a/e2e-apps/github-issues/src/pages/issue-705/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-705/index.vue
@@ -10,6 +10,8 @@ const route = useRoute()
 const router = useRouter()
 const routePath = computed(() => route.path)
 const hookCalls: Array<{ phase: string, to?: string, from: string }> = []
+const backHookCalls: Array<{ phase: string, to?: string, from: string }> = []
+const BACK_RESULT_STORAGE_KEY = '__weapp_vite_issue_705_back_result__'
 const PUSH_RESULT_STORAGE_KEY = '__weapp_vite_issue_705_push_result__'
 const SWITCH_TAB_RESULT_STORAGE_KEY = '__weapp_vite_issue_705_switch_tab_result__'
 let lastFailure: null | { cause: string, type: number } = null
@@ -33,12 +35,32 @@ function createSnapshot() {
   }
 }
 
+function recordBackHook(call: { phase: string, to?: string, from: string }) {
+  const backProbe = wx.getStorageSync(BACK_RESULT_STORAGE_KEY)
+  if (backProbe?.stage !== 'started' && backHookCalls.length === 0) {
+    return
+  }
+  if (backProbe?.stage === 'started') {
+    backHookCalls.length = 0
+  }
+  backHookCalls.push(call)
+  wx.setStorageSync(BACK_RESULT_STORAGE_KEY, {
+    hooks: backHookCalls.slice(),
+    route: {
+      fullPath: route.fullPath,
+      path: route.path,
+    },
+  })
+}
+
 const removeBeforeEach = router.beforeEach((to, from) => {
-  hookCalls.push({
+  const call = {
     phase: 'before',
     to: to?.path,
     from: from.path,
-  })
+  }
+  hookCalls.push(call)
+  recordBackHook(call)
   wx.setStorageSync(PUSH_RESULT_STORAGE_KEY, {
     from: from.path,
     stage: 'before',
@@ -47,11 +69,13 @@ const removeBeforeEach = router.beforeEach((to, from) => {
 })
 
 const removeAfterEach = router.afterEach((to, from, failure) => {
-  hookCalls.push({
+  const call = {
     phase: 'after',
     to: to?.path,
     from: from.path,
-  })
+  }
+  hookCalls.push(call)
+  recordBackHook(call)
   lastFailure = failure
     ? {
         cause: String((failure.cause as any)?.errMsg ?? failure.cause ?? ''),

--- a/e2e/ide/github-issues.runtime.issue705.test.ts
+++ b/e2e/ide/github-issues.runtime.issue705.test.ts
@@ -10,6 +10,7 @@ import {
 } from './github-issues.runtime.shared'
 
 const PUSH_RESULT_STORAGE_KEY = '__weapp_vite_issue_705_push_result__'
+const BACK_RESULT_STORAGE_KEY = '__weapp_vite_issue_705_back_result__'
 const SWITCH_TAB_RESULT_STORAGE_KEY = '__weapp_vite_issue_705_switch_tab_result__'
 const TAB_PUSH_RESULT_STORAGE_KEY = '__weapp_vite_issue_705_tab_push_result__'
 const STORAGE_TIMEOUT = 8_000
@@ -35,6 +36,21 @@ async function waitForStorage(miniProgram: any, key: string) {
     await new Promise(resolve => setTimeout(resolve, 200))
   }
   throw new Error(`Timed out waiting for issue #705 storage probe: key=${key} latest=${JSON.stringify(latest)}`)
+}
+
+async function waitForBackHooks(miniProgram: any) {
+  const start = Date.now()
+  let latest: any
+  while (Date.now() - start <= STORAGE_TIMEOUT) {
+    latest = await miniProgram.callWxMethodWithOptions('getStorageSync', {
+      timeout: 2_500,
+    }, BACK_RESULT_STORAGE_KEY).catch(() => undefined)
+    if (latest?.hooks?.length >= 2) {
+      return latest
+    }
+    await new Promise(resolve => setTimeout(resolve, 200))
+  }
+  throw new Error(`Timed out waiting for issue #705 back hooks: ${JSON.stringify(latest)}`)
 }
 
 function expectNavigationResult(result: any, from: string) {
@@ -181,7 +197,10 @@ describe.sequential('e2e app: github-issues / issue #705', () => {
     let miniProgram = await getSharedMiniProgram(ctx)
     try {
       for (const backMode of ['router', 'native', 'system'] as const) {
-        await removeStorage(miniProgram, PUSH_RESULT_STORAGE_KEY)
+        await Promise.all([
+          removeStorage(miniProgram, BACK_RESULT_STORAGE_KEY),
+          removeStorage(miniProgram, PUSH_RESULT_STORAGE_KEY),
+        ])
         const issuePage = await relaunchPage(
           miniProgram,
           ISSUE_PAGE_PATH,
@@ -209,6 +228,9 @@ describe.sequential('e2e app: github-issues / issue #705', () => {
         }
 
         if (backMode === 'system') {
+          await targetPage.callMethodWithOptions('_runE2E', {
+            timeout: 5_000,
+          }, 'prepareBack')
           await navigateBackFromHost(miniProgram)
         }
         else {
@@ -218,6 +240,19 @@ describe.sequential('e2e app: github-issues / issue #705', () => {
         }
 
         const returnedPage = await waitForIssue705Page(miniProgram)
+        const backResult = await waitForBackHooks(miniProgram)
+        expect(backResult.hooks).toEqual([
+          {
+            phase: 'before',
+            to: 'pages/issue-705/index',
+            from: 'pages/issue-550/index',
+          },
+          {
+            phase: 'after',
+            to: 'pages/issue-705/index',
+            from: 'pages/issue-550/index',
+          },
+        ])
         const returnedSnapshot = await returnedPage.callMethodWithOptions('_runE2E', {
           timeout: 5_000,
         })

--- a/packages-runtime/wevu/src/router/backNavigation.ts
+++ b/packages-runtime/wevu/src/router/backNavigation.ts
@@ -1,0 +1,76 @@
+import type { SetupContextRouter } from '../runtime/types/props'
+import type { NavigationRunResult } from './navigationResult'
+import type {
+  NavigationGuard,
+  RouteLocationNormalizedLoaded,
+  RouteLocationRaw,
+} from './types'
+import { resolvePageRoute } from '../routerInternal/shared'
+import { getCurrentMiniProgramPages } from '../runtime/platform'
+import { createNavigationFailure, runNavigationGuards } from './navigationCore'
+import { createNavigationRunResult } from './navigationResult'
+import { NavigationFailureType } from './types'
+
+interface RunBackNavigationGuardsOptions {
+  target?: RouteLocationNormalizedLoaded
+  from: RouteLocationNormalizedLoaded
+  nativeRouter: SetupContextRouter
+  beforeEachGuards: ReadonlySet<NavigationGuard>
+  beforeResolveGuards: ReadonlySet<NavigationGuard>
+  resolveWithCodec: (to: RouteLocationRaw, currentPath: string) => RouteLocationNormalizedLoaded
+}
+
+export function resolveBackNavigationTarget(
+  delta: number,
+  from: RouteLocationNormalizedLoaded,
+  resolveWithCodec: (to: RouteLocationRaw, currentPath: string) => RouteLocationNormalizedLoaded,
+): RouteLocationNormalizedLoaded | undefined {
+  const pages = getCurrentMiniProgramPages()
+  const targetPage = pages[pages.length - 1 - delta]
+  if (!targetPage) {
+    return undefined
+  }
+  const target = resolvePageRoute(targetPage)
+  return resolveWithCodec(target.fullPath, from.path)
+}
+
+export async function runBackNavigationGuards(
+  options: RunBackNavigationGuardsOptions,
+): Promise<NavigationRunResult> {
+  const {
+    target,
+    from,
+    nativeRouter,
+    beforeEachGuards,
+    beforeResolveGuards,
+    resolveWithCodec,
+  } = options
+  const guardContext = {
+    mode: 'back' as const,
+    to: target,
+    from,
+    nativeRouter,
+  }
+
+  for (const guards of [beforeEachGuards, beforeResolveGuards]) {
+    const guardResult = await runNavigationGuards(guards, guardContext, resolveWithCodec)
+    if (guardResult.status === 'failure') {
+      return createNavigationRunResult('back', from, target, guardResult.failure)
+    }
+    if (guardResult.status === 'redirect') {
+      return createNavigationRunResult(
+        'back',
+        from,
+        target,
+        createNavigationFailure(
+          NavigationFailureType.aborted,
+          target,
+          from,
+          'Redirect is not supported in back navigation guards',
+        ),
+      )
+    }
+  }
+
+  return createNavigationRunResult('back', from, target)
+}

--- a/packages-runtime/wevu/src/router/createRouter.ts
+++ b/packages-runtime/wevu/src/router/createRouter.ts
@@ -1,4 +1,6 @@
 import type { RouteResolveCodec } from '../routerInternal/shared'
+import type { NavigationRunResult } from './navigationResult'
+import type { RouteStateSyncPayload } from './routeSync'
 import type {
   NavigationAfterEach,
   NavigationErrorHandler,
@@ -20,10 +22,12 @@ import {
   resolveNamedRouteLocation,
   resolvePath,
   resolveRouteOptionEntries,
+  snapshotRouteLocation,
   stringifyQuery,
   warnDuplicateRouteEntries,
 } from '../routerInternal/shared'
 import { getMiniProgramGlobalObject } from '../runtime/platform'
+import { runBackNavigationGuards } from './backNavigation'
 import { setActiveRouter } from './instance'
 import { createNavigationApi } from './navigationApi'
 import { createNavigationResultController } from './navigationResult'
@@ -58,6 +62,7 @@ export function createRouter(options: UseRouterOptions = {}): RouterNavigation {
     .filter(Boolean)
   const tabBarPathSet = new Set(normalizedTabBarEntries)
   const routeRegistry = createRouteRegistry(namedRouteLookup)
+  let managedNavigationCount = 0
   const routerOptions = createRouterOptionsSnapshot(
     normalizedTabBarEntries,
     routeRegistry.getRoutes(),
@@ -103,10 +108,44 @@ export function createRouter(options: UseRouterOptions = {}): RouterNavigation {
     return enrichRouteRecordState(resolveRouteLocation(rawTo, currentPath, routeResolveCodec))
   }
 
+  let route: Readonly<RouteLocationNormalizedLoaded>
+  let emitObservedNavigationAfterEach: ((result: NavigationRunResult) => Promise<void>) | undefined
+
+  function isExternalBackSync(payload: RouteStateSyncPayload): boolean {
+    return payload.source === 'page'
+      || (payload.source === 'native' && payload.method === 'navigateBack')
+  }
+
+  function beforeRouteStateSync(
+    nextRoute: RouteLocationNormalizedLoaded,
+    payload: RouteStateSyncPayload,
+  ) {
+    if (
+      managedNavigationCount > 0
+      || !isExternalBackSync(payload)
+      || nextRoute.fullPath === route.fullPath
+    ) {
+      return
+    }
+
+    const from = snapshotRouteLocation(route)
+    void runBackNavigationGuards({
+      target: nextRoute,
+      from,
+      nativeRouter,
+      beforeEachGuards,
+      beforeResolveGuards,
+      resolveWithCodec,
+    }).then((result) => {
+      return emitObservedNavigationAfterEach?.(result)
+    })
+  }
+
   const routeController = createRouteStateController({
+    beforeRouteStateSync,
     resolveRoute: enrichRouteRecordState,
   })
-  const route = routeController.route
+  route = routeController.route
 
   function resolve(to: RouteLocationRaw): RouteLocationNormalizedLoaded {
     return resolveWithCodec(to, route.path)
@@ -118,6 +157,7 @@ export function createRouter(options: UseRouterOptions = {}): RouterNavigation {
     nativeRouter,
     rejectOnError,
   })
+  emitObservedNavigationAfterEach = navigationResultController.emitNavigationAfterEach
 
   const navigationApi = createNavigationApi({
     nativeRouter,
@@ -131,6 +171,16 @@ export function createRouter(options: UseRouterOptions = {}): RouterNavigation {
     resolveWithCodec,
     settleNavigationResult: navigationResultController.settleNavigationResult,
   })
+
+  async function runManagedNavigation<T>(navigation: () => Promise<T>): Promise<T> {
+    managedNavigationCount += 1
+    try {
+      return await navigation()
+    }
+    finally {
+      managedNavigationCount -= 1
+    }
+  }
 
   function beforeEach(guard: NavigationGuard): () => void {
     beforeEachGuards.add(guard)
@@ -175,11 +225,11 @@ export function createRouter(options: UseRouterOptions = {}): RouterNavigation {
     isReady(): Promise<void> {
       return readyPromise
     },
-    push: navigationApi.push,
-    replace: navigationApi.replace,
-    back: navigationApi.back,
-    go: navigationApi.go,
-    forward: navigationApi.forward,
+    push: to => runManagedNavigation(() => navigationApi.push(to)),
+    replace: to => runManagedNavigation(() => navigationApi.replace(to)),
+    back: delta => runManagedNavigation(() => navigationApi.back(delta)),
+    go: delta => runManagedNavigation(() => navigationApi.go(delta)),
+    forward: () => runManagedNavigation(() => navigationApi.forward()),
     hasRoute: routeRegistry.hasRoute,
     getRoutes: routeRegistry.getRoutes,
     addRoute: routeRegistry.addRoute,

--- a/packages-runtime/wevu/src/router/navigationApi.ts
+++ b/packages-runtime/wevu/src/router/navigationApi.ts
@@ -10,11 +10,11 @@ import type {
   RouteLocationRaw,
 } from './types'
 import { snapshotRouteLocation } from '../routerInternal/shared'
+import { resolveBackNavigationTarget, runBackNavigationGuards } from './backNavigation'
 import {
   createNavigationFailure,
   executeNavigationMethod,
   isNavigationFailure,
-  runNavigationGuards,
 } from './navigationCore'
 import { createNavigationRunResult } from './navigationResult'
 import { navigateWithTarget } from './navigationTarget'
@@ -114,63 +114,28 @@ export function createNavigationApi(options: CreateNavigationApiOptions) {
 
   async function back(delta = 1): Promise<void | NavigationFailure> {
     const from = snapshotRouteLocation(route)
-    const beforeEachResult = await runNavigationGuards(beforeEachGuards, {
-      mode: 'back',
+    const target = resolveBackNavigationTarget(delta, from, resolveWithCodec)
+    const guardResult = await runBackNavigationGuards({
+      target,
       from,
       nativeRouter: nativeRouter as any,
-    }, resolveWithCodec)
-    if (beforeEachResult.status === 'failure') {
-      return settleNavigationResult(createNavigationRunResult('back', from, undefined, beforeEachResult.failure))
-    }
-    if (beforeEachResult.status === 'redirect') {
-      return settleNavigationResult(
-        createNavigationRunResult(
-          'back',
-          from,
-          undefined,
-          createNavigationFailure(
-            NavigationFailureType.aborted,
-            undefined,
-            from,
-            'Redirect is not supported in back navigation guards',
-          ),
-        ),
-      )
-    }
-
-    const beforeResolveResult = await runNavigationGuards(beforeResolveGuards, {
-      mode: 'back',
-      from,
-      nativeRouter: nativeRouter as any,
-    }, resolveWithCodec)
-    if (beforeResolveResult.status === 'failure') {
-      return settleNavigationResult(createNavigationRunResult('back', from, undefined, beforeResolveResult.failure))
-    }
-    if (beforeResolveResult.status === 'redirect') {
-      return settleNavigationResult(
-        createNavigationRunResult(
-          'back',
-          from,
-          undefined,
-          createNavigationFailure(
-            NavigationFailureType.aborted,
-            undefined,
-            from,
-            'Redirect is not supported in back navigation guards',
-          ),
-        ),
-      )
+      beforeEachGuards,
+      beforeResolveGuards,
+      resolveWithCodec,
+    })
+    if (guardResult.failure) {
+      return settleNavigationResult(guardResult)
     }
 
     const result = await executeNavigationMethod(
       nativeRouter.navigateBack as (options: Record<string, any>) => unknown,
       { delta },
-      undefined,
+      target,
       from,
     )
     const runResult = isNavigationFailure(result)
-      ? createNavigationRunResult('back', from, undefined, result)
-      : createNavigationRunResult('back', from)
+      ? createNavigationRunResult('back', from, target, result)
+      : guardResult
     return settleNavigationResult(runResult)
   }
 

--- a/packages-runtime/wevu/src/router/navigationResult.ts
+++ b/packages-runtime/wevu/src/router/navigationResult.ts
@@ -73,7 +73,12 @@ export function createNavigationResultController(options: {
 
   async function settleNavigationResult(result: NavigationRunResult): Promise<void | NavigationFailure> {
     if (!result.failure) {
-      notifyRouteStateSync(result.to ? { route: result.to } : undefined)
+      notifyRouteStateSync(result.to
+        ? {
+            route: result.to,
+            source: 'router',
+          }
+        : undefined)
     }
     await emitNavigationAfterEach(result)
     if (result.failure && shouldRejectNavigationFailure(result.failure)) {
@@ -83,6 +88,7 @@ export function createNavigationResultController(options: {
   }
 
   return {
+    emitNavigationAfterEach,
     settleNavigationResult,
   }
 }

--- a/packages-runtime/wevu/src/router/routeSync.ts
+++ b/packages-runtime/wevu/src/router/routeSync.ts
@@ -5,6 +5,8 @@ export interface RouteStateSyncPayload {
   page?: MiniProgramPageLike
   route?: RouteLocationNormalizedLoaded
   url?: string
+  source?: 'native' | 'page' | 'router'
+  method?: NativeRouterMethodName
 }
 
 type RouteStateSyncHandler = (payload?: RouteStateSyncPayload) => void
@@ -34,15 +36,25 @@ export function notifyRouteStateSync(payload?: RouteStateSyncPayload) {
 
 function createNativeRouteStateSyncPayload(methodName: NativeRouterMethodName, option: unknown): RouteStateSyncPayload | undefined {
   if (methodName === 'navigateBack') {
-    return undefined
+    return {
+      method: methodName,
+      source: 'native',
+    }
   }
   if (option && typeof option === 'object') {
     const url = (option as Record<string, unknown>).url
     if (typeof url === 'string') {
-      return { url }
+      return {
+        method: methodName,
+        source: 'native',
+        url,
+      }
     }
   }
-  return undefined
+  return {
+    method: methodName,
+    source: 'native',
+  }
 }
 
 export function installRouteStateSyncOnNativeRouter(nativeRouter: unknown) {

--- a/packages-runtime/wevu/src/router/useRoute.ts
+++ b/packages-runtime/wevu/src/router/useRoute.ts
@@ -1,5 +1,6 @@
 import type { MiniProgramPageLifetime } from '../runtime/types'
 import type { SetupContextRouter } from '../runtime/types/props'
+import type { RouteStateSyncPayload } from './routeSync'
 import type { LocationQueryRaw, RouteLocationNormalizedLoaded } from './types'
 import { reactive, readonly } from '../reactivity'
 import { cloneLocationQuery, cloneRouteLocationRedirectedFrom, cloneRouteMeta, cloneRouteParams, cloneRouteRecordMatchedList, resolveCurrentRoute, resolvePageRoute } from '../routerInternal/shared'
@@ -14,6 +15,13 @@ import { registerRouteStateSyncHandler } from './routeSync'
 
 export interface UseRouteOptions {
   resolveRoute?: (route: RouteLocationNormalizedLoaded) => RouteLocationNormalizedLoaded
+}
+
+interface RouteStateControllerOptions extends UseRouteOptions {
+  beforeRouteStateSync?: (
+    nextRoute: RouteLocationNormalizedLoaded,
+    payload: RouteStateSyncPayload,
+  ) => void
 }
 
 export interface RouteStateController {
@@ -61,7 +69,7 @@ function applyRouteState(
   }
 }
 
-export function createRouteStateController(options: UseRouteOptions = {}): RouteStateController {
+export function createRouteStateController(options: RouteStateControllerOptions = {}): RouteStateController {
   const setupContext = getCurrentSetupContext()
   if (!setupContext) {
     throw new Error('useRoute() 必须在 setup() 的同步阶段调用')
@@ -80,10 +88,17 @@ export function createRouteStateController(options: UseRouteOptions = {}): Route
   })
   applyRouteState(routeState, currentRoute)
 
-  function syncRoute(queryOverride?: LocationQueryRaw, routeOverride?: RouteLocationNormalizedLoaded) {
+  function syncRoute(
+    queryOverride?: LocationQueryRaw,
+    routeOverride?: RouteLocationNormalizedLoaded,
+    payload?: RouteStateSyncPayload,
+  ) {
     const nextRoute = routeOverride
       ? resolveRoute(routeOverride)
       : resolveRoute(resolveCurrentRoute(queryOverride, fallbackPage))
+    if (payload) {
+      options.beforeRouteStateSync?.(nextRoute, payload)
+    }
     applyRouteState(routeState, nextRoute)
   }
 
@@ -101,18 +116,18 @@ export function createRouteStateController(options: UseRouteOptions = {}): Route
   })
   const unregisterRouteStateSync = registerRouteStateSyncHandler((payload) => {
     if (payload?.route) {
-      syncRoute(undefined, payload.route)
+      syncRoute(undefined, payload.route, payload)
       return
     }
     if (payload?.page) {
-      syncRoute(undefined, resolvePageRoute(payload.page))
+      syncRoute(undefined, resolvePageRoute(payload.page), payload)
       return
     }
     if (payload?.url) {
-      syncRoute(undefined, resolveRouteLocation(payload.url, routeState.path))
+      syncRoute(undefined, resolveRouteLocation(payload.url, routeState.path), payload)
       return
     }
-    syncRoute()
+    syncRoute(undefined, undefined, payload)
   })
   onUnload(() => {
     unregisterRouteStateSync()

--- a/packages-runtime/wevu/src/runtime/register/component/lifecycle.ts
+++ b/packages-runtime/wevu/src/runtime/register/component/lifecycle.ts
@@ -1,3 +1,4 @@
+import type { MiniProgramPageLike } from '../../../routerInternal/shared'
 import type { ComponentPropsOptions, ComputedDefinitions, DefineComponentOptions, InternalRuntimeState, MethodDefinitions, RuntimeApp } from '../../types'
 import type { WatchMap } from '../watch'
 import {
@@ -134,7 +135,10 @@ export function createPageLifecycleHooks<D extends object, C extends ComputedDef
       }
       setRuntimeSetDataVisibility(this, true)
       if (isPage) {
-        notifyRouteStateSync({ page: this })
+        notifyRouteStateSync({
+          page: this as MiniProgramPageLike,
+          source: 'page',
+        })
       }
       callHookList(this, 'onShow', args)
       if (typeof userOnShow === 'function') {

--- a/packages-runtime/wevu/src/runtime/vueCompat/router.ts
+++ b/packages-runtime/wevu/src/runtime/vueCompat/router.ts
@@ -87,7 +87,11 @@ function createScopedRuntimeRouter(rawRouter: RuntimeRouter, basePath?: string):
         url: nextUrl,
         success: (...args: any[]) => {
           if (typeof nextUrl === 'string') {
-            notifyRouteStateSync({ url: nextUrl })
+            notifyRouteStateSync({
+              method: methodName,
+              source: 'native',
+              url: nextUrl,
+            })
           }
           return typeof originalSuccess === 'function'
             ? originalSuccess(...args)

--- a/packages-runtime/wevu/test/router-navigation.test.ts
+++ b/packages-runtime/wevu/test/router-navigation.test.ts
@@ -3335,6 +3335,7 @@ describe('router navigation helpers', () => {
 
     setCurrentInstance(instance)
     setCurrentSetupContext({ instance, emit: vi.fn(), attrs: {}, slots: {} })
+    ;(globalThis as any).wx = instance.router
     ;(globalThis as any).getCurrentPages = vi.fn(() => pages)
 
     const router = createRouter({
@@ -3360,6 +3361,78 @@ describe('router navigation helpers', () => {
     expect(navigateTo).toHaveBeenCalledTimes(2)
   })
 
+  it('provides the resolved stack target to router.back guards and hooks', async () => {
+    const pages = [
+      {
+        route: 'pages/page1/index',
+        options: {
+          source: 'back-target',
+        },
+      },
+      {
+        route: 'pages/page2/index',
+        options: {},
+      },
+    ]
+    const navigateBack = vi.fn((options: any) => {
+      pages.pop()
+      options.success?.({})
+    })
+    const guardCalls: any[] = []
+    const afterCalls: any[] = []
+    const instance = {
+      __wevu: {},
+      [WEVU_HOOKS_KEY]: {},
+      router: {
+        switchTab: vi.fn(),
+        reLaunch: vi.fn(),
+        redirectTo: vi.fn(),
+        navigateTo: vi.fn(),
+        navigateBack,
+      },
+    } as any
+
+    setCurrentInstance(instance)
+    setCurrentSetupContext({ instance, emit: vi.fn(), attrs: {}, slots: {} })
+    ;(globalThis as any).wx = instance.router
+    ;(globalThis as any).getCurrentPages = vi.fn(() => pages)
+
+    const router = createRouter({
+      routes: [
+        {
+          name: 'page1',
+          path: '/pages/page1/index',
+        },
+        {
+          name: 'page2',
+          path: '/pages/page2/index',
+        },
+      ],
+    })
+    notifyRouteStateSync({ page: pages[1] })
+    router.beforeEach((to, from) => {
+      guardCalls.push({ to, from })
+    })
+    router.afterEach((to, from) => {
+      afterCalls.push({ to, from })
+    })
+
+    await expect(router.back()).resolves.toBeUndefined()
+
+    expect(guardCalls).toMatchObject([
+      {
+        from: { path: 'pages/page2/index' },
+        to: {
+          fullPath: '/pages/page1/index?source=back-target',
+          name: 'page1',
+          path: 'pages/page1/index',
+        },
+      },
+    ])
+    expect(afterCalls).toMatchObject(guardCalls)
+    expect(router.currentRoute.fullPath).toBe('/pages/page1/index?source=back-target')
+  })
+
   it('restores currentRoute from the activated page when the host performs back navigation', async () => {
     const page1 = {
       route: 'pages/page1/index',
@@ -3367,7 +3440,7 @@ describe('router navigation helpers', () => {
         source: 'host-back',
       },
     }
-    const pages = [page1]
+    const pages: Array<{ options: Record<string, string>, route: string }> = [page1]
     const navigateTo = vi.fn((options: any) => {
       pages.push({
         route: 'pages/page2/index',
@@ -3403,13 +3476,37 @@ describe('router navigation helpers', () => {
         },
       ],
     })
+    const guardCalls: any[] = []
+    const afterCalls: any[] = []
+    router.beforeEach((to, from) => {
+      guardCalls.push({ to, from })
+    })
+    router.afterEach((to, from) => {
+      afterCalls.push({ to, from })
+    })
 
     await router.push({ name: 'page2' })
     expect(router.currentRoute.path).toBe('pages/page2/index')
+    guardCalls.length = 0
+    afterCalls.length = 0
 
-    notifyRouteStateSync({ page: page1 })
+    notifyRouteStateSync({ page: page1, source: 'page' })
+    await vi.waitFor(() => {
+      expect(afterCalls).toHaveLength(1)
+    })
     expect(router.currentRoute.fullPath).toBe('/pages/page1/index?source=host-back')
     expect(router.currentRoute.name).toBe('page1')
+    expect(guardCalls).toMatchObject([
+      {
+        from: { path: 'pages/page2/index' },
+        to: {
+          fullPath: '/pages/page1/index?source=host-back',
+          name: 'page1',
+          path: 'pages/page1/index',
+        },
+      },
+    ])
+    expect(afterCalls).toMatchObject(guardCalls)
 
     await expect(router.push({ name: 'page2' })).resolves.toBeUndefined()
     expect(navigateTo).toHaveBeenCalledTimes(2)

--- a/packages-runtime/wevu/test/runtime-register-component-lifecycle-extra.test.ts
+++ b/packages-runtime/wevu/test/runtime-register-component-lifecycle-extra.test.ts
@@ -215,7 +215,10 @@ describe('runtime: component page lifecycle extra', () => {
     expect(instance[WEVU_ROUTE_DONE_CALLED_KEY]).toBe(false)
     expect(mocks.ensureMiniProgramGlobalPatched).toHaveBeenCalledTimes(1)
     expect(mocks.bindCurrentPageInstance).toHaveBeenCalledWith(instance)
-    expect(mocks.notifyRouteStateSync).toHaveBeenCalledWith({ page: instance })
+    expect(mocks.notifyRouteStateSync).toHaveBeenCalledWith({
+      page: instance,
+      source: 'page',
+    })
     expect(mocks.resolvePageOptions).toHaveBeenCalledWith(instance)
     expect(mocks.mountRuntimeInstance).toHaveBeenCalledTimes(1)
 


### PR DESCRIPTION
## 问题

wevu 6.18.6 的返回导航仍有两处与 Vue Router 心智不一致：

- `router.back()` 会执行 hooks，但 `to` 为 `undefined`
- `wx.navigateBack()` 与宿主系统返回只同步 `currentRoute`，不触发 `beforeEach` / `afterEach`

根因是返回目标解析、受管导航 hooks 与宿主 route sync 分属不同通道；上一版只修复了状态恢复，没有让外部返回进入导航生命周期。

## 修复

- 从 `getCurrentPages()` 页面栈解析 `router.back(delta)` 的目标路由，并保留页面 query、route record、name 与 matched 信息。
- 抽取统一的返回守卫流程，让 `beforeEach`、`beforeResolve` 和 `afterEach` 共享完整 `to` / `from`。
- 为 route sync 标记 `router`、`native`、`page` 来源；原生返回和系统返回在应用新路由状态前进入同一守卫流程。
- 为 router API 增加受管导航边界，避免宿主成功回调与页面 `onShow` 重复触发 hooks。
- 扩展 issue #705 复现页与 runtime E2E，覆盖 `router.back()`、`wx.navigateBack()`、宿主返回及返回后再次 push。
- 增加 `wevu` 与 `create-weapp-vite` patch changeset。

## 验证

- `pnpm --filter wevu test`：73 files / 793 tests passed
- `pnpm --filter wevu typecheck`
- `pnpm --filter wevu test:types`
- 目标 TypeScript / Vue 文件 ESLint 与 Vue stylelint
- `pnpm --filter wevu build`
- `pnpm --filter e2e-app-github-issues build`
- `node --import tsx scripts/check-e2e-ide-shared-launch.ts`
- issue #705 headless runtime E2E：2 tests passed，覆盖三种返回路径
- changeset create-weapp-vite / catalog guard

真实 WeChat DevTools 单文件复验中，构建、登录预检和 bridge 连接成功，但在进入 issue 页面前持续发生 `reLaunch` 协议超时；多轮重连期间 runtime 统计始终为 0 warning/error/exception/log，未执行到业务断言，因此归类为 DevTools 基础设施阻断。相同断言在 headless provider 下完整通过。

关联 #705
目标反馈：https://github.com/weapp-vite/weapp-vite/issues/705#issuecomment-5066627550