### PR TITLE
test(solid): 增加高性能 JSX runtime POC

### DIFF
--- a/apps/runtime-bench-solid/README.md
+++ b/apps/runtime-bench-solid/README.md
@@ -1,0 +1,37 @@
+# Solid-style JSX runtime POC
+
+这个工程验证一种面向小程序的高性能 JSX 路线：JSX 在构建期编译为原生 WXML，运行时使用 Solid signals 追踪顶层 binding，并把同一微任务内的变更合并为一次 `setData`。
+
+它不是通用 renderer，也不维护虚拟 Host Tree：
+
+```text
+TSX template -> Wevu JSX AST compiler -> native WXML
+Solid signal -> binding effect -> microtask batch -> setData
+```
+
+## 当前覆盖
+
+- 原生 WXML 列表和文本 binding
+- 首屏、详情页和 100 卡片更新 benchmark
+- 同步 signal 变更合并为一次 `setData`
+- 页面卸载时释放 Solid owner 和 binding effects
+
+## POC 边界
+
+- template 标识符与 runtime binding 目前通过名称约定关联，编译器尚未生成或校验 binding metadata
+- 尚未实现事件桥接、自定义组件、动态组件和无法静态化节点的 fallback
+- compiler plugin 与 runtime 都是 benchmark 工程内部实现，不代表公开配置或包接口
+
+## 验证
+
+```bash
+pnpm --filter runtime-bench-solid typecheck
+pnpm --filter runtime-bench-solid build
+pnpm --filter weapp-vite exec vitest run test/solid/poc.test.ts test/solid/runtime-bench.test.ts
+```
+
+真实微信开发者工具 benchmark 由仓库根目录执行：
+
+```bash
+pnpm e2e:runtime-bench
+```

--- a/apps/runtime-bench-solid/README.md
+++ b/apps/runtime-bench-solid/README.md
@@ -21,6 +21,7 @@ Solid signal -> binding effect -> microtask batch -> setData
 - template 标识符与 runtime binding 目前通过名称约定关联，编译器尚未生成或校验 binding metadata
 - 尚未实现事件桥接、自定义组件、动态组件和无法静态化节点的 fallback
 - compiler plugin 与 runtime 都是 benchmark 工程内部实现，不代表公开配置或包接口
+- 当前显式使用 classic HMR；app-local compiler 尚未接入 stateful HMR patch 协议
 
 ## 验证
 

--- a/apps/runtime-bench-solid/package.json
+++ b/apps/runtime-bench-solid/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "runtime-bench-solid",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Solid-style JSX 小程序运行时 benchmark POC",
+  "scripts": {
+    "build": "wv build",
+    "dev": "wv dev",
+    "postinstall": "wv prepare",
+    "typecheck": "vue-tsc --noEmit -p .weapp-vite/tsconfig.app.json"
+  },
+  "dependencies": {
+    "solid-js": "1.9.14"
+  },
+  "devDependencies": {
+    "miniprogram-api-typings": "catalog:",
+    "typescript": "catalog:",
+    "vue-tsc": "catalog:",
+    "weapp-vite": "workspace:*",
+    "wevu": "workspace:*"
+  }
+}

--- a/apps/runtime-bench-solid/project.config.json
+++ b/apps/runtime-bench-solid/project.config.json
@@ -1,0 +1,16 @@
+{
+  "description": "Solid-style JSX runtime benchmark POC",
+  "miniprogramRoot": "dist/",
+  "compileType": "miniprogram",
+  "setting": {
+    "postcss": false,
+    "minified": false,
+    "enhance": false,
+    "compileHotReLoad": false,
+    "es6": true,
+    "minifyWXML": true
+  },
+  "simulatorType": "wechat",
+  "libVersion": "3.13.2",
+  "appid": "wxb3d842a4a7e3440d"
+}

--- a/apps/runtime-bench-solid/project.private.config.json
+++ b/apps/runtime-bench-solid/project.private.config.json
@@ -1,0 +1,36 @@
+{
+  "description": "项目私有配置文件",
+  "projectname": "runtime-bench-solid",
+  "condition": {
+    "miniprogram": {
+      "list": [
+        {
+          "name": "Solid index",
+          "pathName": "pages/index/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
+          "name": "Solid detail",
+          "pathName": "pages/detail/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
+          "name": "Solid update",
+          "pathName": "pages/update/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        }
+      ]
+    }
+  },
+  "setting": {
+    "compileHotReLoad": true,
+    "urlCheck": false
+  },
+  "libVersion": "3.15.0"
+}

--- a/apps/runtime-bench-solid/solidTemplatePlugin.ts
+++ b/apps/runtime-bench-solid/solidTemplatePlugin.ts
@@ -1,0 +1,61 @@
+import type { Plugin } from 'vite'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { compileJsxFile } from 'wevu/compiler'
+
+export interface SolidTemplatePluginOptions {
+  templates: string[]
+}
+
+export async function compileSolidTemplate(source: string, filename: string) {
+  const warnings: string[] = []
+  const result = await compileJsxFile(source, filename, {
+    isPage: true,
+    warn: warning => warnings.push(warning),
+  })
+  if (!result.template) {
+    throw new Error(`[solid-poc] ${filename} 未生成 WXML template`)
+  }
+  return { template: result.template, warnings }
+}
+
+function resolveOutputFile(template: string) {
+  return template.replace(/\/template\.tsx$/, '/index.wxml')
+}
+
+export function solidTemplatePlugin(options: SolidTemplatePluginOptions): Plugin {
+  const templates = new Map<string, string>()
+  let root = process.cwd()
+
+  return {
+    name: 'runtime-bench:solid-template',
+    enforce: 'pre',
+    configResolved(config) {
+      root = config.root
+    },
+    async buildStart() {
+      templates.clear()
+      for (const relativeFile of options.templates) {
+        const file = path.resolve(root, 'src', relativeFile)
+        const source = await fs.readFile(file, 'utf8')
+        const result = await compileSolidTemplate(source, file)
+        for (const warning of result.warnings) {
+          this.warn(warning)
+        }
+        templates.set(resolveOutputFile(relativeFile), result.template)
+      }
+    },
+    generateBundle(_options, bundle) {
+      for (const [fileName, source] of templates) {
+        const existing = bundle[fileName]
+        if (existing?.type === 'asset') {
+          existing.source = source
+        }
+        else {
+          this.emitFile({ type: 'asset', fileName, source })
+        }
+      }
+    },
+  }
+}

--- a/apps/runtime-bench-solid/src/app.json
+++ b/apps/runtime-bench-solid/src/app.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://vite.icebreaker.top/app.json",
+  "pages": [
+    "pages/index/index",
+    "pages/detail/index",
+    "pages/update/index"
+  ],
+  "window": {
+    "navigationBarTitleText": "Solid-style Runtime Bench",
+    "navigationBarBackgroundColor": "#0f766e",
+    "navigationBarTextStyle": "white"
+  },
+  "style": "v2",
+  "componentFramework": "glass-easel"
+}

