### PR TITLE
feat(web-runtime): 增加页面 Head 与首屏资源提示

### DIFF
--- a/.changeset/web-runtime-seo-head.md
+++ b/.changeset/web-runtime-seo-head.md
@@ -1,0 +1,5 @@
+---
+"@weapp-vite/web": minor
+---
+
+为 Web Runtime 增加页面 Head 与首屏资源提示能力：路由切换会同步小程序页面标题、description 和 canonical，并支持去重注入浏览器 Resource Hints。

--- a/apps/weapp-vite-web-demo/vite.config.ts
+++ b/apps/weapp-vite-web-demo/vite.config.ts
@@ -39,6 +39,16 @@ export default defineConfig({
           routing: {
             mode: 'history',
           },
+          seo: {
+            defaultTitle: 'weapp-vite Web Runtime',
+            titleTemplate: '%s | weapp-vite',
+            description: '原生小程序页面的 Web Runtime 演示。',
+          },
+          resourceHints: {
+            links: [
+              { rel: 'preconnect', href: 'https://static.example.test' },
+            ],
+          },
         },
       },
       vite: {

--- a/e2e/web-runtime/web-demo.test.ts
+++ b/e2e/web-runtime/web-demo.test.ts
@@ -435,6 +435,26 @@ describeWeb.sequential('web runtime browser baseline (weapp-vite-web-demo)', () 
     }
   })
 
