### PR TITLE
fix(weapp-vite): 完善构建后重写的 sourcemap 映射

### DIFF
--- a/.changeset/fix-sourcemap-rewrites.md
+++ b/.changeset/fix-sourcemap-rewrites.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复构建后 npm 路径、平台 API 和动态全局对象重写继续沿用旧 sourcemap，导致原生 TypeScript 产物无法准确回溯源码位置的问题。

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -986,17 +986,24 @@ describe.sequential('e2e app: github-issues (build)', () => {
     const pageJs = await fs.readFile(pageJsPath, 'utf-8')
     const pageMap = JSON.parse(await fs.readFile(pageMapPath, 'utf-8')) as Parameters<typeof TraceMap>[0]
     const sourceTs = await fs.readFile(path.join(APP_ROOT, sourceFile), 'utf-8')
-    const expectedSourceLine = sourceTs
-      .split('\n')
-      .findIndex(line => line.includes(`camelCase('issue 769 sourcemap marker')`)) + 1
-    const generatedPosition = findGeneratedPosition(pageJs, 'issue 769 sourcemap marker')
-    const originalPosition = originalPositionFor(new TraceMap(pageMap), generatedPosition)
+    const sourceLines = sourceTs.split('\n')
+    const sourceMap = new TraceMap(pageMap)
+    const mappedMarkers = [
+      ['issue 769 sourcemap marker', `camelCase('issue 769 sourcemap marker')`],
+      ['Page({', 'Page({'],
+      ['_runE2E() {', '_runE2E() {'],
+      ['issue769SourcemapMarker', `ok: issue769NpmMarker === 'issue769SourcemapMarker'`],
+    ]
 
     expect(pageJs).toMatch(/require\((['"])\.\.\/miniprogram_npm\/camelcase(?:\/index)?\1\)/)
     expect(await fs.pathExists(pageMapPath)).toBe(true)
-    expect(expectedSourceLine).toBeGreaterThan(0)
-    expect(originalPosition.source?.replaceAll('\\', '/')).toContain(sourceFile)
-    expect(originalPosition.line).toBe(expectedSourceLine)
+    for (const [generatedMarker, sourceMarker] of mappedMarkers) {
+      const expectedSourceLine = sourceLines.findIndex(line => line.includes(sourceMarker)) + 1
+      const originalPosition = originalPositionFor(sourceMap, findGeneratedPosition(pageJs, generatedMarker))
+      expect(expectedSourceLine).toBeGreaterThan(0)
+      expect(originalPosition.source?.replaceAll('\\', '/')).toContain(sourceFile)
+      expect(originalPosition.line).toBe(expectedSourceLine)
+    }
   })
 
   it('issue #479: injects indirect wevu page feature hooks from local helpers', async () => {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/platform.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/platform.test.ts
@@ -1,4 +1,6 @@
 import type { OutputBundle, OutputChunk } from 'rolldown'
+import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping'
+import MagicString from 'magic-string'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { analyzeScripts } from '../../../../../ast'
 import {
@@ -43,6 +45,38 @@ function createChunk(fileName: string, code: string): OutputChunk {
     sourcemapFileName: null,
     type: 'chunk',
   } as unknown as OutputChunk
+}
+
+function attachIdentitySourceMap(chunk: OutputChunk, source: string) {
+  chunk.map = new MagicString(chunk.code).generateMap({
+    hires: true,
+    includeContent: true,
+    source,
+  }) as any
+}
+
+function expectMarkerMappedToSource(
+  chunk: OutputChunk,
+  source: string,
+  sourceCode: string,
+  marker: string,
+) {
+  const generatedIndex = chunk.code.indexOf(marker)
+  const sourceIndex = sourceCode.indexOf(marker)
+  expect(generatedIndex).toBeGreaterThanOrEqual(0)
+  expect(sourceIndex).toBeGreaterThanOrEqual(0)
+  expect(chunk.map).toBeTruthy()
+
+  const generatedPrefix = chunk.code.slice(0, generatedIndex)
+  const sourcePrefix = sourceCode.slice(0, sourceIndex)
+  const original = originalPositionFor(new TraceMap(chunk.map as any), {
+    column: generatedPrefix.length - generatedPrefix.lastIndexOf('\n') - 1,
+    line: generatedPrefix.split('\n').length,
+  })
+
+  expect(original.source).toBe(source)
+  expect(original.line).toBe(sourcePrefix.split('\n').length)
+  expect(original.column).toBe(sourcePrefix.length - sourcePrefix.lastIndexOf('\n') - 1)
 }
 
 describe('bundle script analysis warmup', () => {
@@ -113,6 +147,23 @@ describe('bundle script analysis warmup', () => {
 
     expect(analyzeScripts).toHaveBeenCalledTimes(1)
     expect(chunk.code).toContain('/node_modules/pkg')
+  })
+
+  it('keeps sourcemaps aligned after platform npm import rewriting', () => {
+    const source = 'src/pages/index.ts'
+    const code = `const dep = require('pkg'); const issue769PlatformNpmMarker = dep`
+    const chunk = createChunk('pages/index.js', code)
+    attachIdentitySourceMap(chunk, source)
+    const bundle: OutputBundle = {
+      [chunk.fileName]: chunk,
+    }
+
+    rewriteBundleNpmImportsByPlatform('alipay', bundle, {
+      pkg: '1.0.0',
+    })
+
+    expect(chunk.code).toContain('/node_modules/pkg')
+    expectMarkerMappedToSource(chunk, source, code, 'issue769PlatformNpmMarker')
   })
 
   it('keeps analysis cache valid after npm import rewriting', () => {
@@ -201,5 +252,30 @@ describe('bundle script analysis warmup', () => {
     expect(setupFunction.code).toBe(`function runSetupFunction(setup) { return setup() }`)
     expect(functionGlobal.code).toBe(`const root = globalThis`)
     expect(browserTernary.code).toBe(`const root = globalThis`)
+  })
+
+  it('keeps sourcemaps aligned after platform api and dynamic global rewrites', () => {
+    const platformSource = 'src/pages/platform.ts'
+    const platformCode = [
+      `wx.getStorageSync('key')`,
+      `const issue769PlatformApiMarker = true`,
+    ].join('\n')
+    const platformChunk = createChunk('pages/platform.js', platformCode)
+    attachIdentitySourceMap(platformChunk, platformSource)
+
+    rewriteBundlePlatformApi({ [platformChunk.fileName]: platformChunk }, 'wpi')
+
+    expect(platformChunk.code).toContain('__weappViteInjectedApi__.getStorageSync')
+    expectMarkerMappedToSource(platformChunk, platformSource, platformCode, 'issue769PlatformApiMarker')
+
+    const globalSource = 'src/pages/global.ts'
+    const globalCode = `const root = Function("return this")(); const issue769GlobalMarker = root`
+    const globalChunk = createChunk('pages/global.js', globalCode)
+    attachIdentitySourceMap(globalChunk, globalSource)
+
+    rewriteBundleDynamicGlobalResolution({ [globalChunk.fileName]: globalChunk })
+
+    expect(globalChunk.code).toContain('const root = globalThis')
+    expectMarkerMappedToSource(globalChunk, globalSource, globalCode, 'issue769GlobalMarker')
   })
 })

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/platform.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/platform.test.ts
@@ -239,11 +239,13 @@ describe('bundle script analysis warmup', () => {
     const setupFunction = createChunk('pages/setup.js', `function runSetupFunction(setup) { return setup() }`)
     const functionGlobal = createChunk('pages/function.js', `const root = Function("return this")()`)
     const browserTernary = createChunk('pages/browser.js', `const root = typeof self<"u"?self:typeof window<"u"?window:globalThis`)
+    const nestedBrowserTernary = createChunk('pages/nested.js', `const root = typeof self<"u"?self:typeof window<"u"?window:Function("return this")()`)
     const bundle: OutputBundle = {
       [plain.fileName]: plain,
       [setupFunction.fileName]: setupFunction,
       [functionGlobal.fileName]: functionGlobal,
       [browserTernary.fileName]: browserTernary,
+      [nestedBrowserTernary.fileName]: nestedBrowserTernary,
     }
 
     rewriteBundleDynamicGlobalResolution(bundle)
@@ -252,6 +254,7 @@ describe('bundle script analysis warmup', () => {
     expect(setupFunction.code).toBe(`function runSetupFunction(setup) { return setup() }`)
     expect(functionGlobal.code).toBe(`const root = globalThis`)
     expect(browserTernary.code).toBe(`const root = globalThis`)
+    expect(nestedBrowserTernary.code).toBe(`const root = globalThis`)
   })
 
   it('keeps sourcemaps aligned after platform api and dynamic global rewrites', () => {

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/platform.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/platform.ts
@@ -1,20 +1,22 @@
 import type { OutputBundle, OutputChunk } from 'rolldown'
 import type { ScriptAnalysisResult } from '../../../../../ast'
 import type { MpPlatform } from '../../../../../types'
+import MagicString from 'magic-string'
 import { analyzeScript, analyzeScripts, mayContainPlatformApiAccess, mayContainStaticRequireLiteral, platformApiIdentifiers } from '../../../../../ast'
-import { generate, parseJsLike, traverse } from '../../../../../utils/babel'
+import { parseJsLike, traverse } from '../../../../../utils/babel'
 import {
   hasNpmDependencyPrefix,
   normalizeNpmImportLookupPath,
   normalizeNpmImportPathByPlatform,
   resolveNpmDependencyId,
 } from '../../../../../utils/npmImport'
-import { rewriteMiniProgramPlatformApiAccess } from '../../platformApiRewrite'
+import { createMiniProgramPlatformApiRewrite, rewriteMiniProgramPlatformApiAccess } from '../../platformApiRewrite'
 import {
   BROWSER_GLOBAL_HOST_TERNARY_RE,
   DYNAMIC_GLOBAL_RESOLUTION_RE,
 } from '../constants'
-import { getRequireImportLiteral, setRequireImportLiteral } from './literals'
+import { getRequireImportLiteral } from './literals'
+import { applyMagicStringChunkRewrite } from './sourcemap'
 
 function mayNeedChunkScriptAnalysis(code: string) {
   if (code.includes('require')) {
@@ -152,7 +154,7 @@ export function normalizeNpmImportByPlatform(
   })
 }
 
-export function rewriteChunkNpmImportsByPlatform(
+function createPlatformNpmImportRewrite(
   platform: MpPlatform | undefined,
   code: string,
   dependencies: Record<string, string> | undefined,
@@ -163,11 +165,12 @@ export function rewriteChunkNpmImportsByPlatform(
   },
 ) {
   if (!(options?.analysis?.hasStaticRequireLiteral ?? mayContainStaticRequireLiteral(code, { engine: options?.astEngine }))) {
-    return code
+    return
   }
 
   try {
     const ast = parseJsLike(code)
+    const magicString = new MagicString(code)
     let mutated = false
 
     traverse(ast as any, {
@@ -196,20 +199,39 @@ export function rewriteChunkNpmImportsByPlatform(
           return
         }
 
-        setRequireImportLiteral(firstArg, nextValue)
+        if (
+          typeof firstArg.start !== 'number'
+          || typeof firstArg.end !== 'number'
+          || firstArg.start < 0
+          || firstArg.end < firstArg.start
+        ) {
+          return
+        }
+
+        magicString.update(firstArg.start, firstArg.end, JSON.stringify(nextValue))
         mutated = true
       },
     })
 
-    if (!mutated) {
-      return code
+    if (mutated) {
+      return magicString
     }
-
-    return generate(ast as any).code
   }
   catch {
-    return code
   }
+}
+
+export function rewriteChunkNpmImportsByPlatform(
+  platform: MpPlatform | undefined,
+  code: string,
+  dependencies: Record<string, string> | undefined,
+  mode?: string,
+  options?: {
+    analysis?: Pick<ChunkScriptAnalysis, 'hasStaticRequireLiteral'>
+    astEngine?: 'babel' | 'oxc'
+  },
+) {
+  return createPlatformNpmImportRewrite(platform, code, dependencies, mode, options)?.toString() ?? code
 }
 
 export function rewriteBundleNpmImportsByPlatform(
@@ -237,14 +259,14 @@ export function rewriteBundleNpmImportsByPlatform(
       astEngine: options?.astEngine,
       cache: options?.analysisCache,
     })
-    const nextCode = rewriteChunkNpmImportsByPlatform(platform, chunk.code, dependencies, mode, {
+    const magicString = createPlatformNpmImportRewrite(platform, chunk.code, dependencies, mode, {
       ...options,
       analysis,
     })
-    if (nextCode === chunk.code) {
+    if (!magicString) {
       continue
     }
-    chunk.code = nextCode
+    applyMagicStringChunkRewrite(chunk, magicString)
     rememberChunkScriptAnalysis(chunk, analysis, {
       cache: options?.analysisCache,
     })
@@ -274,14 +296,14 @@ export function rewriteBundlePlatformApi(
       astEngine: options?.astEngine,
       cache: options?.analysisCache,
     })
-    const nextCode = replacePlatformApiAccess(chunk.code, globalName, {
+    const magicString = createMiniProgramPlatformApiRewrite(chunk.code, globalName, {
       ...options,
       analysis,
     })
-    if (nextCode === chunk.code) {
+    if (!magicString) {
       continue
     }
-    chunk.code = nextCode
+    applyMagicStringChunkRewrite(chunk, magicString)
   }
 }
 
@@ -308,9 +330,16 @@ export function rewriteBundleDynamicGlobalResolution(bundle: OutputBundle) {
       continue
     }
 
-    chunk.code = chunk.code
-      .replaceAll(DYNAMIC_GLOBAL_RESOLUTION_RE, 'globalThis')
-      .replaceAll(BROWSER_GLOBAL_HOST_TERNARY_RE, 'globalThis')
+    const magicString = new MagicString(chunk.code)
+    for (const expression of [DYNAMIC_GLOBAL_RESOLUTION_RE, BROWSER_GLOBAL_HOST_TERNARY_RE]) {
+      expression.lastIndex = 0
+      for (const match of chunk.code.matchAll(expression)) {
+        if (typeof match.index === 'number') {
+          magicString.update(match.index, match.index + match[0].length, 'globalThis')
+        }
+      }
+    }
+    applyMagicStringChunkRewrite(chunk, magicString)
   }
 }
 

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/platform.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/platform.ts
@@ -296,6 +296,9 @@ export function rewriteBundlePlatformApi(
       astEngine: options?.astEngine,
       cache: options?.analysisCache,
     })
+    if (analysis && !analysis.hasPlatformApiAccess) {
+      continue
+    }
     const magicString = createMiniProgramPlatformApiRewrite(chunk.code, globalName, {
       ...options,
       analysis,
@@ -308,6 +311,17 @@ export function rewriteBundlePlatformApi(
 }
 
 export function rewriteBundleDynamicGlobalResolution(bundle: OutputBundle) {
+  const applyPatternRewrite = (chunk: OutputChunk, expression: RegExp) => {
+    expression.lastIndex = 0
+    const magicString = new MagicString(chunk.code)
+    for (const match of chunk.code.matchAll(expression)) {
+      if (typeof match.index === 'number') {
+        magicString.update(match.index, match.index + match[0].length, 'globalThis')
+      }
+    }
+    applyMagicStringChunkRewrite(chunk, magicString)
+  }
+
   for (const output of Object.values(bundle)) {
     if (output?.type !== 'chunk') {
       continue
@@ -323,23 +337,15 @@ export function rewriteBundleDynamicGlobalResolution(bundle: OutputBundle) {
 
     const hasDynamicGlobalResolution = DYNAMIC_GLOBAL_RESOLUTION_RE.test(chunk.code)
     DYNAMIC_GLOBAL_RESOLUTION_RE.lastIndex = 0
+    if (hasDynamicGlobalResolution) {
+      applyPatternRewrite(chunk, DYNAMIC_GLOBAL_RESOLUTION_RE)
+    }
+
     const hasBrowserGlobalHostTernary = BROWSER_GLOBAL_HOST_TERNARY_RE.test(chunk.code)
     BROWSER_GLOBAL_HOST_TERNARY_RE.lastIndex = 0
-
-    if (!hasDynamicGlobalResolution && !hasBrowserGlobalHostTernary) {
-      continue
+    if (hasBrowserGlobalHostTernary) {
+      applyPatternRewrite(chunk, BROWSER_GLOBAL_HOST_TERNARY_RE)
     }
-
-    const magicString = new MagicString(chunk.code)
-    for (const expression of [DYNAMIC_GLOBAL_RESOLUTION_RE, BROWSER_GLOBAL_HOST_TERNARY_RE]) {
-      expression.lastIndex = 0
-      for (const match of chunk.code.matchAll(expression)) {
-        if (typeof match.index === 'number') {
-          magicString.update(match.index, match.index + match[0].length, 'globalThis')
-        }
-      }
-    }
-    applyMagicStringChunkRewrite(chunk, magicString)
   }
 }
 

--- a/packages/weapp-vite/src/plugins/core/lifecycle/platformApiRewrite.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/platformApiRewrite.ts
@@ -1,10 +1,11 @@
 import type { AstParserLike } from '../../../ast'
 import { WEAPP_VITE_INJECTED_API_IDENTIFIER } from '@weapp-core/constants'
+import MagicString from 'magic-string'
 import { platformApiIdentifiers } from '../../../ast'
-import { generate, parseJsLike, traverse } from '../../../utils/babel'
+import { parseJsLike, traverse } from '../../../utils/babel'
 import { createWeapiAccessExpression } from '../../../utils/weapi'
 
-export function rewriteMiniProgramPlatformApiAccess(
+export function createMiniProgramPlatformApiRewrite(
   code: string,
   globalName: string,
   _options?: {
@@ -16,6 +17,7 @@ export function rewriteMiniProgramPlatformApiAccess(
 
   try {
     const ast = parseJsLike(code)
+    const magicString = new MagicString(code)
     let mutated = false
 
     const rewritePath = (path: any) => {
@@ -30,10 +32,15 @@ export function rewriteMiniProgramPlatformApiAccess(
       if (path.scope?.hasBinding?.(identifierName)) {
         return
       }
-      path.node.object = {
-        type: 'Identifier',
-        name: injectedApiIdentifier,
+      if (
+        typeof object.start !== 'number'
+        || typeof object.end !== 'number'
+        || object.start < 0
+        || object.end < object.start
+      ) {
+        return
       }
+      magicString.update(object.start, object.end, injectedApiIdentifier)
       mutated = true
     }
 
@@ -42,15 +49,23 @@ export function rewriteMiniProgramPlatformApiAccess(
       OptionalMemberExpression: rewritePath,
     })
 
-    if (!mutated) {
-      return code
+    if (mutated) {
+      const aliasCode = `var ${injectedApiIdentifier} = ${createWeapiAccessExpression(globalName)};`
+      magicString.prepend(`${aliasCode}\n`)
+      return magicString
     }
-
-    const transformedCode = generate(ast as any).code
-    const aliasCode = `var ${injectedApiIdentifier} = ${createWeapiAccessExpression(globalName)};`
-    return `${aliasCode}\n${transformedCode}`
   }
   catch {
-    return code
   }
+}
+
+export function rewriteMiniProgramPlatformApiAccess(
+  code: string,
+  globalName: string,
+  options?: {
+    engine?: 'babel' | 'oxc'
+    parserLike?: AstParserLike
+  },
+) {
+  return createMiniProgramPlatformApiRewrite(code, globalName, options)?.toString() ?? code
 }


### PR DESCRIPTION
## 摘要
- 让跨平台 npm 路径、平台 API 与动态全局对象的构建后重写使用 MagicString 片段更新，并组合已有 sourcemap。
- 避免 rewrite 后继续复用旧 map，导致原生 TypeScript 产物无法准确回溯源码。
- 扩展 issue #769 的真实构建回归到 npm 使用、Page 注册、方法体和返回分支四个映射点。

## 验证
- pnpm vitest run packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/localRoot.test.ts packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/platform.test.ts packages/weapp-vite/src/plugins/core/lifecycle/platformApiRewrite.test.ts packages/weapp-vite/src/cli/commands/build.test.ts packages/weapp-vite/src/cli/runtime.test.ts
- pnpm exec eslint packages/weapp-vite/src/plugins/core/lifecycle/platformApiRewrite.ts packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/platform.ts packages/weapp-vite/src/plugins/core/lifecycle/emit/rewrite/platform.test.ts e2e/ci/github-issues.build.test.ts
- pnpm --filter weapp-vite typecheck
- pnpm --filter weapp-vite build
- node packages/weapp-vite/bin/weapp-vite.js build e2e-apps/github-issues --platform weapp --sourcemap --outDir .codex-tmp/issue-769-build --emptyOutDir
- node --import tsx scripts/check-create-weapp-vite-changeset.ts
- node --import tsx scripts/check-catalog-changeset.ts

## 说明
platform.ts 原本已超过 300 行；npm、平台 API 与动态全局 rewrite 共享同一 bundle 分析缓存和生成生命周期，保留在同一模块可避免拆分后增加跨模块状态传递。

Fixes #769