--- a/apps/runtime-bench-solid/src/app.ts
+++ b/apps/runtime-bench-solid/src/app.ts
@@ -1,0 +1,5 @@
+App({
+  globalData: {
+    appName: 'runtime-bench-solid',
+  },
+})

--- a/apps/runtime-bench-solid/src/app.wxss
+++ b/apps/runtime-bench-solid/src/app.wxss
@@ -1,0 +1,75 @@
+page {
+  color: #0f172a;
+  background: #f1f5f9;
+}
+
+.page {
+  min-height: 100vh;
+  padding: 24rpx;
+}
+
+.hero,
+.card {
+  padding: 22rpx;
+  margin-top: 12rpx;
+  background: #fff;
+  border-radius: 16rpx;
+  box-shadow: 0 12rpx 30rpx rgb(15 23 42 / 6%);
+}
+
+.hero {
+  padding: 28rpx;
+  margin-top: 0;
+}
+
+.hero__title,
+.card__title {
+  font-weight: 600;
+}
+
+.hero__title {
+  font-size: 36rpx;
+}
+
+.hero__subtitle,
+.hero__summary,
+.card__meta,
+.card__summary {
+  margin-top: 10rpx;
+  color: #475569;
+}
+
+.card__row,
+.card__meta,
+.card__tags {
+  display: flex;
+  gap: 12rpx;
+  align-items: center;
+}
+
+.card__row,
+.card__meta {
+  justify-content: space-between;
+}
+
+.card__title {
+  font-size: 30rpx;
+}
+
+.card__badge,
+.card__tag {
+  padding: 4rpx 12rpx;
+  font-size: 22rpx;
+  background: #d1fae5;
+  border-radius: 999rpx;
+}
+
+.card__badge--active {
+  color: #15803d;
+  background: #dcfce7;
+}
+
+.card__tags {
+  flex-wrap: wrap;
+  margin-top: 12rpx;
+}

--- a/apps/runtime-bench-solid/src/jsx.d.ts
+++ b/apps/runtime-bench-solid/src/jsx.d.ts
@@ -1,0 +1,11 @@
+declare namespace JSX {
+  type Element = unknown
+
+  interface IntrinsicElements {
+    [name: string]: Record<string, unknown>
+  }
+}
+
+declare module 'solid-js/dist/solid.js' {
+  export * from 'solid-js'
+}

--- a/apps/runtime-bench-solid/src/pages/detail/index.ts
+++ b/apps/runtime-bench-solid/src/pages/detail/index.ts
@@ -1,0 +1,60 @@
+import type { SolidBenchRuntime } from '../shared'
+import { createMemo, createRoot, createSignal } from 'solid-js/dist/solid.js'
+import { createSolidMiniProgramRoot } from '../../runtime'
+import {
+  createBenchCards,
+  createEmptyMetrics,
+  DETAIL_CARD_COUNT,
+  now,
+  patchSetData,
+  summarizeBenchCards,
+} from '../../utils/bench'
+import { snapshot } from '../shared'
+
+const runtimes = new WeakMap<object, SolidBenchRuntime>()
+
+Page({
+  data: {},
+  onLoad() {
+    const loadStartedAt = now()
+    const setDataCounter = { total: 0, firstCommitAt: null }
+    patchSetData(this, setDataCounter)
+    const root = createSolidMiniProgramRoot(this)
+    const runtime = createRoot((dispose) => {
+      const [cards, setCards] = createSignal(createBenchCards(7, DETAIL_CARD_COUNT))
+      const summary = createMemo(() => summarizeBenchCards(cards()))
+      root.mount({ cards, summary })
+      return {
+        cards,
+        dispose,
+        metrics: createEmptyMetrics(),
+        root,
+        setCards,
+        setDataCounter,
+      }
+    })
+    runtime.metrics.loadToReadyMs = -loadStartedAt
+    runtimes.set(this, runtime)
+  },
+  onReady() {
+    const runtime = runtimes.get(this)
+    if (!runtime) {
+      return
+    }
+    const loadStartedAt = -runtime.metrics.loadToReadyMs
+    runtime.metrics.loadToReadyMs = now() - loadStartedAt
+    runtime.metrics.firstCommitMs = runtime.setDataCounter.firstCommitAt === null
+      ? 0
+      : runtime.setDataCounter.firstCommitAt - loadStartedAt
+  },
+  onUnload() {
+    const runtime = runtimes.get(this)
+    runtime?.root.dispose()
+    runtime?.dispose()
+    runtimes.delete(this)
+  },
+  readBenchState() {
+    const runtime = runtimes.get(this)
+    return runtime ? snapshot(runtime, 'solid-detail-ready') : undefined
+  },
+})

--- a/apps/runtime-bench-solid/src/pages/detail/template.tsx
+++ b/apps/runtime-bench-solid/src/pages/detail/template.tsx
@@ -1,0 +1,41 @@
+import type { BenchCard } from '../../utils/bench'
+
+declare const cards: BenchCard[]
+declare const summary: string
+
+export default {
+  render() {
+    return (
+      <view className="page">
+        <view id="bench-ready-marker" className="hero">
+          <view className="hero__title">Solid-style Detail Target</view>
+          <view className="hero__summary">{summary}</view>
+        </view>
+        {cards.map(card => (
+          <view key={card.id} className="card">
+            <view className="card__row">
+              <text className="card__title">{card.title}</text>
+              <text className={card.active ? 'card__badge card__badge--active' : 'card__badge'}>
+                {card.active ? 'active' : 'idle'}
+              </text>
+            </view>
+            <view className="card__meta">
+              <text>
+                score
+                {card.score}
+              </text>
+              <text>
+                delta
+                {card.delta}
+              </text>
+            </view>
+            <view className="card__summary">{card.summary}</view>
+            <view className="card__tags">
+              {card.tags.map(tag => <text key={tag} className="card__tag">{tag}</text>)}
+            </view>
+          </view>
+        ))}
+      </view>
+    )
+  },
+}

