### PR TITLE
fix(ci): 等待 HMR 共享产物与稳定内存采样

### DIFF
--- a/e2e/ci/hmr-complex-developer-flow.test.ts
+++ b/e2e/ci/hmr-complex-developer-flow.test.ts
@@ -13,7 +13,7 @@ import {
   resolvePlatforms,
   waitForFileContains,
 } from '../utils/hmr-helpers'
-import { toRelativeImport, waitForWevuRuntimeChunkContaining } from '../utils/wevu-vendor'
+import { toRelativeImport, waitForWevuSharedRuntimeChunkContaining } from '../utils/wevu-vendor'
 import { APP_ROOT, CLI_PATH, DIST_ROOT, waitForFile } from '../wevu-runtime.utils'
 
 const HMR_SRC_DIR = path.join(APP_ROOT, 'src/pages/hmr')
@@ -73,11 +73,19 @@ function createPageScriptWithMarker(source: string, marker: string) {
 
 async function waitForSharedStoreMarker(marker: string, retrySource: string) {
   try {
-    return await waitForWevuRuntimeChunkContaining(DIST_ROOT, marker, 30_000)
+    return await waitForWevuSharedRuntimeChunkContaining(
+      DIST_ROOT,
+      [marker, 'setupCounter', 'optionsCounter'],
+      30_000,
+    )
   }
   catch {
     await replaceFileByRename(SHARED_STORE, `${retrySource}\n`)
-    return await waitForWevuRuntimeChunkContaining(DIST_ROOT, marker, 90_000)
+    return await waitForWevuSharedRuntimeChunkContaining(
+      DIST_ROOT,
+      [marker, 'setupCounter', 'optionsCounter'],
+      90_000,
+    )
   }
 }
 

--- a/e2e/ci/hmr-shared-runtime-deps.test.ts
+++ b/e2e/ci/hmr-shared-runtime-deps.test.ts
@@ -4,7 +4,7 @@ import { startDevProcess } from '../utils/dev-process'
 import { cleanupResidualDevProcesses } from '../utils/dev-process-cleanup'
 import { createDevProcessEnv } from '../utils/dev-process-env'
 import { createHmrMarker, replaceFileByRename, replaceSharedStoreInitialName, resolvePlatforms } from '../utils/hmr-helpers'
-import { findWevuRuntimeChunk, toRelativeImport, waitForWevuRuntimeChunkContaining } from '../utils/wevu-vendor'
+import { toRelativeImport, waitForWevuSharedRuntimeChunkContaining } from '../utils/wevu-vendor'
 import { APP_ROOT, CLI_PATH, DIST_ROOT, waitForFile } from '../wevu-runtime.utils'
 
 const SHARED_STORE_SOURCE_PATH = path.join(APP_ROOT, 'src/shared/store.ts')
@@ -21,28 +21,11 @@ function replaceSharedStoreMarker(source: string, marker: string) {
 }
 
 async function waitForSharedStoreRuntimeChunk(marker: string, timeoutMs: number) {
-  const start = Date.now()
-  while (Date.now() - start < timeoutMs) {
-    try {
-      return await findWevuRuntimeChunk(
-        DIST_ROOT,
-        (code, filePath) => {
-          const normalizedPath = filePath.replaceAll('\\', '/')
-          return !normalizedPath.includes('/pages/')
-            && code.includes(marker)
-            && code.includes('useSetupStore')
-            && code.includes('useOptionsStore')
-            && code.includes('getPluginRecords')
-        },
-        `shared store runtime ${marker}`,
-      )
-    }
-    catch {
-      await new Promise(resolve => setTimeout(resolve, 250))
-    }
-  }
-
-  throw new Error(`Timed out waiting for shared store runtime chunk under ${DIST_ROOT} to contain marker: ${marker}`)
+  return await waitForWevuSharedRuntimeChunkContaining(
+    DIST_ROOT,
+    [marker, 'useSetupStore', 'useOptionsStore', 'getPluginRecords'],
+    timeoutMs,
+  )
 }
 
 async function waitForCommonMarkerWithRetry(
@@ -81,7 +64,7 @@ describe.sequential('HMR shared runtime dependencies (dev watch)', () => {
 
     try {
       await dev.waitFor(waitForFile(path.join(DIST_ROOT, 'app.json'), 90_000), `${platform} app.json generated`)
-      await dev.waitFor(waitForWevuRuntimeChunkContaining(DIST_ROOT, 'setupCounter', 90_000), `${platform} initial shared runtime`)
+      await dev.waitFor(waitForSharedStoreRuntimeChunk('setupCounter', 90_000), `${platform} initial shared runtime`)
       await dev.waitFor(waitForFile(STORE_PAGE_JS_PATH, 90_000), `${platform} initial store page js`)
       await dev.waitFor(waitForFile(STORE_SHARE_PAGE_JS_PATH, 90_000), `${platform} initial store-share page js`)
 
@@ -127,7 +110,7 @@ describe.sequential('HMR shared runtime dependencies (dev watch)', () => {
 
     try {
       await dev.waitFor(waitForFile(path.join(DIST_ROOT, 'app.json'), 90_000), `${platform} app.json generated`)
-      await dev.waitFor(waitForWevuRuntimeChunkContaining(DIST_ROOT, 'setupCounter', 90_000), `${platform} initial shared runtime`)
+      await dev.waitFor(waitForSharedStoreRuntimeChunk('setupCounter', 90_000), `${platform} initial shared runtime`)
 
       await replaceFileByRename(SHARED_STORE_SOURCE_PATH, firstUpdatedSource)
       await replaceFileByRename(SHARED_STORE_SOURCE_PATH, secondUpdatedSource)

--- a/e2e/utils/dev-memory.test.ts
+++ b/e2e/utils/dev-memory.test.ts
@@ -83,10 +83,14 @@ describe('dev-memory inspector sampling', () => {
     try {
       await expect(sampleHeapAfterGc('ws://127.0.0.1:1/devtools/page/1', 10))
         .rejects
-        .toThrow('Timed out waiting for inspector command HeapProfiler.collectGarbage after 10ms.')
+        .toThrow('Timed out waiting for inspector command Runtime.evaluate after 10ms.')
       expect(SilentCommandWebSocket.instances.at(-1)?.send).toHaveBeenCalledWith(JSON.stringify({
         id: 1,
-        method: 'HeapProfiler.collectGarbage',
+        method: 'Runtime.evaluate',
+        params: {
+          expression: 'typeof global.gc === "function" && global.gc(); process.memoryUsage()',
+          returnByValue: true,
+        },
       }))
       expect(SilentCommandWebSocket.instances.at(-1)?.close).toHaveBeenCalledTimes(1)
     }

--- a/e2e/utils/dev-memory.ts
+++ b/e2e/utils/dev-memory.ts
@@ -14,7 +14,7 @@ interface InspectorResponse<T = unknown> {
 }
 
 const INSPECTOR_URL_RE = /Debugger listening on (ws:\/\/\S+)/
-const DEFAULT_INSPECTOR_COMMAND_TIMEOUT_MS = 5_000
+const DEFAULT_INSPECTOR_COMMAND_TIMEOUT_MS = 15_000
 const DEFAULT_HEAP_SETTLEMENT_ATTEMPTS = 6
 const DEFAULT_HEAP_SETTLEMENT_INTERVAL_MS = 500
 const DEFAULT_HEAP_SETTLEMENT_TOLERANCE_BYTES = 8 * 1024 * 1024
@@ -89,15 +89,19 @@ function sendInspectorCommand<T>(
   params?: Record<string, unknown>,
   timeoutMs = DEFAULT_INSPECTOR_COMMAND_TIMEOUT_MS,
 ) {
-  const task = new Promise<T>((resolve, reject) => {
+  return new Promise<T>((resolve, reject) => {
     let onError: () => void
     let onMessage: (event: MessageEvent) => void
+    let timer: ReturnType<typeof setTimeout> | undefined
     let settled = false
     const settle = (callback: () => void) => {
       if (settled) {
         return
       }
       settled = true
+      if (timer) {
+        clearTimeout(timer)
+      }
       removeInspectorListeners(socket, onMessage, onError)
       callback()
     }
@@ -126,13 +130,20 @@ function sendInspectorCommand<T>(
 
     socket.addEventListener('message', onMessage)
     socket.addEventListener('error', onError, { once: true })
-    socket.send(JSON.stringify({
-      id: commandId,
-      method,
-      params,
-    }))
+    timer = setTimeout(() => {
+      settle(() => reject(new Error(`Timed out waiting for inspector command ${method} after ${timeoutMs}ms.`)))
+    }, timeoutMs)
+    try {
+      socket.send(JSON.stringify({
+        id: commandId,
+        method,
+        params,
+      }))
+    }
+    catch (error) {
+      settle(() => reject(error))
+    }
   })
-  return withTimeout(task, timeoutMs, () => new Error(`Timed out waiting for inspector command ${method} after ${timeoutMs}ms.`))
 }
 
 export async function waitForInspectorUrl(
@@ -158,13 +169,12 @@ export async function sampleHeapAfterGc(
   const socket = new WebSocket(inspectorUrl)
   try {
     await waitForWebSocketOpen(socket, timeoutMs)
-    await sendInspectorCommand(socket, 1, 'HeapProfiler.collectGarbage', undefined, timeoutMs)
     const evaluated = await sendInspectorCommand<{
       result?: {
         value?: DevHeapUsage
       }
-    }>(socket, 2, 'Runtime.evaluate', {
-      expression: 'process.memoryUsage()',
+    }>(socket, 1, 'Runtime.evaluate', {
+      expression: 'typeof global.gc === "function" && global.gc(); process.memoryUsage()',
       returnByValue: true,
     }, timeoutMs)
     const usage = evaluated.result?.value

--- a/e2e/utils/wevu-vendor.test.ts
+++ b/e2e/utils/wevu-vendor.test.ts
@@ -1,0 +1,33 @@
+import os from 'node:os'
+import { fs } from '@weapp-core/shared/node'
+import path from 'pathe'
+import { afterEach, describe, expect, it } from 'vitest'
+import { waitForWevuSharedRuntimeChunkContaining } from './wevu-vendor'
+
+const tempRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map(tempRoot => fs.remove(tempRoot)))
+})
+
+describe('wevu vendor helpers', () => {
+  it('waits for a shared chunk instead of returning an intermediate page output', async () => {
+    const distRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'weapp-vite-wevu-vendor-'))
+    tempRoots.push(distRoot)
+    const marker = 'SHARED-RUNTIME-CONVERGENCE'
+    await fs.outputFile(
+      path.join(distRoot, 'pages/store/index.js'),
+      `const pageMarker = "${marker}";`,
+    )
+
+    const pendingChunk = waitForWevuSharedRuntimeChunkContaining(distRoot, [marker], 2_000)
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await fs.outputFile(
+      path.join(distRoot, 'common.js'),
+      `const sharedMarker = "${marker}";`,
+    )
+
+    const chunk = await pendingChunk
+    expect(path.relative(distRoot, chunk.path).replaceAll('\\', '/')).toBe('common.js')
+  })
+})

--- a/e2e/utils/wevu-vendor.ts
+++ b/e2e/utils/wevu-vendor.ts
@@ -199,6 +199,42 @@ export async function waitForWevuRuntimeChunkContaining(
   throw new Error(`Timed out waiting for wevu runtime chunk under ${distRoot} to contain marker: ${marker}`)
 }
 
+/**
+ * 轮询等待非页面共享 runtime chunk 同时包含指定片段。
+ *
+ * @param distRoot - 小程序产物目录
+ * @param snippets - 期望同时出现的源码片段
+ * @param timeoutMs - 超时时间
+ * @returns 匹配到的共享 chunk 路径和源码
+ */
+export async function waitForWevuSharedRuntimeChunkContaining(
+  distRoot: string,
+  snippets: string[],
+  timeoutMs = 90_000,
+): Promise<WevuVendorChunk> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    try {
+      return await findWevuRuntimeChunk(
+        distRoot,
+        (code, filePath) => {
+          const normalizedPath = filePath.replaceAll('\\', '/')
+          return !normalizedPath.includes('/pages/')
+            && snippets.every(snippet => code.includes(snippet))
+        },
+        `shared runtime ${snippets.join(' + ')}`,
+      )
+    }
+    catch {
+      await new Promise(resolve => setTimeout(resolve, 250))
+    }
+  }
+
+  throw new Error(
+    `Timed out waiting for shared runtime chunk under ${distRoot} to contain snippets: ${snippets.join(', ')}`,
+  )
+}
+
 export function toRelativeImport(fromFilePath: string, toFilePath: string) {
   const relativePath = path.relative(path.dirname(fromFilePath), toFilePath).replaceAll('\\', '/')
   return relativePath.startsWith('.') ? relativePath : `./${relativePath}`


### PR DESCRIPTION
## 背景

PR #746 合并后的 HMR 矩阵暴露了两个跨平台竞态：Ubuntu 会在共享 chunk 落盘前误选页面中间产物；Windows 在大模板场景下可能超过固定 5 秒的 inspector GC 超时。

## 修改

- 新增共享 runtime chunk 等待器，明确排除 pages 产物，并要求全部稳定语义片段同时出现。
- 让两条 HMR 用例复用该等待器，避免把页面脚本当成共享 chunk。
- 将 GC 与内存读取合并为一次 Runtime.evaluate 往返，默认 inspector 命令超时调整为 15 秒。
- 统一清理 inspector 的 timer 与事件监听，覆盖超时、发送异常和正常响应。
- 新增共享 chunk 竞态回归测试并更新内存采样契约测试。

## 验证

- pnpm --filter weapp-vite... build
- pnpm vitest run -c e2e/vitest.e2e.hmr-guard.config.ts e2e/utils/wevu-vendor.test.ts e2e/utils/dev-memory.test.ts e2e/ci/hmr-complex-developer-flow.test.ts e2e/ci/hmr-shared-runtime-deps.test.ts e2e/ci/template-tailwind-hmr.test.ts
- pnpm eslint e2e/ci/hmr-complex-developer-flow.test.ts e2e/ci/hmr-shared-runtime-deps.test.ts e2e/utils/dev-memory.test.ts e2e/utils/dev-memory.ts e2e/utils/wevu-vendor.ts e2e/utils/wevu-vendor.test.ts --max-warnings=0
- git diff --check

## 发布

纯 CI/E2E 基础设施修复，不改变用户可见行为，因此不添加 changeset，也不联动 create-weapp-vite。