### PR TITLE
fix(weapp-vite): 修复原生 TS sourcemap 映射

### DIFF
--- a/.changeset/fix-native-ts-sourcemap.md
+++ b/.changeset/fix-native-ts-sourcemap.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复 `wv build --sourcemap` 未透传到 Vite 构建配置，以及分包 npm 本地化重写后原生 TypeScript 页面 sourcemap 继续沿用旧映射导致行号错乱的问题。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -610,6 +610,13 @@
           "launchMode": "default"
         },
         {
+          "name": "subpackages/item/issue-769/index",
+          "pathName": "subpackages/item/issue-769/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "subpackages/item/login-required/index",
           "pathName": "subpackages/item/login-required/index",
           "query": "",

--- a/e2e-apps/github-issues/src/subpackages/item/issue-769/index.json
+++ b/e2e-apps/github-issues/src/subpackages/item/issue-769/index.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "issue-769"
+}

--- a/e2e-apps/github-issues/src/subpackages/item/issue-769/index.ts
+++ b/e2e-apps/github-issues/src/subpackages/item/issue-769/index.ts
@@ -1,0 +1,16 @@
+import camelCase from 'camelcase'
+
+const issue769NpmMarker = camelCase('issue 769 sourcemap marker')
+
+Page({
+  data: {
+    issue769NpmMarker,
+    title: 'issue-769 native sourcemap',
+  },
+  _runE2E() {
+    return {
+      issue769NpmMarker,
+      ok: issue769NpmMarker === 'issue769SourcemapMarker',
+    }
+  },
+})

--- a/e2e-apps/github-issues/src/subpackages/item/issue-769/index.wxml
+++ b/e2e-apps/github-issues/src/subpackages/item/issue-769/index.wxml
@@ -1,0 +1,4 @@
+<view class="issue769-page">
+  <text>{{title}}</text>
+  <text>{{issue769NpmMarker}}</text>
+</view>

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable e18e/ban-dependencies -- e2e build assertions reuse shared fs helpers to inspect generated artifacts. */
+import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping'
 import { fs } from '@weapp-core/shared/node'
 import { execa } from 'execa'
 import { fdir } from 'fdir'
