### PR TITLE
feat(web-runtime): 增加浏览器历史路由与深链接

### DIFF
--- a/.changeset/tidy-web-routing.md
+++ b/.changeset/tidy-web-routing.md
@@ -1,0 +1,5 @@
+---
+"@weapp-vite/web": minor
+---
+
+为 Web Runtime 增加可配置的浏览器路由模式，支持 history/hash 深链接、地址栏同步及前进后退恢复页面栈，默认继续使用 memory 模式保持现有预览行为。

--- a/apps/weapp-vite-web-demo/vite.config.ts
+++ b/apps/weapp-vite-web-demo/vite.config.ts
@@ -34,6 +34,13 @@ export default defineConfig({
       },
     },
     web: {
+      pluginOptions: {
+        runtime: {
+          routing: {
+            mode: 'history',
+          },
+        },
+      },
       vite: {
         server: {
           host: webHost ?? '127.0.0.1',

--- a/e2e/web-runtime/web-demo.test.ts
+++ b/e2e/web-runtime/web-demo.test.ts
@@ -405,6 +405,36 @@ describeWeb.sequential('web runtime browser baseline (weapp-vite-web-demo)', () 
     }
   })
 
+  it('restores a deep link and page stack on browser back', async () => {
+    const page = await browser!.newPage()
+    try {
+      await page.goto(`${WEB_URL}/pages/interactive/index?from=deep-link`, { waitUntil: 'domcontentloaded' })
+      await expect.poll(async () => {
+        const snapshot = await readCurrentPageSnapshot(page)
+        return snapshot?.route
+      }, { timeout: 45_000 }).toBe('pages/interactive/index')
+      await expect.poll(() => page.evaluate(() => window.location.pathname + window.location.search))
+        .toBe('/pages/interactive/index?from=deep-link')
+
+      await page.evaluate(async () => {
+        await (window as any).wx.navigateTo({
+          url: 'pages/interactive/detail?id=component-flow&from=deep-link',
+        })
+      })
+      await expect.poll(async () => (await readCurrentPageSnapshot(page))?.route, { timeout: 45_000 })
+        .toBe('pages/interactive/detail')
+
+      await page.goBack()
+      await expect.poll(async () => (await readCurrentPageSnapshot(page))?.route, { timeout: 45_000 })
+        .toBe('pages/interactive/index')
+      await expect.poll(async () => page.evaluate(() => window.location.pathname + window.location.search))
+        .toBe('/pages/interactive/index?from=deep-link')
+    }
+    finally {
+      await page.close()
+    }
+  })
+
   it('preserves page instance, lifecycle state and scroll position after navigateBack', async () => {
     const page = await browser!.newPage()
     try {

--- a/packages-runtime/web/README.md
+++ b/packages-runtime/web/README.md
@@ -63,6 +63,26 @@ weappWebPlugin({
 
 已有项目需要保留浏览器全宽布局时，设置 `runtime.viewport.mode: 'responsive'`。
 
+## 浏览器路由
+
+默认使用 `memory` 模式，路由只在运行时页面栈内生效。生产站点可以根据部署方式开启地址栏同步：
+
+```ts
+weappWebPlugin({
+  runtime: {
+    routing: {
+      mode: 'history', // 服务端回退到 index.html
+      base: '/mini',
+    },
+  },
+})
+```
+
+- `history` 使用真实路径，支持从 `/mini/pages/detail/index?sku=42` 深链接进入页面，并同步 `navigateTo`、`redirectTo`、`reLaunch`、`switchTab` 和 `navigateBack`。
+- `hash` 使用 `#/pages/detail/index`，适合没有服务端 history fallback 的静态托管。
+- 两种浏览器模式都会响应前进/后退事件并恢复页面栈；`base` 应与部署目录保持一致。
+- 默认 `memory` 保持现有预览与测试行为，不修改浏览器地址栏。
+
 ## 宿主注入
 
 Web Runtime 默认读取浏览器原语；测试容器、沙箱或业务宿主可以在注册页面前注入最小 host：

--- a/packages-runtime/web/src/plugin/entry.ts
+++ b/packages-runtime/web/src/plugin/entry.ts
@@ -52,6 +52,9 @@ export function generateEntryModule(
   if (pluginOptions?.runtime?.viewport) {
     runtimeOptions.viewport = pluginOptions.runtime.viewport
   }
+  if (pluginOptions?.runtime?.routing) {
+    runtimeOptions.routing = pluginOptions.runtime.routing
+  }
   if (Object.keys(runtimeOptions).length > 0) {
     initOptions.runtime = runtimeOptions
   }

--- a/packages-runtime/web/src/plugin/types.ts
+++ b/packages-runtime/web/src/plugin/types.ts
@@ -1,5 +1,6 @@
 import type { NavigationBarConfig } from '../compiler/wxml'
 import type { WxssTransformOptions } from '../css/wxss'
+import type { WebRoutingConfig } from '../runtime/polyfill/routeRuntime/history'
 import type { WebTabBarConfig } from '../shared/tabBar'
 
 export interface WeappWebPluginOptions {
@@ -48,6 +49,8 @@ export interface WeappWebPluginOptions {
       maxWidth?: number
       desktopBreakpoint?: number
     }
+    /** Web 路由与浏览器地址栏同步策略。 */
+    routing?: WebRoutingConfig
   }
   /**
    * weapp-vite runtime provider 注入的内部绑定。

--- a/packages-runtime/web/src/runtime/index.ts
+++ b/packages-runtime/web/src/runtime/index.ts
@@ -151,6 +151,18 @@ export {
   uploadFile,
   vibrateShort,
 } from './polyfill'
+export {
+  disposeWebRouting,
+  getWebRoutingConfig,
+  resolveWebRoutingConfig,
+} from './polyfill/routeRuntime/history'
+export type {
+  ResolvedWebRoutingConfig,
+  WebRouteHistoryState,
+  WebRouteTarget,
+  WebRoutingConfig,
+  WebRoutingMode,
+} from './polyfill/routeRuntime/history'
 export { createRenderContext } from './renderContext'
 export type { RenderContext } from './renderContext'
 export { setupRpx } from './rpx'

--- a/packages-runtime/web/src/runtime/polyfill/routeRuntime.ts
+++ b/packages-runtime/web/src/runtime/polyfill/routeRuntime.ts
@@ -3,6 +3,7 @@ import type { ButtonFormConfig } from '../button'
 import type { ComponentPublicInstance } from '../component'
 import type { NavigationBarMetrics } from '../navigationBar'
 import type { WebViewportConfig } from '../viewport'
+import type { WebRouteHistoryState, WebRouteTarget, WebRoutingConfig } from './routeRuntime/history'
 import type { AppLaunchOptions, AppRuntime, ComponentRawOptions, ComponentRecord, NavigateBackOptions, PageRawOptions, PageRecord, PageStackEntry, RegisterMeta, RouteOptions } from './routeRuntime/options'
 import { slugify } from '../../shared/slugify'
 import {
@@ -23,6 +24,12 @@ import {
   resolveCurrentPages,
   resolveFallbackLaunchOptions,
 } from './appState'
+import {
+  configureWebRouting,
+  getWebHistoryStack,
+  readWebRouteTarget,
+  syncWebRouting,
+} from './routeRuntime/history'
 import {
   augmentPageComponentOptions,
   dispatchPageLifetimeToComponents,
@@ -71,11 +78,43 @@ function ensureAppLaunched(entry: PageStackEntry) {
 
 const pageStack = new PageStackRuntime(pageRegistry, ensureAppLaunched)
 
+function syncCurrentWebRoute(operation: 'push' | 'replace') {
+  syncWebRouting(pageStack.entries, operation)
+}
+
+function reconcileWebRoute(target: WebRouteTarget | undefined, state: WebRouteHistoryState | undefined) {
+  const currentIds = pageStack.entries.map(entry => entry.id)
+  const historyStack = getWebHistoryStack(state)
+  if (historyStack?.length) {
+    const desiredIds = historyStack.map(entry => entry.id)
+    const samePrefix = desiredIds.every((id, index) => currentIds[index] === id)
+    if (samePrefix && desiredIds.length < currentIds.length) {
+      pageStack.back(currentIds.length - desiredIds.length)
+    }
+    else if (samePrefix && desiredIds.length > currentIds.length) {
+      for (const entry of historyStack.slice(currentIds.length)) {
+        pageStack.push(entry.id, { ...entry.query })
+      }
+    }
+    else if (desiredIds.length) {
+      const last = historyStack[historyStack.length - 1]!
+      pageStack.relaunch(last.id, { ...last.query })
+    }
+    syncTabBarRoute(pageStack.entries[pageStack.entries.length - 1]?.id ?? '')
+    return
+  }
+  if (target && pageRegistry.has(target.id)) {
+    pageStack.relaunch(target.id, { ...target.query })
+    syncTabBarRoute(target.id)
+  }
+}
+
 function performSwitchTab(options: RouteOptions) {
   const { id, query } = parsePageUrl(options?.url ?? '')
   const succeeded = pageStack.switchTab(id, query)
   if (succeeded) {
     syncTabBarRoute(id)
+    syncCurrentWebRoute('push')
   }
   return resolveRouteAction('switchTab', options, succeeded, 'not a tabBar page')
 }
@@ -112,12 +151,14 @@ export function initializePageRoutes(
         dedupe?: boolean
       }
       viewport?: WebViewportConfig
+      routing?: WebRoutingConfig
     }
   },
 ) {
   setRuntimeExecutionMode(options?.runtime?.executionMode)
   setRuntimeWarningOptions(options?.runtime?.warnings)
   setupWebViewport(options?.runtime?.viewport)
+  configureWebRouting(options?.runtime?.routing, ids, reconcileWebRoute)
   ensureNativeComponentsDefined()
   pageOrder = Array.from(new Set(ids))
   configureTabBar(options?.tabBar, url => performSwitchTab({ url }))
@@ -136,8 +177,12 @@ export function initializePageRoutes(
     setButtonFormConfig(options.form)
   }
   if (!pageStack.entries.length) {
-    if (pageStack.push(pageOrder[0], {})) {
-      syncTabBarRoute(pageOrder[0])
+    const initialTarget = readWebRouteTarget(pageOrder)
+    const initialId = initialTarget?.id ?? pageOrder[0]
+    const initialQuery = initialTarget?.query ?? {}
+    if (pageStack.push(initialId, initialQuery)) {
+      syncTabBarRoute(initialId)
+      syncCurrentWebRoute('replace')
     }
   }
 }
@@ -223,6 +268,7 @@ export function navigateTo(options: RouteOptions) {
   const succeeded = pageStack.push(id, query)
   if (succeeded) {
     syncTabBarRoute(id)
+    syncCurrentWebRoute('push')
   }
   return resolveRouteAction('navigateTo', options, succeeded)
 }
@@ -232,6 +278,7 @@ export function redirectTo(options: RouteOptions) {
   const succeeded = pageStack.replace(id, query)
   if (succeeded) {
     syncTabBarRoute(id)
+    syncCurrentWebRoute('replace')
   }
   return resolveRouteAction('redirectTo', options, succeeded)
 }
@@ -241,6 +288,7 @@ export function reLaunch(options: RouteOptions) {
   const succeeded = pageStack.relaunch(id, query)
   if (succeeded) {
     syncTabBarRoute(id)
+    syncCurrentWebRoute('replace')
   }
   return resolveRouteAction('reLaunch', options, succeeded)
 }
@@ -253,6 +301,7 @@ export function navigateBack(options?: NavigateBackOptions) {
   const succeeded = pageStack.back(options?.delta)
   if (succeeded) {
     syncTabBarRoute(pageStack.entries[pageStack.entries.length - 1]?.id ?? '')
+    syncCurrentWebRoute('replace')
   }
   return resolveRouteAction('navigateBack', options, succeeded)
 }

--- a/packages-runtime/web/src/runtime/polyfill/routeRuntime/history.ts
+++ b/packages-runtime/web/src/runtime/polyfill/routeRuntime/history.ts
@@ -1,0 +1,224 @@
+import type { PageStackEntry } from './options'
+
+export type WebRoutingMode = 'memory' | 'history' | 'hash'
+
+export interface WebRoutingConfig {
+  mode?: WebRoutingMode
+  /** 部署目录前缀，例如 /mini-program。 */
+  base?: string
+}
+
+export interface ResolvedWebRoutingConfig {
+  mode: WebRoutingMode
+  base: string
+}
+
+export interface WebRouteTarget {
+  id: string
+  query: Record<string, string>
+}
+
+export interface WebRouteHistoryState {
+  __weappWebRuntime?: {
+    stack: WebRouteTarget[]
+  }
+}
+
+const DEFAULT_CONFIG: ResolvedWebRoutingConfig = {
+  mode: 'memory',
+  base: '/',
+}
+
+let resolvedConfig = { ...DEFAULT_CONFIG }
+let knownPageIds = new Set<string>()
+let popstateHandler: (() => void) | undefined
+let hashchangeHandler: (() => void) | undefined
+
+function normalizeBase(base?: string) {
+  if (!base?.trim()) {
+    return '/'
+  }
+  const normalized = base.trim().replace(/\\/g, '/').replace(/^\/*/, '/').replace(/\/*$/, '')
+  return normalized || '/'
+}
+
+export function resolveWebRoutingConfig(config?: WebRoutingConfig): ResolvedWebRoutingConfig {
+  return {
+    mode: config?.mode === 'history' || config?.mode === 'hash' ? config.mode : 'memory',
+    base: normalizeBase(config?.base),
+  }
+}
+
+function isBrowserHistoryAvailable() {
+  return typeof window !== 'undefined'
+    && typeof window.history?.pushState === 'function'
+    && typeof window.history?.replaceState === 'function'
+}
+
+function normalizePath(path: string) {
+  const decoded = decodeURIComponent(path || '/')
+  const withoutQuery = decoded.split('?')[0] ?? '/'
+  const withoutLeading = withoutQuery.replace(/^\/+/, '').replace(/\/+$/, '')
+  return withoutLeading.replace(/\.html$/, '')
+}
+
+function parseQuery(search: string) {
+  const query: Record<string, string> = {}
+  const params = new URLSearchParams(search.startsWith('?') ? search : `?${search}`)
+  for (const [key, value] of params.entries()) {
+    query[key] = value
+  }
+  return query
+}
+
+function toQueryString(query: Record<string, string>) {
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(query)) {
+    params.set(key, value)
+  }
+  const search = params.toString()
+  return search ? `?${search}` : ''
+}
+
+function resolvePageId(path: string) {
+  const normalized = normalizePath(path)
+  if (knownPageIds.has(normalized)) {
+    return normalized
+  }
+  const indexId = `${normalized}/index`
+  if (knownPageIds.has(indexId)) {
+    return indexId
+  }
+  return undefined
+}
+
+function resolveTargetFromUrl(url: URL) {
+  if (resolvedConfig.mode === 'hash') {
+    const rawHash = url.hash.replace(/^#\/?/, '')
+    const [path, query = ''] = rawHash.split('?')
+    const id = resolvePageId(path ?? '')
+    return id ? { id, query: parseQuery(query) } : undefined
+  }
+
+  const base = resolvedConfig.base === '/' ? '' : resolvedConfig.base
+  const matchesBase = !base || url.pathname === base || url.pathname.startsWith(`${base}/`)
+  const path = matchesBase ? url.pathname.slice(base.length) : url.pathname
+  const id = resolvePageId(path)
+  return id ? { id, query: parseQuery(url.search) } : undefined
+}
+
+export function readWebRouteTarget(pageIds: string[], url?: string): WebRouteTarget | undefined {
+  knownPageIds = new Set(pageIds)
+  if (resolvedConfig.mode === 'memory' || typeof URL === 'undefined') {
+    return undefined
+  }
+  const runtimeUrl = url ?? (typeof window !== 'undefined' ? window.location.href : undefined)
+  if (!runtimeUrl) {
+    return undefined
+  }
+  try {
+    return resolveTargetFromUrl(new URL(runtimeUrl, 'http://weapp-vite.local'))
+  }
+  catch {
+    return undefined
+  }
+}
+
+function formatRouteUrl(target: WebRouteTarget) {
+  const query = toQueryString(target.query)
+  const path = `${target.id}${query}`
+  if (resolvedConfig.mode === 'hash') {
+    const prefix = resolvedConfig.base === '/' ? '' : resolvedConfig.base
+    return `${prefix}/#/${path}`
+  }
+  const prefix = resolvedConfig.base === '/' ? '' : resolvedConfig.base
+  return `${prefix}/${path}`
+}
+
+function toHistoryState(entries: PageStackEntry[]): WebRouteHistoryState {
+  return {
+    __weappWebRuntime: {
+      stack: entries.map(entry => ({
+        id: entry.id,
+        query: { ...entry.query },
+      })),
+    },
+  }
+}
+
+function resolveCurrentUrl() {
+  if (typeof window === 'undefined') {
+    return undefined
+  }
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`
+}
+
+export function disposeWebRouting() {
+  if (typeof window !== 'undefined') {
+    if (popstateHandler) {
+      window.removeEventListener('popstate', popstateHandler)
+    }
+    if (hashchangeHandler) {
+      window.removeEventListener('hashchange', hashchangeHandler)
+    }
+  }
+  popstateHandler = undefined
+  hashchangeHandler = undefined
+  resolvedConfig = { ...DEFAULT_CONFIG }
+  knownPageIds = new Set()
+}
+
+export function configureWebRouting(
+  config: WebRoutingConfig | undefined,
+  pageIds: string[],
+  onPopState: (target: WebRouteTarget | undefined, state: WebRouteHistoryState | undefined) => void,
+) {
+  disposeWebRouting()
+  resolvedConfig = resolveWebRoutingConfig(config)
+  knownPageIds = new Set(pageIds)
+  if (resolvedConfig.mode === 'memory' || typeof window === 'undefined') {
+    return resolvedConfig
+  }
+
+  popstateHandler = () => {
+    const state = window.history.state as WebRouteHistoryState | undefined
+    onPopState(readWebRouteTarget(pageIds), state)
+  }
+  window.addEventListener('popstate', popstateHandler)
+  if (resolvedConfig.mode === 'hash') {
+    hashchangeHandler = () => {
+      const state = window.history.state as WebRouteHistoryState | undefined
+      onPopState(readWebRouteTarget(pageIds), state)
+    }
+    window.addEventListener('hashchange', hashchangeHandler)
+  }
+  return resolvedConfig
+}
+
+export function syncWebRouting(entries: PageStackEntry[], operation: 'push' | 'replace') {
+  if (resolvedConfig.mode === 'memory' || !isBrowserHistoryAvailable() || !entries.length) {
+    return
+  }
+  const target = entries[entries.length - 1]!
+  const url = formatRouteUrl({ id: target.id, query: target.query })
+  const state = toHistoryState(entries)
+  if (operation === 'push') {
+    window.history.pushState(state, '', url)
+  }
+  else {
+    window.history.replaceState(state, '', url)
+  }
+}
+
+export function getWebHistoryStack(state: WebRouteHistoryState | undefined) {
+  const stack = state?.__weappWebRuntime?.stack
+  return Array.isArray(stack) ? stack : undefined
+}
+
+export function getWebRoutingConfig() {
+  return { ...resolvedConfig }
+}
+
+export function getWebRoutingUrl() {
+  return resolveCurrentUrl()
+}

--- a/packages-runtime/web/test/history.test.ts
+++ b/packages-runtime/web/test/history.test.ts
@@ -1,0 +1,140 @@
+import type { PageStackEntry } from '../src/runtime/polyfill/routeRuntime/options'
+import {
+  configureWebRouting,
+  disposeWebRouting,
+  getWebHistoryStack,
+  getWebRoutingConfig,
+  readWebRouteTarget,
+  resolveWebRoutingConfig,
+  syncWebRouting,
+} from '../src/runtime/polyfill/routeRuntime/history'
+
+interface FakeWindow {
+  location: Location
+  history: History
+  addEventListener: (type: string, listener: () => void) => void
+  removeEventListener: (type: string, listener: () => void) => void
+  listeners?: Map<string, Set<() => void>>
+}
+
+function createFakeWindow(initialUrl: string) {
+  let currentUrl = new URL(initialUrl)
+  let state: unknown
+  const listeners = new Map<string, Set<() => void>>()
+  const location = {
+    get href() {
+      return currentUrl.href
+    },
+    get pathname() {
+      return currentUrl.pathname
+    },
+    get search() {
+      return currentUrl.search
+    },
+    get hash() {
+      return currentUrl.hash
+    },
+  } as Location
+  const history = {
+    get state() {
+      return state
+    },
+    pushState(nextState: unknown, _title: string, nextUrl: string) {
+      state = nextState
+      currentUrl = new URL(nextUrl, currentUrl)
+    },
+    replaceState(nextState: unknown, _title: string, nextUrl: string) {
+      state = nextState
+      currentUrl = new URL(nextUrl, currentUrl)
+    },
+  } as History
+  const fakeWindow: FakeWindow = {
+    location,
+    history,
+    listeners,
+    addEventListener(type, listener) {
+      const bucket = listeners.get(type) ?? new Set()
+      bucket.add(listener)
+      listeners.set(type, bucket)
+    },
+    removeEventListener(type, listener) {
+      listeners.get(type)?.delete(listener)
+    },
+  }
+  return { fakeWindow, listeners }
+}
+
+function withWindow(fakeWindow: FakeWindow, callback: () => void) {
+  const previous = (globalThis as Record<string, unknown>).window
+  Object.assign(globalThis, { window: fakeWindow })
+  try {
+    callback()
+  }
+  finally {
+    disposeWebRouting()
+    if (previous === undefined) {
+      delete (globalThis as Record<string, unknown>).window
+    }
+    else {
+      Object.assign(globalThis, { window: previous })
+    }
+  }
+}
+
+function entry(id: string, query: Record<string, string> = {}): PageStackEntry {
+  return { id, query, active: true }
+}
+
+describe('web runtime browser routing', () => {
+  it('normalizes routing mode and deployment base', () => {
+    expect(resolveWebRoutingConfig()).toEqual({ mode: 'memory', base: '/' })
+    expect(resolveWebRoutingConfig({ mode: 'history', base: ' /mini/ ' })).toEqual({
+      mode: 'history',
+      base: '/mini',
+    })
+    expect(getWebRoutingConfig()).toEqual({ mode: 'memory', base: '/' })
+  })
+
+  it('reads a history deep link and replaces the initial entry', () => {
+    const { fakeWindow } = createFakeWindow('https://example.test/mini/pages/detail/index?sku=42')
+    withWindow(fakeWindow, () => {
+      const onPopState = vi.fn()
+      configureWebRouting({ mode: 'history', base: '/mini' }, [
+        'pages/index/index',
+        'pages/detail/index',
+      ], onPopState)
+      expect(readWebRouteTarget(['pages/index/index', 'pages/detail/index'])).toEqual({
+        id: 'pages/detail/index',
+        query: { sku: '42' },
+      })
+      syncWebRouting([entry('pages/detail/index', { sku: '42' })], 'replace')
+      expect(fakeWindow.location.pathname).toBe('/mini/pages/detail/index')
+      expect(fakeWindow.location.search).toBe('?sku=42')
+      expect(getWebHistoryStack(fakeWindow.history.state)).toEqual([
+        { id: 'pages/detail/index', query: { sku: '42' } },
+      ])
+      fakeWindow.listeners?.get('popstate')?.forEach(listener => listener())
+      expect(onPopState).toHaveBeenCalledWith(
+        { id: 'pages/detail/index', query: { sku: '42' } },
+        fakeWindow.history.state,
+      )
+    })
+  })
+
+  it('supports hash routing for static hosting and cleans listeners', () => {
+    const { fakeWindow, listeners } = createFakeWindow('https://example.test/mini/#/pages/index/index')
+    withWindow(fakeWindow, () => {
+      configureWebRouting({ mode: 'hash', base: '/mini' }, ['pages/index/index'], vi.fn())
+      expect(readWebRouteTarget(['pages/index/index'])).toEqual({
+        id: 'pages/index/index',
+        query: {},
+      })
+      syncWebRouting([entry('pages/index/index')], 'push')
+      expect(fakeWindow.location.hash).toBe('#/pages/index/index')
+      expect(listeners.get('popstate')?.size).toBe(1)
+      expect(listeners.get('hashchange')?.size).toBe(1)
+    })
+    expect(listeners.get('popstate')?.size).toBe(0)
+    expect(listeners.get('hashchange')?.size).toBe(0)
+  })
+})

--- a/packages-runtime/web/test/plugin.test.ts
+++ b/packages-runtime/web/test/plugin.test.ts
@@ -66,6 +66,10 @@ describe('weappWebPlugin', () => {
           maxWidth: 414,
           desktopBreakpoint: 720,
         },
+        routing: {
+          mode: 'history',
+          base: '/mini',
+        },
       },
     })
     await (plugin.configResolved as ((...args: any[]) => any))?.call({ warn() {} } as any, { root, command: 'build' } as any)
@@ -76,7 +80,7 @@ describe('weappWebPlugin', () => {
     const code = (plugin.load as ((...args: any[]) => any))?.call({} as any, entryId) as string
     expect(code).toContain('initializePageRoutes(["pages/index/index"]')
     expect(code).toContain('"tabBar":{"color":"#666666","selectedColor":"#07c160","backgroundColor":"#ffffff","borderStyle":"black","position":"bottom","custom":false,"list":[{"pagePath":"pages/index/index","text":"首页","iconPath":"assets/home.png"}]}')
-    expect(code).toContain('"runtime":{"executionMode":"safe","warnings":{"level":"off","dedupe":false},"viewport":{"mode":"responsive","maxWidth":414,"desktopBreakpoint":720}}')
+    expect(code).toContain('"runtime":{"executionMode":"safe","warnings":{"level":"off","dedupe":false},"viewport":{"mode":"responsive","maxWidth":414,"desktopBreakpoint":720},"routing":{"mode":"history","base":"/mini"}}')
     expect(code).toContain('"rpx":{"designWidth":750}')
   })
 

--- a/website/config/web.md
+++ b/website/config/web.md
@@ -66,6 +66,10 @@ export default defineConfig({
             maxWidth: 375,
             desktopBreakpoint: 600,
           },
+          routing: {
+            mode: 'history',
+            base: '/mini',
+          },
         },
       },
       vite: {
@@ -137,6 +141,12 @@ Web 产物输出目录，默认一般是 `dist/web`。
   - 设备容器最大宽度，默认 `375`
 - `runtime.viewport.desktopBreakpoint`
   - 开始使用居中设备容器的浏览器宽度，默认 `600`
+- `runtime.routing.mode`
+  - `memory`：只维护 Web Runtime 页面栈，不修改地址栏（默认）
+  - `history`：使用真实路径，支持深链接与浏览器前进/后退
+  - `hash`：使用 `#/pages/...`，适合静态托管
+- `runtime.routing.base`
+  - Web 项目的部署目录前缀，例如 `/mini`
 
 默认视口同时约束页面滚动、导航栏和 `fixed` 元素；`rpx` 也按设备容器宽度计算，而不是按桌面浏览器窗口计算。
 

--- a/website/guide/web-compat-matrix.md
+++ b/website/guide/web-compat-matrix.md
@@ -92,6 +92,7 @@ keywords:
 | `wx.setTabBarBadge` / `removeTabBarBadge` / `showTabBarRedDot` / `hideTabBarRedDot`                      | `✅` | 支持标准 tabBar badge 与红点状态；非法 index 按微信形状回调和 Promise 失败。                            |
 | `wx.loadSubPackage` / `wx.preloadSubpackage`                                                             | `🟡` | 当前提供 no-op 成功桥接，主要用于兼容分包加载调用链，不执行真实下载与预加载流程。                       |
 | `wx.navigateBack`                                                                                        | `✅` | 支持 `delta` 回退。                                                                                     |
+| 浏览器深链接与前进/后退                                                                                  | `✅` | `runtime.routing` 支持 `history` / `hash`；默认 `memory`，可按部署目录设置 `base`。                     |
 | `wx.setNavigationBarTitle`                                                                               | `🟡` | 依赖默认导航栏组件存在。                                                                                |
 | `wx.setNavigationBarColor`                                                                               | `🟡` | 依赖默认导航栏组件存在。                                                                                |
 | `wx.setBackgroundColor` / `wx.setBackgroundTextStyle`                                                    | `🟡` | 提供页面背景与文本样式的近似桥接，基于 DOM 样式设置，不等价小程序原生渲染语义。                         |

--- a/website/packages/web.md
+++ b/website/packages/web.md
@@ -47,6 +47,10 @@ export default defineConfig({
           maxWidth: 375,
           desktopBreakpoint: 600,
         },
+        routing: {
+          mode: 'history',
+          base: '/mini',
+        },
       },
     }),
   ],
@@ -80,6 +84,15 @@ export default defineConfig({
 - `showTabBar` / `hideTabBar`、`setTabBarItem`、`setTabBarStyle`、badge 与 red-dot API 会真实更新布局和视觉状态
 
 需要保留旧的浏览器全宽行为时，将 `runtime.viewport.mode` 设置为 `responsive`。
+
+## 浏览器路由
+
+默认 `runtime.routing.mode` 为 `memory`，只维护小程序页面栈。部署到生产站点时可选择：
+
+- `history`：使用 `/pages/foo/index` 路径，支持深链接与浏览器前进/后退；服务端需要把未知路径回退到 Web 入口。
+- `hash`：使用 `#/pages/foo/index`，适合静态托管，不需要服务端配置。
+
+`runtime.routing.base` 用于部署在子目录的站点，例如 `/mini`。两种浏览器模式都会把页面栈和地址栏状态同步，未配置时保持原有 `memory` 行为。
 
 ## 宿主注入
 

--- a/website/public/llms-index.json
+++ b/website/public/llms-index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-07-25T02:00:33.346Z",
+  "generatedAt": "2026-07-25T03:11:04.525Z",
   "site": "https://vite.icebreaker.top",
   "count": 271,
   "items": [
@@ -5883,6 +5883,7 @@
         "Vite 插件接入",
         "运行时能力",
         "视觉与组件适配",
+        "浏览器路由",
         "宿主注入",
         "能力边界"
       ],

--- a/website/public/seo-quality-report.json
+++ b/website/public/seo-quality-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-25T02:02:00.243Z",
+  "generatedAt": "2026-07-25T03:11:07.044Z",
   "site": "https://vite.icebreaker.top",
   "totals": {
     "files": 271,


### PR DESCRIPTION
## 变更内容

- 为 Web Runtime 增加可配置的 `memory`、`history`、`hash` 路由模式。
- 支持基于部署目录的深链接首屏、地址栏同步及浏览器前进/后退恢复页面栈。
- 为 demo 增加 history 路由配置，并补充深链接浏览器 E2E。
- 更新 `@weapp-vite/web` README、Web 配置文档、兼容矩阵和网站生成索引。

## 验证

- `pnpm --filter @weapp-vite/web typecheck`
- `pnpm --filter @weapp-vite/web test`
- 相关 ESLint 检查
- `pnpm --filter @weapp-vite/web build`
- `pnpm --filter weapp-vite-web-demo exec wv build -p h5`
- `pnpm --filter website-weapp-vite build`
- `pnpm e2e:web`（17 passed）
- changeset/catalog 检查

## 发布说明

包含 `@weapp-vite/web` minor changeset；未修改 `weapp-vite`、模板或脚手架，因此不联动 `create-weapp-vite`。