### PR TITLE
fix(wevu): 彻底修复 scoped slot 挂载前绑定同步

### DIFF
--- a/.changeset/fix-scoped-slot-pre-attach-sync.md
+++ b/.changeset/fix-scoped-slot-pre-attach-sync.md
@@ -1,0 +1,6 @@
+---
+"wevu": patch
+"create-weapp-vite": patch
+---
+
+修复增强 scoped slot 的宿主属性早于 runtime 挂载时，owner proxy 与 slot props 未同步到新 runtime、导致模板计算值回退为空的问题。

--- a/e2e-apps/github-issues/src/components/issue-558/Issue558RenderProbe/index.json
+++ b/e2e-apps/github-issues/src/components/issue-558/Issue558RenderProbe/index.json
@@ -1,0 +1,3 @@
+{
+  "component": true
+}

--- a/e2e-apps/github-issues/src/components/issue-558/Issue558RenderProbe/index.ts
+++ b/e2e-apps/github-issues/src/components/issue-558/Issue558RenderProbe/index.ts
@@ -1,0 +1,45 @@
+function reportRenderedValue(caseName: unknown, value: unknown) {
+  if (typeof caseName !== 'string' || !caseName) {
+    return
+  }
+  const pages = getCurrentPages() as Array<Record<string, any>>
+  const currentPage = pages[pages.length - 1]
+  if (!currentPage) {
+    return
+  }
+  const renderedCases = currentPage.__issue558RenderedCases
+    ?? (currentPage.__issue558RenderedCases = {})
+  if (caseName === 'listScoped') {
+    const values = Array.isArray(renderedCases.listScoped)
+      ? renderedCases.listScoped
+      : (renderedCases.listScoped = [])
+    if (typeof value === 'string' && value && !values.includes(value)) {
+      values.push(value)
+    }
+    return
+  }
+  renderedCases[caseName] = typeof value === 'string' ? value : ''
+}
+
+Component({
+  properties: {
+    caseName: {
+      type: String,
+      value: '',
+    },
+    value: {
+      type: null,
+      value: null,
+    },
+  },
+  observers: {
+    'caseName, value': function (caseName: string, value: unknown) {
+      reportRenderedValue(caseName, value)
+    },
+  },
+  lifetimes: {
+    ready() {
+      reportRenderedValue(this.properties.caseName, this.properties.value)
+    },
+  },
+})

--- a/e2e-apps/github-issues/src/components/issue-558/Issue558RenderProbe/index.wxml
+++ b/e2e-apps/github-issues/src/components/issue-558/Issue558RenderProbe/index.wxml
@@ -1,0 +1,6 @@
+<text
+  class="issue558-result"
+  data-issue558-case="{{caseName}}"
+>
+  {{value}}
+</text>