--- a/apps/runtime-bench-solid/src/pages/index/index.ts
+++ b/apps/runtime-bench-solid/src/pages/index/index.ts
@@ -1,0 +1,65 @@
+import type { SolidBenchRuntime } from '../shared'
+import { createMemo, createRoot, createSignal } from 'solid-js/dist/solid.js'
+import { createSolidMiniProgramRoot } from '../../runtime'
+import {
+  createBenchCards,
+  createEmptyMetrics,
+  INDEX_CARD_COUNT,
+  navigateTo,
+  now,
+  patchSetData,
+  summarizeBenchCards,
+} from '../../utils/bench'
+import { snapshot } from '../shared'
+
+const runtimes = new WeakMap<object, SolidBenchRuntime>()
+
+Page({
+  data: {},
+  onLoad() {
+    const loadStartedAt = now()
+    const setDataCounter = { total: 0, firstCommitAt: null }
+    patchSetData(this, setDataCounter)
+    const root = createSolidMiniProgramRoot(this)
+    const runtime = createRoot((dispose) => {
+      const [cards, setCards] = createSignal(createBenchCards(1, INDEX_CARD_COUNT))
+      const summary = createMemo(() => summarizeBenchCards(cards()))
+      root.mount({ cards, summary })
+      return {
+        cards,
+        dispose,
+        metrics: createEmptyMetrics(),
+        root,
+        setCards,
+        setDataCounter,
+      }
+    })
+    runtime.metrics.loadToReadyMs = -loadStartedAt
+    runtimes.set(this, runtime)
+  },
+  onReady() {
+    const runtime = runtimes.get(this)
+    if (!runtime) {
+      return
+    }
+    const loadStartedAt = -runtime.metrics.loadToReadyMs
+    runtime.metrics.loadToReadyMs = now() - loadStartedAt
+    runtime.metrics.firstCommitMs = runtime.setDataCounter.firstCommitAt === null
+      ? 0
+      : runtime.setDataCounter.firstCommitAt - loadStartedAt
+  },
+  onUnload() {
+    const runtime = runtimes.get(this)
+    runtime?.root.dispose()
+    runtime?.dispose()
+    runtimes.delete(this)
+  },
+  readBenchState() {
+    const runtime = runtimes.get(this)
+    return runtime ? snapshot(runtime, 'solid-index-ready') : undefined
+  },
+  async navigateToDetail() {
+    await navigateTo('/pages/detail/index')
+    return true
+  },
+})

--- a/apps/runtime-bench-solid/src/pages/index/template.tsx
+++ b/apps/runtime-bench-solid/src/pages/index/template.tsx
@@ -1,0 +1,39 @@
+import type { BenchCard } from '../../utils/bench'
+
+declare const cards: BenchCard[]
+declare const summary: string
+
+export default {
+  render() {
+    return (
+      <view className="page">
+        <view id="bench-ready-marker" className="hero">
+          <view className="hero__title">Solid-style JSX Runtime</view>
+          <view className="hero__subtitle">原生 WXML + fine-grained signal bindings</view>
+          <view className="hero__summary">{summary}</view>
+        </view>
+        {cards.map(card => (
+          <view key={card.id} className="card">
+            <view className="card__row">
+              <text className="card__title">{card.title}</text>
+              <text className={card.active ? 'card__badge card__badge--active' : 'card__badge'}>
+                {card.active ? 'active' : 'idle'}
+              </text>
+            </view>
+            <view className="card__meta">
+              <text>
+                score
+                {card.score}
+              </text>
+              <text>
+                delta
+                {card.delta}
+              </text>
+            </view>
+            <view className="card__summary">{card.summary}</view>
+          </view>
+        ))}
+      </view>
+    )
+  },
+}

--- a/apps/runtime-bench-solid/src/pages/shared.ts
+++ b/apps/runtime-bench-solid/src/pages/shared.ts
@@ -1,0 +1,23 @@
+import type { Accessor, Setter } from 'solid-js'
+import type { SolidMiniProgramRoot } from '../runtime'
+import type { BenchCard, BenchMetrics, SetDataCounter } from '../utils/bench'
+
+export interface SolidBenchRuntime {
+  cards: Accessor<BenchCard[]>
+  dispose: () => void
+  metrics: BenchMetrics
+  root: SolidMiniProgramRoot
+  setCards: Setter<BenchCard[]>
+  setDataCounter: SetDataCounter
+}
+
+export function snapshot(runtime: SolidBenchRuntime, readyMarker: string) {
+  const cards = runtime.cards()
+  return {
+    readyMarker,
+    cardCount: cards.length,
+    summary: `cards=${cards.length}`,
+    metrics: runtime.metrics,
+    totalSetDataCalls: runtime.setDataCounter.total,
+  }
+}

