### PR TITLE
fix(dashboard): 改进宽屏布局与页面滚动体验

### DIFF
--- a/.changeset/improve-dashboard-layout.md
+++ b/.changeset/improve-dashboard-layout.md
@@ -1,0 +1,6 @@
+---
+"@weapp-vite/dashboard": patch
+"create-weapp-vite": patch
+---
+
+优化 dashboard 的宽屏空间利用率与纵向滚动体验，压缩双语标题和拖拽控制占用，并修复问题中心在较窄视口下的横向拥挤。

--- a/packages/dashboard/src/App.vue
+++ b/packages/dashboard/src/App.vue
@@ -55,9 +55,9 @@ watch(() => route.fullPath, () => {
 </script>
 
 <template>
-  <div class="h-dvh overflow-hidden px-3 py-3 text-(--dashboard-text) md:px-4 md:py-4 lg:px-5">
-    <div class="mx-auto grid h-full max-w-400 gap-3 overflow-hidden lg:grid-cols-[17rem_minmax(0,1fr)]">
-      <aside class="hidden min-h-0 overflow-hidden lg:block">
+  <div class="min-h-dvh overflow-x-hidden px-3 py-3 text-(--dashboard-text) md:px-4 md:py-4 lg:px-5">
+    <div class="mx-auto grid max-w-480 items-start gap-3 lg:grid-cols-[16rem_minmax(0,1fr)]">
+      <aside class="hidden min-h-0 lg:sticky lg:top-4 lg:block lg:h-[calc(100dvh-2rem)]">
         <div class="grid h-full grid-rows-[minmax(0,1fr)_auto] gap-3">
           <AppSurfaceCard
             eyebrow="Shell"
@@ -82,7 +82,7 @@ watch(() => route.fullPath, () => {
         </div>
       </aside>
 
-      <div class="grid min-h-0 min-w-0 grid-rows-[auto_minmax(0,1fr)] gap-3 overflow-hidden">
+      <div class="grid min-h-0 min-w-0 gap-3">
         <AppShellHeader
           :title="pageMeta.title"
           :description="pageMeta.description"
@@ -92,7 +92,7 @@ watch(() => route.fullPath, () => {
           @set-theme="setThemePreference"
         />
 
-        <div class="min-h-0 overflow-hidden">
+        <div class="min-h-[calc(100dvh-8rem)] min-w-0">
           <RouterView />
         </div>
       </div>

--- a/packages/dashboard/src/features/dashboard/components/ActionCenterPanel.vue
+++ b/packages/dashboard/src/features/dashboard/components/ActionCenterPanel.vue
@@ -62,7 +62,7 @@ const {
           type="search"
         >
       </div>
-      <div class="grid grid-cols-3 gap-2">
+      <div class="grid gap-2 sm:grid-cols-2 2xl:grid-cols-3">
         <select
           v-model="actionToneFilter"
           class="h-9 min-w-0 rounded-md border border-(--dashboard-border) bg-(--dashboard-panel-muted) px-2.5 text-sm text-(--dashboard-text) outline-none transition focus:border-(--dashboard-accent)"

--- a/packages/dashboard/src/features/dashboard/components/AnalyzeDraggableGrid.vue
+++ b/packages/dashboard/src/features/dashboard/components/AnalyzeDraggableGrid.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, shallowRef, watch } from 'vue'
+import DashboardIcon from './DashboardIcon.vue'
 
 interface AnalyzeDraggableGridItem {
   id: string
@@ -85,32 +86,39 @@ watch(
     <article
       v-for="item in orderedItems"
       :key="item.id"
-      class="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-lg border border-dashed border-transparent transition"
+      class="relative min-h-0 rounded-lg border border-dashed border-transparent pt-2 transition"
       :class="[item.className, draggingId === item.id ? 'border-(--dashboard-accent) opacity-70' : '']"
       @dragover.prevent
       @drop="handleDrop(item)"
     >
-      <div class="flex min-h-0 items-center justify-between gap-2 pb-1">
+      <div class="absolute inset-x-0 top-0 z-10 flex -translate-y-1/2 items-center justify-center gap-2 px-2">
         <button
-          class="inline-flex min-w-0 cursor-grab items-center gap-2 rounded-md border border-(--dashboard-border) bg-(--dashboard-panel-muted) px-2 py-1 text-[11px] uppercase tracking-[0.16em] text-(--dashboard-text-soft) transition hover:border-(--dashboard-border-strong) hover:text-(--dashboard-text)"
+          class="inline-flex h-7 w-7 shrink-0 cursor-grab items-center justify-center rounded-md border border-(--dashboard-border) bg-(--dashboard-panel-strong) text-(--dashboard-text-soft) shadow-(--dashboard-shadow) transition hover:border-(--dashboard-border-strong) hover:text-(--dashboard-text)"
           draggable="true"
           type="button"
+          :aria-label="`拖动调整${item.label}模块位置`"
+          :title="`拖动调整${item.label}模块位置`"
           @dragend="draggingId = null"
           @dragstart="handleDragStart(item, $event)"
         >
-          <span aria-hidden="true">::</span>
-          <span class="truncate">{{ item.label }}</span>
+          <span class="h-4 w-4" aria-hidden="true">
+            <DashboardIcon name="metric-drag" />
+          </span>
         </button>
         <button
           v-if="orderedItems.length > 1 && item.id === orderedItems[0]?.id"
-          class="shrink-0 rounded-full border border-(--dashboard-border) bg-(--dashboard-panel-muted) px-2 py-1 text-[11px] text-(--dashboard-text-soft) transition hover:border-(--dashboard-border-strong) hover:text-(--dashboard-text)"
+          class="absolute right-2 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-(--dashboard-border) bg-(--dashboard-panel-strong) text-(--dashboard-text-soft) shadow-(--dashboard-shadow) transition hover:border-(--dashboard-border-strong) hover:text-(--dashboard-text)"
           type="button"
+          aria-label="重置模块布局"
+          title="重置模块布局"
           @click="resetOrder"
         >
-          重置布局
+          <span class="h-4 w-4" aria-hidden="true">
+            <DashboardIcon name="metric-reset" />
+          </span>
         </button>
       </div>
-      <div class="min-h-0 overflow-hidden">
+      <div class="min-h-0">
         <slot :name="item.id" :item="item" />
       </div>
     </article>

--- a/packages/dashboard/src/features/dashboard/components/AnalyzeResultSections.vue
+++ b/packages/dashboard/src/features/dashboard/components/AnalyzeResultSections.vue
@@ -100,7 +100,7 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <section v-if="activeTab === 'overview'" class="min-h-0 overflow-hidden">
+  <section v-if="activeTab === 'overview'" class="min-h-0">
     <AnalyzeDraggableGrid
       grid-class="grid h-full min-h-0 gap-2 overflow-hidden"
       :items="overviewLayoutItems"
@@ -122,7 +122,7 @@ const emit = defineEmits<{
     </AnalyzeDraggableGrid>
   </section>
 
-  <section v-else-if="activeTab === 'diagnostics'" class="min-h-0 overflow-hidden">
+  <section v-else-if="activeTab === 'diagnostics'" class="min-h-0">
     <AnalyzeDiagnosticsSection
       :action-items="actionItems"
       :active-work-queue-item-id="activeWorkQueueItemId"
@@ -146,7 +146,7 @@ const emit = defineEmits<{
     />
   </section>
 
-  <section v-else-if="activeTab === 'review'" class="min-h-0 overflow-hidden">
+  <section v-else-if="activeTab === 'review'" class="min-h-0">
     <AnalyzeDraggableGrid
       grid-class="grid h-full min-h-0 gap-2 overflow-hidden"
       :items="reviewLayoutItems"
@@ -163,7 +163,7 @@ const emit = defineEmits<{
     </AnalyzeDraggableGrid>
   </section>
 
-  <section v-else-if="activeTab === 'treemap'" class="min-h-0 overflow-hidden">
+  <section v-else-if="activeTab === 'treemap'" class="min-h-0">
     <AnalyzeDraggableGrid
       grid-class="grid h-full min-h-0 gap-2 overflow-hidden"
       :items="treemapLayoutItems"
@@ -186,7 +186,7 @@ const emit = defineEmits<{
     </AnalyzeDraggableGrid>
   </section>
 
-  <section v-else-if="activeTab === 'files'" class="min-h-0 overflow-hidden">
+  <section v-else-if="activeTab === 'files'" class="min-h-0">
     <AnalyzeDetailsPanel
       :largest-files="filteredLargestFiles"
       :selected-file-modules="selectedFileModules"
@@ -202,7 +202,7 @@ const emit = defineEmits<{
     />
   </section>
 
-  <section v-else-if="activeTab === 'source'" class="min-h-0 overflow-hidden">
+  <section v-else-if="activeTab === 'source'" class="min-h-0">
     <AnalyzeDraggableGrid
       grid-class="grid h-full min-h-0 gap-2 overflow-hidden"
       :items="sourceLayoutItems"
@@ -219,7 +219,7 @@ const emit = defineEmits<{
     </AnalyzeDraggableGrid>
   </section>
 
-  <section v-else-if="activeTab === 'packages'" class="min-h-0 overflow-hidden">
+  <section v-else-if="activeTab === 'packages'" class="min-h-0">
     <AnalyzeDraggableGrid
       grid-class="grid h-full min-h-0 gap-2 overflow-hidden"
       :items="packagesLayoutItems"
@@ -235,7 +235,7 @@ const emit = defineEmits<{
     </AnalyzeDraggableGrid>
   </section>
 
-  <section v-else class="min-h-0 overflow-hidden">
+  <section v-else class="min-h-0">
     <AnalyzeDraggableGrid
       grid-class="grid h-full min-h-0 gap-2 overflow-hidden"
       :items="modulesLayoutItems"

--- a/packages/dashboard/src/features/dashboard/components/AppPanelHeader.vue
+++ b/packages/dashboard/src/features/dashboard/components/AppPanelHeader.vue
@@ -20,7 +20,7 @@ const iconClassName = iconFrameStyles()
           <DashboardIcon :name="iconName" />
         </span>
       </span>
-      <div>
+      <div class="min-w-0 md:flex md:flex-wrap md:items-baseline md:gap-x-2">
         <h2 class="text-lg font-semibold text-(--dashboard-text)">
           {{ title }}
         </h2>

--- a/packages/dashboard/src/features/dashboard/components/AppSectionHeading.vue
+++ b/packages/dashboard/src/features/dashboard/components/AppSectionHeading.vue
@@ -12,16 +12,16 @@ withDefaults(defineProps<{
 </script>
 
 <template>
-  <div class="space-y-1.5">
-    <p v-if="eyebrow" class="text-[11px] uppercase tracking-[0.28em] text-(--dashboard-accent)">
-      {{ eyebrow }}
-    </p>
+  <div>
     <div class="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
-      <div>
+      <div class="min-w-0 sm:flex sm:flex-wrap sm:items-baseline sm:gap-x-2.5">
+        <p v-if="eyebrow" class="text-[11px] uppercase tracking-[0.28em] text-(--dashboard-accent)">
+          {{ eyebrow }}
+        </p>
         <h2 class="text-xl font-semibold tracking-tight md:text-2xl">
           {{ title }}
         </h2>
-        <p v-if="description" class="mt-1 text-sm leading-6 text-(--dashboard-text-muted)">
+        <p v-if="description" class="mt-1 w-full text-sm leading-6 text-(--dashboard-text-muted)">
           {{ description }}
         </p>
       </div>

--- a/packages/dashboard/src/features/dashboard/components/AppShellHeader.vue
+++ b/packages/dashboard/src/features/dashboard/components/AppShellHeader.vue
@@ -39,14 +39,14 @@ function handleThemeChange(event: Event): void {
             <DashboardIcon name="nav-menu" />
           </span>
         </button>
-        <div>
+        <div class="min-w-0 md:flex md:flex-wrap md:items-baseline md:gap-x-3">
           <p class="text-[11px] uppercase tracking-[0.28em] text-(--dashboard-accent)">
             weapp-vite dashboard
           </p>
-          <h1 class="mt-1 text-2xl font-semibold tracking-tight md:text-[1.8rem]">
+          <h1 class="mt-1 text-2xl font-semibold tracking-tight md:mt-0 md:text-[1.8rem]">
             {{ title }}
           </h1>
-          <p v-if="description" class="mt-1 max-w-3xl text-sm leading-6 text-(--dashboard-text-muted)">
+          <p v-if="description" class="mt-1 w-full max-w-3xl text-sm leading-6 text-(--dashboard-text-muted)">
             {{ description }}
           </p>
         </div>

--- a/packages/dashboard/src/features/dashboard/components/AppSurfaceCard.vue
+++ b/packages/dashboard/src/features/dashboard/components/AppSurfaceCard.vue
@@ -42,14 +42,14 @@ const hasHeader = Boolean(props.title || props.description || slots.header)
             <DashboardIcon :name="iconName" />
           </span>
         </span>
-        <div class="min-w-0">
+        <div class="min-w-0 sm:flex sm:flex-wrap sm:items-baseline sm:gap-x-2.5">
           <p v-if="eyebrow" class="text-[11px] uppercase tracking-[0.24em] text-(--dashboard-accent)">
             {{ eyebrow }}
           </p>
-          <h2 v-if="title" class="text-lg font-semibold tracking-tight">
+          <h2 v-if="title" class="text-lg font-semibold tracking-tight sm:whitespace-nowrap">
             {{ title }}
           </h2>
-          <p v-if="description" class="mt-1 text-sm leading-6 text-(--dashboard-text-muted)">
+          <p v-if="description" class="mt-1 w-full text-sm leading-6 text-(--dashboard-text-muted)">
             {{ description }}
           </p>
         </div>

--- a/packages/dashboard/src/features/dashboard/components/DashboardIcon.vue
+++ b/packages/dashboard/src/features/dashboard/components/DashboardIcon.vue
@@ -52,6 +52,7 @@ const ICON_CLASS_MAP: Record<DashboardIconName, string> = {
   'metric-bookmark': 'icon-[mdi--bookmark-check-outline]',
   'metric-link': 'icon-[mdi--link-variant]',
   'metric-reset': 'icon-[mdi--restore]',
+  'metric-drag': 'icon-[mdi--drag-horizontal-variant]',
   'token-color': 'icon-[mdi--palette-outline]',
   'token-surface': 'icon-[mdi--card-bulleted-outline]',
   'token-type': 'icon-[mdi--format-letter-spacing]',

--- a/packages/dashboard/src/features/dashboard/types/base.ts
+++ b/packages/dashboard/src/features/dashboard/types/base.ts
@@ -53,6 +53,7 @@ export type DashboardIconName
     | 'metric-bookmark'
     | 'metric-link'
     | 'metric-reset'
+    | 'metric-drag'
     | 'token-color'
     | 'token-surface'
     | 'token-type'

--- a/packages/dashboard/src/pages/activity.vue
+++ b/packages/dashboard/src/pages/activity.vue
@@ -31,12 +31,12 @@ const {
 </script>
 
 <template>
-  <div class="grid h-full min-h-0 gap-3 overflow-hidden xl:grid-cols-[minmax(0,1.25fr)_minmax(22rem,0.75fr)]">
+  <div class="grid min-h-[46rem] items-start gap-3 xl:grid-cols-[minmax(0,1.25fr)_minmax(22rem,0.75fr)] xl:items-stretch">
     <AppSurfaceCard
       eyebrow="Event Feed"
       title="事件控制台"
       icon-name="hero-commands"
-      content-class="min-h-0 overflow-hidden"
+      content-class="min-h-[42rem] overflow-hidden"
     >
       <div class="grid h-full min-h-0 grid-rows-[minmax(0,9rem)_auto_minmax(6rem,1fr)] gap-3 overflow-hidden">
         <AppEventFilterPanel

--- a/packages/dashboard/src/pages/analyze.vue
+++ b/packages/dashboard/src/pages/analyze.vue
@@ -84,7 +84,7 @@ const {
 </script>
 
 <template>
-  <div class="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-2 overflow-hidden">
+  <div class="grid min-h-[calc(100dvh-8rem)] grid-rows-[auto_minmax(44rem,1fr)] gap-4">
     <AnalyzeEmptyPayloadPanel v-if="!resultRef" />
 
     <AnalyzeToolbar

--- a/packages/dashboard/src/pages/index.vue
+++ b/packages/dashboard/src/pages/index.vue
@@ -25,14 +25,14 @@ const readinessSummary = computed(() => createWorkspaceReadinessSummary({
 </script>
 
 <template>
-  <div class="grid h-full min-h-0 gap-3 overflow-hidden xl:grid-cols-[minmax(0,0.92fr)_minmax(24rem,0.72fr)]">
+  <div class="grid min-h-[calc(100dvh-8rem)] items-start gap-3 xl:grid-cols-[minmax(0,1.12fr)_minmax(24rem,0.72fr)] xl:items-stretch">
     <AppSurfaceCard
       eyebrow="Status"
       title="当前工作区"
       icon-name="status-live"
       tone="strong"
       padding="md"
-      content-class="min-h-0 overflow-hidden"
+      content-class="min-h-[46rem]"
     >
       <div class="grid h-full min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] gap-3 overflow-hidden">
         <AppInsetPanel>
@@ -70,7 +70,7 @@ const readinessSummary = computed(() => createWorkspaceReadinessSummary({
       </div>
     </AppSurfaceCard>
 
-    <section class="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-3 overflow-hidden">
+    <section class="grid min-h-[46rem] grid-rows-[auto_minmax(34rem,1fr)] gap-3">
       <WorkspaceReadinessPanel :summary="readinessSummary" />
 
       <AppSurfaceCard tone="default" padding="md" content-class="min-h-0 overflow-hidden">

--- a/packages/dashboard/src/style.css
+++ b/packages/dashboard/src/style.css
@@ -47,7 +47,7 @@
   body {
     min-height: 100vh;
     margin: 0;
-    overflow: hidden;
+    overflow: hidden auto;
     font-family: 'IBM Plex Sans', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
     color: var(--dashboard-text);
     background-color: var(--dashboard-bg);
@@ -57,8 +57,8 @@
   }
 
   #app {
-    height: 100vh;
-    height: 100dvh;
+    min-height: 100vh;
+    min-height: 100dvh;
   }
 
   ::selection {


### PR DESCRIPTION
## 背景

针对 discussion 中关于 dashboard 空间利用率和小屏浏览体验的建议，调整工作区壳层与 Analyze 面板的布局边界。

关联讨论：https://github.com/weapp-vite/weapp-vite/discussions/338#discussioncomment-17875404

## 改动

- 将固定单屏壳层改为页面级纵向滚动，并保持桌面侧栏 sticky
- 将桌面最大内容宽度放宽至 1920px，提高宽屏横向空间利用率
- 压缩双语标题的垂直占用，给核心内容留出更多高度
- 将拖拽与布局重置收敛为带无障碍标签的图标控件
- 调整问题中心筛选器的响应式列数，避免较窄视口横向拥挤
- 为工作台、活动流和 Analyze 视图提供稳定的最小工作高度

## 验证

- `pnpm run check`（`packages/dashboard`）
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`
- `node --import tsx scripts/check-catalog-changeset.ts`
- 通过 `dashboard-ui-lab` 验证 1920x720、1920x1080 与 390x844 视口
- 验证亮色和暗色主题，浏览器控制台无错误或警告
- 确认页面可纵向滚动且无页面级横向溢出

## Changeset

- `@weapp-vite/dashboard`: patch
- `create-weapp-vite`: patch