@@ -86,6 +87,16 @@ function createCachedEnvLinePattern(variableName: string) {
   return new RegExp(
     `const ${variableName} = .*globalThis\\["__weappViteImportMetaEnv"\\].*JSON\\.parse\\(`,
   )
+}
+
+function findGeneratedPosition(code: string, needle: string) {
+  const lines = code.split('\n')
+  const lineIndex = lines.findIndex(line => line.includes(needle))
+  expect(lineIndex).toBeGreaterThanOrEqual(0)
+  return {
+    column: lines[lineIndex].indexOf(needle),
+    line: lineIndex + 1,
+  }
 }
 
 function createObjectPropertyPattern(property: string, value: string) {
@@ -950,6 +961,28 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(componentJs).toContain('issue-475 component marker')
     expect(componentJs).toMatch(createCachedEnvLinePattern('componentEnv'))
     expect(componentJs).not.toContain('const componentEnv = {\n')
+  })
+
+  it('issue #769: keeps native ts sourcemaps aligned after local npm rewrite', async () => {
+    await runBuildWithSourcemap()
+
+    const sourceFile = 'src/subpackages/item/issue-769/index.ts'
+    const pageJsPath = path.join(DIST_ROOT, 'subpackages/item/issue-769/index.js')
+    const pageMapPath = `${pageJsPath}.map`
+    const pageJs = await fs.readFile(pageJsPath, 'utf-8')
+    const pageMap = JSON.parse(await fs.readFile(pageMapPath, 'utf-8')) as Parameters<typeof TraceMap>[0]
+    const sourceTs = await fs.readFile(path.join(APP_ROOT, sourceFile), 'utf-8')
+    const expectedSourceLine = sourceTs
+      .split('\n')
+      .findIndex(line => line.includes(`camelCase('issue 769 sourcemap marker')`)) + 1
+    const generatedPosition = findGeneratedPosition(pageJs, 'issue 769 sourcemap marker')
+    const originalPosition = originalPositionFor(new TraceMap(pageMap), generatedPosition)
+
+    expect(pageJs).toMatch(/require\((['"])\.\.\/miniprogram_npm\/camelcase(?:\/index)?\1\)/)
+    expect(await fs.pathExists(pageMapPath)).toBe(true)
+    expect(expectedSourceLine).toBeGreaterThan(0)
+    expect(originalPosition.source?.replaceAll('\\', '/')).toContain(sourceFile)
+    expect(originalPosition.line).toBe(expectedSourceLine)
   })
 
   it('issue #479: injects indirect wevu page feature hooks from local helpers', async () => {
@@ -2521,6 +2554,7 @@ describe.sequential('e2e app: github-issues (build)', () => {
 
     expect(itemSubPackage?.pages).toEqual([
       'index',
+      'issue-769/index',
       'login-required/index',
     ])
     expect(await fs.pathExists(invalidSharedPageWxmlPath)).toBe(false)

--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
     "@changesets/cli": "^2.31.1",
     "@commitlint/cli": "^21.2.1",
     "@icebreakers/changelog-github": "^2.0.0",
+    "@jridgewell/trace-mapping": "^0.3.31",
     "@oxc-node/cli": "^0.1.0",
     "@oxc-node/core": "^0.1.0",
     "@swc-node/register": "^1.12.1",

--- a/packages/weapp-vite/src/cli/commands/build.test.ts
+++ b/packages/weapp-vite/src/cli/commands/build.test.ts
@@ -219,6 +219,30 @@ describe('build cli command', () => {
     expect(loggerSuccessMock).toHaveBeenCalledWith(expect.stringContaining('小程序构建完成，耗时：'))
   })
 
+  it('passes build output options through inline config', async () => {
+    const action = createBuildActionHandler()
+
+    await action('/project', {
+      emptyOutDir: true,
+      minify: false,
+      outDir: 'dist-debug',
+      platform: 'weapp',
+      sourcemap: true,
+    })
+
+    expect(createInlineConfigMock).toHaveBeenCalledWith(expect.anything(), {
+      inlineConfig: {
+        build: {
+          emptyOutDir: true,
+          minify: false,
+          outDir: 'dist-debug',
+          sourcemap: true,
+        },
+      },
+      scope: undefined,
+    })
+  })
+
   it('forwards trust-project setting when opening ide after build', async () => {
     const action = createBuildActionHandler()
 

--- a/packages/weapp-vite/src/cli/commands/build.ts
+++ b/packages/weapp-vite/src/cli/commands/build.ts
@@ -1,5 +1,6 @@
 import type { CAC } from 'cac'
 import type { ChildProcess } from 'node:child_process'
+import type { InlineConfig } from 'vite'
 import type { AnalyzeDashboardHandle, DashboardRuntimeEventInput } from '../analyze/dashboard'
 import type { GlobalCLIOptions } from '../types'
 import process from 'node:process'
@@ -45,6 +46,54 @@ function terminateStaleSassEmbeddedProcess() {
 
 function emitDashboardEvents(handle: AnalyzeDashboardHandle | undefined, events: DashboardRuntimeEventInput[]) {
   handle?.emitRuntimeEvents(events)
+}
+
+function normalizeBuildSourcemap(
+  value: GlobalCLIOptions['sourcemap'],
+): NonNullable<InlineConfig['build']>['sourcemap'] {
+  if (value === 'true') {
+    return true
+  }
+  if (value === 'false') {
+    return false
+  }
+  return value
+}
+
+function normalizeBuildMinify(
+  value: GlobalCLIOptions['minify'],
+): NonNullable<InlineConfig['build']>['minify'] {
+  if (value === 'true') {
+    return true
+  }
+  if (value === 'false') {
+    return false
+  }
+  return value
+}
+
+function hasCliOption(options: GlobalCLIOptions, key: keyof GlobalCLIOptions) {
+  return Object.prototype.hasOwnProperty.call(options, key)
+}
+
+function createBuildInlineConfig(options: GlobalCLIOptions): InlineConfig | undefined {
+  const build: NonNullable<InlineConfig['build']> = {}
+  if (typeof options.outDir === 'string') {
+    build.outDir = options.outDir
+  }
+  if (hasCliOption(options, 'sourcemap')) {
+    build.sourcemap = normalizeBuildSourcemap(options.sourcemap)
+  }
+  if (hasCliOption(options, 'minify')) {
+    build.minify = normalizeBuildMinify(options.minify)
+  }
+  if (typeof options.emptyOutDir === 'boolean') {
+    build.emptyOutDir = options.emptyOutDir
+  }
+
+  return Object.keys(build).length
+    ? { build }
+    : undefined
 }
 
 export function shouldScheduleCompletedProductionBuildExit(options: GlobalCLIOptions, analyzeHandle: AnalyzeDashboardHandle | undefined) {
@@ -107,7 +156,10 @@ export function registerBuildCommand(cli: CAC) {
         const cwd = root ?? process.cwd()
         const configFile = resolveConfigFile(options)
         targets = resolveRuntimeTargets(options)
-        const inlineConfig = createInlineConfig(targets, { scope: options.scope })
+        const inlineConfig = createInlineConfig(targets, {
+          scope: options.scope,
+          inlineConfig: createBuildInlineConfig(options),
+        })
         ctx = await createCompilerContext({
           cwd,
           mode: options.mode ?? 'production',

--- a/packages/weapp-vite/src/cli/runtime.test.ts
+++ b/packages/weapp-vite/src/cli/runtime.test.ts
@@ -54,6 +54,20 @@ describe('cli runtime target resolution', () => {
     expect(createInlineConfig(resolveRuntimeTargets({}))).toBeUndefined()
   })
 
+  it('uses explicit inline config when runtime target does not add one', () => {
+    expect(createInlineConfig(resolveRuntimeTargets({}), {
+      inlineConfig: {
+        build: {
+          sourcemap: true,
+        },
+      },
+    })).toEqual({
+      build: {
+        sourcemap: true,
+      },
+    })
+  })
+
   it('composes backend inline config in execution order', () => {
     const targets = resolveRuntimeTargets({ platform: 'all' })
 
@@ -78,6 +92,25 @@ describe('cli runtime target resolution', () => {
           usePolling: true,
           interval: 100,
         },
+      },
+    })
+  })
+
+  it('keeps explicit inline build options while composing backend config', () => {
+    const targets = resolveRuntimeTargets({ platform: 'all' })
+
+    expect(createInlineConfig(targets, {
+      inlineConfig: {
+        build: {
+          outDir: 'dist-weapp',
+          sourcemap: true,
+        },
+      },
+    })).toMatchObject({
+      build: {
+        outDir: 'dist-weapp',
+        sourcemap: true,
+        watch: {},
       },
     })
   })

--- a/packages/weapp-vite/src/cli/runtime.ts
+++ b/packages/weapp-vite/src/cli/runtime.ts
@@ -49,7 +49,7 @@ export function resolveRuntimeTargets(options: { platform?: string, p?: string }
 
 export function createInlineConfig(
   execution: RuntimeTargets,
-  options: { scope?: string, host?: string | boolean } = {},
+  options: { scope?: string, host?: string | boolean, inlineConfig?: InlineConfig } = {},
 ): InlineConfig | undefined {
   const configs = execution.entries
     .map(entry => entry.driver.createInlineConfig({
@@ -60,10 +60,13 @@ export function createInlineConfig(
     }))
     .filter((config): config is InlineConfig => Boolean(config))
   if (configs.length === 0) {
-    return undefined
+    return options.inlineConfig
   }
-  return configs.slice(1).reduce(
+  const merged = configs.slice(1).reduce(
     (merged, config) => defu<InlineConfig, InlineConfig[]>(merged, config),
     configs[0],
   )
+  return options.inlineConfig
+    ? defu<InlineConfig, InlineConfig[]>(options.inlineConfig, merged)
+    : merged
 }

--- a/packages/weapp-vite/src/cli/types.ts
+++ b/packages/weapp-vite/src/cli/types.ts
@@ -30,6 +30,10 @@ export interface GlobalCLIOptions {
   'loginRetry'?: string
   'loginRetryTimeout'?: string
   'nonInteractive'?: boolean
+  'outDir'?: string
+  'sourcemap'?: boolean | 'false' | 'hidden' | 'inline' | 'true'
+  'minify'?: boolean | 'esbuild' | 'false' | 'oxc' | 'terser' | 'true'
+  'emptyOutDir'?: boolean
   'analyze'?: boolean
   'ui'?: boolean
   'watch'?: boolean

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/localRoot.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/localRoot.test.ts
@@ -1,4 +1,5 @@
 import type { OutputAsset, OutputBundle, OutputChunk } from 'rolldown'
+import MagicString from 'magic-string'
 import { describe, expect, it } from 'vitest'
 import { rewriteBundleNpmImportsToLocalRoots } from './localRoot'
 
@@ -168,5 +169,68 @@ describe('rewriteBundleNpmImportsToLocalRoots', () => {
     expect(rootChunk.code).not.toContain(`require("./pkg-a/miniprogram_npm/ui-lib/button")`)
     expect(pageChunk.code).toContain(`require("../miniprogram_npm/ui-lib/button")`)
     expect(JSON.parse(String(rootJson.source)).usingComponents.button).toBe('./miniprogram_npm/ui-lib/button')
+  })
+
+  it('keeps chunk sourcemap empty when sourcemaps are disabled', () => {
+    const chunk = createChunk('subpackages/item/pages/index.js', `const comp = require('ui-lib/button')`)
+    const bundle: OutputBundle = {
+      [chunk.fileName]: chunk,
+    }
+
+    rewriteBundleNpmImportsToLocalRoots(
+      bundle,
+      {
+        'ui-lib': '1.0.0',
+      },
+      [
+        {
+          root: 'subpackages/item',
+          dependencies: ['ui-lib'],
+        },
+      ],
+    )
+
+    expect(chunk.code).toContain(`require("../miniprogram_npm/ui-lib/button")`)
+    expect(chunk.map).toBeNull()
+  })
+
+  it('updates sourcemaps when rewriting local npm imports in chunks', () => {
+    const code = [
+      `var require_camelcase = require("camelcase");`,
+      `var import_camelcase = __toESM(require_camelcase, 1);`,
+      `const issue769NpmMarker = (0, import_camelcase.default)("issue 769 sourcemap marker");`,
+      `Page({ data: { issue769NpmMarker } });`,
+    ].join('\n')
+    const source = 'src/subpackages/item/issue-769/index.ts'
+    const chunk = createChunk('subpackages/item/issue-769/index.js', code)
+    const originalMap = new MagicString(code).generateMap({
+      hires: 'boundary',
+      includeContent: true,
+      source,
+    })
+    chunk.map = originalMap as any
+    const bundle: OutputBundle = {
+      [chunk.fileName]: chunk,
+    }
+
+    rewriteBundleNpmImportsToLocalRoots(
+      bundle,
+      {
+        camelcase: '9.0.0',
+      },
+      [
+        {
+          root: 'subpackages/item',
+          dependencies: ['camelcase'],
+        },
+      ],
+    )
+
+    expect(chunk.code).toContain(`require("../miniprogram_npm/camelcase/index")`)
+    expect(chunk.code).toContain(`__toESM(require_camelcase)`)
+    expect(chunk.code).not.toContain(`__toESM(require_camelcase,)`)
+    expect(chunk.map).not.toBe(originalMap)
+    expect(chunk.map?.sources).toContain(source)
+    expect(chunk.map?.sourcesContent?.join('\n')).toContain('issue769NpmMarker')
   })
 })

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/localRoot.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/localRoot.ts
@@ -1,14 +1,15 @@
 import type { OutputBundle, OutputChunk } from 'rolldown'
 import type { ChunkScriptAnalysisCache } from './platform'
+import MagicString from 'magic-string'
 import path from 'pathe'
 import { toPosixPath } from '../../../../../utils'
-import { generate, parseJsLike, traverse } from '../../../../../utils/babel'
+import { parseJsLike, traverse } from '../../../../../utils/babel'
 import {
   getRequireImportLiteral,
   normalizeWeappLocalNpmImport,
-  setRequireImportLiteral,
 } from './literals'
 import { getChunkScriptAnalysis, matchesSubPackageDependency, rememberChunkScriptAnalysis } from './platform'
+import { applyMagicStringChunkRewrite } from './sourcemap'
 
 export interface LocalRootNpmRewriteSubPackageMeta {
   root: string
@@ -46,6 +47,23 @@ function isToEsmCall(node: any) {
 
 function isNumericOneLiteral(node: any) {
   return (node?.type === 'NumericLiteral' || node?.type === 'Literal') && node.value === 1
+}
+
+function hasNodeRange(node: any): node is { start: number, end: number } {
+  return Number.isInteger(node?.start) && Number.isInteger(node?.end) && node.start >= 0 && node.end >= node.start
+}
+
+function findPreviousCommaIndex(code: string, start: number) {
+  for (let index = start - 1; index >= 0; index--) {
+    const char = code[index]
+    if (char === ',') {
+      return index
+    }
+    if (!/\s/.test(char)) {
+      return start
+    }
+  }
+  return start
 }
 
 function getLocalizedBindingNameFromExpression(node: any, localizedRequireBindings: Set<string>) {
@@ -99,6 +117,7 @@ export function rewriteChunkNpmImportsToLocalRoot(
 
   try {
     const ast = parseJsLike(chunk.code)
+    const magicString = new MagicString(chunk.code)
     let mutated = false
     const localizedRequireBindings = new Set<string>()
 
@@ -163,7 +182,11 @@ export function rewriteChunkNpmImportsToLocalRoot(
             return
           }
 
-          setRequireImportLiteral(firstArg, nextValue)
+          if (!hasNodeRange(firstArg)) {
+            return
+          }
+
+          magicString.update(firstArg.start, firstArg.end, JSON.stringify(nextValue))
           if (isRelativeMiniprogramNpmImport(nextValue) && path.parentPath?.node?.type === 'VariableDeclarator' && path.parentPath.node.id?.type === 'Identifier') {
             localizedRequireBindings.add(path.parentPath.node.id.name)
           }
@@ -190,13 +213,18 @@ export function rewriteChunkNpmImportsToLocalRoot(
           return
         }
 
-        path.node.arguments = [firstArg]
+        const secondArg = args[1]
+        if (!hasNodeRange(firstArg) || !hasNodeRange(secondArg)) {
+          return
+        }
+
+        magicString.remove(findPreviousCommaIndex(chunk.code, secondArg.start), secondArg.end)
         mutated = true
       },
     })
 
     if (mutated) {
-      chunk.code = generate(ast as any).code
+      applyMagicStringChunkRewrite(chunk, magicString)
       rememberChunkScriptAnalysis(chunk, analysis, {
         cache: options?.analysisCache,
       })

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/sourcemap.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/sourcemap.ts
@@ -1,0 +1,24 @@
+import type MagicString from 'magic-string'
+import type { OutputChunk } from 'rolldown'
+import { composeSourceMaps, normalizeEncodedSourceMapLike } from '../../../../../utils/sourcemap'
+
+export function applyMagicStringChunkRewrite(chunk: OutputChunk, magicString: MagicString) {
+  const previousCode = chunk.code
+  const nextCode = magicString.toString()
+  if (nextCode === previousCode) {
+    return false
+  }
+
+  const previousMap = normalizeEncodedSourceMapLike(chunk.map)
+
+  chunk.code = nextCode
+  if (previousMap) {
+    const nextMap = magicString.generateMap({
+      hires: 'boundary',
+      includeContent: true,
+      source: chunk.fileName,
+    })
+    chunk.map = composeSourceMaps(nextMap as any, previousMap) as any
+  }
+  return true
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       '@icebreakers/changelog-github':
         specifier: ^2.0.0
         version: 2.0.0(encoding@0.1.13)
+      '@jridgewell/trace-mapping':
+        specifier: ^0.3.31
+        version: 0.3.31
       '@oxc-node/cli':
         specifier: ^0.1.0
         version: 0.1.0


### PR DESCRIPTION
## 摘要
- 修复 `wv build --sourcemap` 未透传到 Vite `build.sourcemap` 的问题
- 将分包 npm 本地化重写改为 MagicString 片段更新，并在已有 sourcemap 时 compose 映射，避免原生 TS 产物行号错乱
- 在 `e2e-apps/github-issues` 增加 issue #769 原生 TS 分包页面复现，并新增 sourcemap 回溯断言

## 验证
- `pnpm vitest run packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/localRoot.test.ts packages/weapp-vite/src/cli/runtime.test.ts packages/weapp-vite/src/cli/commands/build.test.ts`
- `pnpm --filter weapp-vite typecheck`
- `pnpm --filter weapp-vite lint:src`
- `pnpm --filter weapp-vite build`
- `pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #769"`
- `pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts`

Fixes #769