--- a/apps/runtime-bench-solid/src/pages/update/index.ts
+++ b/apps/runtime-bench-solid/src/pages/update/index.ts
@@ -1,0 +1,114 @@
+import type { SolidBenchRuntime } from '../shared'
+import { createMemo, createRoot, createSignal } from 'solid-js/dist/solid.js'
+import { createSolidMiniProgramRoot } from '../../runtime'
+import {
+  createBenchCards,
+  createEmptyMetrics,
+  mutateBenchCards,
+  now,
+  patchSetData,
+  summarizeBenchCards,
+  UPDATE_CARD_COUNT,
+  waitForNativeFlush,
+} from '../../utils/bench'
+import { snapshot } from '../shared'
+
+const runtimes = new WeakMap<object, SolidBenchRuntime>()
+
+Page({
+  data: {},
+  onLoad() {
+    const setDataCounter = { total: 0, firstCommitAt: null }
+    patchSetData(this, setDataCounter)
+    const root = createSolidMiniProgramRoot(this)
+    const runtime = createRoot((dispose) => {
+      const [cards, setCards] = createSignal(createBenchCards(11, UPDATE_CARD_COUNT))
+      const summary = createMemo(() => summarizeBenchCards(cards()))
+      root.mount({ cards, summary })
+      return {
+        cards,
+        dispose,
+        metrics: createEmptyMetrics(),
+        root,
+        setCards,
+        setDataCounter,
+      }
+    })
+    runtimes.set(this, runtime)
+  },
+  onUnload() {
+    const runtime = runtimes.get(this)
+    runtime?.root.dispose()
+    runtime?.dispose()
+    runtimes.delete(this)
+  },
+  readBenchState() {
+    const runtime = runtimes.get(this)
+    return runtime ? snapshot(runtime, 'solid-update-ready') : undefined
+  },
+  async runSingleCommitBench(rounds = 180) {
+    const runtime = runtimes.get(this)
+    if (!runtime) {
+      return undefined
+    }
+    const startCalls = runtime.setDataCounter.total
+    const startAt = now()
+    let cards = runtime.cards()
+    const computeStartedAt = now()
+    for (let index = 0; index < rounds; index += 1) {
+      cards = mutateBenchCards(cards, index + 1)
+    }
+    const computeMs = now() - computeStartedAt
+    const dispatchStartedAt = now()
+    runtime.setCards(cards)
+    const dispatchMs = now() - dispatchStartedAt
+    const flushStartedAt = now()
+    await runtime.root.flush()
+    await waitForNativeFlush()
+    const flushMs = now() - flushStartedAt
+    runtime.metrics = {
+      ...runtime.metrics,
+      singleCommitMs: now() - startAt,
+      singleCommitComputeMs: computeMs,
+      singleCommitCommitMs: dispatchMs + flushMs,
+      singleCommitDispatchMs: dispatchMs,
+      singleCommitFlushMs: flushMs,
+      singleCommitSetDataCalls: runtime.setDataCounter.total - startCalls,
+    }
+    return snapshot(runtime, 'solid-update-ready')
+  },
+  async runMicroCommitBench(rounds = 40) {
+    const runtime = runtimes.get(this)
+    if (!runtime) {
+      return undefined
+    }
+    const startCalls = runtime.setDataCounter.total
+    const startAt = now()
+    let cards = runtime.cards()
+    let computeMs = 0
+    let dispatchMs = 0
+    let flushMs = 0
+    for (let index = 0; index < rounds; index += 1) {
+      const computeStartedAt = now()
+      cards = mutateBenchCards(cards, index + 1)
+      computeMs += now() - computeStartedAt
+      const dispatchStartedAt = now()
+      runtime.setCards(cards)
+      dispatchMs += now() - dispatchStartedAt
+      const flushStartedAt = now()
+      await runtime.root.flush()
+      await waitForNativeFlush()
+      flushMs += now() - flushStartedAt
+    }
+    runtime.metrics = {
+      ...runtime.metrics,
+      microCommitMs: now() - startAt,
+      microCommitComputeMs: computeMs,
+      microCommitCommitMs: dispatchMs + flushMs,
+      microCommitDispatchMs: dispatchMs,
+      microCommitFlushMs: flushMs,
+      microCommitSetDataCalls: runtime.setDataCounter.total - startCalls,
+    }
+    return snapshot(runtime, 'solid-update-ready')
+  },
+})

--- a/apps/runtime-bench-solid/src/pages/update/template.tsx
+++ b/apps/runtime-bench-solid/src/pages/update/template.tsx
@@ -1,0 +1,38 @@
+import type { BenchCard } from '../../utils/bench'
+
+declare const cards: BenchCard[]
+declare const summary: string
+
+export default {
+  render() {
+    return (
+      <view className="page">
+        <view id="bench-ready-marker" className="hero">
+          <view className="hero__title">Solid-style Update Benchmark</view>
+          <view className="hero__summary">{summary}</view>
+        </view>
+        {cards.map(card => (
+          <view key={card.id} className="card">
+            <view className="card__row">
+              <text className="card__title">{card.title}</text>
+              <text className={card.active ? 'card__badge card__badge--active' : 'card__badge'}>
+                {card.active ? 'active' : 'idle'}
+              </text>
+            </view>
+            <view className="card__meta">
+              <text>
+                score
+                {card.score}
+              </text>
+              <text>
+                delta
+                {card.delta}
+              </text>
+            </view>
+            <view className="card__summary">{card.summary}</view>
+          </view>
+        ))}
+      </view>
+    )
+  },
+}

--- a/apps/runtime-bench-solid/src/runtime.ts
+++ b/apps/runtime-bench-solid/src/runtime.ts
@@ -1,0 +1,76 @@
+import type { Accessor } from 'solid-js'
+import { createRenderEffect, createRoot } from 'solid-js/dist/solid.js'
+
+export interface SolidMiniProgramRoot {
+  dispose: () => void
+  flush: () => Promise<void>
+  mount: (bindings: Record<string, Accessor<unknown>>) => void
+}
+
+export function createSolidMiniProgramRoot(adapter: {
+  setData: (payload: Record<string, unknown>, callback?: () => void) => void
+}): SolidMiniProgramRoot {
+  let disposeOwner: (() => void) | undefined
+  let disposed = false
+  let scheduled = false
+  let pending: Record<string, unknown> = {}
+  let pendingFlush = Promise.resolve()
+
+  function schedule(name: string, value: unknown) {
+    if (disposed) {
+      return
+    }
+    pending[name] = value
+    if (scheduled) {
+      return
+    }
+    scheduled = true
+    pendingFlush = new Promise<void>((resolve) => {
+      Promise.resolve().then(() => {
+        scheduled = false
+        const payload = pending
+        pending = {}
+        if (disposed || Object.keys(payload).length === 0) {
+          resolve()
+          return
+        }
+        adapter.setData(payload, resolve)
+      })
+    })
+  }
+
+  return {
+    dispose() {
+      disposed = true
+      pending = {}
+      disposeOwner?.()
+      disposeOwner = undefined
+    },
+    flush() {
+      return pendingFlush
+    },
+    mount(bindings) {
+      if (disposeOwner) {
+        throw new Error('Solid mini-program root 只能 mount 一次')
+      }
+      const initial: Record<string, unknown> = {}
+      let mounting = true
+      disposeOwner = createRoot((dispose) => {
+        for (const [name, read] of Object.entries(bindings)) {
+          createRenderEffect(() => {
+            const value = read()
+            if (mounting) {
+              initial[name] = value
+            }
+            else {
+              schedule(name, value)
+            }
+          })
+        }
+        mounting = false
+        return dispose
+      })
+      adapter.setData(initial)
+    },
+  }
+}

