### PR TITLE
fix(ci): 避免发布阶段重复校验已消费 changeset

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "catalog:sync:weapi": "pnpm --filter @wevu/api catalog:sync",
     "catalog:sync:create-weapp-vite": "node --import tsx packages/create-weapp-vite/scripts/generate-template-catalog.ts",
     "deps:up": "node --import tsx scripts/upgrade-workspace-deps.ts",
-    "publish-packages": "pnpm run catalog:sync:create-weapp-vite && pnpm run changeset:catalog:auto && pnpm run check:catalog-changeset && pnpm run check:create-weapp-vite-changeset && pnpm run check:publishable-workspace-changeset && pnpm run check:publishable-workspace-dependency-protocols && pnpm run check:weapp-core-constants-changeset && pnpm run check:weapp-core-constants-dependency-range && pnpm run check:rolldown:single-version && pnpm run ci:release && turbo run test && turbo run test:types && changeset version && pnpm run check:weapp-core-constants-release-version && changeset publish",
+    "publish-packages": "pnpm run catalog:sync:create-weapp-vite && pnpm run changeset:catalog:auto && pnpm run check:catalog-changeset && pnpm run check:create-weapp-vite-changeset && pnpm run check:publishable-workspace-dependency-protocols && pnpm run check:weapp-core-constants-changeset && pnpm run check:weapp-core-constants-dependency-range && pnpm run check:rolldown:single-version && pnpm run ci:release && turbo run test && turbo run test:types && changeset version && pnpm run check:weapp-core-constants-release-version && changeset publish",
     "repo:init": "repo init",
     "repo:upgrade": "repo workspace upgrade",
     "repo:clean": "repo workspace clean",

--- a/scripts/check-publishable-workspace-changeset.test.ts
+++ b/scripts/check-publishable-workspace-changeset.test.ts
@@ -204,7 +204,7 @@ it('collectConstantsDependentReleaseIssues accepts complete constants release se
   assert.deepEqual(issues, [])
 })
 
-it('publish-packages runs constants guards before publishing packages', async () => {
+it('publish-packages runs release guards without rechecking consumed changesets', async () => {
   const packageJsonPath = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     '../package.json',
@@ -215,11 +215,13 @@ it('publish-packages runs constants guards before publishing packages', async ()
   }
 
   const publishScript = packageJson.scripts?.['publish-packages'] ?? ''
+  const workspaceChangesetGuardIndex = publishScript.indexOf('check:publishable-workspace-changeset')
   const changesetGuardIndex = publishScript.indexOf('check:weapp-core-constants-changeset')
   const versionIndex = publishScript.indexOf('changeset version')
   const versionGuardIndex = publishScript.indexOf('check:weapp-core-constants-release-version')
   const publishIndex = publishScript.indexOf('changeset publish')
 
+  assert.equal(workspaceChangesetGuardIndex, -1)
   assert.notEqual(changesetGuardIndex, -1)
   assert.notEqual(versionIndex, -1)
   assert.notEqual(versionGuardIndex, -1)


### PR DESCRIPTION
## 问题

6.18.7 版本 PR 合并后，Changesets 已正常消费 changeset；`publish-packages` 仍再次执行源码变更阶段的 changeset presence guard，导致 Release workflow 在进入构建和 npm trusted publishing 前误报六个发布包缺少 changeset。

## 修复

- 从 `publish-packages` 移除仅适用于 PR/源码变更阶段的 `check:publishable-workspace-changeset`
- 保留 CI Policy 中的 changeset 门禁，以及 dependency protocol、constants、build、test、type test、version 和 publish guards
- 增加回归断言，确保发布脚本不会重复校验已消费的 changeset

## 验证

- `pnpm vitest run scripts/check-publishable-workspace-changeset.test.ts`
- `pnpm exec eslint package.json scripts/check-publishable-workspace-changeset.test.ts --max-warnings=0`
- `pnpm lint-staged`