### PR TITLE
fix(weapp-vite): 保留 CSS pre 管线的 sidecar 内容

### DIFF
--- a/.changeset/issue-779-css-pre.md
+++ b/.changeset/issue-779-css-pre.md
@@ -1,0 +1,6 @@
+---
+'weapp-vite': patch
+'create-weapp-vite': patch
+---
+
+修复 CSS `pre` 插件处理结果未传递到 Tailwind 与小程序样式 sidecar 输出的问题，样式生成现在优先使用 Vite 管线中的内存内容。

--- a/e2e-apps/github-issues/package.json
+++ b/e2e-apps/github-issues/package.json
@@ -24,6 +24,8 @@
   "devDependencies": {
     "@weapp-vite/dashboard": "workspace:*",
     "socket.io-client": "^4.8.3",
+    "tailwindcss": "catalog:tailwind4",
+    "weapp-tailwindcss": "catalog:weapp-tailwindcss-fixed",
     "weapp-vite": "workspace:*",
     "wevu": "workspace:*"
   }

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -687,6 +687,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-779/index",
+          "pathName": "pages/issue-779/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/require-async/index",
           "pathName": "pages/require-async/index",
           "query": "",

--- a/e2e-apps/github-issues/src/pages/issue-779/index.css
+++ b/e2e-apps/github-issues/src/pages/issue-779/index.css
@@ -1,0 +1,1 @@
+@charset "issue-779-disk-marker";

--- a/e2e-apps/github-issues/src/pages/issue-779/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-779/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <view class="issue-779-page">issue 779</view>
+</template>
+
+<style src="./index.css"></style>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import process from 'node:process'
+import { WeappTailwindcss } from 'weapp-tailwindcss/vite'
 import { defineConfig } from 'weapp-vite'
 
 const issue393ChunkModeEnabled = process.env.WEAPP_GITHUB_ISSUE_393 === 'true'
@@ -12,6 +13,7 @@ const issue621AugmentedEnvEnabled = process.env.WEAPP_GITHUB_ISSUE_621_AUGMENTED
 const issue595ScopedBuildEnabled = process.env.WEAPP_GITHUB_ISSUE_595_SCOPED === 'true'
 const issue642ScopedBuildEnabled = process.env.WEAPP_GITHUB_ISSUE_642_SCOPED === 'true'
 const issue724ProbeEnabled = process.env.WEAPP_GITHUB_ISSUE_724_PROBE === 'true'
+const issue779CssPreEnabled = process.env.WEAPP_GITHUB_ISSUE_779_CSS_PRE === 'true'
 const issue651NoExtResolvedId = path.resolve(import.meta.dirname, 'src/issue-fixtures/issue-651/ResolverNoExt/index')
 const issue651WithExtResolvedId = path.resolve(import.meta.dirname, 'src/issue-fixtures/issue-651/ResolverWithExt/index.vue')
 const e2eTargetFile = process.env.WEAPP_VITE_E2E_TARGET_FILE?.replaceAll('\\', '/') ?? ''
@@ -394,8 +396,44 @@ const issue724ProbePlugins = issue724ProbeEnabled
     ]
   : []
 
+const issue779CssPrePlugin = issue779CssPreEnabled
+  ? [
+      {
+        name: 'github-issues:issue-779-css-pre',
+        enforce: 'pre' as const,
+        transform(_code: string, id: string) {
+          const normalizedId = id.replaceAll('\\', '/')
+          if (!normalizedId.includes('/src/pages/issue-779/') || !id.includes('weapp-vite-sidecar=style')) {
+            return null
+          }
+          return `@import "tailwindcss";\n.issue-779-pre-marker { color: rgb(1, 2, 3); }`
+        },
+      },
+      WeappTailwindcss(),
+      {
+        name: 'github-issues:issue-779-css-pipeline-probe',
+        transform(code: string, id: string) {
+          const normalizedId = id.replaceAll('\\', '/')
+          if (!normalizedId.includes('/src/pages/issue-779/') || !id.includes('weapp-vite-sidecar=style')) {
+            return null
+          }
+          if (
+            !code.includes('.issue-779-pre-marker')
+            || code.includes('.issue-779-disk-marker')
+          ) {
+            throw new Error(`issue #779 Tailwind pipeline did not preserve the pre-transformed CSS: ${normalizedId}`)
+          }
+          return null
+        },
+      },
+    ]
+  : undefined
+
 export default defineConfig({
-  plugins: issue724ProbePlugins,
+  plugins: [
+    ...issue724ProbePlugins,
+    ...(issue779CssPrePlugin ?? []),
+  ],
   define: {
     'import.meta.env.ISSUE_484_FLAG': '123456',
   },
@@ -525,5 +563,11 @@ export default defineConfig({
                     outDir: 'dist-issue-642',
                   },
                 }
-              : {}),
+              : issue779CssPreEnabled
+                ? {
+                    build: {
+                      outDir: 'dist-issue-779',
+                    },
+                  }
+                : {}),
 })