--- a/apps/runtime-bench-solid/src/utils/bench.ts
+++ b/apps/runtime-bench-solid/src/utils/bench.ts
@@ -1,0 +1,124 @@
+export interface BenchCard {
+  id: string
+  title: string
+  summary: string
+  score: number
+  delta: number
+  active: boolean
+  tags: string[]
+}
+
+export interface BenchMetrics {
+  loadToReadyMs: number
+  firstCommitMs: number
+  singleCommitMs: number
+  singleCommitComputeMs: number
+  singleCommitCommitMs: number
+  singleCommitDispatchMs: number
+  singleCommitFlushMs: number
+  singleCommitSetDataCalls: number
+  microCommitMs: number
+  microCommitComputeMs: number
+  microCommitCommitMs: number
+  microCommitDispatchMs: number
+  microCommitFlushMs: number
+  microCommitSetDataCalls: number
+}
+
+export interface SetDataCounter {
+  total: number
+  firstCommitAt: number | null
+}
+
+export const INDEX_CARD_COUNT = 120
+export const DETAIL_CARD_COUNT = 180
+export const UPDATE_CARD_COUNT = 100
+
+export function now() {
+  return Date.now()
+}
+
+export function createBenchCards(seed: number, count: number): BenchCard[] {
+  return Array.from({ length: count }, (_, index) => {
+    const rank = seed * 13 + index * 7
+    return {
+      id: `card-${seed}-${index}`,
+      title: `Benchmark Card ${index + 1}`,
+      summary: `seed=${seed} rank=${rank % 97} lane=${index % 5}`,
+      score: (rank * 17) % 1000,
+      delta: (rank % 19) - 9,
+      active: (index + seed) % 4 === 0,
+      tags: [
+        `lane-${index % 5}`,
+        `seed-${seed % 7}`,
+        (index + seed) % 2 === 0 ? 'hot' : 'warm',
+      ],
+    }
+  })
+}
+
+export function mutateBenchCards(cards: BenchCard[], step: number): BenchCard[] {
+  return cards.map((card, index) => {
+    const nextScore = (card.score + step + index * 3) % 1000
+    const nextDelta = ((card.delta + step + index) % 21) - 10
+    const nextActive = (index + step) % 5 === 0
+    return {
+      ...card,
+      score: nextScore,
+      delta: nextDelta,
+      active: nextActive,
+      summary: `step=${step} rank=${(nextScore + nextDelta + index) % 113} lane=${index % 5}`,
+      tags: [
+        `lane-${index % 5}`,
+        `step-${step % 9}`,
+        nextActive ? 'hot' : 'warm',
+      ],
+    }
+  })
+}
+
+export function summarizeBenchCards(cards: BenchCard[]) {
+  const activeCount = cards.filter(card => card.active).length
+  const checksum = cards.reduce((total, card) => total + card.score + card.delta, 0)
+  return `cards=${cards.length} active=${activeCount} checksum=${checksum}`
+}
+
+export function createEmptyMetrics(): BenchMetrics {
+  return {
+    loadToReadyMs: 0,
+    firstCommitMs: 0,
+    singleCommitMs: 0,
+    singleCommitComputeMs: 0,
+    singleCommitCommitMs: 0,
+    singleCommitDispatchMs: 0,
+    singleCommitFlushMs: 0,
+    singleCommitSetDataCalls: 0,
+    microCommitMs: 0,
+    microCommitComputeMs: 0,
+    microCommitCommitMs: 0,
+    microCommitDispatchMs: 0,
+    microCommitFlushMs: 0,
+    microCommitSetDataCalls: 0,
+  }
+}
+
+export function patchSetData(instance: any, counter: SetDataCounter) {
+  const rawSetData = instance.setData.bind(instance)
+  instance.setData = (payload: Record<string, unknown>, callback?: () => void) => {
+    counter.total += 1
+    if (counter.firstCommitAt === null) {
+      counter.firstCommitAt = now()
+    }
+    return rawSetData(payload, callback)
+  }
+}
+
+export async function waitForNativeFlush() {
+  await new Promise<void>(resolve => wx.nextTick(resolve))
+}
+
+export async function navigateTo(url: string) {
+  await new Promise<void>((resolve, reject) => {
+    wx.navigateTo({ url, success: () => resolve(), fail: reject })
+  })
+}

--- a/apps/runtime-bench-solid/tsconfig.json
+++ b/apps/runtime-bench-solid/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "references": [
+    { "path": "./.weapp-vite/tsconfig.app.json" },
+    { "path": "./.weapp-vite/tsconfig.server.json" },
+    { "path": "./.weapp-vite/tsconfig.node.json" },
+    { "path": "./.weapp-vite/tsconfig.shared.json" }
+  ],
+  "files": []
+}

--- a/apps/runtime-bench-solid/weapp-vite.config.ts
+++ b/apps/runtime-bench-solid/weapp-vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'weapp-vite/config'
+import { solidTemplatePlugin } from './solidTemplatePlugin'
+
+export default defineConfig({
+  build: {
+    minify: true,
+  },
+  plugins: [solidTemplatePlugin({
+    templates: [
+      'pages/index/template.tsx',
+      'pages/detail/template.tsx',
+      'pages/update/template.tsx',
+    ],
+  })],
+  weapp: {
+    srcRoot: 'src',
+  },
+})

--- a/apps/runtime-bench-solid/weapp-vite.config.ts
+++ b/apps/runtime-bench-solid/weapp-vite.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
     ],
   })],
   weapp: {
+    hmr: {
+      runtime: 'classic',
+    },
     srcRoot: 'src',
   },
 })

