### PR TITLE
fix(weapp-vite): 修复 axios 真机调试白屏

### DIFF
--- a/.changeset/fix-issue-764-request-globals-prelude.md
+++ b/.changeset/fix-issue-764-request-globals-prelude.md
@@ -1,0 +1,6 @@
+---
+'create-weapp-vite': patch
+'weapp-vite': patch
+---
+
+修复默认 wevu 模板安装 axios 后真机调试可能白屏的问题：自动识别请求客户端依赖时默认提前生成 request globals app prelude，确保页面模块执行前已经安装 `fetch`、`XMLHttpRequest` 和 `URL` 等兼容全局对象。

--- a/e2e-apps/github-issues/package.json
+++ b/e2e-apps/github-issues/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@wevu/web-apis": "workspace:*",
+    "axios": "^1.19.0",
     "camelcase": "^9.0.0",
     "dayjs": "catalog:",
     "merge": "catalog:",

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -526,6 +526,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-764/index",
+          "pathName": "pages/issue-764/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-528/index",
           "pathName": "pages/issue-528/index",
           "query": "",

--- a/e2e-apps/github-issues/src/pages/issue-764/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-764/index.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import axios from 'axios'
+
+definePageJson({
+  navigationBarTitleText: 'issue-764',
+})
+
+definePageMeta({
+  layout: false,
+})
+
+const axiosAdapterReady = typeof axios.request === 'function'
+</script>
+
+<template>
+  <view id="issue-764-page" class="issue-764-page" :data-axios-ready="axiosAdapterReady ? 'true' : 'false'">
+    <text class="issue-764-title">issue-764 axios runtime</text>
+    <text class="issue-764-status">axiosReady = {{ axiosAdapterReady }}</text>
+  </view>
+</template>
+
+<style>
+.issue-764-page {
+  min-height: 100vh;
+  padding: 32rpx;
+}
+
+.issue-764-title,
+.issue-764-status {
+  display: block;
+  margin-bottom: 16rpx;
+  font-size: 28rpx;
+  line-height: 1.5;
+}
+</style>

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable e18e/ban-dependencies -- e2e build assertions reuse shared fs helpers to inspect generated artifacts. */
 import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping'
+import { REQUEST_GLOBAL_PRELUDE_MARKER } from '@weapp-core/constants'
 import { fs } from '@weapp-core/shared/node'
 import { execa } from 'execa'
 import { fdir } from 'fdir'