--- a/e2e-apps/github-issues/src/pages/issue-558/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-558/index.vue
@@ -8,6 +8,9 @@ import NamedSlotCard from '../../components/issue-558/NamedSlotCard/index.vue'
 
 definePageJson({
   navigationBarTitleText: 'issue-558',
+  usingComponents: {
+    'issue-558-render-probe': '/components/issue-558/Issue558RenderProbe/index',
+  },
 })
 
 function func(text: string = '') {
@@ -20,26 +23,34 @@ const defaultText = 'default'
 const nestedText = 'nested'
 const visible = true
 
+const expectedRenderedCases = {
+  plainDefault: '987654321',
+  namedHeader: 'redaeh',
+  explicitDefault: 'tluafed',
+  namedScopedFooter: 'retoof-987654321',
+  defaultScoped: '987654321-2-tluafed-depocs',
+  listScoped: [
+    '987654321-0-ahpla',
+    '987654321-1-ateb',
+  ],
+  nestedOuter: 'retuo',
+  nestedDefault: 'detsen',
+}
+
 function _runE2E() {
-  const defaultScopedLabel = 'scoped-default'
-  const defaultScopedCount = 2
-  const namedFooterSuffix = '-footer'
-  const listRows = [
-    { label: 'alpha' },
-    { label: 'beta' },
-  ]
+  const pages = getCurrentPages() as Array<Record<string, any>>
+  const currentPage = pages[pages.length - 1]
+  const renderedCases = { ...(currentPage?.__issue558RenderedCases ?? {}) }
+  const ok = Object.entries(expectedRenderedCases).every(([caseName, expected]) => {
+    const rendered = renderedCases[caseName]
+    return Array.isArray(expected)
+      ? Array.isArray(rendered) && expected.every((value, index) => rendered[index] === value)
+      : rendered === expected
+  })
 
   return {
-    ok: true,
-    cases: {
-      plainDefault: func(text),
-      namedHeader: func(headerText),
-      explicitDefault: func(defaultText),
-      namedScopedFooter: func(text + namedFooterSuffix),
-      defaultScoped: func(`${defaultScopedLabel}-${defaultScopedCount}-${text}`),
-      listScoped: listRows.map((item, index) => func(`${item.label}-${index}-${text}`)),
-      nestedDefault: func(nestedText),
-    },
+    ok,
+    cases: renderedCases,
   }
 }
 </script>
@@ -51,70 +62,60 @@ function _runE2E() {
     </view>
 
     <Cell>
-      <text
-        class="issue558-result"
-        data-issue558-case="plain-default"
-      >
-        {{ func(text) }}
-      </text>
+      <issue-558-render-probe
+        case-name="plainDefault"
+        :value="func(text)"
+      />
     </Cell>
 
     <NamedSlotCard>
       <template #header>
-        <text
-          class="issue558-result"
-          data-issue558-case="named-header"
-        >
-          {{ func(headerText) }}
-        </text>
+        <issue-558-render-probe
+          case-name="namedHeader"
+          :value="func(headerText)"
+        />
       </template>
 
       <template #default>
-        <text
-          class="issue558-result"
-          data-issue558-case="explicit-default"
-        >
-          {{ func(defaultText) }}
-        </text>
+        <issue-558-render-probe
+          case-name="explicitDefault"
+          :value="func(defaultText)"
+        />
       </template>
 
       <template #footer="{ suffix }">
-        <text
-          class="issue558-result"
-          data-issue558-case="named-scoped-footer"
-        >
-          {{ func(text + suffix) }}
-        </text>
+        <issue-558-render-probe
+          case-name="namedScopedFooter"
+          :value="func(text + suffix)"
+        />
       </template>
     </NamedSlotCard>
 
     <DefaultScopedCell v-slot="{ label, count }">
-      <text
+      <issue-558-render-probe
         v-if="visible"
-        class="issue558-result"
-        data-issue558-case="default-scoped"
-      >
-        {{ func(`${label}-${count}-${text}`) }}
-      </text>
+        case-name="defaultScoped"
+        :value="func(`${label}-${count}-${text}`)"
+      />
     </DefaultScopedCell>
 
     <ListScopedCell v-slot="{ item, index }">
-      <text
-        class="issue558-result"
-        :data-issue558-case="`list-scoped-${index}`"
-      >
-        {{ func(`${item.label}-${index}-${text}`) }}
-      </text>
+      <issue-558-render-probe
+        case-name="listScoped"
+        :value="func(`${item.label}-${index}-${text}`)"
+      />
     </ListScopedCell>
 
     <Issue558NestedSlotGroup>
+      <issue-558-render-probe
+        case-name="nestedOuter"
+        :value="func('outer')"
+      />
       <Issue558NestedSlotCell>
-        <text
-          class="issue558-result"
-          data-issue558-case="nested-default"
-        >
-          {{ func(nestedText) }}
-        </text>
+        <issue-558-render-probe
+          case-name="nestedDefault"
+          :value="func(nestedText)"
+        />
       </Issue558NestedSlotCell>
     </Issue558NestedSlotGroup>
   </view>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -59,7 +59,6 @@ const githubIssuesRouteGroups: Record<string, string[]> = {
   ],
   'github-issues.runtime.issue558.test.ts': [
     'pages/issue-558/**',
-    'components/issue-558/**',
   ],
   'github-issues.runtime.issue554.test.ts': [
     'pages/issue-554/**',
@@ -222,7 +221,6 @@ function resolveGithubIssuesAutoRoutes() {
     return {
       include: [
         'pages/issue-558/**',
-        'components/issue-558/**',
       ],
     }
   }

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -1560,6 +1560,9 @@ describe.sequential('e2e app: github-issues (build)', () => {
     const scopedSlotJsFiles = files
       .filter(file => file.startsWith('pages/issue-558/index.__scoped-slot-') && file.endsWith('.js'))
       .sort()
+    const scopedSlotJsonFiles = files
+      .filter(file => file.startsWith('pages/issue-558/index.__scoped-slot-') && file.endsWith('.json'))
+      .sort()
     const runtime = await findWevuRuntimeChunk(
       DIST_ROOT,
       code => code.includes('__wvOwnerProxy'),
@@ -1570,6 +1573,7 @@ describe.sequential('e2e app: github-issues (build)', () => {
     const pageJson = await fs.readJson(pageJsonPath) as { usingComponents?: Record<string, string> }
     const scopedSlotWxml = (await Promise.all(scopedSlotFiles.map(file => fs.readFile(path.join(DIST_ROOT, file), 'utf-8')))).join('\n')
     const scopedSlotJs = (await Promise.all(scopedSlotJsFiles.map(file => fs.readFile(path.join(DIST_ROOT, file), 'utf-8')))).join('\n')
+    const scopedSlotJson = (await Promise.all(scopedSlotJsonFiles.map(file => fs.readFile(path.join(DIST_ROOT, file), 'utf-8')))).join('\n')
     const cellWxml = await fs.readFile(cellWxmlPath, 'utf-8')
     const defaultScopedCellWxml = await fs.readFile(defaultScopedCellWxmlPath, 'utf-8')
     const listScopedCellWxml = await fs.readFile(listScopedCellWxmlPath, 'utf-8')
@@ -1583,25 +1587,32 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageWxml).toContain('generic:scoped-slots-header=')
     expect(pageWxml).toContain('generic:scoped-slots-footer=')
     expect(pageJson.usingComponents).toMatchObject({
-      Cell: '/components/issue-558/Cell/index',
-      DefaultScopedCell: '/components/issue-558/DefaultScopedCell/index',
-      Issue558NestedSlotCell: '/components/issue-558/Issue558NestedSlotCell/index',
-      Issue558NestedSlotGroup: '/components/issue-558/Issue558NestedSlotGroup/index',
-      ListScopedCell: '/components/issue-558/ListScopedCell/index',
-      NamedSlotCard: '/components/issue-558/NamedSlotCard/index',
+      'Cell': '/components/issue-558/Cell/index',
+      'DefaultScopedCell': '/components/issue-558/DefaultScopedCell/index',
+      'Issue558NestedSlotCell': '/components/issue-558/Issue558NestedSlotCell/index',
+      'Issue558NestedSlotGroup': '/components/issue-558/Issue558NestedSlotGroup/index',
+      'issue-558-render-probe': '/components/issue-558/Issue558RenderProbe/index',
+      'ListScopedCell': '/components/issue-558/ListScopedCell/index',
+      'NamedSlotCard': '/components/issue-558/NamedSlotCard/index',
     })
     expect(Object.values(pageJson.usingComponents ?? {}).some(value => value.startsWith('/pages/issue-558/index.__scoped-slot-'))).toBe(true)
     expect(scopedSlotFiles.length).toBeGreaterThanOrEqual(5)
     expect(scopedSlotJsFiles.length).toBe(scopedSlotFiles.length)
-    expect(pageWxml).toContain('data-issue558-case="plain-default"')
-    expect(pageWxml).not.toContain('data-issue558-case="nested-default"')
-    expect(scopedSlotWxml).toContain('data-issue558-case="named-header"')
-    expect(scopedSlotWxml).toContain('data-issue558-case="explicit-default"')
-    expect(scopedSlotWxml).toContain('data-issue558-case="named-scoped-footer"')
-    expect(scopedSlotWxml).toContain('data-issue558-case="default-scoped"')
-    expect(scopedSlotWxml).toContain('data-issue558-case="{{\'list-scoped-\'+__wvSlotPropsData.index}}"')
-    expect(scopedSlotWxml).toContain('data-issue558-case="nested-default"')
-    expect(scopedSlotWxml).not.toContain('data-issue558-case="plain-default"')
+    expect(scopedSlotJsonFiles.length).toBe(scopedSlotFiles.length)
+    expect(pageWxml).toMatch(/<issue-558-render-probe case-name="plainDefault" value="\{\{__wv_bind_\d+\}\}"/)
+    expect(scopedSlotWxml).not.toContain('case-name="plainDefault"')
+    expect(scopedSlotJson).toContain('/components/issue-558/Issue558RenderProbe/index')
+    for (const caseName of [
+      'namedHeader',
+      'explicitDefault',
+      'namedScopedFooter',
+      'defaultScoped',
+      'listScoped',
+      'nestedOuter',
+      'nestedDefault',
+    ]) {
+      expect(scopedSlotWxml).toMatch(new RegExp(`<issue-558-render-probe case-name="${caseName}" value="\\{\\{__wv_bind_\\d+\\}\\}"`))
+    }
     expect(scopedSlotJs).toContain('__wvOwnerProxy')
     expect(scopedSlotJs).toContain('.func')
     expect(scopedSlotJs).toContain('.text')

--- a/e2e/ide/github-issues.runtime.issue558.test.ts
+++ b/e2e/ide/github-issues.runtime.issue558.test.ts
@@ -4,6 +4,7 @@ import path from 'pathe'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import {
   closeSharedMiniProgram,
+  delay,
   DIST_ROOT,
   getSharedMiniProgram,
   PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT,
@@ -14,17 +15,42 @@ import {
 
 const ISSUE_558_AUGMENTED_ENV = 'WEAPP_GITHUB_ISSUE_558_AUGMENTED'
 
-function getIssue558ExpectedCases(cases: Record<string, any>) {
-  return [
-    ['plain-default', cases.plainDefault],
-    ['named-header', cases.namedHeader],
-    ['explicit-default', cases.explicitDefault],
-    ['named-scoped-footer', cases.namedScopedFooter],
-    ['default-scoped', cases.defaultScoped],
-    ['list-scoped-0', Array.isArray(cases.listScoped) ? cases.listScoped[0] : undefined],
-    ['list-scoped-1', Array.isArray(cases.listScoped) ? cases.listScoped[1] : undefined],
-    ['nested-default', cases.nestedDefault],
-  ].filter((entry): entry is [string, string] => typeof entry[1] === 'string' && entry[1].length > 0)
+const ISSUE_558_EXPECTED_RENDERED_CASES = {
+  plainDefault: '987654321',
+  namedHeader: 'redaeh',
+  explicitDefault: 'tluafed',
+  namedScopedFooter: 'retoof-987654321',
+  defaultScoped: '987654321-2-tluafed-depocs',
+  listScoped: [
+    '987654321-0-ahpla',
+    '987654321-1-ateb',
+  ],
+  nestedOuter: 'retuo',
+  nestedDefault: 'detsen',
+}
+
+async function waitForIssue558Runtime(page: any, timeoutMs = 30_000) {
+  const startedAt = Date.now()
+  let latest: Record<string, any> | null = null
+  let lastError: unknown
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      latest = await page.callMethod('_runE2E')
+      if (latest?.ok === true) {
+        return latest
+      }
+    }
+    catch (error) {
+      lastError = error
+    }
+    await delay(160)
+  }
+
+  if (latest == null && lastError) {
+    throw lastError
+  }
+  return latest
 }
 
 async function readIssue558WxmlBundle() {
@@ -54,32 +80,19 @@ describe.sequential('e2e app: github-issues / issue #558', () => {
       const issuePage = await relaunchPage(miniProgram, '/pages/issue-558/index', undefined, 20_000, {
         readiness: async (page) => {
           const runtime = await page.callMethod('_runE2E')
-          return runtime?.ok === true
+          return runtime != null && typeof runtime.cases === 'object'
         },
       })
       if (!issuePage) {
         throw new Error('Failed to launch issue-558 page')
       }
 
-      const runtime = await issuePage.callMethod('_runE2E')
-      const cases = runtime?.cases ?? {}
+      const runtime = await waitForIssue558Runtime(issuePage)
       const renderedWxml = await readIssue558WxmlBundle()
 
+      expect(runtime?.cases).toEqual(ISSUE_558_EXPECTED_RENDERED_CASES)
       expect(runtime?.ok).toBe(true)
-      for (const [, expected] of getIssue558ExpectedCases(cases)) {
-        expect(expected).toBeTruthy()
-      }
-      for (const caseName of [
-        'plain-default',
-        'named-header',
-        'explicit-default',
-        'named-scoped-footer',
-        'default-scoped',
-        'nested-default',
-      ]) {
-        expect(renderedWxml).toContain(`data-issue558-case="${caseName}"`)
-      }
-      expect(renderedWxml).toContain('data-issue558-case="{{\'list-scoped-\'+__wvSlotPropsData.index}}"')
+      expect(renderedWxml).toContain('<issue-558-render-probe')
     }
     finally {
       await releaseSharedMiniProgram(miniProgram)

--- a/packages-runtime/wevu/src/runtime/define/scopedSlotOptions.ts
+++ b/packages-runtime/wevu/src/runtime/define/scopedSlotOptions.ts
@@ -228,10 +228,23 @@ function syncSlotPropsData(
   }
   instance[WEVU_SLOT_PROPS_DATA_KEY] = merged
   const runtimeState = instance?.__wevu?.state
+  const runtimeSnapshotChanged = Boolean(
+    runtimeState
+    && typeof runtimeState === 'object'
+    && (
+      !hasOwn(runtimeState, WEVU_SLOT_PROPS_DATA_KEY)
+      || !isDeepEqualValue(
+        runtimeState[WEVU_SLOT_PROPS_DATA_KEY] ?? {},
+        snapshot,
+        20,
+        { keys: 10_000 },
+      )
+    ),
+  )
   if (runtimeState && typeof runtimeState === 'object') {
     runtimeState[WEVU_SLOT_PROPS_DATA_KEY] = merged
   }
-  return { merged, snapshot, snapshotChanged }
+  return { merged, runtimeSnapshotChanged, snapshot, snapshotChanged }
 }
 
 function mergeSlotProps(
@@ -239,8 +252,8 @@ function mergeSlotProps(
   computed?: ComputedDefinitions,
   override?: { [WEVU_SLOT_SCOPE_KEY]?: unknown, [WEVU_SLOT_PROPS_KEY]?: unknown },
 ) {
-  const { snapshot, snapshotChanged } = syncSlotPropsData(instance, override)
-  if (snapshotChanged && typeof instance?.setData === 'function') {
+  const { runtimeSnapshotChanged, snapshot, snapshotChanged } = syncSlotPropsData(instance, override)
+  if ((snapshotChanged || runtimeSnapshotChanged) && typeof instance?.setData === 'function') {
     instance.setData({ [WEVU_SLOT_PROPS_DATA_KEY]: snapshot })
   }
   if (snapshotChanged) {
@@ -249,12 +262,13 @@ function mergeSlotProps(
 }
 
 function setOwnerProxy(instance: any, proxy: any) {
-  if (instance[WEVU_SLOT_OWNER_PROXY_KEY] === proxy) {
-    return false
+  let changed = false
+  if (instance[WEVU_SLOT_OWNER_PROXY_KEY] !== proxy) {
+    instance[WEVU_SLOT_OWNER_PROXY_KEY] = proxy
+    changed = true
   }
-  instance[WEVU_SLOT_OWNER_PROXY_KEY] = proxy
   const data = instance?.data
-  if (data && typeof data === 'object') {
+  if (data && typeof data === 'object' && data[WEVU_SLOT_OWNER_PROXY_KEY] !== proxy) {
     try {
       Object.defineProperty(data, WEVU_SLOT_OWNER_PROXY_KEY, {
         value: proxy,
@@ -266,12 +280,18 @@ function setOwnerProxy(instance: any, proxy: any) {
     catch {
       data[WEVU_SLOT_OWNER_PROXY_KEY] = proxy
     }
+    changed = true
   }
   const runtimeState = instance?.__wevu?.state
-  if (runtimeState && typeof runtimeState === 'object') {
+  if (
+    runtimeState
+    && typeof runtimeState === 'object'
+    && runtimeState[WEVU_SLOT_OWNER_PROXY_KEY] !== proxy
+  ) {
     runtimeState[WEVU_SLOT_OWNER_PROXY_KEY] = proxy
+    changed = true
   }
-  return true
+  return changed
 }
 
 function updateOwnerBindings(instance: any, snapshot: Record<string, any>, proxy: any, computed?: ComputedDefinitions) {

--- a/packages-runtime/wevu/test/runtime-scoped-slots.test.ts
+++ b/packages-runtime/wevu/test/runtime-scoped-slots.test.ts
@@ -363,6 +363,42 @@ describe('runtime: scoped slots', () => {
     }))
   })
 
+  it('restores owner-proxy computed bindings when owner id arrives before attach', () => {
+    const computed = {
+      __wv_bind_0(this: any) {
+        try {
+          return this[WEVU_SLOT_OWNER_PROXY_KEY].func(this[WEVU_SLOT_OWNER_PROXY_KEY].text)
+        }
+        catch {
+          return undefined
+        }
+      },
+    }
+    createWevuScopedSlotComponent({ computed })
+    const opts = registeredComponents.pop()!
+    expect(opts).toBeTruthy()
+
+    const ownerId = allocateOwnerId()
+    const proxy = {
+      text: '123456789',
+      func: (text: string) => text.split('').reverse().join(''),
+    }
+    updateOwnerSnapshot(ownerId, { text: '123456789' }, proxy as any)
+
+    const inst: any = {
+      data: typeof opts.data === 'function' ? opts.data() : {},
+      properties: { [WEVU_SLOT_OWNER_ID_PROP]: ownerId },
+      setData: vi.fn(),
+    }
+    opts.properties[WEVU_SLOT_OWNER_ID_PROP].observer.call(inst, ownerId)
+    opts.lifetimes.attached.call(inst)
+
+    expect(inst.__wevu.state[WEVU_SLOT_OWNER_PROXY_KEY]).toEqual(proxy)
+    expect(inst.setData).toHaveBeenCalledWith(expect.objectContaining({
+      __wv_bind_0: '987654321',
+    }))
+  })
+
   it('binds owner-proxy computed bindings from dedicated owner id prop', () => {
     const computed = {
       __wv_bind_0(this: any) {
@@ -663,6 +699,28 @@ describe('runtime: scoped slots', () => {
     expect(inst.setData).toHaveBeenCalledWith(expect.objectContaining({
       __wv_bind_0: ['ALPHA'],
     }))
+  })
+
+  it('restores native slot props data when slot props arrive before attach', () => {
+    createWevuScopedSlotComponent()
+    const opts = registeredComponents.pop()!
+    expect(opts).toBeTruthy()
+
+    const inst: any = {
+      data: typeof opts.data === 'function' ? opts.data() : {},
+      properties: {
+        [WEVU_SLOT_SCOPE_KEY]: null,
+        [WEVU_SLOT_PROPS_KEY]: ['item', { label: 'alpha' }, 'index', 0],
+      },
+      setData: vi.fn(),
+    }
+    opts.properties[WEVU_SLOT_PROPS_KEY].observer.call(inst, inst.properties[WEVU_SLOT_PROPS_KEY])
+    inst.setData.mockClear()
+    opts.lifetimes.attached.call(inst)
+
+    expect(inst.setData).toHaveBeenCalledWith({
+      [WEVU_SLOT_PROPS_DATA_KEY]: { item: { label: 'alpha' }, index: 0 },
+    })
   })
 
   it('keeps slot props readable when owner id arrives before slot prop observers', () => {


### PR DESCRIPTION
## 问题

Issue #558 现有 IDE 用例直接调用页面函数并检查静态 WXML，没有验证 scoped slot 组件实际收到的计算值。真实 DevTools 验证发现，owner id / slot props 在 runtime 挂载前到达时，只同步到了原生实例，后挂载的 runtime state 仍保留空占位，导致 computed 结果被回退为空。

## 修复

- 分别维护 scoped-slot owner proxy 在原生实例、native data 与 runtime state 的同步状态。
- runtime state 首次接收 slot props 时向 native data 重放一次，保留等价更新去重。
- 使用原生小程序探针验证普通、具名、显式默认、作用域、v-for 与嵌套插槽的真实渲染值。
- 修正 issue #558 定向路由裁剪，避免把 fixture 组件误当页面编译。
- 增加 wevu 与 create-weapp-vite patch changeset。

## 验证

- `pnpm --filter wevu build`
- `pnpm --filter wevu typecheck`
- `pnpm vitest run packages-runtime/wevu/test/runtime-scoped-slots.test.ts`（34/34）
- issue #558 定向 build E2E
- issue #558 mpcore headless runtime E2E
- issue #558 真实微信开发者工具 runtime E2E（0 warn / 0 error / 0 exception）
- `node --import tsx scripts/check-e2e-ide-shared-launch.ts`（95 files）

Fixes #558