--- a/docs/reports/2026-08-10-solid-jsx-runtime-poc-report.md
+++ b/docs/reports/2026-08-10-solid-jsx-runtime-poc-report.md
@@ -1,0 +1,94 @@
+# 2026-08-10 Solid-style JSX runtime POC report
+
+## 目标
+
+本 POC 评估一条不同于 React universal renderer 的 JSX 路线：保留 JSX 开发体验，但在构建期生成原生 WXML，运行时只用细粒度 signal 驱动稳定 binding，不维护或协调一棵动态 Host Tree。
+
+它要回答两个问题：
+
+1. Solid-style signal + 原生 WXML 是否能避开 React 高频动态提交的主要开销。
+2. 这条路线是否已经成熟到值得进入 `weapp-vite` 公共配置和正式 runtime。
+
+## 架构
+
+```text
+TSX template
+  -> app-local Vite plugin
+  -> Wevu JSX AST compiler
+  -> native WXML
+
+solid-js signals
+  -> top-level binding effects
+  -> microtask coalescing
+  -> page.setData(binding payload)
+```
+
+这里复用了 `wevu/compiler` 已有的 JSX AST 到 WXML 能力，而不是再实现一套 JSX parser。构建产物仍由 Vite plugin 的 `emitFile` 写出，runtime 不直接写入最终 bundle。
+
+运行时 `mount()` 首次把全部 binding 合并为一次 `setData`；后续多个同步 signal 变更在同一个微任务内合并。页面卸载时释放 Solid owner 和 effects。
+
+## 验证范围
+
+- 工程：`apps/runtime-bench-solid`
+- Solid：`1.9.14`
+- runtime provider：真实微信开发者工具
+- Node.js：`v24.18.0`
+- 每个场景采样 3 次，取中位数
+- 卡片数量、数据结构、纯计算函数和更新轮次与现有 Native / Wevu / React benchmark 一致
+- 主包：`15.2 KB`
+
+构建断言确认更新页产出原生 `wx:for="{{cards}}"`、`wx:key="card.id"` 和 `{{card.summary}}`，且不包含 React dynamic renderer 的 `{{root:root}}` Host Tree 入口。
+
+## 真实 DevTools 结果
+
+### Solid 本轮数据
+
+| 场景 | metricMs | computeMs | commitMs | dispatchMs | flushMs | setData |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 100 卡片，180 轮计算后单次提交 | 81 | 71 | 10 | 0 | 10 | 1 |
+| 100 卡片，40 次微提交 | 371 | 10 | 361 | 3 | 358 | 40 |
+
+首屏 `readyMs` 中位数为 `10ms`，详情页 `readyMs` 中位数为 `6ms`；两者 `firstCommitMs` 均为 `0ms`。外层 `wallMs` 包含 DevTools、automator 和 bridge 固定成本，不用于框架排序。
+
+### 与现有基线的方向性比较
+
+下表中的 Native / Wevu / React 来自 2026-08-09 同设备、同 provider、同负载报告；Solid 来自本轮。由于不是同一次完整 runner 采样，只能用于投资判断，不能作为正式倍率声明。
+
+| 场景 | Native | Wevu diff | React dynamic | Solid signals |
+| --- | ---: | ---: | ---: | ---: |
+| 单次大提交 metricMs | 66 | 58 | 75 | 81 |
+| 单次大提交 commitMs | 3 | 4 | 19 | 10 |
+| 40 次微提交 metricMs | 96 | 97 | 600 | 371 |
+| 40 次微提交 commitMs | 80 | 84 | 587 | 361 |
+
+本轮完整四工程 runner 在 Native 的第二个详情页样本遇到 `navigateToDetail` automator bridge 失败，因此没有生成同 commit 的四方 checkpoint。随后单独执行 Solid worker 完整通过；第一次连接曾发生一次 `reLaunch` 超时，session 自动恢复后全部样本完成。这是 DevTools 自动化稳定性限制，最终报告没有把失败尝试计入样本。
+
+## 结论
+
+### 值得继续，但应投资在 compiler/runtime contract，而不是直接发布框架
+
+Solid-style 路线验证了核心方向：原生 WXML 加稳定 binding 能避开 React dynamic Host Tree 的大量 reconciliation / dispatch 成本。40 次微提交从 React 基线的 `600ms` 降到 `371ms`，dispatch 从 `416ms` 降到 `3ms`。
+
+但它还没有达到 Wevu/Native 的水平。Solid 的 40 次提交主要耗时落在宿主 flush（`358ms`），说明去掉 reconciliation 后，`setData` 次数和 payload 仍是首要边界。单次提交 `81ms` 也没有胜过 Wevu 的 `58ms`；其中大部分是共享卡片计算，Solid commit 本身为 `10ms`。
+
+因此建议进入第二阶段、限定范围的编译器 POC，不建议现在新增 `weapp.solid` 配置、公开 runtime 包或模板。
+
+## 产品化前必须解决
+
+1. 编译器生成 binding manifest，明确每个 WXML 标识符对应的 accessor、路径和更新粒度，消除当前依赖 `cards` / `summary` 同名约定的隐式契约。
+2. 支持事件、自定义组件、条件/列表作用域，并定义无法静态化 JSX 的诊断或 island fallback。
+3. 将列表更新从顶层 `cards` 全量 payload 推进到可证明正确的路径级 patch，再测 payload bytes、序列化和宿主 flush。
+4. 对齐生命周期、错误边界、资源释放和 HMR，保留静态宿主解析，不能依赖动态求值。
+5. 增加真实业务页面和至少 10 次稳定采样；修复 benchmark 的导航 bridge 抖动后，再做同 commit 四方比较。
+
+## 投资闸门
+
+下一阶段达到以下条件后，才值得讨论正式包和公共配置：
+
+- 100 卡片 40 次微提交稳定接近 Wevu，目标不高于 Wevu 的 `1.5x`
+- 同步 signal 更新保持一次 `setData`，路径级更新不引入错误合并
+- template/runtime binding 由编译器闭环校验，不再依赖人工命名约定
+- 事件、组件、条件和列表具备最小可用闭环及真实 DevTools E2E
+- 相比 Wevu 的新增维护成本能由 JSX 生态复用或显著运行时收益抵消
+
+当前判断：**Go for compiler-stage POC，No-go for public productization**。

--- a/docs/reports/2026-08-10-solid-jsx-runtime-poc-report.md
+++ b/docs/reports/2026-08-10-solid-jsx-runtime-poc-report.md
@@ -78,7 +78,7 @@ Solid-style 路线验证了核心方向：原生 WXML 加稳定 binding 能避�
 1. 编译器生成 binding manifest，明确每个 WXML 标识符对应的 accessor、路径和更新粒度，消除当前依赖 `cards` / `summary` 同名约定的隐式契约。
 2. 支持事件、自定义组件、条件/列表作用域，并定义无法静态化 JSX 的诊断或 island fallback。
 3. 将列表更新从顶层 `cards` 全量 payload 推进到可证明正确的路径级 patch，再测 payload bytes、序列化和宿主 flush。
-4. 对齐生命周期、错误边界、资源释放和 HMR，保留静态宿主解析，不能依赖动态求值。
+4. 对齐生命周期、错误边界、资源释放和 HMR；当前 POC 显式使用 classic HMR，产品化前需要接入 stateful patch 协议，同时保留静态宿主解析，不能依赖动态求值。
 5. 增加真实业务页面和至少 10 次稳定采样；修复 benchmark 的导航 bridge 抖动后，再做同 commit 四方比较。
 
 ## 投资闸门

