### PR TITLE
修复 buildScope 导致分包页面进入主包

### DIFF
--- a/.changeset/fix-issue-793-build-scope.md
+++ b/.changeset/fix-issue-793-build-scope.md
@@ -1,0 +1,6 @@
+---
+'weapp-vite': patch
+'create-weapp-vite': patch
+---
+
+修复 `buildScope` 与自动路由分包识别冲突导致的分包页面被错误加入主包并参与构建的问题。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -694,6 +694,20 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-793/index",
+          "pathName": "pages/issue-793/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
+          "name": "subs/issue-793/index",
+          "pathName": "subs/issue-793/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/require-async/index",
           "pathName": "pages/require-async/index",
           "query": "",

--- a/e2e-apps/github-issues/src/pages/issue-793/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-793/index.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+definePageJson({})
+</script>
+
+<template>
+  <view>issue-793 main package</view>
+</template>

--- a/e2e-apps/github-issues/src/subs/issue-793/index.vue
+++ b/e2e-apps/github-issues/src/subs/issue-793/index.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+definePageJson({})
+</script>
+
+<template>
+  <view>issue-793 excluded subpackage</view>
+</template>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -14,6 +14,7 @@ const issue595ScopedBuildEnabled = process.env.WEAPP_GITHUB_ISSUE_595_SCOPED ===
 const issue642ScopedBuildEnabled = process.env.WEAPP_GITHUB_ISSUE_642_SCOPED === 'true'
 const issue724ProbeEnabled = process.env.WEAPP_GITHUB_ISSUE_724_PROBE === 'true'
 const issue779CssPreEnabled = process.env.WEAPP_GITHUB_ISSUE_779_CSS_PRE === 'true'
+const issue793BuildScopeEnabled = process.env.WEAPP_GITHUB_ISSUE_793_BUILD_SCOPE === 'true'
 const issue651NoExtResolvedId = path.resolve(import.meta.dirname, 'src/issue-fixtures/issue-651/ResolverNoExt/index')
 const issue651WithExtResolvedId = path.resolve(import.meta.dirname, 'src/issue-fixtures/issue-651/ResolverWithExt/index.vue')
 const e2eTargetFile = process.env.WEAPP_VITE_E2E_TARGET_FILE?.replaceAll('\\', '/') ?? ''