+  it('syncs browser head metadata with the active mini-program page', async () => {
+    const page = await browser!.newPage()
+    try {
+      await openHomePage(page)
+      await expect.poll(() => page.title()).toBe('初始模板 | weapp-vite')
+      await expect.poll(() => page.locator('meta[name="description"]').getAttribute('content'))
+        .toBe('原生小程序页面的 Web Runtime 演示。')
+      await expect.poll(() => page.locator('link[rel="preconnect"][href="https://static.example.test"]').count())
+        .toBe(1)
+
+      await navigateToInteractiveFromHome(page)
+      await expect.poll(() => page.title()).toBe('互动场景 | weapp-vite')
+      await page.goBack()
+      await expect.poll(() => page.title()).toBe('初始模板 | weapp-vite')
+    }
+    finally {
+      await page.close()
+    }
+  })
+
   it('preserves page instance, lifecycle state and scroll position after navigateBack', async () => {
     const page = await browser!.newPage()
     try {

--- a/packages-runtime/web/README.md
+++ b/packages-runtime/web/README.md
@@ -128,6 +128,34 @@ setWebRuntimeHost({
 - `redirectTo` 只替换并卸载当前页面；`reLaunch` 会从栈顶开始卸载全部旧页面后挂载目标页面。
 - `getCurrentPages()` 返回当前活动路由栈；其他 tab 页面可保活但不会混入当前 tab 栈。路由 API 支持 `success` / `fail` / `complete` 回调与 Promise 结果。
 
+## 页面 Head 与首屏资源
+
+启用 `runtime.seo` 后，页面配置中的 `navigationBarTitleText` 会在路由切换时同步到 `document.title`，并可统一写入 description 与 canonical。`titleTemplate` 使用 `%s` 代表当前页面标题：
+
+```ts
+weappWebPlugin({
+  runtime: {
+    seo: {
+      defaultTitle: '商城',
+      titleTemplate: '%s | Web Demo',
+      description: '小程序页面的 Web 运行时演示。',
+    },
+  },
+})
+```
+
+`resourceHints.links` 会去重注入 `preconnect`、`dns-prefetch`、`prefetch` 或 `preload` 链接，适合声明首屏字体、图片和 API 域名：
+
+```ts
+const runtime = {
+  resourceHints: {
+    links: [{ rel: 'preconnect', href: 'https://cdn.example.com' }],
+  },
+}
+```
+
+Head 管理只在浏览器文档存在时生效，不会把客户端路由误认为完整 SSR；服务端预渲染仍需要后续接入独立的 HTML 入口。
+
 ## App Shell 与 tabBar
 
 - Vite 插件会读取 `app.json.tabBar`，标准 tabBar 在 Web 侧使用受设备视口约束的 App Shell 渲染；颜色、背景、边框、图标、文字和底部安全区由同一份配置驱动。
@@ -145,4 +173,4 @@ setWebRuntimeHost({
 - 更全面的模板语法和原生组件语义
 - 继续扩展组件属性系统和页面级滚动事件
 - 全局 API 兼容层与更精细的样式适配
-- SSR、SEO 友好的页面容器与首屏优化
+- SSR / 服务端预渲染入口

--- a/packages-runtime/web/src/plugin/entry.ts
+++ b/packages-runtime/web/src/plugin/entry.ts
@@ -55,6 +55,12 @@ export function generateEntryModule(
   if (pluginOptions?.runtime?.routing) {
     runtimeOptions.routing = pluginOptions.runtime.routing
   }
+  if (pluginOptions?.runtime?.seo) {
+    runtimeOptions.seo = pluginOptions.runtime.seo
+  }
+  if (pluginOptions?.runtime?.resourceHints) {
+    runtimeOptions.resourceHints = pluginOptions.runtime.resourceHints
+  }
   if (Object.keys(runtimeOptions).length > 0) {
     initOptions.runtime = runtimeOptions
   }

--- a/packages-runtime/web/src/plugin/register.ts
+++ b/packages-runtime/web/src/plugin/register.ts
@@ -84,6 +84,9 @@ function overwriteCall(
   if (styleIdent) {
     metaParts.push(`style: ${styleIdent}`)
   }
+  if (meta.navigationBar) {
+    metaParts.push(`navigationBar: ${JSON.stringify(meta.navigationBar)}`)
+  }
   const metaCode = `{ ${metaParts.join(', ')} }`
   s.overwrite(callee.start!, callee.end!, registerName)
   s.appendLeft(insertPosition, `, ${metaCode}`)

--- a/packages-runtime/web/src/plugin/scan.ts
+++ b/packages-runtime/web/src/plugin/scan.ts
@@ -164,6 +164,10 @@ export async function scanProject({ srcRoot, warn, state }: ScanProjectOptions) 
     const pageJsonBasePath = join(srcRoot, `${pageId}.json`)
     const pageJsonPath = await resolveJsonPath(pageJsonBasePath)
     const pageJson = pageJsonPath ? await readJsonFile(pageJsonPath) : undefined
+    const navigationConfig = mergeNavigationConfig(
+      appNavigationDefaults,
+      pageJson ? pickNavigationConfig(pageJson) : {},
+    )
 
     state.moduleMeta.set(normalizePath(script), {
       kind: 'page',
@@ -171,6 +175,7 @@ export async function scanProject({ srcRoot, warn, state }: ScanProjectOptions) 
       scriptPath: script,
       templatePath: template,
       stylePath: style,
+      navigationBar: Object.keys(navigationConfig).length > 0 ? navigationConfig : undefined,
     })
 
     pages.set(script, {
@@ -217,15 +222,7 @@ export async function scanProject({ srcRoot, warn, state }: ScanProjectOptions) 
       return
     }
 
-    if (pageJson) {
-      state.pageNavigationMap.set(
-        normalizePath(template),
-        mergeNavigationConfig(appNavigationDefaults, pickNavigationConfig(pageJson)),
-      )
-      return
-    }
-
-    state.pageNavigationMap.set(normalizePath(template), { ...appNavigationDefaults })
+    state.pageNavigationMap.set(normalizePath(template), navigationConfig)
   }
 
   const appJsonBasePath = join(srcRoot, 'app.json')
@@ -247,6 +244,9 @@ export async function scanProject({ srcRoot, warn, state }: ScanProjectOptions) 
         },
       })
     }
+
+    const windowConfig = isRecord(appJson?.window) ? appJson.window : undefined
+    appNavigationDefaults = pickNavigationConfig(windowConfig)
 
     if (appJson?.pages && Array.isArray(appJson.pages)) {
       for (const page of appJson.pages) {
@@ -271,8 +271,6 @@ export async function scanProject({ srcRoot, warn, state }: ScanProjectOptions) 
       }
     }
 
-    const windowConfig = isRecord(appJson?.window) ? appJson.window : undefined
-    appNavigationDefaults = pickNavigationConfig(windowConfig)
     appTabBar = normalizeWebTabBarConfig(appJson?.tabBar)
   }
 

--- a/packages-runtime/web/src/plugin/types.ts
+++ b/packages-runtime/web/src/plugin/types.ts
@@ -1,6 +1,7 @@
 import type { NavigationBarConfig } from '../compiler/wxml'
 import type { WxssTransformOptions } from '../css/wxss'
 import type { WebRoutingConfig } from '../runtime/polyfill/routeRuntime/history'
+import type { WebResourceHintsConfig, WebSeoConfig } from '../runtime/seo'
 import type { WebTabBarConfig } from '../shared/tabBar'
 
 export interface WeappWebPluginOptions {
@@ -51,6 +52,10 @@ export interface WeappWebPluginOptions {
     }
     /** Web 路由与浏览器地址栏同步策略。 */
     routing?: WebRoutingConfig
+    /** 页面切换时同步浏览器 Head 的 SEO 配置。 */
+    seo?: WebSeoConfig
+    /** 首屏或关键资源的浏览器 Resource Hints。 */
+    resourceHints?: WebResourceHintsConfig
   }
   /**
    * weapp-vite runtime provider 注入的内部绑定。
@@ -69,6 +74,7 @@ export interface ModuleMeta {
   scriptPath: string
   templatePath?: string
   stylePath?: string
+  navigationBar?: NavigationBarConfig
 }
 
 export interface PageEntry {

--- a/packages-runtime/web/src/runtime/index.ts
+++ b/packages-runtime/web/src/runtime/index.ts
@@ -167,6 +167,14 @@ export { createRenderContext } from './renderContext'
 export type { RenderContext } from './renderContext'
 export { setupRpx } from './rpx'
 export type { RpxConfig } from './rpx'
+export {
+  configureWebSeo,
+  resetWebDocumentHead,
+  setupWebResourceHints,
+  syncWebDocumentHead,
+  updateWebDocumentTitle,
+} from './seo'
+export type { WebPageHead, WebResourceHint, WebResourceHintRelation, WebResourceHintsConfig, WebSeoConfig } from './seo'
 export { injectStyle, removeStyle } from './style'
 export { createTemplate, renderTemplate } from './template'
 export type { TemplateRenderer, TemplateScope } from './template'

--- a/packages-runtime/web/src/runtime/polyfill/navigationBarRuntime.ts
+++ b/packages-runtime/web/src/runtime/polyfill/navigationBarRuntime.ts
@@ -1,3 +1,5 @@
+import { updateWebDocumentTitle } from '../seo'
+
 interface RuntimeWarningOptions {
   key: string
   context: string
@@ -45,6 +47,7 @@ export function createNavigationBarRuntimeBridge(
       }
       if (options?.title !== undefined) {
         bar.setAttribute('title', options.title)
+        updateWebDocumentTitle(options.title)
       }
       return Promise.resolve()
     },

--- a/packages-runtime/web/src/runtime/polyfill/routeRuntime.ts
+++ b/packages-runtime/web/src/runtime/polyfill/routeRuntime.ts
@@ -2,6 +2,7 @@ import type { WebTabBarConfig } from '../../shared/tabBar'
 import type { ButtonFormConfig } from '../button'
 import type { ComponentPublicInstance } from '../component'
 import type { NavigationBarMetrics } from '../navigationBar'
+import type { WebResourceHintsConfig, WebSeoConfig } from '../seo'
 import type { WebViewportConfig } from '../viewport'
 import type { WebRouteHistoryState, WebRouteTarget, WebRoutingConfig } from './routeRuntime/history'
 import type { AppLaunchOptions, AppRuntime, ComponentRawOptions, ComponentRecord, NavigateBackOptions, PageRawOptions, PageRecord, PageStackEntry, RegisterMeta, RouteOptions } from './routeRuntime/options'
@@ -17,6 +18,7 @@ import { setRuntimeExecutionMode } from '../execution'
 import { ensureNativeComponentsDefined } from '../nativeComponents'
 import { ensureNavigationBarDefined, setNavigationBarMetrics } from '../navigationBar'
 import { setupRpx } from '../rpx'
+import { configureWebSeo, setupWebResourceHints, syncWebDocumentHead } from '../seo'
 import { setupWebViewport } from '../viewport'
 import { setRuntimeWarningOptions } from '../warning'
 import {
@@ -78,8 +80,17 @@ function ensureAppLaunched(entry: PageStackEntry) {
 
 const pageStack = new PageStackRuntime(pageRegistry, ensureAppLaunched)
 
+function syncCurrentWebDocument() {
+  const current = pageStack.entries[pageStack.entries.length - 1]
+  syncWebDocumentHead({
+    route: current?.id,
+    title: current ? pageRegistry.get(current.id)?.navigationBar?.title : undefined,
+  })
+}
+
 function syncCurrentWebRoute(operation: 'push' | 'replace') {
   syncWebRouting(pageStack.entries, operation)
+  syncCurrentWebDocument()
 }
 
 function reconcileWebRoute(target: WebRouteTarget | undefined, state: WebRouteHistoryState | undefined) {
@@ -101,11 +112,13 @@ function reconcileWebRoute(target: WebRouteTarget | undefined, state: WebRouteHi
       pageStack.relaunch(last.id, { ...last.query })
     }
     syncTabBarRoute(pageStack.entries[pageStack.entries.length - 1]?.id ?? '')
+    syncCurrentWebDocument()
     return
   }
   if (target && pageRegistry.has(target.id)) {
     pageStack.relaunch(target.id, { ...target.query })
     syncTabBarRoute(target.id)
+    syncCurrentWebDocument()
   }
 }
 
@@ -152,12 +165,16 @@ export function initializePageRoutes(
       }
       viewport?: WebViewportConfig
       routing?: WebRoutingConfig
+      seo?: WebSeoConfig
+      resourceHints?: WebResourceHintsConfig
     }
   },
 ) {
   setRuntimeExecutionMode(options?.runtime?.executionMode)
   setRuntimeWarningOptions(options?.runtime?.warnings)
   setupWebViewport(options?.runtime?.viewport)
+  configureWebSeo(options?.runtime?.seo)
+  setupWebResourceHints(options?.runtime?.resourceHints)
   configureWebRouting(options?.runtime?.routing, ids, reconcileWebRoute)
   ensureNativeComponentsDefined()
   pageOrder = Array.from(new Set(ids))
@@ -196,6 +213,7 @@ export function registerPage<T extends PageRawOptions | undefined>(options: T, m
   const existing = pageRegistry.get(meta.id)
   if (existing) {
     existing.hooks = normalized.hooks
+    existing.navigationBar = meta.navigationBar
     const component = augmentPageComponentOptions(normalized.component, existing)
     defineComponent(tag, {
       template,
@@ -208,6 +226,7 @@ export function registerPage<T extends PageRawOptions | undefined>(options: T, m
     tag,
     hooks: normalized.hooks,
     instances: new Set(),
+    navigationBar: meta.navigationBar,
   }
   const component = augmentPageComponentOptions(normalized.component, record)
   defineComponent(tag, {

--- a/packages-runtime/web/src/runtime/polyfill/routeRuntime/options.ts
+++ b/packages-runtime/web/src/runtime/polyfill/routeRuntime/options.ts
@@ -1,3 +1,4 @@
+import type { NavigationBarConfig } from '../../../compiler/wxml'
 import type { ComponentOptions, ComponentPublicInstance } from '../../component'
 import type { TemplateRenderer } from '../../template'
 import type { MiniProgramAsyncOptions, MiniProgramBaseResult } from '../types'
@@ -6,6 +7,7 @@ export interface RegisterMeta {
   id: string
   template?: TemplateRenderer
   style?: string
+  navigationBar?: NavigationBarConfig
 }
 
 export interface PageHooks {
@@ -20,6 +22,7 @@ export interface PageRecord {
   tag: string
   hooks: PageHooks
   instances: Set<ComponentPublicInstance>
+  navigationBar?: NavigationBarConfig
 }
 
 export interface ComponentRecord {

--- a/packages-runtime/web/src/runtime/seo/index.ts
+++ b/packages-runtime/web/src/runtime/seo/index.ts
@@ -1,0 +1,157 @@
+export type WebResourceHintRelation = 'preconnect' | 'dns-prefetch' | 'prefetch' | 'preload'
+
+export interface WebResourceHint {
+  href: string
+  rel: WebResourceHintRelation
+  as?: string
+  type?: string
+  crossOrigin?: 'anonymous' | 'use-credentials'
+}
+
+export interface WebResourceHintsConfig {
+  links?: WebResourceHint[]
+}
+
+export interface WebSeoConfig {
+  enabled?: boolean
+  defaultTitle?: string
+  titleTemplate?: string
+  description?: string
+  canonical?: boolean
+}
+
+export interface WebPageHead {
+  route?: string
+  title?: string
+}
+
+const HEAD_MARKER = 'data-weapp-web-head'
+const HEAD_OWNER = 'weapp-web-runtime'
+let seoConfig: WebSeoConfig = { enabled: false }
+
+function getDocument(): Document | undefined {
+  return typeof document === 'undefined' ? undefined : document
+}
+
+function findOrCreateMeta(documentRef: Document, name: string) {
+  const selector = `meta[${HEAD_MARKER}="${HEAD_OWNER}"][name="${name}"]`
+  const existing = documentRef.head?.querySelector(selector) as HTMLMetaElement | null
+  if (existing) {
+    return existing
+  }
+  const meta = documentRef.createElement('meta')
+  meta.setAttribute('name', name)
+  meta.setAttribute(HEAD_MARKER, HEAD_OWNER)
+  documentRef.head?.append(meta)
+  return meta
+}
+
+function resolveTitle(title: string | undefined, route: string | undefined) {
+  const raw = title || seoConfig.defaultTitle || route || ''
+  if (!seoConfig.titleTemplate || !raw) {
+    return raw
+  }
+  return seoConfig.titleTemplate.includes('%s')
+    ? seoConfig.titleTemplate.replaceAll('%s', raw)
+    : `${raw}${seoConfig.titleTemplate}`
+}
+
+function resolveCanonicalUrl() {
+  if (typeof window === 'undefined' || !window.location) {
+    return undefined
+  }
+  try {
+    const url = new URL(window.location.href)
+    url.search = ''
+    url.hash = ''
+    return url.href
+  }
+  catch {
+    return undefined
+  }
+}
+
+export function configureWebSeo(next?: WebSeoConfig) {
+  seoConfig = next
+    ? { enabled: next.enabled !== false, ...next }
+    : { enabled: false }
+  const documentRef = getDocument()
+  if (!documentRef || seoConfig.enabled === false) {
+    return
+  }
+  if (seoConfig.description !== undefined) {
+    findOrCreateMeta(documentRef, 'description').content = seoConfig.description
+  }
+}
+
+export function syncWebDocumentHead(head: WebPageHead) {
+  const documentRef = getDocument()
+  if (!documentRef || seoConfig.enabled === false) {
+    return
+  }
+  const title = resolveTitle(head.title, head.route)
+  if (title) {
+    documentRef.title = title
+  }
+  if (seoConfig.description !== undefined) {
+    findOrCreateMeta(documentRef, 'description').content = seoConfig.description
+  }
+  if (seoConfig.canonical !== false) {
+    const canonical = resolveCanonicalUrl()
+    if (canonical && documentRef.head) {
+      let link = documentRef.head.querySelector(`link[${HEAD_MARKER}="${HEAD_OWNER}"][rel="canonical"]`) as HTMLLinkElement | null
+      if (!link) {
+        link = documentRef.createElement('link')
+        link.rel = 'canonical'
+        link.setAttribute(HEAD_MARKER, HEAD_OWNER)
+        documentRef.head.append(link)
+      }
+      link.href = canonical
+    }
+  }
+}
+
+export function updateWebDocumentTitle(title: string) {
+  syncWebDocumentHead({ title })
+}
+
+export function setupWebResourceHints(config?: WebResourceHintsConfig) {
+  const documentRef = getDocument()
+  if (!documentRef?.head || !config?.links?.length) {
+    return
+  }
+  for (const hint of config.links) {
+    if (!hint || typeof hint.href !== 'string' || !hint.href || typeof hint.rel !== 'string') {
+      continue
+    }
+    const selector = `link[${HEAD_MARKER}="${HEAD_OWNER}"][rel="${hint.rel}"][href="${hint.href}"]`
+    let link = documentRef.head.querySelector(selector) as HTMLLinkElement | null
+    if (!link) {
+      link = documentRef.createElement('link')
+      link.rel = hint.rel
+      link.href = hint.href
+      link.setAttribute(HEAD_MARKER, HEAD_OWNER)
+      documentRef.head.append(link)
+    }
+    if (hint.as) {
+      link.as = hint.as
+    }
+    if (hint.type) {
+      link.type = hint.type
+    }
+    if (hint.crossOrigin) {
+      link.crossOrigin = hint.crossOrigin
+    }
+  }
+}
+
+export function resetWebDocumentHead() {
+  const documentRef = getDocument()
+  if (!documentRef?.head) {
+    return
+  }
+  documentRef.head.querySelectorAll(`[${HEAD_MARKER}="${HEAD_OWNER}"]`).forEach(node => node.remove())
+  seoConfig = { enabled: false }
+}
+
+export type { WebSeoConfig as WebRuntimeSeoConfig }

--- a/packages-runtime/web/test/plugin.test.ts
+++ b/packages-runtime/web/test/plugin.test.ts
@@ -52,6 +52,7 @@ describe('weappWebPlugin', () => {
     }))
     await writeFile(join(pageDir, 'index.js'), 'Page({})')
     await writeFile(join(pageDir, 'index.wxml'), '<view>index</view>')
+    await writeFile(join(pageDir, 'index.json'), JSON.stringify({ navigationBarTitleText: '首页' }))
 
     const plugin = weappWebPlugin({
       srcDir: 'src',
@@ -70,6 +71,14 @@ describe('weappWebPlugin', () => {
           mode: 'history',
           base: '/mini',
         },
+        seo: {
+          defaultTitle: '商城',
+          titleTemplate: '%s | Demo',
+          description: '商品详情',
+        },
+        resourceHints: {
+          links: [{ rel: 'preconnect', href: 'https://cdn.example.test' }],
+        },
       },
     })
     await (plugin.configResolved as ((...args: any[]) => any))?.call({ warn() {} } as any, { root, command: 'build' } as any)
@@ -80,8 +89,14 @@ describe('weappWebPlugin', () => {
     const code = (plugin.load as ((...args: any[]) => any))?.call({} as any, entryId) as string
     expect(code).toContain('initializePageRoutes(["pages/index/index"]')
     expect(code).toContain('"tabBar":{"color":"#666666","selectedColor":"#07c160","backgroundColor":"#ffffff","borderStyle":"black","position":"bottom","custom":false,"list":[{"pagePath":"pages/index/index","text":"首页","iconPath":"assets/home.png"}]}')
-    expect(code).toContain('"runtime":{"executionMode":"safe","warnings":{"level":"off","dedupe":false},"viewport":{"mode":"responsive","maxWidth":414,"desktopBreakpoint":720},"routing":{"mode":"history","base":"/mini"}}')
+    expect(code).toContain('"runtime":{"executionMode":"safe","warnings":{"level":"off","dedupe":false},"viewport":{"mode":"responsive","maxWidth":414,"desktopBreakpoint":720},"routing":{"mode":"history","base":"/mini"},"seo":{"defaultTitle":"商城","titleTemplate":"%s | Demo","description":"商品详情"},"resourceHints":{"links":[{"rel":"preconnect","href":"https://cdn.example.test"}]}}')
     expect(code).toContain('"rpx":{"designWidth":750}')
+    const transformedPage = await (plugin.transform as (code: string, id: string) => Promise<any> | any).call(
+      {},
+      'Page({})',
+      join(pageDir, 'index.js'),
+    )
+    expect(transformedPage?.code).toContain('navigationBar: {"title":"首页"}')
   })
 
   it('loads runtime polyfill from a Vite fs path in virtual entry modules', async () => {

--- a/packages-runtime/web/test/seo.test.ts
+++ b/packages-runtime/web/test/seo.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  configureWebSeo,
+  resetWebDocumentHead,
+  setupWebResourceHints,
+  syncWebDocumentHead,
+  updateWebDocumentTitle,
+} from '../src/runtime/seo'
+
+class FakeElement {
+  tagName: string
+  children: FakeElement[] = []
+  attributes = new Map<string, string>()
+  content = ''
+  rel = ''
+  href = ''
+  as = ''
+  type = ''
+  crossOrigin = ''
+  removed = false
+
+  constructor(tagName: string) {
+    this.tagName = tagName
+  }
+
+  setAttribute(name: string, value: string) {
+    this.attributes.set(name, value)
+  }
+
+  getAttribute(name: string) {
+    return this.attributes.get(name) ?? null
+  }
+
+  append(...nodes: FakeElement[]) {
+    this.children.push(...nodes)
+  }
+
+  remove() {
+    this.removed = true
+  }
+
+  querySelector(selector: string) {
+    return this.querySelectorAll(selector)[0] ?? null
+  }
+
+  querySelectorAll(selector: string) {
+    return this.children.filter((child) => {
+      const marker = selector.includes(`[data-weapp-web-head="weapp-web-runtime"]`)
+      if (marker && child.getAttribute('data-weapp-web-head') !== 'weapp-web-runtime') {
+        return false
+      }
+      const rel = selector.match(/\[rel="([^"]+)"\]/)?.[1]
+      const href = selector.match(/\[href="([^"]+)"\]/)?.[1]
+      const name = selector.match(/\[name="([^"]+)"\]/)?.[1]
+      return (!rel || child.rel === rel)
+        && (!href || child.href === href)
+        && (!name || child.getAttribute('name') === name)
+    })
+  }
+}
+
+class FakeDocument {
+  title = ''
+  readyState = 'complete'
+  head = new FakeElement('head')
+  body = new FakeElement('body')
+
+  createElement(tagName: string) {
+    return new FakeElement(tagName)
+  }
+}
+
+const originalDocument = (globalThis as Record<string, unknown>).document
+const originalWindow = (globalThis as Record<string, unknown>).window
+
+afterEach(() => {
+  resetWebDocumentHead()
+  if (originalDocument === undefined) {
+    delete (globalThis as Record<string, unknown>).document
+  }
+  else {
+    Object.assign(globalThis, { document: originalDocument })
+  }
+  if (originalWindow === undefined) {
+    delete (globalThis as Record<string, unknown>).window
+  }
+  else {
+    Object.assign(globalThis, { window: originalWindow })
+  }
+})
+
+describe('web runtime document head', () => {
+  it('syncs route title, description, canonical and resource hints without duplicates', () => {
+    const documentRef = new FakeDocument()
+    Object.assign(globalThis, {
+      document: documentRef,
+      window: { location: { href: 'https://example.test/mini/pages/detail?sku=42#top' } },
+    })
+
+    configureWebSeo({
+      defaultTitle: '商城',
+      titleTemplate: '%s | Web Demo',
+      description: '商品详情',
+    })
+    setupWebResourceHints({
+      links: [
+        { rel: 'preconnect', href: 'https://cdn.example.test' },
+        { rel: 'preconnect', href: 'https://cdn.example.test' },
+      ],
+    })
+    syncWebDocumentHead({ route: 'pages/detail/index', title: '详情' })
+
+    expect(documentRef.title).toBe('详情 | Web Demo')
+    expect(documentRef.head.querySelectorAll('[data-weapp-web-head="weapp-web-runtime"]').length).toBe(3)
+    const description = documentRef.head.querySelector('[name="description"]')
+    expect(description?.content).toBe('商品详情')
+    const canonical = documentRef.head.querySelector('[rel="canonical"]')
+    expect(canonical?.href).toBe('https://example.test/mini/pages/detail')
+  })
+
+  it('updates the active page title through the navigation bridge API', () => {
+    const documentRef = new FakeDocument()
+    Object.assign(globalThis, { document: documentRef })
+    configureWebSeo({ enabled: true })
+
+    updateWebDocumentTitle('新标题')
+
+    expect(documentRef.title).toBe('新标题')
+  })
+})

--- a/skills/weapp-vite-best-practices/references/web-runtime-compatibility.md
+++ b/skills/weapp-vite-best-practices/references/web-runtime-compatibility.md
@@ -2,6 +2,8 @@
 
 - Web runtime 用来验证跨平台渲染和 Web API 适配，不等价于微信 DevTools 或真机。
 - 默认 `runtime.viewport.mode` 为 `mini-program`：移动宽度下铺满，600px 以上使用 375px 居中容器；旧全宽行为显式使用 `responsive`。
+- `runtime.seo` 会在页面栈切换后同步 `document.title`、description 和 canonical；标题默认取页面 `navigationBarTitleText`，`titleTemplate` 用 `%s` 表示页面标题，`enabled: false` 可关闭。
+- `runtime.resourceHints.links` 只在浏览器 Head 中去重注入 `preconnect`、`dns-prefetch`、`prefetch` 和 `preload`，不会改变小程序产物，也不等同于 SSR。
 - `rpx` 按设备容器宽度计算。排查桌面端比例问题时先检查 `#app` 实际宽度和 `--rpx`，不要直接用 `window.innerWidth` 推断。
 - `view`、`text`、`image`、`button`、`input`、`scroll-view`、`form`、`label`、`textarea`、checkbox/radio group、`switch`、`picker`、`picker-view`、`picker-view-column`、`slider`、`navigator`、`swiper` / `swiper-item` 会编译成 `weapp-*` 运行时标签；编写浏览器断言时不要继续假设它们是 `div`、`span`、`img` 或原生表单元素。
 - 表单提交只收集带 `name` 且未禁用的控件；checkbox group 返回数组、radio group 返回单值、switch 返回布尔值。验证 reset 时同时检查控件状态和页面提交结果，不要只检查 DOM attribute。

--- a/website/config/web.md
+++ b/website/config/web.md
@@ -70,6 +70,14 @@ export default defineConfig({
             mode: 'history',
             base: '/mini',
           },
+          seo: {
+            defaultTitle: '商城',
+            titleTemplate: '%s | Web Demo',
+            description: '小程序页面的 Web 运行时演示。',
+          },
+          resourceHints: {
+            links: [{ rel: 'preconnect', href: 'https://cdn.example.com' }],
+          },
         },
       },
       vite: {
@@ -147,6 +155,18 @@ Web 产物输出目录，默认一般是 `dist/web`。
   - `hash`：使用 `#/pages/...`，适合静态托管
 - `runtime.routing.base`
   - Web 项目的部署目录前缀，例如 `/mini`
+- `runtime.seo`
+  - 路由切换时同步 `document.title`、description 和 canonical；`enabled: false` 可关闭
+- `runtime.seo.defaultTitle`
+  - 没有页面标题时使用的默认标题
+- `runtime.seo.titleTemplate`
+  - 标题模板，`%s` 会替换为当前页面标题
+- `runtime.seo.description`
+  - 全站 description meta 内容
+- `runtime.seo.canonical`
+  - 是否维护去掉 query/hash 的 canonical 链接，默认开启
+- `runtime.resourceHints.links`
+  - 去重注入的 `preconnect` / `dns-prefetch` / `prefetch` / `preload` 链接数组
 
 默认视口同时约束页面滚动、导航栏和 `fixed` 元素；`rpx` 也按设备容器宽度计算，而不是按桌面浏览器窗口计算。
 

--- a/website/guide/web-compat-matrix.md
+++ b/website/guide/web-compat-matrix.md
@@ -81,92 +81,93 @@ keywords:
 
 ## `wx` API 矩阵（Web bridge）
 
-| API                                                                                                      | 状态 | 说明                                                                                                    |
-| -------------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------------------------------------------------------- |
-| `wx.navigateTo`                                                                                          | `✅` | 支持基础页面栈推进。                                                                                    |
-| `wx.redirectTo`                                                                                          | `✅` | 支持替换当前页面。                                                                                      |
-| `wx.reLaunch`                                                                                            | `✅` | 支持重建路由栈。                                                                                        |
-| `wx.switchTab`                                                                                           | `✅` | 只接受 tabBar 路由；关闭非 tab 页面并缓存其他 tab 页面实例，重复点击不会重跑生命周期。                  |
-| `wx.showTabBar` / `wx.hideTabBar`                                                                        | `✅` | 控制标准 Web App Shell 显隐，并同步页面底部 inset 与安全区布局。                                        |
-| `wx.setTabBarItem` / `wx.setTabBarStyle`                                                                 | `✅` | 动态更新标准 tabBar 的文字、图标、颜色、背景与边框。                                                    |
-| `wx.setTabBarBadge` / `removeTabBarBadge` / `showTabBarRedDot` / `hideTabBarRedDot`                      | `✅` | 支持标准 tabBar badge 与红点状态；非法 index 按微信形状回调和 Promise 失败。                            |
-| `wx.loadSubPackage` / `wx.preloadSubpackage`                                                             | `🟡` | 当前提供 no-op 成功桥接，主要用于兼容分包加载调用链，不执行真实下载与预加载流程。                       |
-| `wx.navigateBack`                                                                                        | `✅` | 支持 `delta` 回退。                                                                                     |
-| 浏览器深链接与前进/后退                                                                                  | `✅` | `runtime.routing` 支持 `history` / `hash`；默认 `memory`，可按部署目录设置 `base`。                     |
-| `wx.setNavigationBarTitle`                                                                               | `🟡` | 依赖默认导航栏组件存在。                                                                                |
-| `wx.setNavigationBarColor`                                                                               | `🟡` | 依赖默认导航栏组件存在。                                                                                |
-| `wx.setBackgroundColor` / `wx.setBackgroundTextStyle`                                                    | `🟡` | 提供页面背景与文本样式的近似桥接，基于 DOM 样式设置，不等价小程序原生渲染语义。                         |
-| `wx.showNavigationBarLoading` / `hideNavigationBarLoading`                                               | `🟡` | 依赖默认导航栏组件存在。                                                                                |
-| `wx.showLoading` / `wx.hideLoading`                                                                      | `🟡` | 提供轻量 DOM loading 层，视觉行为为近似实现。                                                           |
-| `wx.nextTick`                                                                                            | `🟡` | 基于微任务队列调度回调，时序近似小程序行为。                                                            |
-| `wx.showModal`                                                                                           | `🟡` | 基于浏览器 `confirm/alert`，`confirmText/cancelText` 不生效。                                           |
-| `wx.showActionSheet`                                                                                     | `🟡` | 通过浏览器 `prompt` 或预设索引桥接选择结果，交互样式与真机 ActionSheet 不一致。                         |
-| `wx.showToast`                                                                                           | `🟡` | 提供轻量 DOM toast，样式与真机不完全一致。                                                              |
-| `wx.startPullDownRefresh` / `wx.stopPullDownRefresh`                                                     | `🟡` | Web 侧均作为 no-op 成功桥接，便于兼容下拉刷新调用链。                                                   |
-| `wx.hideKeyboard`                                                                                        | `🟡` | 通过 `blur` 当前聚焦输入元素近似桥接收起键盘能力，行为受浏览器焦点模型限制。                            |
-| `wx.pageScrollTo`                                                                                        | `🟡` | 支持 `scrollTop/duration` 的基础滚动，`selector` 等高级能力未覆盖。                                     |
-| `wx.createCanvasContext`                                                                                 | `🟡` | 跨 Shadow DOM 定位真实 Canvas，支持常用路径、填充和变换；高级 API 未全量覆盖。                          |
-| `wx.createVideoContext`                                                                                  | `🟡` | 跨 Shadow DOM 定位真实 video，并提供 play/pause/seek 等控制；不包含原生播放器完整语义。                 |
-| `wx.createWorker`                                                                                        | `🟡` | 基于浏览器 Worker 桥接消息收发与错误监听（`postMessage/onMessage/onError`），线程模型与真机不完全一致。 |
-| `wx.createSelectorQuery`                                                                                 | `🟡` | 支持 `in/select/selectAll/selectViewport` 与 `boundingClientRect/scrollOffset/fields/node` 高频子集。   |
-| `wx.setClipboardData` / `wx.getClipboardData`                                                            | `🟡` | 依赖浏览器剪贴板权限；失败时会回调 `fail`。                                                             |
-| `wx.request`                                                                                             | `🟡` | 基于 `fetch` 桥接，支持常见 JSON/text 场景；上传下载与高级拦截能力未覆盖。                              |
-| `wx.uploadFile`                                                                                          | `🟡` | 基于 `fetch + FormData` 桥接文件上传，支持基础表单字段；上传任务进度与中断控制语义未覆盖。              |
-| `wx.downloadFile`                                                                                        | `🟡` | 基于 `fetch` + `Blob URL` 桥接，返回临时 URL；文件系统语义与真机不一致。                                |
-| `wx.openDocument`                                                                                        | `🟡` | 支持 URL 或内存文件桥接到浏览器新窗口预览，文档菜单与内置查看器行为不等价。                             |
-| `wx.chooseImage`                                                                                         | `🟡` | 优先使用 `showOpenFilePicker`，降级到文件输入框选择；结果为浏览器临时 URL。                             |
-| `wx.chooseMedia`                                                                                         | `🟡` | 基于文件选择器桥接图片/视频选择，结果为浏览器临时 URL，媒体元信息（时长/尺寸）当前为近似占位值。        |
-| `wx.chooseVideo`                                                                                         | `🟡` | 基于媒体文件选择桥接视频选择，返回浏览器临时 URL；时长/尺寸字段当前为近似占位值。                       |
-| `wx.compressImage`                                                                                       | `🟡` | 优先基于 Canvas 执行近似压缩，失败或能力缺失时回退原图路径；压缩质量与真机语义不完全一致。              |
-| `wx.compressVideo`                                                                                       | `🟡` | 当前提供 no-op 兼容桥接（默认返回原视频路径），可通过预设结果注入压缩后的临时路径用于调试流程。         |
-| `wx.getImageInfo`                                                                                        | `🟡` | 基于浏览器 `Image` 对象读取图片宽高与类型；EXIF 与方向能力为近似值。                                    |
-| `wx.getVideoInfo`                                                                                        | `🟡` | 优先读取运行时预设，降级尝试浏览器 video 元信息；文件大小、帧率、码率等字段当前为近似值。               |
-| `wx.chooseMessageFile`                                                                                   | `🟡` | 基于文件选择器桥接消息文件选择，返回浏览器临时文件信息；会话/聊天上下文语义与真机不同。                 |
-| `wx.chooseFile`                                                                                          | `🟡` | 基于文件选择器桥接通用文件选择，支持 `extension` 过滤；返回浏览器临时文件信息。                         |
-| `wx.previewImage`                                                                                        | `🟡` | 使用浏览器 `window.open` 预览图片，依赖浏览器弹窗策略。                                                 |
-| `wx.previewMedia`                                                                                        | `🟡` | 基于浏览器新窗口预览媒体 URL，不提供小程序原生媒体预览器的手势、切换与播放控制能力。                    |
-| `wx.openVideoEditor`                                                                                     | `🟡` | 当前提供 API 级兼容桥接（默认返回原视频路径），可通过预设结果注入编辑后路径用于调试流程。               |
-| `wx.saveImageToPhotosAlbum`                                                                              | `🟡` | 通过浏览器下载行为近似桥接保存流程，不具备系统相册写入与权限弹窗等真机语义。                            |
-| `wx.saveVideoToPhotosAlbum`                                                                              | `🟡` | 通过浏览器下载行为近似桥接保存流程，不具备系统相册写入与权限弹窗等真机语义。                            |
-| `wx.saveFile`                                                                                            | `🟡` | 将临时文件路径近似持久化到 Web 内存文件系统并返回 `savedFilePath`，不等价真机文件沙箱语义。             |
-| `wx.saveFileToDisk`                                                                                      | `🟡` | 通过浏览器下载行为近似桥接保存文件流程，不具备小程序容器内的系统文件管理语义。                          |
-| `wx.login` / `wx.checkSession` / `wx.getAccountInfoSync`                                                 | `🟡` | 提供 Web 环境下的登录态占位桥接与会话校验，不等价真实小程序登录会话。                                   |
-| `wx.getUserInfo` / `wx.getUserProfile`                                                                   | `🟡` | 提供用户信息读取与授权确认占位桥接，可通过预设结果注入用户资料，不触发系统级授权弹窗。                  |
-| `wx.showShareMenu` / `wx.updateShareMenu`                                                                | `🟡` | 提供 API 级成功回调桥接，不覆盖平台级分享能力差异。                                                     |
-| `wx.getExtConfigSync` / `wx.getExtConfig`                                                                | `🟡` | 返回 Web runtime 注入的扩展配置快照（默认空对象）。                                                     |
-| `wx.getUpdateManager` / `wx.getLogManager`                                                               | `🟡` | 返回 Web 侧更新/日志桥接对象：更新流程可通过预设状态驱动，日志输出映射到浏览器 console。                |
-| `wx.cloud.init` / `wx.cloud.callFunction`                                                                | `🟡` | 提供云能力初始化与云函数调用占位桥接，返回 mock 结果用于流程调试，不连接真实云环境。                    |
-| `wx.reportAnalytics`                                                                                     | `🟡` | 在运行时内存中记录事件用于调试，不会真实上报到微信数据分析后台。                                        |
-| `wx.navigateToMiniProgram` / `wx.exitMiniProgram`                                                        | `🟡` | 提供 API 级桥接用于流程调试，不执行真实小程序容器跳转/退出。                                            |
-| `wx.openCustomerServiceChat`                                                                             | `🟡` | 可选地通过浏览器打开客服链接，企业微信会话能力不等价。                                                  |
-| `wx.makePhoneCall`                                                                                       | `🟡` | 通过浏览器 `tel:` 链接桥接拨号流程，受设备与浏览器支持限制。                                            |
-| `wx.chooseAddress`                                                                                       | `🟡` | 支持通过运行时预设或 `prompt` 输入桥接收货地址选择，不包含小程序原生地址簿与用户授权弹窗能力。          |
-| `wx.chooseLocation`                                                                                      | `🟡` | 支持通过预设值或 `prompt` 输入经纬度完成桥接，不包含地图选点 UI 与 POI 选择能力。                       |
-| `wx.openLocation`                                                                                        | `🟡` | 通过地图 URL 跳转近似桥接定位查看能力，不等价微信内置地图页面行为。                                     |
-| `wx.requestPayment`                                                                                      | `🟡` | 仅提供成功回调级占位桥接，不涉及真实支付签名与交易流程。                                                |
-| `wx.requestSubscribeMessage`                                                                             | `🟡` | 提供订阅消息授权结果占位桥接，可通过预设值控制模板消息确认结果，不触发平台级订阅弹窗。                  |
-| `wx.createRewardedVideoAd` / `wx.createInterstitialAd`                                                   | `🟡` | 提供广告对象生命周期桥接（`load/show/onError/onClose`），不触发真实广告网络与平台策略。                 |
-| `wx.createVKSession`                                                                                     | `🟡` | 提供 VKSession 生命周期占位桥接（`start/stop/destroy/on/off`），不包含真实 VisionKit 推理能力。         |
-| `wx.getNetworkType` / `wx.onNetworkStatusChange` / `wx.offNetworkStatusChange`                           | `🟡` | 基于 `navigator.onLine` 与浏览器网络事件，网络类型为近似值。                                            |
-| `wx.scanCode`                                                                                            | `🟡` | 提供基于输入/预设结果的占位扫码桥接，用于流程调试，不等价真实摄像头扫码能力。                           |
-| `wx.getLocation`                                                                                         | `🟡` | 基于浏览器 Geolocation API 桥接，坐标与精度字段受浏览器权限策略影响。                                   |
-| `wx.getFuzzyLocation`                                                                                    | `🟡` | 优先读取运行时预设并降级到定位结果模糊化桥接（经纬度保留两位小数），精度字段为近似值。                  |
-| `wx.vibrateShort`                                                                                        | `🟡` | 通过浏览器 `navigator.vibrate` 触发短振动，实际效果受设备与权限限制。                                   |
-| `wx.getBatteryInfo` / `wx.getBatteryInfoSync`                                                            | `🟡` | 优先读取浏览器 Battery API，缺失时回退到缓存近似值。                                                    |
-| `wx.getFileSystemManager`                                                                                | `🟡` | 提供基于内存的文件读写桥接（`writeFile/readFile` 及 sync 版本），用于开发调试，不等价真机沙箱文件系统。 |
-| `wx.setStorage` / `getStorage` / `removeStorage` / `clearStorage` / `getStorageInfo`                     | `🟡` | 基于内存 + `localStorage` 前缀桥接；与真机容量和隔离策略不完全一致。                                    |
-| `wx.setStorageSync` / `getStorageSync` / `removeStorageSync` / `clearStorageSync` / `getStorageInfoSync` | `🟡` | 提供同步桥接，缺失 key 时 `getStorageSync` 返回空字符串。                                               |
-| `wx.getSystemInfo` / `wx.getSystemInfoSync` / `wx.getWindowInfo`                                         | `🟡` | 基于浏览器环境推断，字段为近似值。                                                                      |
-| `wx.onWindowResize` / `wx.offWindowResize`                                                               | `🟡` | 基于浏览器 `resize` 事件桥接窗口尺寸变化回调，触发时序与真机可能有差异。                                |
-| `wx.getDeviceInfo` / `wx.getSystemSetting` / `wx.getAppAuthorizeSetting`                                 | `🟡` | 返回浏览器可推断字段与默认授权状态（多数字段为近似/占位值）。                                           |
-| `wx.getSetting` / `wx.authorize` / `wx.openSetting`                                                      | `🟡` | 提供基于运行时内存状态的权限桥接，支持常见 scope 调试，不会触发系统级授权弹窗。                         |
-| `wx.openAppAuthorizeSetting`                                                                             | `🟡` | 提供应用级授权设置结果桥接，可通过预设状态注入授权结果，不触发系统级授权设置页。                        |
-| `wx.getAppBaseInfo`                                                                                      | `🟡` | 提供浏览器环境下的基础信息近似值（语言、主题、平台等）。                                                |
-| `wx.getMenuButtonBoundingClientRect`                                                                     | `🟡` | 返回基于窗口尺寸的启发式胶囊按钮区域，不保证与真机一致。                                                |
-| `wx.getLaunchOptionsSync` / `wx.getEnterOptionsSync`                                                     | `🟡` | 返回基于当前 Web runtime 路由推断的启动参数快照。                                                       |
-| `wx.canIUse`                                                                                             | `🟡` | 支持 API 级能力探测（`wx.xxx`）；复杂组件/样式规则探测未覆盖。                                          |
-| `getCurrentPages` / `getApp`                                                                             | `✅` | 提供基础桥接能力。                                                                                      |
-| 其他常见 API（多媒体高级能力等）                                                                         | `⛔` | 尚未内置桥接，需业务层自行兼容。                                                                        |
+| API                                                                                                      | 状态 | 说明                                                                                                                        |
+| -------------------------------------------------------------------------------------------------------- | ---- | --------------------------------------------------------------------------------------------------------------------------- |
+| `wx.navigateTo`                                                                                          | `✅` | 支持基础页面栈推进。                                                                                                        |
+| `wx.redirectTo`                                                                                          | `✅` | 支持替换当前页面。                                                                                                          |
+| `wx.reLaunch`                                                                                            | `✅` | 支持重建路由栈。                                                                                                            |
+| `wx.switchTab`                                                                                           | `✅` | 只接受 tabBar 路由；关闭非 tab 页面并缓存其他 tab 页面实例，重复点击不会重跑生命周期。                                      |
+| `wx.showTabBar` / `wx.hideTabBar`                                                                        | `✅` | 控制标准 Web App Shell 显隐，并同步页面底部 inset 与安全区布局。                                                            |
+| `wx.setTabBarItem` / `wx.setTabBarStyle`                                                                 | `✅` | 动态更新标准 tabBar 的文字、图标、颜色、背景与边框。                                                                        |
+| `wx.setTabBarBadge` / `removeTabBarBadge` / `showTabBarRedDot` / `hideTabBarRedDot`                      | `✅` | 支持标准 tabBar badge 与红点状态；非法 index 按微信形状回调和 Promise 失败。                                                |
+| `wx.loadSubPackage` / `wx.preloadSubpackage`                                                             | `🟡` | 当前提供 no-op 成功桥接，主要用于兼容分包加载调用链，不执行真实下载与预加载流程。                                           |
+| `wx.navigateBack`                                                                                        | `✅` | 支持 `delta` 回退。                                                                                                         |
+| 浏览器深链接与前进/后退                                                                                  | `✅` | `runtime.routing` 支持 `history` / `hash`；默认 `memory`，可按部署目录设置 `base`。                                         |
+| 页面 Head 与首屏资源提示                                                                                 | `✅` | `runtime.seo` 同步标题、description、canonical；`runtime.resourceHints.links` 去重注入浏览器 Resource Hints，不等同于 SSR。 |
+| `wx.setNavigationBarTitle`                                                                               | `🟡` | 依赖默认导航栏组件存在。                                                                                                    |
+| `wx.setNavigationBarColor`                                                                               | `🟡` | 依赖默认导航栏组件存在。                                                                                                    |
+| `wx.setBackgroundColor` / `wx.setBackgroundTextStyle`                                                    | `🟡` | 提供页面背景与文本样式的近似桥接，基于 DOM 样式设置，不等价小程序原生渲染语义。                                             |
+| `wx.showNavigationBarLoading` / `hideNavigationBarLoading`                                               | `🟡` | 依赖默认导航栏组件存在。                                                                                                    |
+| `wx.showLoading` / `wx.hideLoading`                                                                      | `🟡` | 提供轻量 DOM loading 层，视觉行为为近似实现。                                                                               |
+| `wx.nextTick`                                                                                            | `🟡` | 基于微任务队列调度回调，时序近似小程序行为。                                                                                |
+| `wx.showModal`                                                                                           | `🟡` | 基于浏览器 `confirm/alert`，`confirmText/cancelText` 不生效。                                                               |
+| `wx.showActionSheet`                                                                                     | `🟡` | 通过浏览器 `prompt` 或预设索引桥接选择结果，交互样式与真机 ActionSheet 不一致。                                             |
+| `wx.showToast`                                                                                           | `🟡` | 提供轻量 DOM toast，样式与真机不完全一致。                                                                                  |
+| `wx.startPullDownRefresh` / `wx.stopPullDownRefresh`                                                     | `🟡` | Web 侧均作为 no-op 成功桥接，便于兼容下拉刷新调用链。                                                                       |
+| `wx.hideKeyboard`                                                                                        | `🟡` | 通过 `blur` 当前聚焦输入元素近似桥接收起键盘能力，行为受浏览器焦点模型限制。                                                |
+| `wx.pageScrollTo`                                                                                        | `🟡` | 支持 `scrollTop/duration` 的基础滚动，`selector` 等高级能力未覆盖。                                                         |
+| `wx.createCanvasContext`                                                                                 | `🟡` | 跨 Shadow DOM 定位真实 Canvas，支持常用路径、填充和变换；高级 API 未全量覆盖。                                              |
+| `wx.createVideoContext`                                                                                  | `🟡` | 跨 Shadow DOM 定位真实 video，并提供 play/pause/seek 等控制；不包含原生播放器完整语义。                                     |
+| `wx.createWorker`                                                                                        | `🟡` | 基于浏览器 Worker 桥接消息收发与错误监听（`postMessage/onMessage/onError`），线程模型与真机不完全一致。                     |
+| `wx.createSelectorQuery`                                                                                 | `🟡` | 支持 `in/select/selectAll/selectViewport` 与 `boundingClientRect/scrollOffset/fields/node` 高频子集。                       |
+| `wx.setClipboardData` / `wx.getClipboardData`                                                            | `🟡` | 依赖浏览器剪贴板权限；失败时会回调 `fail`。                                                                                 |
+| `wx.request`                                                                                             | `🟡` | 基于 `fetch` 桥接，支持常见 JSON/text 场景；上传下载与高级拦截能力未覆盖。                                                  |
+| `wx.uploadFile`                                                                                          | `🟡` | 基于 `fetch + FormData` 桥接文件上传，支持基础表单字段；上传任务进度与中断控制语义未覆盖。                                  |
+| `wx.downloadFile`                                                                                        | `🟡` | 基于 `fetch` + `Blob URL` 桥接，返回临时 URL；文件系统语义与真机不一致。                                                    |
+| `wx.openDocument`                                                                                        | `🟡` | 支持 URL 或内存文件桥接到浏览器新窗口预览，文档菜单与内置查看器行为不等价。                                                 |
+| `wx.chooseImage`                                                                                         | `🟡` | 优先使用 `showOpenFilePicker`，降级到文件输入框选择；结果为浏览器临时 URL。                                                 |
+| `wx.chooseMedia`                                                                                         | `🟡` | 基于文件选择器桥接图片/视频选择，结果为浏览器临时 URL，媒体元信息（时长/尺寸）当前为近似占位值。                            |
+| `wx.chooseVideo`                                                                                         | `🟡` | 基于媒体文件选择桥接视频选择，返回浏览器临时 URL；时长/尺寸字段当前为近似占位值。                                           |
+| `wx.compressImage`                                                                                       | `🟡` | 优先基于 Canvas 执行近似压缩，失败或能力缺失时回退原图路径；压缩质量与真机语义不完全一致。                                  |
+| `wx.compressVideo`                                                                                       | `🟡` | 当前提供 no-op 兼容桥接（默认返回原视频路径），可通过预设结果注入压缩后的临时路径用于调试流程。                             |
+| `wx.getImageInfo`                                                                                        | `🟡` | 基于浏览器 `Image` 对象读取图片宽高与类型；EXIF 与方向能力为近似值。                                                        |
+| `wx.getVideoInfo`                                                                                        | `🟡` | 优先读取运行时预设，降级尝试浏览器 video 元信息；文件大小、帧率、码率等字段当前为近似值。                                   |
+| `wx.chooseMessageFile`                                                                                   | `🟡` | 基于文件选择器桥接消息文件选择，返回浏览器临时文件信息；会话/聊天上下文语义与真机不同。                                     |
+| `wx.chooseFile`                                                                                          | `🟡` | 基于文件选择器桥接通用文件选择，支持 `extension` 过滤；返回浏览器临时文件信息。                                             |
+| `wx.previewImage`                                                                                        | `🟡` | 使用浏览器 `window.open` 预览图片，依赖浏览器弹窗策略。                                                                     |
+| `wx.previewMedia`                                                                                        | `🟡` | 基于浏览器新窗口预览媒体 URL，不提供小程序原生媒体预览器的手势、切换与播放控制能力。                                        |
+| `wx.openVideoEditor`                                                                                     | `🟡` | 当前提供 API 级兼容桥接（默认返回原视频路径），可通过预设结果注入编辑后路径用于调试流程。                                   |
+| `wx.saveImageToPhotosAlbum`                                                                              | `🟡` | 通过浏览器下载行为近似桥接保存流程，不具备系统相册写入与权限弹窗等真机语义。                                                |
+| `wx.saveVideoToPhotosAlbum`                                                                              | `🟡` | 通过浏览器下载行为近似桥接保存流程，不具备系统相册写入与权限弹窗等真机语义。                                                |
+| `wx.saveFile`                                                                                            | `🟡` | 将临时文件路径近似持久化到 Web 内存文件系统并返回 `savedFilePath`，不等价真机文件沙箱语义。                                 |
+| `wx.saveFileToDisk`                                                                                      | `🟡` | 通过浏览器下载行为近似桥接保存文件流程，不具备小程序容器内的系统文件管理语义。                                              |
+| `wx.login` / `wx.checkSession` / `wx.getAccountInfoSync`                                                 | `🟡` | 提供 Web 环境下的登录态占位桥接与会话校验，不等价真实小程序登录会话。                                                       |
+| `wx.getUserInfo` / `wx.getUserProfile`                                                                   | `🟡` | 提供用户信息读取与授权确认占位桥接，可通过预设结果注入用户资料，不触发系统级授权弹窗。                                      |
+| `wx.showShareMenu` / `wx.updateShareMenu`                                                                | `🟡` | 提供 API 级成功回调桥接，不覆盖平台级分享能力差异。                                                                         |
+| `wx.getExtConfigSync` / `wx.getExtConfig`                                                                | `🟡` | 返回 Web runtime 注入的扩展配置快照（默认空对象）。                                                                         |
+| `wx.getUpdateManager` / `wx.getLogManager`                                                               | `🟡` | 返回 Web 侧更新/日志桥接对象：更新流程可通过预设状态驱动，日志输出映射到浏览器 console。                                    |
+| `wx.cloud.init` / `wx.cloud.callFunction`                                                                | `🟡` | 提供云能力初始化与云函数调用占位桥接，返回 mock 结果用于流程调试，不连接真实云环境。                                        |
+| `wx.reportAnalytics`                                                                                     | `🟡` | 在运行时内存中记录事件用于调试，不会真实上报到微信数据分析后台。                                                            |
+| `wx.navigateToMiniProgram` / `wx.exitMiniProgram`                                                        | `🟡` | 提供 API 级桥接用于流程调试，不执行真实小程序容器跳转/退出。                                                                |
+| `wx.openCustomerServiceChat`                                                                             | `🟡` | 可选地通过浏览器打开客服链接，企业微信会话能力不等价。                                                                      |
+| `wx.makePhoneCall`                                                                                       | `🟡` | 通过浏览器 `tel:` 链接桥接拨号流程，受设备与浏览器支持限制。                                                                |
+| `wx.chooseAddress`                                                                                       | `🟡` | 支持通过运行时预设或 `prompt` 输入桥接收货地址选择，不包含小程序原生地址簿与用户授权弹窗能力。                              |
+| `wx.chooseLocation`                                                                                      | `🟡` | 支持通过预设值或 `prompt` 输入经纬度完成桥接，不包含地图选点 UI 与 POI 选择能力。                                           |
+| `wx.openLocation`                                                                                        | `🟡` | 通过地图 URL 跳转近似桥接定位查看能力，不等价微信内置地图页面行为。                                                         |
+| `wx.requestPayment`                                                                                      | `🟡` | 仅提供成功回调级占位桥接，不涉及真实支付签名与交易流程。                                                                    |
+| `wx.requestSubscribeMessage`                                                                             | `🟡` | 提供订阅消息授权结果占位桥接，可通过预设值控制模板消息确认结果，不触发平台级订阅弹窗。                                      |
+| `wx.createRewardedVideoAd` / `wx.createInterstitialAd`                                                   | `🟡` | 提供广告对象生命周期桥接（`load/show/onError/onClose`），不触发真实广告网络与平台策略。                                     |
+| `wx.createVKSession`                                                                                     | `🟡` | 提供 VKSession 生命周期占位桥接（`start/stop/destroy/on/off`），不包含真实 VisionKit 推理能力。                             |
+| `wx.getNetworkType` / `wx.onNetworkStatusChange` / `wx.offNetworkStatusChange`                           | `🟡` | 基于 `navigator.onLine` 与浏览器网络事件，网络类型为近似值。                                                                |
+| `wx.scanCode`                                                                                            | `🟡` | 提供基于输入/预设结果的占位扫码桥接，用于流程调试，不等价真实摄像头扫码能力。                                               |
+| `wx.getLocation`                                                                                         | `🟡` | 基于浏览器 Geolocation API 桥接，坐标与精度字段受浏览器权限策略影响。                                                       |
+| `wx.getFuzzyLocation`                                                                                    | `🟡` | 优先读取运行时预设并降级到定位结果模糊化桥接（经纬度保留两位小数），精度字段为近似值。                                      |
+| `wx.vibrateShort`                                                                                        | `🟡` | 通过浏览器 `navigator.vibrate` 触发短振动，实际效果受设备与权限限制。                                                       |
+| `wx.getBatteryInfo` / `wx.getBatteryInfoSync`                                                            | `🟡` | 优先读取浏览器 Battery API，缺失时回退到缓存近似值。                                                                        |
+| `wx.getFileSystemManager`                                                                                | `🟡` | 提供基于内存的文件读写桥接（`writeFile/readFile` 及 sync 版本），用于开发调试，不等价真机沙箱文件系统。                     |
+| `wx.setStorage` / `getStorage` / `removeStorage` / `clearStorage` / `getStorageInfo`                     | `🟡` | 基于内存 + `localStorage` 前缀桥接；与真机容量和隔离策略不完全一致。                                                        |
+| `wx.setStorageSync` / `getStorageSync` / `removeStorageSync` / `clearStorageSync` / `getStorageInfoSync` | `🟡` | 提供同步桥接，缺失 key 时 `getStorageSync` 返回空字符串。                                                                   |
+| `wx.getSystemInfo` / `wx.getSystemInfoSync` / `wx.getWindowInfo`                                         | `🟡` | 基于浏览器环境推断，字段为近似值。                                                                                          |
+| `wx.onWindowResize` / `wx.offWindowResize`                                                               | `🟡` | 基于浏览器 `resize` 事件桥接窗口尺寸变化回调，触发时序与真机可能有差异。                                                    |
+| `wx.getDeviceInfo` / `wx.getSystemSetting` / `wx.getAppAuthorizeSetting`                                 | `🟡` | 返回浏览器可推断字段与默认授权状态（多数字段为近似/占位值）。                                                               |
+| `wx.getSetting` / `wx.authorize` / `wx.openSetting`                                                      | `🟡` | 提供基于运行时内存状态的权限桥接，支持常见 scope 调试，不会触发系统级授权弹窗。                                             |
+| `wx.openAppAuthorizeSetting`                                                                             | `🟡` | 提供应用级授权设置结果桥接，可通过预设状态注入授权结果，不触发系统级授权设置页。                                            |
+| `wx.getAppBaseInfo`                                                                                      | `🟡` | 提供浏览器环境下的基础信息近似值（语言、主题、平台等）。                                                                    |
+| `wx.getMenuButtonBoundingClientRect`                                                                     | `🟡` | 返回基于窗口尺寸的启发式胶囊按钮区域，不保证与真机一致。                                                                    |
+| `wx.getLaunchOptionsSync` / `wx.getEnterOptionsSync`                                                     | `🟡` | 返回基于当前 Web runtime 路由推断的启动参数快照。                                                                           |
+| `wx.canIUse`                                                                                             | `🟡` | 支持 API 级能力探测（`wx.xxx`）；复杂组件/样式规则探测未覆盖。                                                              |
+| `getCurrentPages` / `getApp`                                                                             | `✅` | 提供基础桥接能力。                                                                                                          |
+| 其他常见 API（多媒体高级能力等）                                                                         | `⛔` | 尚未内置桥接，需业务层自行兼容。                                                                                            |
 
 ## 已知限制
 

--- a/website/packages/web.md
+++ b/website/packages/web.md
@@ -51,6 +51,14 @@ export default defineConfig({
           mode: 'history',
           base: '/mini',
         },
+        seo: {
+          defaultTitle: '商城',
+          titleTemplate: '%s | Web Demo',
+          description: '小程序页面的 Web 运行时演示。',
+        },
+        resourceHints: {
+          links: [{ rel: 'preconnect', href: 'https://cdn.example.com' }],
+        },
       },
     }),
   ],
@@ -93,6 +101,12 @@ export default defineConfig({
 - `hash`：使用 `#/pages/foo/index`，适合静态托管，不需要服务端配置。
 
 `runtime.routing.base` 用于部署在子目录的站点，例如 `/mini`。两种浏览器模式都会把页面栈和地址栏状态同步，未配置时保持原有 `memory` 行为。
+
+## 页面 Head 与首屏资源
+
+`runtime.seo` 会在浏览器路由切换后同步页面 Head：页面 `navigationBarTitleText` 作为当前标题，`titleTemplate` 使用 `%s` 占位；`description` 写入 description meta，默认还会维护去掉 query/hash 的 canonical 链接。设置 `enabled: false` 可关闭。
+
+`runtime.resourceHints.links` 支持去重注入 `preconnect`、`dns-prefetch`、`prefetch` 和 `preload`。它只影响浏览器文档，不改变小程序构建产物，也不等同于 SSR。
 
 ## 宿主注入
 

--- a/website/public/llms-index.json
+++ b/website/public/llms-index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-07-25T03:11:04.525Z",
+  "generatedAt": "2026-07-25T04:09:20.509Z",
   "site": "https://vite.icebreaker.top",
   "count": 271,
   "items": [
@@ -5884,6 +5884,7 @@
         "运行时能力",
         "视觉与组件适配",
         "浏览器路由",
+        "页面 Head 与首屏资源",
         "宿主注入",
         "能力边界"
       ],

--- a/website/public/seo-quality-report.json
+++ b/website/public/seo-quality-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-25T03:11:07.044Z",
+  "generatedAt": "2026-07-25T04:10:54.068Z",
   "site": "https://vite.icebreaker.top",
   "totals": {
     "files": 271,


### PR DESCRIPTION
## 变更说明

- 新增 `runtime.seo`，在页面栈切换时同步标题、description 与 canonical。
- 新增 `runtime.resourceHints.links`，支持去重注入浏览器 Resource Hints。
- 页面 `navigationBarTitleText` 与 `wx.setNavigationBarTitle` 同步 Web Head。
- 补齐 Web Runtime 单测、浏览器 E2E、demo 配置和公开文档。

## 验证

- `pnpm --filter @weapp-vite/web typecheck`
- `pnpm --filter @weapp-vite/web test`
- `pnpm --filter @weapp-vite/web build`
- `pnpm e2e:web`
- `pnpm --filter website-weapp-vite build`
- changeset 联动检查通过

不涉及 `weapp-vite` CLI 或模板，因此未添加 `create-weapp-vite` 联动 changeset。