--- a/e2e/scripts/run-runtime-bench.ts
+++ b/e2e/scripts/run-runtime-bench.ts
@@ -20,6 +20,7 @@ const WORKER_PATH = path.resolve(import.meta.dirname, './runtime-bench.worker.ts
 const NATIVE_ROOT = path.resolve(import.meta.dirname, '../../apps/runtime-bench-native')
 const VUE_ROOT = path.resolve(import.meta.dirname, '../../apps/runtime-bench-vue')
 const REACT_ROOT = path.resolve(import.meta.dirname, '../../apps/runtime-bench-react')
+const SOLID_ROOT = path.resolve(import.meta.dirname, '../../apps/runtime-bench-solid')
 const LOGIN_CHECK_ROOT = path.resolve(import.meta.dirname, '../../e2e-apps/base')
 const CLI_PATH = path.resolve(import.meta.dirname, '../../packages/weapp-vite/bin/weapp-vite.js')
 const CHECKPOINT_ROOT = path.resolve(import.meta.dirname, '../../.tmp/runtime-bench/checkpoints')
@@ -28,7 +29,7 @@ const runtimeProvider = resolveRuntimeProviderName()
 const RESUME = process.argv.includes('--resume')
 
 interface BenchProject {
-  key: 'native' | 'react' | 'vue'
+  key: 'native' | 'react' | 'solid' | 'vue'
   root: string
 }
 
@@ -36,9 +37,10 @@ const BENCH_PROJECTS: BenchProject[] = [
   { key: 'native', root: NATIVE_ROOT },
   { key: 'vue', root: VUE_ROOT },
   { key: 'react', root: REACT_ROOT },
+  { key: 'solid', root: SOLID_ROOT },
 ]
 
-function compareUpdateSummary(native: BenchUpdateSummary, candidate: BenchUpdateSummary, label: 'react' | 'vue') {
+function compareUpdateSummary(native: BenchUpdateSummary, candidate: BenchUpdateSummary, label: 'react' | 'solid' | 'vue') {
   return {
     native,
     [label]: candidate,
@@ -162,7 +164,8 @@ async function main() {
   const native = results.native
   const vue = results.vue
   const react = results.react
-  if (!native || !vue || !react) {
+  const solid = results.solid
+  if (!native || !vue || !react || !solid) {
     process.stdout.write(`${JSON.stringify({
       complete: false,
       commit,
@@ -179,6 +182,7 @@ async function main() {
       native,
       vue,
       react,
+      solid,
       deltaWallMs: vue.firstScreen.wallMsMedian - native.firstScreen.wallMsMedian,
       deltaReadyMs: vue.firstScreen.readyMsMedian - native.firstScreen.readyMsMedian,
       deltaFirstCommitMs: vue.firstScreen.firstCommitMsMedian - native.firstScreen.firstCommitMsMedian,
@@ -192,11 +196,17 @@ async function main() {
         readyMs: react.firstScreen.readyMsMedian - native.firstScreen.readyMsMedian,
         firstCommitMs: react.firstScreen.firstCommitMsMedian - native.firstScreen.firstCommitMsMedian,
       },
+      solidDelta: {
+        wallMs: solid.firstScreen.wallMsMedian - native.firstScreen.wallMsMedian,
+        readyMs: solid.firstScreen.readyMsMedian - native.firstScreen.readyMsMedian,
+        firstCommitMs: solid.firstScreen.firstCommitMsMedian - native.firstScreen.firstCommitMsMedian,
+      },
     },
     detailNavigation: {
       native,
       vue,
       react,
+      solid,
       deltaWallMs: vue.detailNavigation.wallMsMedian - native.detailNavigation.wallMsMedian,
       deltaReadyMs: vue.detailNavigation.readyMsMedian - native.detailNavigation.readyMsMedian,
       deltaFirstCommitMs: vue.detailNavigation.firstCommitMsMedian - native.detailNavigation.firstCommitMsMedian,
@@ -210,6 +220,11 @@ async function main() {
         readyMs: react.detailNavigation.readyMsMedian - native.detailNavigation.readyMsMedian,
         firstCommitMs: react.detailNavigation.firstCommitMsMedian - native.detailNavigation.firstCommitMsMedian,
       },
+      solidDelta: {
+        wallMs: solid.detailNavigation.wallMsMedian - native.detailNavigation.wallMsMedian,
+        readyMs: solid.detailNavigation.readyMsMedian - native.detailNavigation.readyMsMedian,
+        firstCommitMs: solid.detailNavigation.firstCommitMsMedian - native.detailNavigation.firstCommitMsMedian,
+      },
     },
     updateSingleCommit: {
       diff: compareUpdateSummary(native.updateSingleCommit.diff, vue.updateSingleCommit.diff, 'vue'),
@@ -220,6 +235,7 @@ async function main() {
         ? compareVuePatchVsDiff(vue.updateSingleCommit.diff, vue.updateSingleCommit.patch)
         : undefined,
       reactDynamic: compareUpdateSummary(native.updateSingleCommit.diff, react.updateSingleCommit.diff, 'react'),
+      solidSignals: compareUpdateSummary(native.updateSingleCommit.diff, solid.updateSingleCommit.diff, 'solid'),
     },
     updateMicroCommit: {
       diff: compareUpdateSummary(native.updateMicroCommit.diff, vue.updateMicroCommit.diff, 'vue'),
@@ -230,6 +246,7 @@ async function main() {
         ? compareVuePatchVsDiff(vue.updateMicroCommit.diff, vue.updateMicroCommit.patch)
         : undefined,
       reactDynamic: compareUpdateSummary(native.updateMicroCommit.diff, react.updateMicroCommit.diff, 'react'),
+      solidSignals: compareUpdateSummary(native.updateMicroCommit.diff, solid.updateMicroCommit.diff, 'solid'),
     },
     reactStaticBinding: react.staticBinding,
   }

--- a/packages/weapp-vite/test/solid/poc.test.ts
+++ b/packages/weapp-vite/test/solid/poc.test.ts
@@ -1,0 +1,45 @@
+import { createSignal } from 'solid-js/dist/solid.js'
+import { describe, expect, it } from 'vitest'
+import { compileSolidTemplate } from '../../../../apps/runtime-bench-solid/solidTemplatePlugin'
+import { createSolidMiniProgramRoot } from '../../../../apps/runtime-bench-solid/src/runtime'
+
+describe('Solid-style JSX runtime POC', () => {
+  it('compiles reactive list bindings to native WXML', async () => {
+    const result = await compileSolidTemplate(`
+      declare const cards: Array<{ id: string, title: string }>
+      export default {
+        render() {
+          return <view>{cards.map(card => <text key={card.id}>{card.title}</text>)}</view>
+        },
+      }
+    `, '/project/src/pages/update/template.tsx')
+
+    expect(result.warnings).toEqual([])
+    expect(result.template).toContain('wx:for="{{cards}}"')
+    expect(result.template).toContain('wx:key="card.id"')
+    expect(result.template).toContain('{{card.title}}')
+  })
+
+  it('coalesces synchronous signal changes into one setData commit', async () => {
+    const payloads: Record<string, unknown>[] = []
+    const root = createSolidMiniProgramRoot({
+      setData(payload, callback) {
+        payloads.push(payload)
+        callback?.()
+      },
+    })
+    const [cards, setCards] = createSignal(['one'])
+    const [summary, setSummary] = createSignal('one')
+    root.mount({ cards, summary })
+
+    setCards(['two'])
+    setSummary('two')
+    await root.flush()
+
+    expect(payloads).toEqual([
+      { cards: ['one'], summary: 'one' },
+      { cards: ['two'], summary: 'two' },
+    ])
+    root.dispose()
+  })
+})

--- a/packages/weapp-vite/test/solid/runtime-bench.test.ts
+++ b/packages/weapp-vite/test/solid/runtime-bench.test.ts
@@ -1,0 +1,28 @@
+/* eslint-disable e18e/ban-dependencies -- 构建集成测试需要 execa 驱动 CLI。 */
+import { fs } from '@weapp-core/shared/node'
+import { execa } from 'execa'
+import path from 'pathe'
+import { describe, expect, it } from 'vitest'
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../../../..')
+const CLI_PATH = path.join(REPO_ROOT, 'packages/weapp-vite/bin/weapp-vite.js')
+const APP_ROOT = path.join(REPO_ROOT, 'apps/runtime-bench-solid')
+
+describe.sequential('Solid-style JSX runtime benchmark POC build', () => {
+  it('emits a native WXML list without a dynamic host tree template', async () => {
+    await fs.remove(path.join(APP_ROOT, 'dist'))
+    await execa('node', [CLI_PATH, 'build', APP_ROOT, '--platform', 'weapp', '--skipNpm'], {
+      cwd: APP_ROOT,
+    })
+
+    const appJson = await fs.readJson(path.join(APP_ROOT, 'dist/app.json')) as { pages?: string[] }
+    const updateWxml = await fs.readFile(path.join(APP_ROOT, 'dist/pages/update/index.wxml'), 'utf8')
+    const runnerSource = await fs.readFile(path.join(REPO_ROOT, 'e2e/scripts/run-runtime-bench.ts'), 'utf8')
+
+    expect(appJson.pages).toContain('pages/update/index')
+    expect(updateWxml).toContain('wx:for="{{cards}}"')
+    expect(updateWxml).toContain('{{card.summary}}')
+    expect(updateWxml).not.toContain('{{root:root}}')
+    expect(runnerSource).toContain('../../apps/runtime-bench-solid')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -891,6 +891,28 @@ importers:
         specifier: workspace:*
         version: link:../../packages/weapp-vite
 
+  apps/runtime-bench-solid:
+    dependencies:
+      solid-js:
+        specifier: 1.9.14
+        version: 1.9.14
+    devDependencies:
+      miniprogram-api-typings:
+        specifier: 'catalog:'
+        version: 5.2.3
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vue-tsc:
+        specifier: 'catalog:'
+        version: 3.3.9(typescript@6.0.3)
+      weapp-vite:
+        specifier: workspace:*
+        version: link:../../packages/weapp-vite
+      wevu:
+        specifier: workspace:*
+        version: link:../../packages-runtime/wevu
+
   apps/runtime-bench-vue:
     devDependencies:
       '@weapp-vite/dashboard':
@@ -15461,6 +15483,16 @@ packages:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
 
+  seroval-plugins@1.5.6:
+    resolution: {integrity: sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.6:
+    resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
+    engines: {node: '>=10'}
+
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
@@ -15604,6 +15636,9 @@ packages:
   socks@2.8.9:
     resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  solid-js@1.9.14:
+    resolution: {integrity: sha512-sAEXC0Kk0S1EDg+8ysEWJDbYhA3RRoEjwuySUGlKIemeo0I5YZfOyumNjNs9Sv3y2nmhD+0rW66ag2HsMuQiGQ==}
 
   sort-keys-length@1.0.1:
     resolution: {integrity: sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==}
@@ -30267,6 +30302,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  seroval-plugins@1.5.6(seroval@1.5.6):
+    dependencies:
+      seroval: 1.5.6
+
+  seroval@1.5.6: {}
+
   serve-static@1.16.3(supports-color@10.2.2):
     dependencies:
       encodeurl: 2.0.0
@@ -30514,6 +30555,12 @@ snapshots:
     dependencies:
       ip-address: 10.4.0
       smart-buffer: 4.2.0
+
+  solid-js@1.9.14:
+    dependencies:
+      csstype: 3.2.3
+      seroval: 1.5.6
+      seroval-plugins: 1.5.6(seroval@1.5.6)
 
   sort-keys-length@1.0.1:
     dependencies:


### PR DESCRIPTION
## 背景

验证一条面向小程序的 Solid-style JSX 路线：构建期把 TSX 编译为原生 WXML，运行时使用 Solid signals 驱动稳定 binding，并在微任务内合并 setData。

## 改动

- 新增 `apps/runtime-bench-solid`，覆盖首屏、详情页和 100 卡片更新场景
- 复用 `wevu/compiler` 的 JSX AST 编译能力生成原生 WXML
- 新增最小 signal binding runtime，同步变更合并为一次 setData
- 将 Solid 工程接入四方 runtime benchmark runner
- 增加编译、runtime 合并和最终构建产物测试
- 增加 POC README 与投资评估报告
- 重新生成 pnpm lockfile，引入 `solid-js@1.9.14`

## 实测结论

真实微信开发者工具下，Solid 主包为 15.2 KB：

- 100 卡片、180 轮计算后单次提交：81ms，1 次 setData
- 100 卡片、40 次微提交：371ms，40 次 setData

该路线明显降低了 React dynamic Host Tree 的 reconciliation/dispatch 成本，但尚未达到 Native/Wevu 的微提交水平。因此当前建议继续 compiler-stage POC，暂不增加公共配置或正式 runtime 包。

完整四工程 runner 在 Native 详情页样本遇到 automator bridge 抖动；Solid worker 随后在真实 DevTools 中独立完整通过。报告已明确区分本轮 Solid 数据与既有基线，未作正式倍率声明。

## 验证

- `pnpm exec eslint apps/runtime-bench-solid e2e/scripts/run-runtime-bench.ts packages/weapp-vite/test/solid`
- `pnpm --filter runtime-bench-solid typecheck`
- `pnpm --filter runtime-bench-solid build`
- `pnpm exec vitest run test/solid/poc.test.ts test/solid/runtime-bench.test.ts`（在 `packages/weapp-vite` 执行）
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`
- `node --import tsx scripts/check-catalog-changeset.ts`

## Changeset

本次只新增实验 benchmark app、测试与报告，没有修改公共包行为、API 或模板，因此不添加 changeset，也不联动 `create-weapp-vite`。