--- a/e2e/ci/issue-779-css-pre.test.ts
+++ b/e2e/ci/issue-779-css-pre.test.ts
@@ -1,0 +1,32 @@
+import { fs } from '@weapp-core/shared/node'
+import path from 'pathe'
+import { describe, expect, it } from 'vitest'
+import { runWeappViteBuildWithLogCapture } from '../utils/buildLog'
+
+const CLI_PATH = path.resolve(import.meta.dirname, '../../packages/weapp-vite/bin/weapp-vite.js')
+const APP_ROOT = path.resolve(import.meta.dirname, '../../e2e-apps/github-issues')
+const DIST_ROOT = path.join(APP_ROOT, 'dist-issue-779')
+
+describe.sequential('issue #779 CSS pre transform', () => {
+  it('passes the in-memory pre-transformed SFC style into the emitted wxss sidecar', async () => {
+    await fs.remove(DIST_ROOT)
+
+    await runWeappViteBuildWithLogCapture({
+      cliPath: CLI_PATH,
+      projectRoot: APP_ROOT,
+      platform: 'weapp',
+      cwd: APP_ROOT,
+      label: 'ci:issue-779-css-pre',
+      skipNpm: true,
+      env: {
+        WEAPP_GITHUB_ISSUE_779_CSS_PRE: 'true',
+      },
+    })
+
+    const pageWxss = await fs.readFile(path.join(DIST_ROOT, 'pages/issue-779/index.wxss'), 'utf8')
+    expect(pageWxss).toContain('.issue-779-pre-marker')
+    expect(pageWxss).toContain('box-sizing: border-box')
+    expect(pageWxss).not.toContain('@import "tailwindcss"')
+    expect(pageWxss).not.toContain('.issue-779-disk-marker')
+  })
+})