@@ -432,6 +433,19 @@ describe.sequential('e2e app: github-issues (build)', () => {
     for (const output of [pageJs, pageWxml, pageWxss, componentJs, componentWxml, componentWxss]) {
       expect(output).not.toMatch(/<(?:template|script|style)(?:\s|>)/)
     }
+  })
+
+  it('issue #764: installs axios request globals before page modules execute', async () => {
+    await runBuild()
+
+    const pageJs = await fs.readFile(path.join(DIST_ROOT, 'pages/issue-764/index.js'), 'utf8')
+    const appPreludeJs = await fs.readFile(path.join(DIST_ROOT, 'app.prelude.js'), 'utf8')
+
+    expect(pageJs).toContain('app.prelude.js')
+    expect(appPreludeJs).toContain(`/* ${REQUEST_GLOBAL_PRELUDE_MARKER} */`)
+    expect(appPreludeJs).toContain('"fetch"')
+    expect(appPreludeJs).toContain('"XMLHttpRequest"')
+    expect(appPreludeJs).toContain('"URL"')
   })
 
   it('discussion #338: emits mapped wxml tags from vue html-style templates', async () => {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts
@@ -2117,7 +2117,8 @@ describe('core lifecycle emit hook extra branches', () => {
         type: 'chunk',
         fileName: 'common.js',
         code: [
-          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return { fetch: Promise.resolve, Headers: Object, Request: Object, Response: Object, AbortController: Object, AbortSignal: Object, XMLHttpRequest: Object, WebSocket: Object, URL: Object, URLSearchParams: Object, Blob: Object, FormData: Object }}',
+          'const __keep__ = [XMLHttpRequest, WebSocket];',
+          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return t}',
           'Object.defineProperty(exports,`At`,{enumerable:!0,get:function(){return vn}})',
         ].join(''),
         imports: [],
@@ -2858,6 +2859,70 @@ describe('core lifecycle emit hook extra branches', () => {
     const appCode = bundle['app.js'].code
     expect(appCode).toContain(`/* ${REQUEST_GLOBAL_PRELUDE_MARKER} */`)
     expect(appCode).not.toContain(APP_PRELUDE_CHUNK_MARKER)
+  })
+
+  it('emits synthetic request globals prelude in default require mode without user app.prelude file', async () => {
+    const emittedAssets: Array<{ fileName: string, source: string, type: 'asset' }> = []
+    const state = createState({
+      subPackageMeta: null,
+      entriesMap: new Map([
+        ['app', { type: 'app', path: 'app' }],
+      ]),
+      ctx: {
+        configService: {
+          packageJson: {
+            dependencies: {
+              axios: '^1.8.0',
+            },
+          },
+          weappViteConfig: {},
+          relativeAbsoluteSrcRoot: (id: string) => id.replace('/project/src/', ''),
+        },
+        scanService: {
+          subPackageMap: new Map(),
+          appEntry: {
+            preludePath: undefined,
+          },
+        },
+      },
+    })
+    const hook = createGenerateBundleHook(state, false)
+    const bundle = {
+      'common.js': {
+        type: 'chunk',
+        fileName: 'common.js',
+        code: [
+          'function vn(e={}){const t=e.targets??[`fetch`,`Headers`,`Request`,`Response`,`TextEncoder`,`TextDecoder`,`AbortController`,`AbortSignal`,`XMLHttpRequest`,`WebSocket`];return { fetch: Promise.resolve, Headers: Object, Request: Object, Response: Object, AbortController: Object, AbortSignal: Object, XMLHttpRequest: Object, WebSocket: Object, URL: Object, URLSearchParams: Object, Blob: Object, FormData: Object }}',
+          'Object.defineProperty(exports,`At`,{enumerable:!0,get:function(){return vn}})',
+        ].join(''),
+        imports: [],
+        dynamicImports: [],
+      },
+      'axios.js': {
+        type: 'chunk',
+        fileName: 'axios.js',
+        code: 'const common = require("./common.js");const supportsXhr = typeof XMLHttpRequest !== "undefined"',
+        imports: ['common.js'],
+        dynamicImports: [],
+      },
+      'app.js': {
+        type: 'chunk',
+        fileName: 'app.js',
+        isEntry: true,
+        code: 'require("./axios.js");App({})',
+        imports: ['axios.js'],
+        dynamicImports: [],
+      },
+    } as any
+
+    await hook.call({ emitFile: (asset: any) => emittedAssets.push(asset) }, {}, bundle)
+
+    const appCode = bundle['app.js'].code
+    const appPreludeAsset = emittedAssets.find(asset => asset.fileName === 'app.prelude.js')
+    expect(appCode).toContain(`/* ${APP_PRELUDE_REQUIRE_MARKER} */require("./app.prelude.js")`)
+    expect(appPreludeAsset?.source).toContain(`/* ${REQUEST_GLOBAL_PRELUDE_MARKER} */`)
+    expect(appPreludeAsset?.source).toContain('"XMLHttpRequest"')
+    expect(appPreludeAsset?.source).not.toContain(APP_PRELUDE_CHUNK_MARKER)
   })
 
   it('patches axios chunk defaults env through emit injection', async () => {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping'
 import {
   APP_PRELUDE_CHUNK_MARKER,
   APP_PRELUDE_GUARD_KEY,
@@ -17,6 +18,7 @@ import {
   REQUEST_GLOBAL_SYNTHETIC_EXPORT_NAME,
   REQUEST_GLOBAL_USABLE_CONSTRUCTOR_HELPER,
 } from '@weapp-core/constants'
+import MagicString from 'magic-string'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { FULL_REQUEST_GLOBAL_TARGETS } from '../../../runtime/config/internal/injectRequestGlobals'
 import { createGenerateBundleHook, createRenderStartHook } from './emit'
@@ -2863,6 +2865,12 @@ describe('core lifecycle emit hook extra branches', () => {
 
   it('emits synthetic request globals prelude in default require mode without user app.prelude file', async () => {
     const emittedAssets: Array<{ fileName: string, source: string, type: 'asset' }> = []
+    const source = 'src/pages/issue-764/sourcemap.ts'
+    const pageSource = [
+      `/* ${REQUEST_GLOBAL_LOCAL_BINDINGS_MARKER} */ const before = 1`,
+      'const issue764SourcemapMarker = "issue 764 sourcemap marker"',
+      'Page({ data: { before, issue764SourcemapMarker } })',
+    ].join('\n')
     const state = createState({
       subPackageMeta: null,
       entriesMap: new Map([
@@ -2913,13 +2921,37 @@ describe('core lifecycle emit hook extra branches', () => {
         imports: ['axios.js'],
         dynamicImports: [],
       },
+      'pages/issue-764/sourcemap.js': {
+        type: 'chunk',
+        fileName: 'pages/issue-764/sourcemap.js',
+        isEntry: true,
+        code: pageSource,
+        map: new MagicString(pageSource).generateMap({
+          hires: 'boundary',
+          includeContent: true,
+          source,
+        }),
+        imports: [],
+        dynamicImports: [],
+      },
     } as any
 
     await hook.call({ emitFile: (asset: any) => emittedAssets.push(asset) }, {}, bundle)
 
-    const appCode = bundle['app.js'].code
+    const axiosCode = bundle['axios.js'].code
+    const pageChunk = bundle['pages/issue-764/sourcemap.js']
     const appPreludeAsset = emittedAssets.find(asset => asset.fileName === 'app.prelude.js')
-    expect(appCode).toContain(`/* ${APP_PRELUDE_REQUIRE_MARKER} */require("./app.prelude.js")`)
+    const generatedIndex = pageChunk.code.indexOf('issue 764 sourcemap marker')
+    const generatedBeforeMarker = pageChunk.code.slice(0, generatedIndex).split('\n')
+    const generatedMarkerLinePrefix = generatedBeforeMarker[generatedBeforeMarker.length - 1]
+    const originalPosition = originalPositionFor(new TraceMap(pageChunk.map), {
+      line: generatedBeforeMarker.length,
+      column: generatedMarkerLinePrefix?.length ?? 0,
+    })
+    expect(axiosCode).toContain(`/* ${APP_PRELUDE_REQUIRE_MARKER} */require("./app.prelude.js")`)
+    expect(pageChunk.code).toContain(`/* ${APP_PRELUDE_REQUIRE_MARKER} */require("../../app.prelude.js")`)
+    expect(originalPosition.source).toBe(source)
+    expect(originalPosition.line).toBe(2)
     expect(appPreludeAsset?.source).toContain(`/* ${REQUEST_GLOBAL_PRELUDE_MARKER} */`)
     expect(appPreludeAsset?.source).toContain('"XMLHttpRequest"')
     expect(appPreludeAsset?.source).not.toContain(APP_PRELUDE_CHUNK_MARKER)

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit/appPrelude.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit/appPrelude.ts
@@ -143,7 +143,7 @@ export function emitAppPreludeRequireAssets(
   emitFile?: (asset: { type: 'asset', fileName: string, source: string }) => void,
 ) {
   const preservedRequestGlobalsInstallerChunks = new Set<string>()
-  if (!appPreludeCode) {
+  if (!appPreludeCode && !requestGlobalsPreludeOptions.enabled) {
     return preservedRequestGlobalsInstallerChunks
   }
   const preludeFileNames = new Set<string>()
@@ -165,8 +165,12 @@ export function emitAppPreludeRequireAssets(
     const scopeChunks = Object.values(bundle).filter((output): output is OutputChunk => {
       return output?.type === 'chunk' && resolveAppPreludeRequireFileName(output.fileName, state) === fileName
     })
+    const sortedScopeChunks = [
+      ...scopeChunks.filter(chunk => !requestGlobalsPreludeOptions.installerChunks.has(toPosixPath(chunk.fileName))),
+      ...scopeChunks.filter(chunk => requestGlobalsPreludeOptions.installerChunks.has(toPosixPath(chunk.fileName))),
+    ]
     const requestGlobalsPreludeCode = requestGlobalsPreludeOptions.enabled
-      ? scopeChunks
+      ? sortedScopeChunks
           .map(chunk => createRequestGlobalsPreludeAssetCode(
             fileName,
             chunk,
@@ -210,7 +214,7 @@ export function injectAppPreludeCode(
     return preservedRequestGlobalsInstallerChunks
   }
   const entryChunkFileNames = options.mode === 'entry' ? collectAppPreludeEntryChunkFileNames(state) : undefined
-  if (options.mode === 'require' && appPreludeCode) {
+  if (options.mode === 'require' && (appPreludeCode || requestGlobalsPreludeOptions.enabled)) {
     preservedRequestGlobalsInstallerChunks = emitAppPreludeRequireAssets(bundle, appPreludeCode, state, requestGlobalsPreludeOptions, emitFile)
   }
   for (const output of Object.values(bundle)) {
@@ -237,9 +241,9 @@ export function injectAppPreludeCode(
     const injectedCode = [
       requestGlobalsPreludeCode,
       options.mode === 'require'
-        ? appPreludeCode
-          ? createAppPreludeRequireStatement(chunk.fileName, resolveAppPreludeRequireFileName(chunk.fileName, state))
-          : undefined
+        ? (appPreludeCode || requestGlobalsPreludeOptions.enabled)
+            ? createAppPreludeRequireStatement(chunk.fileName, resolveAppPreludeRequireFileName(chunk.fileName, state))
+            : undefined
         : appPreludeCode,
     ].filter(Boolean).join('\n')
     if (!injectedCode) {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit/appPrelude.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit/appPrelude.ts
@@ -7,6 +7,7 @@ import type {
 import type { ImportMetaDefineRegistry } from '../../../../utils/importMeta'
 import type { CorePluginState } from '../../helpers'
 import { readFile } from 'node:fs/promises'
+import MagicString from 'magic-string'
 import path from 'pathe'
 import { transformWithOxc } from 'vite'
 import { toPosixPath } from '../../../../utils'
@@ -18,6 +19,10 @@ import {
   APP_PRELUDE_GUARD_KEY,
   APP_PRELUDE_REQUIRE_FILE_BASENAME,
   APP_PRELUDE_REQUIRE_MARKER,
+  DIRECTIVE_PROLOGUE_RE,
+  REQUEST_GLOBAL_BUNDLE_MARKER,
+  REQUEST_GLOBAL_LOCAL_BINDINGS_MARKER,
+  REQUEST_GLOBAL_PASSIVE_BINDINGS_MARKER,
   USE_STRICT_PREFIX_RE,
 } from './constants'
 import {
@@ -25,7 +30,7 @@ import {
   createRequestGlobalsPreludeCode,
   resolveRequestGlobalsInstallerImport,
 } from './requestGlobals'
-import { prependChunkCodePreservingDirectives } from './rewrite'
+import { applyMagicStringChunkRewrite } from './rewrite/sourcemap'
 
 interface ResolvedAppPreludeOptions {
   enabled: boolean
@@ -127,6 +132,32 @@ export function createAppPreludeRequireStatement(chunkFileName: string, preludeF
   const relativePath = toPosixPath(path.relative(path.dirname(chunkFileName), preludeFileName))
   const requestPath = relativePath.startsWith('.') ? relativePath : `./${relativePath}`
   return `/* ${APP_PRELUDE_REQUIRE_MARKER} */require(${JSON.stringify(requestPath)})`
+}
+
+function prependChunkCodeWithSourcemap(chunk: OutputChunk, injectedCode: string) {
+  const directiveMatch = chunk.code.match(DIRECTIVE_PROLOGUE_RE)
+  const insertIndex = directiveMatch?.[0] ? directiveMatch[0].length : 0
+  const magicString = new MagicString(chunk.code)
+  magicString.prependLeft(insertIndex, `${injectedCode}\n`)
+  applyMagicStringChunkRewrite(chunk, magicString, { hires: true })
+}
+
+function hasRequestGlobalsPreludeDependency(
+  chunk: OutputChunk,
+  requestGlobalsPreludeOptions: {
+    enabled: boolean
+    installerChunks: Map<string, string>
+  },
+) {
+  if (!requestGlobalsPreludeOptions.enabled) {
+    return false
+  }
+
+  return requestGlobalsPreludeOptions.installerChunks.has(toPosixPath(chunk.fileName))
+    || Boolean(resolveRequestGlobalsInstallerImport(chunk, requestGlobalsPreludeOptions.installerChunks))
+    || chunk.code.includes(REQUEST_GLOBAL_BUNDLE_MARKER)
+    || chunk.code.includes(REQUEST_GLOBAL_LOCAL_BINDINGS_MARKER)
+    || chunk.code.includes(REQUEST_GLOBAL_PASSIVE_BINDINGS_MARKER)
 }
 
 export function emitAppPreludeRequireAssets(
@@ -238,18 +269,20 @@ export function injectAppPreludeCode(
           requestGlobalsPreludeOptions.networkDefaults,
         )
       : undefined
+    const shouldInjectRequirePrelude = appPreludeCode
+      || hasRequestGlobalsPreludeDependency(chunk, requestGlobalsPreludeOptions)
     const injectedCode = [
       requestGlobalsPreludeCode,
       options.mode === 'require'
-        ? (appPreludeCode || requestGlobalsPreludeOptions.enabled)
-            ? createAppPreludeRequireStatement(chunk.fileName, resolveAppPreludeRequireFileName(chunk.fileName, state))
-            : undefined
+        ? shouldInjectRequirePrelude
+          ? createAppPreludeRequireStatement(chunk.fileName, resolveAppPreludeRequireFileName(chunk.fileName, state))
+          : undefined
         : appPreludeCode,
     ].filter(Boolean).join('\n')
     if (!injectedCode) {
       continue
     }
-    chunk.code = prependChunkCodePreservingDirectives(chunk.code, injectedCode)
+    prependChunkCodeWithSourcemap(chunk, injectedCode)
   }
   return preservedRequestGlobalsInstallerChunks
 }

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit/generate.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit/generate.ts
@@ -784,6 +784,7 @@ export function createGenerateBundleHook(state: CorePluginState, isPluginBuild: 
 
       const appPreludePath = scanService.appEntry?.preludePath
       const shouldInjectRequestGlobalsPrelude = injectRequestGlobalsOptions?.prelude === true
+        && Boolean(scanService.appEntry || subPackageMeta)
       const appPreludeOptions = resolveAppPreludeOptions(state)
       const shouldRunAppPrelude = (appPreludeOptions.enabled && Boolean(appPreludePath))
         || shouldInjectRequestGlobalsPrelude

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit/requestGlobals.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit/requestGlobals.ts
@@ -47,6 +47,14 @@ function resolveChunkRequestGlobalsTargets(
     : targets
 }
 
+function resolvePreludeRequestGlobalsTargets(
+  code: string,
+  targets: WeappInjectRequestGlobalsTarget[],
+  mode: 'auto' | 'explicit',
+) {
+  return mode === 'auto' ? targets : resolveChunkRequestGlobalsTargets(code, targets, mode)
+}
+
 function collectTopLevelDeclaredIdentifiers(code: string) {
   const identifiers = new Set<string>()
   try {
@@ -853,7 +861,7 @@ export function createRequestGlobalsPreludeCode(
   mode: 'auto' | 'explicit',
   networkDefaults?: MiniProgramNetworkDefaults,
 ) {
-  const chunkTargets = resolveChunkRequestGlobalsTargets(chunk.code, targets, mode)
+  const chunkTargets = resolvePreludeRequestGlobalsTargets(chunk.code, targets, mode)
   if (chunkTargets.length === 0 || chunk.code.includes(REQUEST_GLOBAL_PRELUDE_MARKER)) {
     return undefined
   }
@@ -900,7 +908,7 @@ export function createRequestGlobalsPreludeAssetCode(
   mode: 'auto' | 'explicit',
   networkDefaults?: MiniProgramNetworkDefaults,
 ) {
-  const chunkTargets = resolveChunkRequestGlobalsTargets(chunk.code, targets, mode)
+  const chunkTargets = resolvePreludeRequestGlobalsTargets(chunk.code, targets, mode)
   if (chunkTargets.length === 0) {
     return undefined
   }
@@ -910,11 +918,20 @@ export function createRequestGlobalsPreludeAssetCode(
   }
 
   const installerImport = resolveRequestGlobalsInstallerImport(chunk, installerChunks)
-  if (!installerImport?.installerChunkFileName || !installerImport.exportName) {
+  let installerChunkFileName = installerImport?.installerChunkFileName
+  let exportName = installerImport?.exportName
+  if (!installerChunkFileName || !exportName) {
+    const ownExportName = installerChunks.get(toPosixPath(chunk.fileName))
+    if (ownExportName) {
+      installerChunkFileName = chunk.fileName
+      exportName = ownExportName
+    }
+  }
+  if (!installerChunkFileName || !exportName) {
     return undefined
   }
 
-  const installerHostCode = `${toRequestGlobalsInstallerModuleExpression(preludeFileName, installerImport.installerChunkFileName, { appRegisteredModule: false })}[${JSON.stringify(installerImport.exportName)}](${createRequestGlobalsInstallerOptionsCode(chunkTargets, networkDefaults)}) || globalThis`
+  const installerHostCode = `${toRequestGlobalsInstallerModuleExpression(preludeFileName, installerChunkFileName, { appRegisteredModule: false })}[${JSON.stringify(exportName)}](${createRequestGlobalsInstallerOptionsCode(chunkTargets, networkDefaults)}) || globalThis`
 
   return [
     `/* ${REQUEST_GLOBAL_PRELUDE_MARKER} */`,

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/sourcemap.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/sourcemap.ts
@@ -2,7 +2,13 @@ import type MagicString from 'magic-string'
 import type { OutputChunk } from 'rolldown'
 import { composeSourceMaps, normalizeEncodedSourceMapLike } from '../../../../../utils/sourcemap'
 
-export function applyMagicStringChunkRewrite(chunk: OutputChunk, magicString: MagicString) {
+export function applyMagicStringChunkRewrite(
+  chunk: OutputChunk,
+  magicString: MagicString,
+  options?: {
+    hires?: boolean | 'boundary'
+  },
+) {
   const previousCode = chunk.code
   const nextCode = magicString.toString()
   if (nextCode === previousCode) {
@@ -14,7 +20,7 @@ export function applyMagicStringChunkRewrite(chunk: OutputChunk, magicString: Ma
   chunk.code = nextCode
   if (previousMap) {
     const nextMap = magicString.generateMap({
-      hires: 'boundary',
+      hires: options?.hires ?? 'boundary',
       includeContent: true,
       source: chunk.fileName,
     })

--- a/packages/weapp-vite/src/runtime/config/internal/injectRequestGlobals.test.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/injectRequestGlobals.test.ts
@@ -45,7 +45,7 @@ describe('injectRequestGlobals helpers', () => {
       },
     })).toEqual({
       mode: 'auto',
-      prelude: false,
+      prelude: true,
       targets: [...fullWebRuntimeTargets],
     })
   })
@@ -57,7 +57,7 @@ describe('injectRequestGlobals helpers', () => {
       },
     })).toEqual({
       mode: 'auto',
-      prelude: false,
+      prelude: true,
       targets: [...fullWebRuntimeTargets],
     })
   })
@@ -69,11 +69,25 @@ describe('injectRequestGlobals helpers', () => {
       },
     })).toEqual({
       mode: 'auto',
-      prelude: false,
+      prelude: true,
       targets: [
         'AbortController',
         'AbortSignal',
       ],
+    })
+  })
+
+  it('allows explicit auto mode to opt out of prelude timing', () => {
+    expect(resolveInjectRequestGlobalsOptions({
+      prelude: false,
+    }, {
+      dependencies: {
+        axios: '^1.0.0',
+      },
+    })).toEqual({
+      mode: 'auto',
+      prelude: false,
+      targets: [...fullWebRuntimeTargets],
     })
   })
 

--- a/packages/weapp-vite/src/runtime/config/internal/injectRequestGlobals.ts
+++ b/packages/weapp-vite/src/runtime/config/internal/injectRequestGlobals.ts
@@ -214,6 +214,13 @@ function hasConfiguredNetworkDefaults(config?: boolean | WeappInjectRequestGloba
   )
 }
 
+function resolveAutoPrelude(config?: boolean | WeappInjectRequestGlobalsConfig) {
+  if (!config || typeof config !== 'object' || !hasOwn(config, 'prelude')) {
+    return true
+  }
+  return config.prelude === true
+}
+
 function resolveAutoRules(config?: boolean | WeappInjectRequestGlobalsConfig): InjectRequestGlobalsAutoRule[] {
   if (hasCustomAutoRuleConfig(config)) {
     return [{
@@ -285,7 +292,7 @@ export function resolveInjectRequestGlobalsOptions(
   return {
     mode: 'auto',
     targets: [...matchedTargets],
-    prelude: config && typeof config === 'object' ? config.prelude === true : false,
+    prelude: resolveAutoPrelude(config),
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1489,6 +1489,9 @@ importers:
       '@wevu/web-apis':
         specifier: workspace:*
         version: link:../../packages-runtime/web-apis
+      axios:
+        specifier: ^1.19.0
+        version: 1.19.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       camelcase:
         specifier: ^9.0.0
         version: 9.0.0


### PR DESCRIPTION
## 摘要
修复 #764：默认 wevu 模板安装 axios 后，真机调试可能因请求相关全局对象注入时序过晚而白屏。

## 改动
- 自动识别 axios 等请求客户端依赖时，默认启用 request globals app prelude。
- 在没有用户 app.prelude 文件的默认 require 模式下，也生成合成 prelude。
- 调整 prelude 目标解析，避免对已重写 chunk 重新分析导致漏注入。
- 新增 github-issues 复现页和构建产物断言，确保页面模块执行前先加载 app.prelude.js。
- 补充 weapp-vite / create-weapp-vite changeset。

## 验证
- pnpm vitest run packages/weapp-vite/src/runtime/config/internal/injectRequestGlobals.test.ts packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts
- pnpm --filter weapp-vite typecheck
- pnpm exec eslint <changed files>
- pnpm exec stylelint e2e-apps/github-issues/src/pages/issue-764/index.vue
- pnpm --filter weapp-vite build
- pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts --testNamePattern "issue #764"

Closes #764