### PR TITLE
fix(ci): 拆分发版 PR 的构建矩阵

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   build-pr:
-    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/') || matrix.os == 'ubuntu-latest')
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/'))
     name: Build and Test (${{ matrix.os }} / Node ${{ matrix.node-version }})
     strategy:
       fail-fast: false
@@ -47,6 +47,39 @@ jobs:
             timeout_minutes: 40
             build_pkgs_script: build:pkgs:ci:macos
             build_script: build:ci:macos
+            lint_script: lint
+      max-parallel: 2
+    uses: ./.github/workflows/reusable-node-command.yml
+    with:
+      runs_on: ${{ matrix.os }}
+      node_version: '${{ matrix.node-version }}'
+      timeout_minutes: ${{ matrix.timeout_minutes }}
+      build_command: pnpm ${{ matrix.build_pkgs_script }}
+      main_command: |
+        pnpm ${{ matrix.lint_script }}
+        pnpm ${{ matrix.build_script }}
+        pnpm test:coverage
+      upload_codecov: true
+    secrets: inherit
+
+  build-release-pr:
+    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'changeset-release/')
+    name: Build and Test (${{ matrix.os }} / Node ${{ matrix.node-version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            node-version: 22
+            timeout_minutes: 25
+            build_pkgs_script: build:pkgs:ci
+            build_script: build:ci
+            lint_script: lint
+          - os: ubuntu-latest
+            node-version: 24
+            timeout_minutes: 25
+            build_pkgs_script: build:pkgs:ci
+            build_script: build:ci
             lint_script: lint
       max-parallel: 2
     uses: ./.github/workflows/reusable-node-command.yml


### PR DESCRIPTION
## 摘要

修复 CI workflow 在 job-level `if` 中引用 `matrix` 上下文导致的调度失败。

## 变更

- 常规 PR 继续运行完整 Build and Test 矩阵。
- `changeset-release/*` PR 改为独立 Ubuntu-only 矩阵，避免触发 Windows/macOS 和报告型门禁噪音。
- 保留已有 release PR 跳过性能、HMR、runtime size 报告型检查的策略。

## 验证

- `ruby -e 'require "yaml"; %w[.github/workflows/ci.yml .github/workflows/ci-e2e.yml .github/workflows/wevu-runtime-size.yml .github/workflows/wevu-runtime-size-comment.yml].each { |f| YAML.load_file(f) }; puts "yaml ok"'`\n- `pnpm eslint --fix --max-warnings=0 --no-warn-ignored .github/workflows/ci.yml .github/workflows/ci-e2e.yml .github/workflows/wevu-runtime-size.yml .github/workflows/wevu-runtime-size-comment.yml`\n- `git diff --check`\n\n说明：尝试临时运行 `actionlint` 时 Go 代理下载超时，未完成该项本地校验。