@@ -195,6 +196,14 @@ const matchedGithubIssuesTestFile = Object.keys(githubIssuesRouteGroups)
   .find(testFile => e2eTargetFile.endsWith(testFile))
 
 function resolveGithubIssuesAutoRoutes() {
+  if (issue793BuildScopeEnabled) {
+    return {
+      include: [
+        'pages/issue-793/**',
+        'subs/issue-793/**',
+      ],
+    }
+  }
   if (issue724ProbeEnabled) {
     return {
       include: [
@@ -442,9 +451,20 @@ export default defineConfig({
     },
     srcRoot: 'src',
     autoRoutes: resolveGithubIssuesAutoRoutes(),
-    subPackages: {
-      'subpackages/require-async': {},
-    },
+    subPackages: issue793BuildScopeEnabled
+      ? {
+          subs: {},
+        }
+      : {
+          'subpackages/require-async': {},
+        },
+    ...(issue793BuildScopeEnabled
+      ? {
+          buildScope: {
+            include: ['pages'],
+          },
+        }
+      : {}),
     typescript: {
       app: {
         compilerOptions: {
@@ -531,41 +551,47 @@ export default defineConfig({
           minify: false,
         },
       }
-    : issue724ProbeEnabled
+    : issue793BuildScopeEnabled
       ? {
           build: {
-            outDir: 'dist-issue-724',
+            outDir: 'dist-issue-793',
           },
         }
-      : issue510AugmentedEnabled
+      : issue724ProbeEnabled
         ? {
             build: {
-              outDir: 'dist-issue-510',
+              outDir: 'dist-issue-724',
             },
           }
-        : slotFallbackCompilerOffEnabled
+        : issue510AugmentedEnabled
           ? {
               build: {
-                outDir: 'dist-slot-fallback-compiler-off',
+                outDir: 'dist-issue-510',
               },
             }
-          : issue595ScopedBuildEnabled
+          : slotFallbackCompilerOffEnabled
             ? {
                 build: {
-                  outDir: 'dist-issue-595',
+                  outDir: 'dist-slot-fallback-compiler-off',
                 },
               }
-            : issue642ScopedBuildEnabled
+            : issue595ScopedBuildEnabled
               ? {
                   build: {
-                    outDir: 'dist-issue-642',
+                    outDir: 'dist-issue-595',
                   },
                 }
-              : issue779CssPreEnabled
+              : issue642ScopedBuildEnabled
                 ? {
                     build: {
-                      outDir: 'dist-issue-779',
+                      outDir: 'dist-issue-642',
                     },
                   }
-                : {}),
+                : issue779CssPreEnabled
+                  ? {
+                      build: {
+                        outDir: 'dist-issue-779',
+                      },
+                    }
+                  : {}),
 })

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -17,6 +17,7 @@ const ISSUE_510_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-510')
 const ISSUE_595_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-595')
 const ISSUE_642_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-642')
 const ISSUE_724_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-724')
+const ISSUE_793_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-793')
 const SLOT_FALLBACK_COMPILER_OFF_DIST_ROOT = path.join(APP_ROOT, 'dist-slot-fallback-compiler-off')
 const SLOT_OWNER_ATTR = `__wvSlotOwnerId="{{__wvSlotOwnerId || __wvOwnerId || ''}}"`
 let standardBuildPromise: Promise<void> | null = null
@@ -400,7 +401,44 @@ async function runSlotFallbackCompilerOffBuild() {
   distVariant = null
 }
 
+async function runIssue793Build() {
+  await fs.remove(ISSUE_793_DIST_ROOT)
+
+  await execa('node', [
+    CLI_PATH,
+    'build',
+    APP_ROOT,
+    '--platform',
+    'weapp',
+    '--skipNpm',
+    '--config',
+    path.join(APP_ROOT, 'weapp-vite.config.ts'),
+  ], {
+    stdio: 'inherit',
+    env: {
+      ...sanitizeBuildCommandEnv(),
+      WEAPP_GITHUB_ISSUE_793_BUILD_SCOPE: 'true',
+    },
+  })
+
+  standardBuildPromise = null
+  distVariant = null
+}
+
 describe.sequential('e2e app: github-issues (build)', () => {
+  it('issue #793: excludes out-of-scope subpackages from routes and output', async () => {
+    await runIssue793Build()
+
+    const appJson = await fs.readJSON(path.join(ISSUE_793_DIST_ROOT, 'app.json')) as {
+      pages?: string[]
+      subPackages?: Array<{ root?: string, pages?: string[] }>
+    }
+
+    expect(appJson.pages).toEqual(['pages/issue-793/index'])
+    expect(appJson.subPackages).toEqual([])
+    expect(await fs.pathExists(path.join(ISSUE_793_DIST_ROOT, 'subs'))).toBe(false)
+  })
+
   it('issue #724: keeps Vue SFC script, template, and style requests isolated', async () => {
     await runIssue724Build()
 

--- a/packages/weapp-vite/src/runtime/autoRoutesPlugin/subPackageRoots.test.ts
+++ b/packages/weapp-vite/src/runtime/autoRoutesPlugin/subPackageRoots.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { createRuntimeState } from '../runtimeState'
+import { getAutoRoutesSubPackageRoots } from './subPackageRoots'
+
+describe('getAutoRoutesSubPackageRoots', () => {
+  it('preserves excluded subpackage roots for route classification', () => {
+    const runtimeState = createRuntimeState()
+    const roots = getAutoRoutesSubPackageRoots({
+      configService: {
+        weappViteConfig: {
+          buildScope: {
+            include: ['pages'],
+          },
+          subPackages: {
+            subs: {},
+          },
+        },
+      } as any,
+      runtimeState,
+    })
+
+    expect(roots).toEqual(['subs'])
+  })
+})

--- a/packages/weapp-vite/src/runtime/autoRoutesPlugin/subPackageRoots.ts
+++ b/packages/weapp-vite/src/runtime/autoRoutesPlugin/subPackageRoots.ts
@@ -1,5 +1,4 @@
 import type { MutableCompilerContext } from '../../context'
-import { applyBuildScopeToSubPackageRoots, resolveBuildScope } from '../buildScope'
 
 interface AppJsonLikeSubPackage {
   root?: string
@@ -31,8 +30,5 @@ export function getAutoRoutesSubPackageRoots(
     roots.add(root)
   }
 
-  return applyBuildScopeToSubPackageRoots(
-    [...roots],
-    resolveBuildScope(ctx.configService?.weappViteConfig?.buildScope),
-  )
+  return [...roots]
 }

--- a/packages/weapp-vite/src/runtime/buildScope.test.ts
+++ b/packages/weapp-vite/src/runtime/buildScope.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest'
 import {
   applyBuildScopeToAppConfig,
   applyBuildScopeToAutoRoutes,
-  applyBuildScopeToSubPackageRoots,
   createBuildScopeConfigFromCli,
   resolveBuildScope,
   resolveBuildScopeFromCli,
@@ -123,12 +122,5 @@ describe('buildScope', () => {
         { root: 'packages/order', pages: ['pages/list/index'] },
       ],
     })
-  })
-
-  it('filters auto-routes subpackage roots before candidate matching', () => {
-    expect(applyBuildScopeToSubPackageRoots(
-      ['packages/order', 'packages/user'],
-      resolveBuildScope({ include: ['packages/order'] }),
-    )).toEqual(['packages/order'])
   })
 })

--- a/packages/weapp-vite/src/runtime/buildScope.ts
+++ b/packages/weapp-vite/src/runtime/buildScope.ts
@@ -215,17 +215,3 @@ export function applyBuildScopeToAutoRoutes(
     subPackages,
   }
 }
-
-export function applyBuildScopeToSubPackageRoots(
-  roots: string[],
-  scope: ResolvedBuildScope | undefined,
-) {
-  if (!scope?.enabled) {
-    return roots
-  }
-
-  const scopedRoots = new Set(scope.subPackageRoots)
-  return roots
-    .map(root => normalizeRoot(root))
-    .filter(root => scopedRoots.has(root))
-}


### PR DESCRIPTION
## 摘要

修复 `buildScope.include` 与自动路由分包识别冲突导致的错误构建结果。

## 根因

自动路由扫描在分类页面前就使用 `buildScope` 过滤分包根。被排除的分包因此不再被识别为分包页面，随后被错误加入主包 `pages`。

## 改动

- 保留完整分包拓扑用于自动路由分类。
- 继续通过统一的 buildScope 后置过滤生成路由快照、`app.json` 和构建入口。
- 增加 issue #793 的单测与 `github-issues` 构建回归。
- 增加中文 changeset，并联动 `create-weapp-vite`。

## 验证

- `pnpm vitest run packages/weapp-vite/src/runtime/buildScope.test.ts packages/weapp-vite/src/runtime/autoRoutesPlugin/subPackageRoots.test.ts packages/weapp-vite/src/runtime/autoRoutesPlugin/routes/scan.test.ts packages/weapp-vite/src/runtime/scanPlugin/service.test.ts`
- `pnpm vitest run -c e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #793"`
- `pnpm --filter weapp-vite typecheck`
- ESLint 定向检查
- changeset 守卫脚本

完整 `pnpm --filter weapp-vite test` 有一个与本改动无关的既有失败：React benchmark fixture 缺少 `@weapp-vite/react` 构建产物；其余为 `668 passed, 12 skipped`。

Fixes #793