--- a/packages/weapp-vite/src/plugins/css.test.ts
+++ b/packages/weapp-vite/src/plugins/css.test.ts
@@ -148,6 +148,7 @@ describe('css plugin shared style injection', () => {
       css: {
         importerToDependencies: new Map<string, Set<string>>(),
         dependencyToImporters: new Map<string, Set<string>>(),
+        transformedSidecarSource: new Map<string, { code: string, diskSource: string }>(),
         emittedSource: new Map(),
         sidecarImports: new Set<string>(),
       },
@@ -185,6 +186,7 @@ describe('css plugin shared style injection', () => {
     pluginContext.addWatchFile.mockClear()
     ;(ctx as any).runtimeState.css.importerToDependencies.clear()
     ;(ctx as any).runtimeState.css.dependencyToImporters.clear()
+    ;(ctx as any).runtimeState.css.transformedSidecarSource.clear()
     ;(ctx as any).runtimeState.css.emittedSource.clear()
     ;(ctx as any).runtimeState.css.sidecarImports.clear()
   })
@@ -881,6 +883,165 @@ describe('css plugin shared style injection', () => {
     expect(bundle['pages/index/index.wxss']?.source).toBe('.page .title{color:red}')
     expect((ctx as any).runtimeState.css.emittedSource.get('pages/index/index.wxss')).toBe('.page .title{color:red}')
     expect(emitted.find(asset => asset.fileName === 'pages/index/index.scss')).toBeUndefined()
+  })
+
+  it('uses the in-memory CSS source produced by an earlier pre plugin for sidecars', async () => {
+    const stylePath = resolve(absoluteSrcRoot, 'pages/index/index.css')
+    const transformedSource = '.pre-plugin-marker { color: red; }'
+    readFileMock.mockResolvedValue('.disk-source { color: blue; }')
+
+    const runtimeState = structuredClone(ctx.runtimeState)
+    runtimeState.css.transformedSidecarSource = new Map()
+    runtimeState.css.emittedSource = new Map()
+    runtimeState.css.sidecarImports = new Set()
+    runtimeState.css.importerToDependencies = new Map()
+    runtimeState.css.dependencyToImporters = new Map()
+    const plugins = css({
+      ...ctx,
+      runtimeState,
+    } as unknown as CompilerContext)
+    const sourcePlugin = plugins[1]
+    await invokeHook(
+      sourcePlugin.transform,
+      pluginContext,
+      transformedSource,
+      `${stylePath}?weapp-vite-sidecar-owner=%2Fproject%2Fsrc%2Fpages%2Findex%2Findex.ts&weapp-vite-sidecar=style&lang.css`,
+    )
+
+    await emitStyleSidecarAsset(
+      { ...ctx, runtimeState } as unknown as CompilerContext,
+      pluginContext,
+      {} as any,
+      stylePath,
+      resolvedConfig,
+    )
+
+    expect(preprocessCSSMock).toHaveBeenCalledWith(transformedSource, stylePath, resolvedConfig)
+    expect(preprocessCSSMock).not.toHaveBeenCalledWith('.disk-source { color: blue; }', stylePath, resolvedConfig)
+    expect(emitted[emitted.length - 1]?.source).toBe(transformedSource)
+  })
+
+  it('does not cache ordinary CSS or Vue style block requests', async () => {
+    const stylePath = resolve(absoluteSrcRoot, 'pages/index/index.css')
+    const plugin = css(ctx)[1]
+
+    await invokeHook(plugin.transform, pluginContext, '.ordinary {}', stylePath)
+    await invokeHook(plugin.transform, pluginContext, '.vue-block {}', `${stylePath}?vue&type=style&index=0&lang.css`)
+
+    expect((ctx as any).runtimeState.css.transformedSidecarSource.size).toBe(0)
+  })
+
+  it('keeps transformed sidecar sources isolated by physical style file', async () => {
+    const firstStylePath = resolve(absoluteSrcRoot, 'pages/first/index.css')
+    const secondStylePath = resolve(absoluteSrcRoot, 'pages/second/index.css')
+    const plugin = css(ctx)[1]
+
+    await invokeHook(
+      plugin.transform,
+      pluginContext,
+      '.first {}',
+      `${firstStylePath}?weapp-vite-sidecar-owner=%2Fproject%2Fsrc%2Fpages%2Ffirst%2Findex.ts&weapp-vite-sidecar=style&lang.css`,
+    )
+    await invokeHook(
+      plugin.transform,
+      pluginContext,
+      '.second {}',
+      `${secondStylePath}?weapp-vite-sidecar-owner=%2Fproject%2Fsrc%2Fpages%2Fsecond%2Findex.ts&weapp-vite-sidecar=style&lang.css`,
+    )
+
+    expect((ctx as any).runtimeState.css.transformedSidecarSource).toEqual(new Map([
+      [firstStylePath, { code: '.first {}', diskSource: '.sidecar{color:red}' }],
+      [secondStylePath, { code: '.second {}', diskSource: '.sidecar{color:red}' }],
+    ]))
+  })
+
+  it('falls back to disk when a style sidecar has no transformed source', async () => {
+    const stylePath = resolve(absoluteSrcRoot, 'pages/fallback/index.css')
+    const diskSource = '.disk-fallback { color: blue; }'
+    readFileMock.mockResolvedValueOnce(diskSource)
+
+    await emitStyleSidecarAsset(ctx, pluginContext, {} as any, stylePath, resolvedConfig)
+
+    expect(readFileMock).toHaveBeenCalledWith(stylePath, 'utf8')
+    expect(preprocessCSSMock).toHaveBeenCalledWith(diskSource, stylePath, resolvedConfig)
+    expect(emitted[emitted.length - 1]?.source).toBe(diskSource)
+  })
+
+  it('drops stale transformed source and falls back to the current disk source', async () => {
+    const stylePath = resolve(absoluteSrcRoot, 'pages/stale/index.css')
+    const diskSource = '.current-disk { color: green; }'
+    const runtimeState = structuredClone(ctx.runtimeState)
+    runtimeState.css.transformedSidecarSource = new Map([[stylePath, {
+      code: '.stale-pre-plugin { color: red; }',
+      diskSource: '.previous-disk { color: blue; }',
+    }]])
+    readFileMock.mockResolvedValue(diskSource)
+
+    await emitStyleSidecarAsset(
+      { ...ctx, runtimeState } as unknown as CompilerContext,
+      pluginContext,
+      {} as any,
+      stylePath,
+      resolvedConfig,
+    )
+
+    expect(preprocessCSSMock).toHaveBeenCalledWith(diskSource, stylePath, resolvedConfig)
+    expect(emitted[emitted.length - 1]?.source).toBe(diskSource)
+    expect(runtimeState.css.transformedSidecarSource.has(stylePath)).toBe(false)
+  })
+
+  it('rebuilds hmr style assets from the transformed sidecar source', async () => {
+    const stylePath = resolve(absoluteSrcRoot, 'pages/index/index.scss')
+    const transformedSource = '$brand: purple;\n.page { .title { color: $brand; } }'
+    preprocessCSSMock.mockResolvedValueOnce({
+      code: '.page .title{color:purple}',
+      deps: [],
+    })
+    const runtimeState = {
+      css: {
+        transformedSidecarSource: new Map([[stylePath, {
+          code: transformedSource,
+          diskSource: '.sidecar{color:red}',
+        }]]),
+        emittedSource: new Map([
+          ['pages/index/index.wxss', '.page .title{color:red}'],
+        ]),
+      },
+      build: {
+        hmr: {
+          didEmitAllEntries: false,
+          lastHmrEntryIds: new Set([resolve(absoluteSrcRoot, 'pages/index/index.ts')]),
+          lastEmittedEntryIds: new Set(),
+          profile: {
+            event: 'update',
+            file: stylePath,
+          },
+        },
+      },
+    }
+    const plugin = css({
+      configService: {
+        ...configService,
+        isDev: true,
+      },
+      runtimeState,
+      scanService,
+    } as unknown as CompilerContext)[0]
+    const bundle: Record<string, any> = {
+      'pages/index/index.wxss': {
+        type: 'asset',
+        fileName: 'pages/index/index.wxss',
+        source: '.page .title{color:red}',
+        originalFileNames: [stylePath],
+      },
+    }
+
+    await invokeHook(plugin.configResolved, pluginContext, resolvedConfig)
+    await invokeHook(plugin.generateBundle, pluginContext, {} as any, bundle, true)
+
+    expect(readFileMock).toHaveBeenCalledWith(stylePath, 'utf8')
+    expect(preprocessCSSMock).toHaveBeenCalledWith(transformedSource, stylePath, resolvedConfig)
+    expect(bundle['pages/index/index.wxss']?.source).toBe('.page .title{color:purple}')
   })
 
   it('rebuilds the current hmr final style asset from the latest sidecar source', async () => {

--- a/packages/weapp-vite/src/plugins/css.ts
+++ b/packages/weapp-vite/src/plugins/css.ts
@@ -5,7 +5,7 @@ import type { SubPackageStyleEntry } from '../types'
 import { fs } from '@weapp-core/shared/fs'
 import path from 'pathe'
 import { preprocessCSS } from 'vite'
-import { parseLogicalEntryId } from '../moduleGraph/protocol'
+import { parseLogicalEntryId, parseSidecarSourceRequest } from '../moduleGraph/protocol'
 import { changeFileExtension, isJsOrTs } from '../utils'
 import { getPathExistsTtlMs } from '../utils/cachePolicy'
 import { normalizeWatchPath } from '../utils/path'
@@ -171,6 +171,23 @@ async function readStyleGraphSource(stylePath: string, fallback: string) {
   catch {
     return fallback
   }
+}
+
+async function resolveMemoryStyleSource(ctx: CompilerContext, stylePath: string) {
+  const sourceId = normalizeFsResolvedId(stylePath, { stripLeadingNullByte: true })
+  const cache = ctx.runtimeState?.css?.transformedSidecarSource
+  const cached = cache?.get(sourceId)
+  if (!cached) {
+    return
+  }
+  try {
+    const diskSource = await fs.readFile(stylePath, 'utf8')
+    if (diskSource === cached.diskSource) {
+      return cached.code
+    }
+  }
+  catch {}
+  cache?.delete(sourceId)
 }
 
 function resolveOutputStyleFileName(
@@ -361,7 +378,7 @@ export async function emitStyleSidecarAsset(
     return false
   }
 
-  const rawCss = await fs.readFile(stylePath, 'utf8')
+  const rawCss = await resolveMemoryStyleSource(ctx, stylePath) ?? await fs.readFile(stylePath, 'utf8')
   const { css, dependencies } = await preprocessStyleSource(rawCss, stylePath, resolvedConfig)
   syncCssImportDependencies(ctx, stylePath, rawCss, dependencies)
   if (typeof pluginCtx.addWatchFile === 'function') {
@@ -486,7 +503,7 @@ async function handleBundleEntry(
       const freshHmrStyleSourcePath = resolveFreshHmrStyleSourcePath(ctx, normalizedFileName)
       const preprocessId = freshHmrStyleSourcePath ?? absOriginal
       const preprocessInput = freshHmrStyleSourcePath
-        ? await readStyleGraphSource(freshHmrStyleSourcePath, canonicalSource)
+        ? await resolveMemoryStyleSource(ctx, freshHmrStyleSourcePath) ?? await readStyleGraphSource(freshHmrStyleSourcePath, canonicalSource)
         : canonicalSource
       const { css, dependencies } = await preprocessStyleSource(preprocessInput, preprocessId, resolvedConfig, {
         enabled: shouldPreprocessWithVite(preprocessId),
@@ -798,6 +815,24 @@ export function css(ctx: CompilerContext): Plugin[] {
         const styleAnalysis = analyzeBundleStyles(rolldownBundle)
         await generateBundleSharedCss.call(this, ctx, configService, bundle, styleAnalysis, resolvedConfig)
         await emitCollectedStyleSidecars.call(this, ctx, rolldownBundle, resolvedConfig)
+      },
+    },
+    {
+      name: 'weapp-vite:css-sidecar-source',
+      async transform(code, id) {
+        const sidecar = parseSidecarSourceRequest(id)
+        if (!sidecar || sidecar.kind !== 'style') {
+          return null
+        }
+        const sourceId = normalizeFsResolvedId(sidecar.sourceId, { stripLeadingNullByte: true })
+        try {
+          const diskSource = await fs.readFile(sourceId, 'utf8')
+          ctx.runtimeState?.css?.transformedSidecarSource.set(sourceId, { code, diskSource })
+        }
+        catch {
+          ctx.runtimeState?.css?.transformedSidecarSource.delete(sourceId)
+        }
+        return null
       },
     },
   ]

--- a/packages/weapp-vite/src/plugins/utils/invalidateEntry/sidecar.test.ts
+++ b/packages/weapp-vite/src/plugins/utils/invalidateEntry/sidecar.test.ts
@@ -49,6 +49,11 @@ function createContext() {
         return new Set<string>()
       }),
     },
+    runtimeState: {
+      css: {
+        transformedSidecarSource: new Map<string, { code: string, diskSource: string }>(),
+      },
+    },
   } as any
 }
 
@@ -96,5 +101,17 @@ describe('invalidateEntryForSidecar', () => {
 
     expect(touchMock).toHaveBeenCalledWith('/project/src/pages/dashboard/index.vue')
     expect(findJsEntryMock).not.toHaveBeenCalledWith('/project/src/shared/helper')
+  })
+
+  it.each(['update', 'delete'] as const)('drops cached CSS sidecar source when the file receives a %s event', async (event) => {
+    const ctx = createContext()
+    ctx.runtimeState.css.transformedSidecarSource.set('/project/src/shared/theme.css', {
+      code: '.theme {}',
+      diskSource: '.theme {}',
+    })
+
+    await invalidateEntryForSidecar(ctx, '/project/src/shared/theme.css', event)
+
+    expect(ctx.runtimeState.css.transformedSidecarSource.has('/project/src/shared/theme.css')).toBe(false)
   })
 })

--- a/packages/weapp-vite/src/plugins/utils/invalidateEntry/sidecar.ts
+++ b/packages/weapp-vite/src/plugins/utils/invalidateEntry/sidecar.ts
@@ -68,6 +68,9 @@ export async function invalidateEntryForSidecar(ctx: CompilerContext, filePath: 
 
   const isCssSidecar = Boolean(ext && watchedCssExts.has(ext))
   const isTemplateSidecar = Boolean(ext && watchedTemplateExts.has(ext))
+  if (isCssSidecar) {
+    ctx.runtimeState?.css?.transformedSidecarSource.delete(normalizedPath)
+  }
   const sidecarCause = configSuffix
     ? 'json-sidecar' as const
     : isCssSidecar

--- a/packages/weapp-vite/src/runtime/buildPlugin/outputs.test.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/outputs.test.ts
@@ -176,6 +176,10 @@ describe('buildPlugin outputs', () => {
         scopedSlotGenerics: new Map([['/components/native/index', new Set(['scoped-slots-default'])]]),
       },
       css: {
+        transformedSidecarSource: new Map([['/project/src/app.css', {
+          code: '.pre-plugin {}',
+          diskSource: '.disk {}',
+        }]]),
         emittedSource: new Map([['app.wxss', '.page {}']]),
       },
       wxml: {
@@ -189,6 +193,7 @@ describe('buildPlugin outputs', () => {
     expect(runtimeState.json.emittedSource.size).toBe(0)
     expect(runtimeState.asset.emittedBuffer.size).toBe(0)
     expect(runtimeState.asset.scopedSlotGenerics.size).toBe(0)
+    expect(runtimeState.css.transformedSidecarSource.size).toBe(0)
     expect(runtimeState.css.emittedSource.size).toBe(0)
     expect(runtimeState.wxml.emittedCode.size).toBe(0)
   })

--- a/packages/weapp-vite/src/runtime/buildPlugin/outputs.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/outputs.ts
@@ -53,6 +53,7 @@ export function resetEmittedOutputCaches(
   runtimeState.asset.scopedSlotGenerics.clear()
   runtimeState.build?.output?.emittedSource.clear()
   runtimeState.css.emittedSource.clear()
+  runtimeState.css.transformedSidecarSource.clear()
   runtimeState.wxml.emittedCode.clear()
 }
 

--- a/packages/weapp-vite/src/runtime/resetRuntimeState.test.ts
+++ b/packages/weapp-vite/src/runtime/resetRuntimeState.test.ts
@@ -13,6 +13,10 @@ describe('runtime state fresh build reset', () => {
     state.autoImport.registry.set('Button', {} as any)
     state.build.hmr.loadedEntrySet.add('/project/src/pages/index.ts')
     state.json.emittedSource.set('app.json', '{}')
+    state.css.transformedSidecarSource.set('/project/src/pages/index/index.css', {
+      code: '.pre-plugin {}',
+      diskSource: '.disk {}',
+    })
     state.css.emittedSource.set('app.wxss', '.page {}')
     state.wxml.emittedCode.set('pages/index/index.wxml', '<view />')
     state.scan.warnedMessages.add('warning')
@@ -26,6 +30,7 @@ describe('runtime state fresh build reset', () => {
     expect(state.autoImport.version).toBe(5)
     expect(state.autoImport.registry.size).toBe(0)
     expect(state.json.emittedSource.size).toBe(0)
+    expect(state.css.transformedSidecarSource.size).toBe(0)
     expect(state.css.emittedSource.size).toBe(0)
     expect(state.wxml.emittedCode.size).toBe(0)
     expect(state.scan.warnedMessages.size).toBe(0)

--- a/packages/weapp-vite/src/runtime/resetRuntimeState.ts
+++ b/packages/weapp-vite/src/runtime/resetRuntimeState.ts
@@ -40,6 +40,7 @@ export function resetRuntimeStateForFreshBuild(runtimeState: RuntimeState): void
   const css = runtimeState.css
   css.importerToDependencies.clear()
   css.dependencyToImporters.clear()
+  css.transformedSidecarSource.clear()
   css.emittedSource.clear()
 
   const wxml = runtimeState.wxml

--- a/packages/weapp-vite/src/runtime/runtimeState.ts
+++ b/packages/weapp-vite/src/runtime/runtimeState.ts
@@ -271,6 +271,7 @@ export interface RuntimeState {
   css: {
     importerToDependencies: Map<string, Set<string>>
     dependencyToImporters: Map<string, Set<string>>
+    transformedSidecarSource: Map<string, { code: string, diskSource: string }>
     emittedSource: Map<string, string>
     sidecarImports: Set<string>
   }
@@ -385,6 +386,7 @@ export function createRuntimeState(): RuntimeState {
     css: {
       importerToDependencies: new Map<string, Set<string>>(),
       dependencyToImporters: new Map<string, Set<string>>(),
+      transformedSidecarSource: new Map<string, { code: string, diskSource: string }>(),
       emittedSource: new Map<string, string>(),
       sidecarImports: new Set<string>(),
     },

--- a/packages/weapp-vite/test/__snapshots__/style.test.ts.snap
+++ b/packages/weapp-vite/test/__snapshots__/style.test.ts.snap
@@ -88,13 +88,15 @@ exports[`build style > dist > pages/index/index.wxss 1`] = `
 ".shared-css {
   color: beige;
 }
+
 .page {
   color: red;
 }
+
 .page .title {
   color: red;
   -webkit-background-clip: text;
-          background-clip: text;
+  background-clip: text;
 }"
 `;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1514,6 +1514,12 @@ importers:
       socket.io-client:
         specifier: ^4.8.3
         version: 4.8.3(bufferutil@4.1.0)(supports-color@10.2.2)
+      tailwindcss:
+        specifier: catalog:tailwind4
+        version: 4.3.3
+      weapp-tailwindcss:
+        specifier: catalog:weapp-tailwindcss-fixed
+        version: 5.2.11(@oxc-project/types@0.143.0)(jiti@2.7.0)(rolldown@1.2.3)(supports-color@10.2.2)(tailwindcss@4.3.3)(tsx@4.23.9)
       weapp-vite:
         specifier: workspace:*
         version: link:../../packages/weapp-vite


### PR DESCRIPTION
## 问题

Issue #779 中，样式 sidecar 虽然经过了 Vite 的 `pre` transform 管线，但 `weapp-vite` 在发射最终样式时重新读取物理文件，导致包括 WeappTailwindcss 在内的前序插件结果被磁盘内容覆盖。

根因位于 `weapp-vite` 的 sidecar 发射边界。`weapp-tailwindcss@5.2.11` 已能识别 sidecar 查询参数和物理源文件，因此本次不修改 weapp-tailwindcss。

## 修复

- 仅缓存可识别的 style sidecar transform 结果，并以物理源文件路径隔离。
- sidecar 发射和 HMR 样式重建优先使用管线内存内容，未经过 transform 时继续回退磁盘。
- fresh build、输出清理和 sidecar 删除时清理缓存，避免 watch 模式残留。
- 增加启用 WeappTailwindcss 的 Issue #779 复现，验证内存 marker、Tailwind preflight 和最终 wxss 输出。
- 增加中文 changeset，同时 bump `weapp-vite` 与 `create-weapp-vite`。

## 验证

- `pnpm vitest run packages/weapp-vite/src/plugins/css.test.ts packages/weapp-vite/src/runtime/resetRuntimeState.test.ts packages/weapp-vite/src/runtime/buildPlugin/outputs.test.ts packages/weapp-vite/src/plugins/utils/invalidateEntry/sidecar.test.ts`
- `pnpm --filter weapp-vite typecheck`
- `pnpm --filter weapp-vite build`
- `pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/issue-779-css-pre.test.ts`
- 对改动 TypeScript 文件执行定向 ESLint
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`
- `node --import tsx scripts/check-catalog-changeset.ts`

Closes #779