### PR TITLE
feat(web-runtime): 对齐应用生命周期与页面滚动所有权

### DIFF
--- a/.changeset/web-runtime-app-lifecycle-scroll.md
+++ b/.changeset/web-runtime-app-lifecycle-scroll.md
@@ -1,0 +1,5 @@
+---
+"@weapp-vite/web": minor
+---
+
+为 Web Runtime 补齐应用前后台生命周期与页面滚动所有权：首次页面挂载前触发 App 启动回调，浏览器可见性切换驱动 onHide/onShow，并让用户滚动、pageScrollTo 与浏览器历史恢复统一归属于当前页面栈项。

--- a/apps/weapp-vite-web-demo/src/app.ts
+++ b/apps/weapp-vite-web-demo/src/app.ts
@@ -1,6 +1,26 @@
-App({
-  globalData: {},
-  onLaunch() {
+const lifecycleState = {
+  launchCount: 0,
+  showCount: 0,
+  hideCount: 0,
+  lastShowPath: '',
+  events: [] as string[],
+}
 
+App({
+  globalData: {
+    lifecycle: lifecycleState,
+  },
+  onLaunch(options) {
+    lifecycleState.launchCount += 1
+    lifecycleState.events.push(`launch:${options.path}`)
+  },
+  onShow(options) {
+    lifecycleState.showCount += 1
+    lifecycleState.lastShowPath = options.path
+    lifecycleState.events.push(`show:${options.path}`)
+  },
+  onHide() {
+    lifecycleState.hideCount += 1
+    lifecycleState.events.push('hide')
   },
 })

--- a/e2e/web-runtime/web-demo.test.ts
+++ b/e2e/web-runtime/web-demo.test.ts
@@ -455,6 +455,81 @@ describeWeb.sequential('web runtime browser baseline (weapp-vite-web-demo)', () 
     }
   })
 
+  it('bridges App foreground lifecycle and keeps launch and enter options distinct', async () => {
+    const page = await browser!.newPage()
+    try {
+      await openHomePage(page)
+      await navigateToInteractiveFromHome(page)
+
+      const snapshot = await page.evaluate(() => {
+        const runtimeWindow = window as any
+        const ownVisibilityState = Object.getOwnPropertyDescriptor(document, 'visibilityState')
+        const ownHidden = Object.getOwnPropertyDescriptor(document, 'hidden')
+        const setVisibility = (visibilityState: 'hidden' | 'visible') => {
+          Object.defineProperty(document, 'visibilityState', {
+            configurable: true,
+            value: visibilityState,
+          })
+          Object.defineProperty(document, 'hidden', {
+            configurable: true,
+            value: visibilityState === 'hidden',
+          })
+          document.dispatchEvent(new Event('visibilitychange'))
+        }
+
+        try {
+          setVisibility('hidden')
+          setVisibility('hidden')
+          setVisibility('visible')
+          setVisibility('visible')
+          return {
+            lifecycle: JSON.parse(JSON.stringify(runtimeWindow.getApp().globalData.lifecycle)),
+            launchOptions: runtimeWindow.wx.getLaunchOptionsSync(),
+            enterOptions: runtimeWindow.wx.getEnterOptionsSync(),
+          }
+        }
+        finally {
+          if (ownVisibilityState) {
+            Object.defineProperty(document, 'visibilityState', ownVisibilityState)
+          }
+          else {
+            delete (document as any).visibilityState
+          }
+          if (ownHidden) {
+            Object.defineProperty(document, 'hidden', ownHidden)
+          }
+          else {
+            delete (document as any).hidden
+          }
+        }
+      })
+
+      expect(snapshot.lifecycle).toEqual({
+        launchCount: 1,
+        showCount: 2,
+        hideCount: 1,
+        lastShowPath: 'pages/interactive/index',
+        events: [
+          'launch:pages/index/index',
+          'show:pages/index/index',
+          'hide',
+          'show:pages/interactive/index',
+        ],
+      })
+      expect(snapshot.launchOptions).toMatchObject({
+        path: 'pages/index/index',
+        query: {},
+      })
+      expect(snapshot.enterOptions).toMatchObject({
+        path: 'pages/interactive/index',
+        query: { from: 'index' },
+      })
+    }
+    finally {
+      await page.close()
+    }
+  })
+
   it('preserves page instance, lifecycle state and scroll position after navigateBack', async () => {
     const page = await browser!.newPage()
     try {

--- a/packages-runtime/web/README.md
+++ b/packages-runtime/web/README.md
@@ -7,7 +7,7 @@
 - 将小程序 `Page` / `Component` 映射为自定义元素，Shadow DOM 隔离样式与事件
 - 事件桥接（如 `bindtap` → `click`），保留 `this.setData`、`this.triggerEvent` 等调用体验
 - 提供宿主中立的小程序桥，并兼容 `wx.navigateTo` / `my.navigateTo` / `tt.navigateTo` 等路由调用，以及 `getCurrentPages`、`onLoad`、`onShow`、`onHide`、`onUnload` 生命周期
-- `App` 级别的 `onLaunch` / `onShow` 回调、`getApp` 全局实例访问
+- `App` 级别的 `onLaunch` / `onShow` / `onHide` 回调、`getApp` 全局实例访问
 - 为 `view`、`text`、`image`、`button`、`input`、`scroll-view`、`navigator`、`swiper` / `swiper-item`、`canvas`、`video`、`cover-view` / `cover-image`、`movable-area` / `movable-view`、picker、slider 及常用表单组件提供保留小程序语义的 Web Components 适配
 - 使用 PostCSS 转换 WXSS 选择器，支持 `page`、原生组件类型选择器、组合选择器和伪类
 - `rpx` 根据实际设备容器宽度动态计算；默认宽屏下使用 375px 居中设备视口
@@ -123,10 +123,12 @@ setWebRuntimeHost({
 
 ## 页面栈与生命周期
 
+- 首次挂载页面前依次触发 `App.onLaunch` / `App.onShow`；浏览器 `visibilitychange` 会驱动去重的 `App.onHide` / `App.onShow`。`getLaunchOptionsSync()` 保留初始入口，`getEnterOptionsSync()` 在重新进入前台时更新为当前页面。
 - `navigateTo` 会保留原页面 DOM、实例和数据，并依次触发原页面 `onHide` 与新页面 `onLoad` / `onShow`。
-- `navigateBack` 只卸载出栈页面，恢复目标页面的同一实例、`onShow` 和页面容器滚动位置，不会重新触发 `onLoad`。
+- `navigateBack` 只卸载出栈页面，恢复目标页面的同一实例、`onShow` 和页面容器滚动位置，不会重新触发 `onLoad`。当前页持续拥有 `#app` 的滚动状态，用户滚动与 `pageScrollTo` 都会写回对应栈项。
 - `redirectTo` 只替换并卸载当前页面；`reLaunch` 会从栈顶开始卸载全部旧页面后挂载目标页面。
 - `getCurrentPages()` 返回当前活动路由栈；其他 tab 页面可保活但不会混入当前 tab 栈。路由 API 支持 `success` / `fail` / `complete` 回调与 Promise 结果。
+- `history` / `hash` 模式使用 `history.scrollRestoration = 'manual'`，避免浏览器窗口滚动与小程序设备容器同时恢复位置；关闭路由同步时会还原原值。
 
 ## 页面 Head 与首屏资源
 

--- a/packages-runtime/web/src/runtime/polyfill/routeRuntime.ts
+++ b/packages-runtime/web/src/runtime/polyfill/routeRuntime.ts
@@ -5,7 +5,7 @@ import type { NavigationBarMetrics } from '../navigationBar'
 import type { WebResourceHintsConfig, WebSeoConfig } from '../seo'
 import type { WebViewportConfig } from '../viewport'
 import type { WebRouteHistoryState, WebRouteTarget, WebRoutingConfig } from './routeRuntime/history'
-import type { AppLaunchOptions, AppRuntime, ComponentRawOptions, ComponentRecord, NavigateBackOptions, PageRawOptions, PageRecord, PageStackEntry, RegisterMeta, RouteOptions } from './routeRuntime/options'
+import type { AppRuntime, ComponentRawOptions, ComponentRecord, NavigateBackOptions, PageRawOptions, PageRecord, RegisterMeta, RouteOptions } from './routeRuntime/options'
 import { slugify } from '../../shared/slugify'
 import {
   configureTabBar,
@@ -21,11 +21,8 @@ import { setupRpx } from '../rpx'
 import { configureWebSeo, setupWebResourceHints, syncWebDocumentHead } from '../seo'
 import { setupWebViewport } from '../viewport'
 import { setRuntimeWarningOptions } from '../warning'
-import {
-  cloneLaunchOptions,
-  resolveCurrentPages,
-  resolveFallbackLaunchOptions,
-} from './appState'
+import { resolveCurrentPages } from './appState'
+import { AppLifecycleRuntime } from './routeRuntime/appLifecycle'
 import {
   configureWebRouting,
   getWebHistoryStack,
@@ -37,7 +34,6 @@ import {
   dispatchPageLifetimeToComponents,
 } from './routeRuntime/lifecycle'
 import {
-  isRecord,
   normalizeComponentOptions,
   normalizePageOptions,
 } from './routeRuntime/options'
@@ -48,37 +44,13 @@ import { parsePageUrl } from './routeRuntime/url'
 const pageRegistry = new Map<string, PageRecord>()
 const componentRegistry = new Map<string, ComponentRecord>()
 let pageOrder: string[] = []
-let appInstance: AppRuntime | undefined
-let appLaunched = false
-let lastLaunchOptions: AppLaunchOptions | undefined
 let pageResizeBridgeBound = false
 
-function ensureAppLaunched(entry: PageStackEntry) {
-  if (!appInstance || appLaunched) {
-    return
-  }
-  const launchOptions: AppLaunchOptions = {
-    path: entry.id,
-    scene: 0,
-    query: entry.query,
-    referrerInfo: {},
-  }
-  lastLaunchOptions = {
-    path: launchOptions.path,
-    scene: launchOptions.scene,
-    query: { ...launchOptions.query },
-    referrerInfo: { ...launchOptions.referrerInfo },
-  }
-  if (typeof appInstance.onLaunch === 'function') {
-    appInstance.onLaunch(launchOptions)
-  }
-  if (typeof appInstance.onShow === 'function') {
-    appInstance.onShow(launchOptions)
-  }
-  appLaunched = true
-}
-
-const pageStack = new PageStackRuntime(pageRegistry, ensureAppLaunched)
+let pageStack: PageStackRuntime
+const appLifecycle = new AppLifecycleRuntime(
+  () => pageStack?.entries[pageStack.entries.length - 1],
+)
+pageStack = new PageStackRuntime(pageRegistry, entry => appLifecycle.ensureLaunched(entry))
 
 function syncCurrentWebDocument() {
   const current = pageStack.entries[pageStack.entries.length - 1]
@@ -176,6 +148,7 @@ export function initializePageRoutes(
   configureWebSeo(options?.runtime?.seo)
   setupWebResourceHints(options?.runtime?.resourceHints)
   configureWebRouting(options?.runtime?.routing, ids, reconcileWebRoute)
+  appLifecycle.bindVisibility()
   ensureNativeComponentsDefined()
   pageOrder = Array.from(new Set(ids))
   configureTabBar(options?.tabBar, url => performSwitchTab({ url }))
@@ -261,25 +234,7 @@ export function registerComponent<T extends ComponentRawOptions | undefined>(opt
 }
 
 export function registerApp<T extends AppRuntime | undefined>(options: T, _meta?: RegisterMeta): T {
-  const resolved = (options ?? {}) as AppRuntime
-  if (appInstance) {
-    const currentGlobal = appInstance.globalData
-    Object.assign(appInstance, resolved)
-    if (isRecord(currentGlobal)) {
-      appInstance.globalData = currentGlobal
-    }
-    else if (!isRecord(appInstance.globalData)) {
-      appInstance.globalData = {}
-    }
-    return options
-  }
-  appInstance = resolved
-  appLaunched = false
-  lastLaunchOptions = undefined
-  if (!isRecord(appInstance.globalData)) {
-    appInstance.globalData = {}
-  }
-  return options
+  return appLifecycle.register(options)
 }
 
 export function navigateTo(options: RouteOptions) {
@@ -330,16 +285,13 @@ export function getCurrentPagesInternal() {
 }
 
 export function getAppInstance() {
-  return appInstance
+  return appLifecycle.instance
 }
 
-export function getLaunchOptionsSync(): AppLaunchOptions {
-  if (lastLaunchOptions) {
-    return cloneLaunchOptions(lastLaunchOptions)
-  }
-  return resolveFallbackLaunchOptions(pageStack.entries)
+export function getLaunchOptionsSync() {
+  return appLifecycle.getLaunchOptions()
 }
 
-export function getEnterOptionsSync(): AppLaunchOptions {
-  return getLaunchOptionsSync()
+export function getEnterOptionsSync() {
+  return appLifecycle.getEnterOptions()
 }

--- a/packages-runtime/web/src/runtime/polyfill/routeRuntime/appLifecycle.ts
+++ b/packages-runtime/web/src/runtime/polyfill/routeRuntime/appLifecycle.ts
@@ -1,0 +1,117 @@
+import type { AppLaunchOptions, AppRuntime, PageStackEntry } from './options'
+import { cloneLaunchOptions, resolveFallbackLaunchOptions } from '../appState'
+import { isRecord } from './options'
+
+type VisibilityDocument = Pick<Document, 'addEventListener' | 'hidden' | 'removeEventListener' | 'visibilityState'>
+
+function resolveEntryOptions(entry: Pick<PageStackEntry, 'id' | 'query'> | undefined): AppLaunchOptions {
+  return resolveFallbackLaunchOptions(entry ? [entry] : [])
+}
+
+function isDocumentHidden(target: VisibilityDocument) {
+  return target.visibilityState === 'hidden' || target.hidden === true
+}
+
+export class AppLifecycleRuntime {
+  #appInstance: AppRuntime | undefined
+  #foreground = false
+  #lastEnterOptions: AppLaunchOptions | undefined
+  #launchOptions: AppLaunchOptions | undefined
+  #launched = false
+  #visibilityDocument: VisibilityDocument | undefined
+  #visibilityHandler: (() => void) | undefined
+
+  constructor(private readonly resolveCurrentEntry: () => PageStackEntry | undefined) {}
+
+  register<T extends AppRuntime | undefined>(options: T): T {
+    const resolved = (options ?? {}) as AppRuntime
+    if (this.#appInstance) {
+      const currentGlobal = this.#appInstance.globalData
+      Object.assign(this.#appInstance, resolved)
+      if (isRecord(currentGlobal)) {
+        this.#appInstance.globalData = currentGlobal
+      }
+      else if (!isRecord(this.#appInstance.globalData)) {
+        this.#appInstance.globalData = {}
+      }
+      return options
+    }
+    this.#appInstance = resolved
+    if (!isRecord(this.#appInstance.globalData)) {
+      this.#appInstance.globalData = {}
+    }
+    return options
+  }
+
+  bindVisibility(target: VisibilityDocument | undefined = typeof document === 'undefined' ? undefined : document) {
+    if (!target || this.#visibilityDocument === target || typeof target.addEventListener !== 'function') {
+      return
+    }
+    this.#unbindVisibility()
+    this.#visibilityDocument = target
+    this.#visibilityHandler = () => this.#syncVisibility(target)
+    target.addEventListener('visibilitychange', this.#visibilityHandler)
+  }
+
+  ensureLaunched(entry: PageStackEntry) {
+    if (!this.#appInstance || this.#launched) {
+      return
+    }
+    const options = resolveEntryOptions(entry)
+    this.#launchOptions = cloneLaunchOptions(options)
+    this.#lastEnterOptions = cloneLaunchOptions(options)
+    this.#foreground = true
+    this.#launched = true
+    this.#appInstance.onLaunch?.(cloneLaunchOptions(options))
+    this.#appInstance.onShow?.(cloneLaunchOptions(options))
+  }
+
+  get instance() {
+    return this.#appInstance
+  }
+
+  getLaunchOptions() {
+    return this.#launchOptions
+      ? cloneLaunchOptions(this.#launchOptions)
+      : resolveEntryOptions(this.resolveCurrentEntry())
+  }
+
+  getEnterOptions() {
+    return this.#lastEnterOptions
+      ? cloneLaunchOptions(this.#lastEnterOptions)
+      : this.getLaunchOptions()
+  }
+
+  dispose() {
+    this.#unbindVisibility()
+  }
+
+  #syncVisibility(target: VisibilityDocument) {
+    if (!this.#appInstance || !this.#launched) {
+      return
+    }
+    if (isDocumentHidden(target)) {
+      if (!this.#foreground) {
+        return
+      }
+      this.#appInstance.onHide?.()
+      this.#foreground = false
+      return
+    }
+    if (this.#foreground) {
+      return
+    }
+    const options = resolveEntryOptions(this.resolveCurrentEntry())
+    this.#lastEnterOptions = cloneLaunchOptions(options)
+    this.#appInstance.onShow?.(cloneLaunchOptions(options))
+    this.#foreground = true
+  }
+
+  #unbindVisibility() {
+    if (this.#visibilityDocument && this.#visibilityHandler) {
+      this.#visibilityDocument.removeEventListener('visibilitychange', this.#visibilityHandler)
+    }
+    this.#visibilityDocument = undefined
+    this.#visibilityHandler = undefined
+  }
+}

--- a/packages-runtime/web/src/runtime/polyfill/routeRuntime/dom.ts
+++ b/packages-runtime/web/src/runtime/polyfill/routeRuntime/dom.ts
@@ -1,28 +1,12 @@
 import type { ComponentPublicInstance } from '../../component'
 import type { PageRecord, PageStackEntry } from './options'
-import { ensureAppContainer, getAppContainer, onDocumentReady } from '../../appShell/container'
+import { ensureAppContainer, onDocumentReady } from '../../appShell/container'
 import { attachRouteMeta } from './lifecycle'
-
-export function getPageContainer() {
-  return getAppContainer()
-}
-
-export function captureEntryScrollPosition(entry: PageStackEntry) {
-  if (!entry.active) {
-    return
-  }
-  const container = getPageContainer()
-  if (container) {
-    entry.scrollTop = container.scrollTop
-  }
-}
-
-export function restoreEntryScrollPosition(entry: PageStackEntry) {
-  const container = getPageContainer()
-  if (container) {
-    container.scrollTop = entry.scrollTop ?? 0
-  }
-}
+import {
+  bindPageScrollOwner,
+  restoreEntryScrollPosition,
+  setEntryScrollOwner,
+} from './scroll'
 
 function applyEntryVisibility(entry: PageStackEntry) {
   const element = entry.element
@@ -30,6 +14,7 @@ function applyEntryVisibility(entry: PageStackEntry) {
     return
   }
   element.setAttribute('data-weapp-page-active', entry.active ? 'true' : 'false')
+  setEntryScrollOwner(entry, entry.active)
   if (entry.active) {
     element.removeAttribute('hidden')
     element.removeAttribute('aria-hidden')
@@ -45,6 +30,7 @@ export function setEntryActiveInDom(entry: PageStackEntry, active: boolean) {
 }
 
 export function unmountEntryFromDom(entry: PageStackEntry) {
+  setEntryScrollOwner(entry, false)
   const element = entry.element
   if (!element) {
     entry.instance = undefined
@@ -60,7 +46,7 @@ export function unmountEntryFromDom(entry: PageStackEntry) {
 export function mountEntryToDom(
   entry: PageStackEntry,
   pageRegistry: Map<string, PageRecord>,
-  onMounted: (entry: PageStackEntry) => void,
+  onBeforeMount: (entry: PageStackEntry) => void,
 ) {
   const record = pageRegistry.get(entry.id)
   if (!record || entry.element) {
@@ -71,6 +57,8 @@ export function mountEntryToDom(
     if (!container) {
       return
     }
+    bindPageScrollOwner(container)
+    onBeforeMount(entry)
     const element = document.createElement(record.tag) as HTMLElement & ComponentPublicInstance
     element.setAttribute('data-weapp-page', entry.id)
     element.setAttribute('style', 'display:block;min-height:100%;box-sizing:border-box;padding-bottom:var(--weapp-tab-bar-inset, 0px);padding-top:var(--weapp-tab-bar-top-inset, 0px);')
@@ -85,6 +73,7 @@ export function mountEntryToDom(
     if (entry.active) {
       restoreEntryScrollPosition(entry)
     }
-    onMounted(entry)
   })
 }
+
+export { getPageContainer } from './scroll'

--- a/packages-runtime/web/src/runtime/polyfill/routeRuntime/history.ts
+++ b/packages-runtime/web/src/runtime/polyfill/routeRuntime/history.ts
@@ -33,6 +33,8 @@ let resolvedConfig = { ...DEFAULT_CONFIG }
 let knownPageIds = new Set<string>()
 let popstateHandler: (() => void) | undefined
 let hashchangeHandler: (() => void) | undefined
+let scrollRestorationHistory: History | undefined
+let previousScrollRestoration: ScrollRestoration | undefined
 
 function normalizeBase(base?: string) {
   if (!base?.trim()) {
@@ -53,6 +55,23 @@ function isBrowserHistoryAvailable() {
   return typeof window !== 'undefined'
     && typeof window.history?.pushState === 'function'
     && typeof window.history?.replaceState === 'function'
+}
+
+function bindManualScrollRestoration() {
+  if (typeof window === 'undefined' || !('scrollRestoration' in window.history)) {
+    return
+  }
+  scrollRestorationHistory = window.history
+  previousScrollRestoration = window.history.scrollRestoration
+  window.history.scrollRestoration = 'manual'
+}
+
+function restoreBrowserScrollRestoration() {
+  if (scrollRestorationHistory && previousScrollRestoration) {
+    scrollRestorationHistory.scrollRestoration = previousScrollRestoration
+  }
+  scrollRestorationHistory = undefined
+  previousScrollRestoration = undefined
 }
 
 function normalizePath(path: string) {
@@ -164,6 +183,7 @@ export function disposeWebRouting() {
   }
   popstateHandler = undefined
   hashchangeHandler = undefined
+  restoreBrowserScrollRestoration()
   resolvedConfig = { ...DEFAULT_CONFIG }
   knownPageIds = new Set()
 }
@@ -179,6 +199,8 @@ export function configureWebRouting(
   if (resolvedConfig.mode === 'memory' || typeof window === 'undefined') {
     return resolvedConfig
   }
+
+  bindManualScrollRestoration()
 
   popstateHandler = () => {
     const state = window.history.state as WebRouteHistoryState | undefined

--- a/packages-runtime/web/src/runtime/polyfill/routeRuntime/options.ts
+++ b/packages-runtime/web/src/runtime/polyfill/routeRuntime/options.ts
@@ -47,6 +47,7 @@ export interface RouteMeta {
 interface AppLifecycleHooks {
   onLaunch?: (this: AppRuntime, options: AppLaunchOptions) => void
   onShow?: (this: AppRuntime, options: AppLaunchOptions) => void
+  onHide?: (this: AppRuntime) => void
 }
 
 export type AppRuntime = Record<string, unknown> & Partial<AppLifecycleHooks> & {

--- a/packages-runtime/web/src/runtime/polyfill/routeRuntime/scroll.ts
+++ b/packages-runtime/web/src/runtime/polyfill/routeRuntime/scroll.ts
@@ -1,0 +1,66 @@
+import type { PageStackEntry } from './options'
+import { getAppContainer } from '../../appShell/container'
+
+type ScrollContainer = HTMLElement & Pick<EventTarget, 'addEventListener' | 'removeEventListener'>
+
+let activeEntry: PageStackEntry | undefined
+let boundContainer: ScrollContainer | undefined
+let scrollHandler: (() => void) | undefined
+
+export function getPageContainer() {
+  return getAppContainer()
+}
+
+export function captureEntryScrollPosition(entry: PageStackEntry) {
+  if (!entry.active) {
+    return
+  }
+  const container = getPageContainer()
+  if (container) {
+    entry.scrollTop = container.scrollTop
+  }
+}
+
+export function restoreEntryScrollPosition(entry: PageStackEntry) {
+  const container = getPageContainer()
+  if (container) {
+    container.scrollTop = entry.scrollTop ?? 0
+  }
+}
+
+export function setEntryScrollOwner(entry: PageStackEntry, active: boolean) {
+  if (active) {
+    activeEntry = entry
+    return
+  }
+  if (activeEntry === entry) {
+    activeEntry = undefined
+  }
+}
+
+export function recordActiveEntryScrollPosition() {
+  if (activeEntry) {
+    captureEntryScrollPosition(activeEntry)
+  }
+}
+
+export function bindPageScrollOwner(container: ScrollContainer) {
+  if (boundContainer === container) {
+    return
+  }
+  if (boundContainer && scrollHandler) {
+    boundContainer.removeEventListener('scroll', scrollHandler)
+  }
+  boundContainer = container
+  scrollHandler = recordActiveEntryScrollPosition
+  container.addEventListener('scroll', scrollHandler, { passive: true })
+}
+
+export function disposePageScrollOwner() {
+  if (boundContainer && scrollHandler) {
+    boundContainer.removeEventListener('scroll', scrollHandler)
+  }
+  activeEntry = undefined
+  boundContainer = undefined
+  scrollHandler = undefined
+}

--- a/packages-runtime/web/src/runtime/polyfill/routeRuntime/stack.ts
+++ b/packages-runtime/web/src/runtime/polyfill/routeRuntime/stack.ts
@@ -1,12 +1,11 @@
 import type { PageRecord, PageStackEntry } from './options'
 import {
-  captureEntryScrollPosition,
   mountEntryToDom,
-  restoreEntryScrollPosition,
   setEntryActiveInDom,
   unmountEntryFromDom,
 } from './dom'
 import { hidePageInstance, showPageInstance } from './lifecycle'
+import { captureEntryScrollPosition, restoreEntryScrollPosition } from './scroll'
 
 export class PageStackRuntime {
   readonly entries: PageStackEntry[] = []
@@ -15,7 +14,7 @@ export class PageStackRuntime {
 
   constructor(
     private readonly pageRegistry: Map<string, PageRecord>,
-    private readonly onMounted: (entry: PageStackEntry) => void,
+    private readonly onBeforeMount: (entry: PageStackEntry) => void,
   ) {}
 
   configureTabPages(ids: Iterable<string>) {
@@ -121,7 +120,7 @@ export class PageStackRuntime {
   }
 
   #mount(entry: PageStackEntry) {
-    mountEntryToDom(entry, this.pageRegistry, this.onMounted)
+    mountEntryToDom(entry, this.pageRegistry, this.onBeforeMount)
   }
 
   #record(entry: PageStackEntry) {

--- a/packages-runtime/web/src/runtime/polyfill/runtimeOps.ts
+++ b/packages-runtime/web/src/runtime/polyfill/runtimeOps.ts
@@ -5,7 +5,7 @@ import {
   scheduleMicrotask,
 } from './async'
 import { resolveSubPackageName } from './platformRuntime'
-import { getPageContainer } from './routeRuntime/dom'
+import { getPageContainer, recordActiveEntryScrollPosition } from './routeRuntime/scroll'
 
 function resolveScrollTop(value: unknown) {
   if (typeof value !== 'number' || Number.isNaN(value)) {
@@ -18,6 +18,7 @@ function setPageScrollTop(top: number) {
   const container = getPageContainer()
   if (container) {
     container.scrollTop = top
+    recordActiveEntryScrollPosition()
     return
   }
   if (typeof window !== 'undefined') {

--- a/packages-runtime/web/test/appLifecycle.test.ts
+++ b/packages-runtime/web/test/appLifecycle.test.ts
@@ -1,0 +1,119 @@
+import type { PageStackEntry } from '../src/runtime/polyfill/routeRuntime/options'
+import { AppLifecycleRuntime } from '../src/runtime/polyfill/routeRuntime/appLifecycle'
+
+class FakeVisibilityDocument {
+  hidden = false
+  visibilityState: DocumentVisibilityState = 'visible'
+  readonly listeners = new Set<() => void>()
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    if (type === 'visibilitychange' && typeof listener === 'function') {
+      this.listeners.add(listener as () => void)
+    }
+  }
+
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    if (type === 'visibilitychange' && typeof listener === 'function') {
+      this.listeners.delete(listener as () => void)
+    }
+  }
+
+  setVisibility(state: DocumentVisibilityState) {
+    this.visibilityState = state
+    this.hidden = state === 'hidden'
+    for (const listener of this.listeners) {
+      listener()
+    }
+  }
+}
+
+function entry(id: string, query: Record<string, string> = {}): PageStackEntry {
+  return { id, query, active: true }
+}
+
+describe('AppLifecycleRuntime', () => {
+  it('launches before page mount and bridges document visibility without duplicate callbacks', () => {
+    let currentEntry = entry('pages/index/index', { source: 'launch' })
+    const runtime = new AppLifecycleRuntime(() => currentEntry)
+    const visibilityDocument = new FakeVisibilityDocument()
+    const calls: Array<{ type: string, path?: string }> = []
+
+    runtime.register({
+      globalData: {},
+      onLaunch(options) {
+        calls.push({ type: 'launch', path: options.path })
+      },
+      onShow(options) {
+        calls.push({ type: 'show', path: options.path })
+      },
+      onHide() {
+        calls.push({ type: 'hide' })
+      },
+    })
+    runtime.bindVisibility(visibilityDocument as unknown as Document)
+    runtime.ensureLaunched(currentEntry)
+
+    expect(calls).toEqual([
+      { type: 'launch', path: 'pages/index/index' },
+      { type: 'show', path: 'pages/index/index' },
+    ])
+    expect(runtime.getLaunchOptions()).toMatchObject({
+      path: 'pages/index/index',
+      query: { source: 'launch' },
+    })
+
+    visibilityDocument.setVisibility('hidden')
+    visibilityDocument.setVisibility('hidden')
+    currentEntry = entry('pages/detail/index', { sku: '42' })
+    visibilityDocument.setVisibility('visible')
+    visibilityDocument.setVisibility('visible')
+
+    expect(calls).toEqual([
+      { type: 'launch', path: 'pages/index/index' },
+      { type: 'show', path: 'pages/index/index' },
+      { type: 'hide' },
+      { type: 'show', path: 'pages/detail/index' },
+    ])
+    expect(runtime.getEnterOptions()).toMatchObject({
+      path: 'pages/detail/index',
+      query: { sku: '42' },
+    })
+
+    runtime.dispose()
+    expect(visibilityDocument.listeners.size).toBe(0)
+  })
+
+  it('keeps globalData and replaces lifecycle hooks during registration updates', () => {
+    const currentEntry = entry('pages/index/index')
+    const runtime = new AppLifecycleRuntime(() => currentEntry)
+    const visibilityDocument = new FakeVisibilityDocument()
+    const originalGlobalData = { count: 1 }
+    const originalHide = vi.fn()
+    const updatedHide = vi.fn()
+
+    runtime.register({ globalData: originalGlobalData, onHide: originalHide })
+    runtime.ensureLaunched(currentEntry)
+    runtime.register({ globalData: { count: 999 }, onHide: updatedHide })
+    runtime.bindVisibility(visibilityDocument as unknown as Document)
+    visibilityDocument.setVisibility('hidden')
+
+    expect(runtime.instance?.globalData).toBe(originalGlobalData)
+    expect(runtime.instance?.globalData).toEqual({ count: 1 })
+    expect(originalHide).not.toHaveBeenCalled()
+    expect(updatedHide).toHaveBeenCalledTimes(1)
+    runtime.dispose()
+  })
+
+  it('marks launch state before callbacks can trigger another route mount', () => {
+    const currentEntry = entry('pages/index/index')
+    const runtime = new AppLifecycleRuntime(() => currentEntry)
+    const onLaunch = vi.fn(() => runtime.ensureLaunched(entry('pages/redirect/index')))
+    const onShow = vi.fn()
+
+    runtime.register({ onLaunch, onShow })
+    runtime.ensureLaunched(currentEntry)
+
+    expect(onLaunch).toHaveBeenCalledTimes(1)
+    expect(onShow).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages-runtime/web/test/history.test.ts
+++ b/packages-runtime/web/test/history.test.ts
@@ -36,6 +36,7 @@ function createFakeWindow(initialUrl: string) {
     },
   } as Location
   const history = {
+    scrollRestoration: 'auto',
     get state() {
       return state
     },
@@ -125,6 +126,7 @@ describe('web runtime browser routing', () => {
     const { fakeWindow, listeners } = createFakeWindow('https://example.test/mini/#/pages/index/index')
     withWindow(fakeWindow, () => {
       configureWebRouting({ mode: 'hash', base: '/mini' }, ['pages/index/index'], vi.fn())
+      expect(fakeWindow.history.scrollRestoration).toBe('manual')
       expect(readWebRouteTarget(['pages/index/index'])).toEqual({
         id: 'pages/index/index',
         query: {},
@@ -136,5 +138,6 @@ describe('web runtime browser routing', () => {
     })
     expect(listeners.get('popstate')?.size).toBe(0)
     expect(listeners.get('hashchange')?.size).toBe(0)
+    expect(fakeWindow.history.scrollRestoration).toBe('auto')
   })
 })

--- a/packages-runtime/web/test/pageScrollOwnership.test.ts
+++ b/packages-runtime/web/test/pageScrollOwnership.test.ts
@@ -1,0 +1,65 @@
+import type { PageStackEntry } from '../src/runtime/polyfill/routeRuntime/options'
+import {
+  bindPageScrollOwner,
+  disposePageScrollOwner,
+  recordActiveEntryScrollPosition,
+  restoreEntryScrollPosition,
+  setEntryScrollOwner,
+} from '../src/runtime/polyfill/routeRuntime/scroll'
+
+class FakeScrollContainer extends EventTarget {
+  scrollTop = 0
+}
+
+function entry(id: string): PageStackEntry {
+  return { id, query: {}, active: true }
+}
+
+describe('page scroll ownership', () => {
+  it('records user and programmatic scrolling on the active page only', () => {
+    const previousDocument = globalThis.document
+    const container = new FakeScrollContainer()
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: {
+        querySelector(selector: string) {
+          return selector === '#app' ? container : null
+        },
+      },
+    })
+
+    try {
+      const first = entry('pages/first/index')
+      const second = entry('pages/second/index')
+      bindPageScrollOwner(container as unknown as HTMLElement)
+      setEntryScrollOwner(first, true)
+
+      container.scrollTop = 72
+      container.dispatchEvent(new Event('scroll'))
+      expect(first.scrollTop).toBe(72)
+
+      setEntryScrollOwner(first, false)
+      setEntryScrollOwner(second, true)
+      restoreEntryScrollPosition(second)
+      expect(container.scrollTop).toBe(0)
+
+      container.scrollTop = 128
+      recordActiveEntryScrollPosition()
+      expect(container.scrollTop).toBe(128)
+      expect(second.scrollTop).toBe(128)
+      expect(first.scrollTop).toBe(72)
+
+      setEntryScrollOwner(second, false)
+      setEntryScrollOwner(first, true)
+      restoreEntryScrollPosition(first)
+      expect(container.scrollTop).toBe(72)
+    }
+    finally {
+      disposePageScrollOwner()
+      Object.defineProperty(globalThis, 'document', {
+        configurable: true,
+        value: previousDocument,
+      })
+    }
+  })
+})

--- a/packages-runtime/web/test/pageStackTabBar.test.ts
+++ b/packages-runtime/web/test/pageStackTabBar.test.ts
@@ -11,10 +11,10 @@ const runtimeSpies = vi.hoisted(() => ({
 vi.mock('../src/runtime/polyfill/routeRuntime/dom', () => ({
   captureEntryScrollPosition() {},
   mountEntryToDom(entry: PageStackEntry, _registry: Map<string, PageRecord>, onMounted: (entry: PageStackEntry) => void) {
+    onMounted(entry)
     runtimeSpies.mounted.push(entry.id)
     entry.element = { remove() {} } as unknown as PageStackEntry['element']
     entry.instance = {} as PageStackEntry['instance']
-    onMounted(entry)
   },
   restoreEntryScrollPosition() {},
   setEntryActiveInDom(entry: PageStackEntry, active: boolean) {

--- a/skills/weapp-vite-best-practices/references/web-runtime-compatibility.md
+++ b/skills/weapp-vite-best-practices/references/web-runtime-compatibility.md
@@ -12,6 +12,8 @@
 - picker-view 的受控 value 要在子列 slot 就绪后验证，避免把连接早期的空列 clamp 结果当成最终状态；slider 行为同时覆盖 `changing` 与 `change`。
 - `navigator` 的声明式跳转与 `wx.navigateTo` 等命令式 API 共用页面栈。验证时同时检查目标 route、query 和 navigateBack 后的页面恢复；`target="miniProgram"` 还要覆盖 success/fail/complete。
 - `navigateTo` 后原页面保持存活并触发 `onHide`；`navigateBack` 恢复同一实例、数据、`onShow` 和 `#app` 滚动位置，不会重跑 `onLoad`。排查返回状态丢失时，同时检查 `getCurrentPages()` 全栈、页面 host 的 `hidden` 状态和容器 `scrollTop`。
+- `App.onLaunch` / `App.onShow` 必须先于首个页面挂载；浏览器 `visibilitychange` 会去重触发 `App.onHide` / `App.onShow`。验证重新进入前台时，分别检查 `getLaunchOptionsSync()` 保留初始入口、`getEnterOptionsSync()` 更新为当前页面。
+- 页面滚动由当前栈项持续持有。用户滚动和 `pageScrollTo` 都应同步到对应页面；history/hash 模式会使用 manual scroll restoration，排查滚动跳变时不要再叠加 `window` 级恢复逻辑。
 - `redirectTo` 只卸载当前页，`reLaunch` 从栈顶开始卸载所有旧页面。路由目标无效或首页执行 `navigateBack` 时，Promise 应 reject，`fail` / `complete` 应收到对应 `errMsg`。
 - 标准 `app.json.tabBar` 会生成受 `#app` 设备视口约束的 Web App Shell。`switchTab` 只能进入 tab 路由，会卸载非 tab 页面并缓存其他 tab 实例；切回时验证 `onLoad` 不重复、`onShow` 正常递增和 `getCurrentPages()` 只返回当前 tab 栈。
 - `showTabBar` / `hideTabBar` 会同步页面 inset；`setTabBarItem`、`setTabBarStyle`、badge 与 red-dot API 会更新 shell。`tabBar.custom: true` 只保留路由语义，不会自动渲染业务自定义组件。

--- a/website/config/web.md
+++ b/website/config/web.md
@@ -196,6 +196,8 @@ Web 产物输出目录，默认一般是 `dist/web`。
 
 Web 页面栈会保留 `navigateTo` 隐藏页面的 DOM、实例、数据和滚动位置。`navigateBack` 恢复同一页面实例并重新触发 `onShow`，不会重复触发 `onLoad`；`redirectTo` 只卸载当前页，`reLaunch` 卸载整个旧页面栈。`getCurrentPages()` 返回所有存活页面，路由 Promise 与 `success` / `fail` / `complete` 回调使用小程序形状的 `errMsg`。
 
+首次页面挂载前会触发 `App.onLaunch` / `App.onShow`，浏览器进入后台或回到前台时通过 `visibilitychange` 去重触发 `App.onHide` / `App.onShow`。`getLaunchOptionsSync()` 始终返回初始入口，`getEnterOptionsSync()` 会在重新进入前台时更新为当前页面。页面容器 `#app` 的滚动位置持续归属于当前栈项；history/hash 路由会关闭浏览器原生滚动恢复，避免窗口和设备容器重复恢复。
+
 尚未完整支持的已知小程序组件会保持可渲染降级并输出去重告警。Web 运行时仍不等价于微信 DevTools 或真机，视觉发布门禁应以 DevTools 基线为真值。
 
 ### `vite`

--- a/website/guide/web-compat-matrix.md
+++ b/website/guide/web-compat-matrix.md
@@ -50,6 +50,7 @@ keywords:
 | `methods` / `triggerEvent`                       | `✅` | 支持事件触发与组件方法调用。                                     |
 | `lifetimes`（`created/attached/ready/detached`） | `✅` | 支持基础生命周期。                                               |
 | `pageLifetimes`（`show/hide`）                   | `🟡` | 在页面显示/隐藏时分发到组件；`resize` 依赖浏览器环境。           |
+| `App.onLaunch/onShow/onHide`                     | `✅` | 启动回调先于首屏页面挂载；前后台切换由 visibilitychange 驱动。   |
 | `behaviors`（递归合并）                          | `✅` | 支持递归合并 `data/properties/methods/lifetimes/pageLifetimes`。 |
 | `observerInit`                                   | `✅` | 可配置初始化阶段 observer 触发策略。                             |
 | `relations` / `externalClasses` 等               | `⛔` | 当前未在 runtime `ComponentOptions` 中实现。                     |
@@ -92,7 +93,7 @@ keywords:
 | `wx.setTabBarBadge` / `removeTabBarBadge` / `showTabBarRedDot` / `hideTabBarRedDot`                      | `✅` | 支持标准 tabBar badge 与红点状态；非法 index 按微信形状回调和 Promise 失败。                                                |
 | `wx.loadSubPackage` / `wx.preloadSubpackage`                                                             | `🟡` | 当前提供 no-op 成功桥接，主要用于兼容分包加载调用链，不执行真实下载与预加载流程。                                           |
 | `wx.navigateBack`                                                                                        | `✅` | 支持 `delta` 回退。                                                                                                         |
-| 浏览器深链接与前进/后退                                                                                  | `✅` | `runtime.routing` 支持 `history` / `hash`；默认 `memory`，可按部署目录设置 `base`。                                         |
+| 浏览器深链接与前进/后退                                                                                  | `✅` | `runtime.routing` 支持 `history` / `hash`；页面栈拥有 `#app` 滚动位置并禁用浏览器原生滚动恢复。                             |
 | 页面 Head 与首屏资源提示                                                                                 | `✅` | `runtime.seo` 同步标题、description、canonical；`runtime.resourceHints.links` 去重注入浏览器 Resource Hints，不等同于 SSR。 |
 | `wx.setNavigationBarTitle`                                                                               | `🟡` | 依赖默认导航栏组件存在。                                                                                                    |
 | `wx.setNavigationBarColor`                                                                               | `🟡` | 依赖默认导航栏组件存在。                                                                                                    |
@@ -164,7 +165,7 @@ keywords:
 | `wx.openAppAuthorizeSetting`                                                                             | `🟡` | 提供应用级授权设置结果桥接，可通过预设状态注入授权结果，不触发系统级授权设置页。                                            |
 | `wx.getAppBaseInfo`                                                                                      | `🟡` | 提供浏览器环境下的基础信息近似值（语言、主题、平台等）。                                                                    |
 | `wx.getMenuButtonBoundingClientRect`                                                                     | `🟡` | 返回基于窗口尺寸的启发式胶囊按钮区域，不保证与真机一致。                                                                    |
-| `wx.getLaunchOptionsSync` / `wx.getEnterOptionsSync`                                                     | `🟡` | 返回基于当前 Web runtime 路由推断的启动参数快照。                                                                           |
+| `wx.getLaunchOptionsSync` / `wx.getEnterOptionsSync`                                                     | `🟡` | launch 保留初始入口；重新进入前台时 enter 更新为当前页面，scene/referrerInfo 仍为 Web 近似值。                              |
 | `wx.canIUse`                                                                                             | `🟡` | 支持 API 级能力探测（`wx.xxx`）；复杂组件/样式规则探测未覆盖。                                                              |
 | `getCurrentPages` / `getApp`                                                                             | `✅` | 提供基础桥接能力。                                                                                                          |
 | 其他常见 API（多媒体高级能力等）                                                                         | `⛔` | 尚未内置桥接，需业务层自行兼容。                                                                                            |

--- a/website/packages/web.md
+++ b/website/packages/web.md
@@ -87,6 +87,8 @@ export default defineConfig({
 - `cover-view` / `cover-image` 保留媒体覆盖层的定位和层级；`movable-area` / `movable-view` 支持边界、方向限制、拖拽及微信形状移动事件
 - `setWebRuntimeHost` / `resetWebRuntimeHost` 提供宿主注入边界；网络、存储、剪贴板、对话框和打开链接可由测试容器或业务宿主接管，未注入能力回退到浏览器 API。
 - `navigateTo` 保活隐藏页面，`navigateBack` 恢复同一实例、数据和滚动位置；`redirectTo` / `reLaunch` 按页面栈语义触发 `onHide` / `onUnload`
+- `App.onLaunch` / `App.onShow` 在首个页面挂载前触发，浏览器前后台切换会驱动去重的 `App.onHide` / `App.onShow`；launch options 与重新进入时的 enter options 分开维护
+- `#app` 滚动由当前页面栈项持续持有，用户滚动和 `pageScrollTo` 都会写回页面状态；history/hash 模式禁用浏览器原生滚动恢复以避免双重恢复
 - `getCurrentPages()` 返回当前活动路由栈，其他保活 tab 页面不会混入当前 tab 栈；路由 API 同时支持 Promise 与 `success` / `fail` / `complete` 回调
 - 读取 `app.json.tabBar` 并在设备容器内渲染标准 App Shell；`switchTab` 缓存 tab 页面、关闭非 tab 页面并保持正确的 `onLoad` / `onShow` 语义
 - `showTabBar` / `hideTabBar`、`setTabBarItem`、`setTabBarStyle`、badge 与 red-dot API 会真实更新布局和视觉状态

--- a/website/public/llms-index.json
+++ b/website/public/llms-index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-07-25T04:09:20.509Z",
+  "generatedAt": "2026-07-25T05:21:22.363Z",
   "site": "https://vite.icebreaker.top",
   "count": 271,
   "items": [

--- a/website/public/seo-quality-report.json
+++ b/website/public/seo-quality-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-25T04:10:54.068Z",
+  "generatedAt": "2026-07-25T05:21:24.787Z",
   "site": "https://vite.icebreaker.top",
   "totals": {
     "files": 271,


### PR DESCRIPTION
## 变更说明

- 首屏页面挂载前触发 `App.onLaunch` / `App.onShow`，并通过去重的 `visibilitychange` 驱动 `App.onHide` / `App.onShow`
- 分离初始 launch options 与重新进入前台的 enter options，保证当前页面查询参数正确更新
- 将用户滚动和 `pageScrollTo` 统一写回当前页面栈项，并在 history/hash 模式启用 manual scroll restoration
- 拆分应用生命周期与页面滚动模块，使 route runtime 主文件保持在 300 行以内

## 文档同步

- 更新 `@weapp-vite/web` README、Web 配置页、包说明、兼容矩阵与最佳实践 compatibility 文档
- 通过网站构建脚本刷新 `llms-index.json` 与 `seo-quality-report.json`，质量问题为 0

## Changeset

- 新增 `@weapp-vite/web` minor changeset
- 未修改 `weapp-vite`、模板或脚手架，不联动 `create-weapp-vite`

## 验证

- `pnpm --filter @weapp-vite/web typecheck`
- `pnpm --filter @weapp-vite/web test`
- `pnpm exec tsc -p apps/weapp-vite-web-demo/tsconfig.json --noEmit`
- 相关 ESLint 检查
- `pnpm --filter @weapp-vite/web build`
- `pnpm --filter weapp-vite build`
- `pnpm --filter "weapp-vite..." build`
- `pnpm e2e:web`（19/19）
- `pnpm --filter website-weapp-vite build`
- `node --import tsx scripts/check-catalog-changeset.ts`
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`