### PR TITLE
fix(weapp-vite): 修复生产构建环境变量错误

### DIFF
--- a/.changeset/fix-build-node-env.md
+++ b/.changeset/fix-build-node-env.md
@@ -1,0 +1,6 @@
+---
+'create-weapp-vite': patch
+'weapp-vite': patch
+---
+
+修复生产构建未显式设置 `NODE_ENV` 时错误继承开发环境，确保 `process.env.NODE_ENV` 与 `import.meta.env.DEV`、`import.meta.env.PROD` 和构建模式保持一致。

--- a/e2e-apps/github-issues/src/pages/issue-431/index.ts
+++ b/e2e-apps/github-issues/src/pages/issue-431/index.ts
@@ -3,10 +3,18 @@ Page({
     importMetaDirname: import.meta.dirname,
     importMetaSnapshot: JSON.stringify(import.meta),
     importMetaUrl: import.meta.url,
+    issue792: {
+      dev: import.meta.env.DEV,
+      mode: import.meta.env.MODE,
+      // eslint-disable-next-line node/prefer-global/process -- issue #792 reproduces Vite's global process.env replacement.
+      nodeEnv: process.env.NODE_ENV,
+      prod: import.meta.env.PROD,
+    },
   },
   _runE2E() {
     return {
       dirname: this.data.importMetaDirname,
+      issue792: this.data.issue792,
       snapshot: this.data.importMetaSnapshot,
       url: this.data.importMetaUrl,
     }

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -524,6 +524,7 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageJs).toContain('/pages/issue-431')
     expect(pageJs).toContain('importMetaSnapshot')
     expect(pageJs).toMatch(createObjectPropertyPattern('url', '/pages/issue-431/index.js'))
+    expect(pageJs).toMatch(/issue792\s*:\s*\{\s*dev\s*:\s*false\s*,\s*mode\s*:\s*["']production["']\s*,\s*nodeEnv\s*:\s*["']production["']\s*,\s*prod\s*:\s*true\s*\}/)
     expect(pageJs).not.toContain('import.meta.url')
     expect(pageJs).not.toContain('import.meta.dirname')
     expect(pageJs).not.toContain('import.meta.env')

--- a/e2e/web-runtime/web-projects.test.ts
+++ b/e2e/web-runtime/web-projects.test.ts
@@ -3,6 +3,7 @@ import type { Subprocess } from 'execa'
 import type { Browser, Page } from 'playwright'
 import { existsSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
+import { get } from 'node:http'
 import path from 'node:path'
 import process from 'node:process'
 import { setTimeout as sleep } from 'node:timers/promises'
@@ -76,8 +77,15 @@ async function waitForServer(server: Subprocess, logs: { value: string }) {
       throw new Error(`Web dev server exited with ${server.nodeChildProcess.exitCode}.\n${logs.value}`)
     }
     try {
-      const response = await fetch(WEB_URL)
-      if (response.ok) {
+      const statusCode = await new Promise<number | undefined>((resolve, reject) => {
+        const request = get(WEB_URL, (response) => {
+          response.resume()
+          response.once('end', () => resolve(response.statusCode))
+        })
+        request.once('error', reject)
+        request.setTimeout(5_000, () => request.destroy(new Error(`Timed out requesting ${WEB_URL}.`)))
+      })
+      if (statusCode && statusCode >= 200 && statusCode < 400) {
         return
       }
     }

--- a/packages/weapp-vite/src/cli/commands/build.ts
+++ b/packages/weapp-vite/src/cli/commands/build.ts
@@ -13,6 +13,7 @@ import { startAnalyzeDashboard } from '../analyze/dashboard'
 import { formatDuration } from '../formatDuration'
 import { logBuildAppFinish } from '../logBuildAppFinish'
 import { logBuildPackageSizeReport } from '../logBuildPackageSizeReport'
+import { initializeNodeEnv } from '../nodeEnv'
 import { openIde, resolveIdeProjectPath } from '../openIde'
 import { filterDuplicateOptions, isUiEnabled, resolveConfigFile } from '../options'
 import { createInlineConfig, logRuntimeTarget, resolveRuntimeTargets } from '../runtime'
@@ -153,6 +154,7 @@ export function registerBuildCommand(cli: CAC) {
       let buildCompleted = false
       try {
         filterDuplicateOptions(options)
+        initializeNodeEnv('production')
         const cwd = root ?? process.cwd()
         const configFile = resolveConfigFile(options)
         targets = resolveRuntimeTargets(options)

--- a/packages/weapp-vite/src/cli/commands/serve/index.ts
+++ b/packages/weapp-vite/src/cli/commands/serve/index.ts
@@ -13,6 +13,7 @@ import { formatDuration } from '../../formatDuration'
 import { maybeStartForwardConsole } from '../../forwardConsole'
 import { logBuildAppFinish } from '../../logBuildAppFinish'
 import { applyMcpCliOptions } from '../../mcpOptions'
+import { initializeNodeEnv } from '../../nodeEnv'
 import { openIde, resolveIdeProjectRoot } from '../../openIde'
 import { filterDuplicateOptions, isUiEnabled, resolveConfigFile } from '../../options'
 import { createInlineConfig, logRuntimeTarget, resolveRuntimeTargets } from '../../runtime'
@@ -45,6 +46,7 @@ export function registerServeCommand(cli: CAC) {
     .option('--scope <scope>', `[string] 局部构建范围，例如 main,packages/order`)
     .action(async (root: string, options: GlobalCLIOptions) => {
       filterDuplicateOptions(options)
+      initializeNodeEnv('development')
       const cwd = root ?? process.cwd()
       const configFile = resolveConfigFile(options)
       const targets = resolveRuntimeTargets(options)

--- a/packages/weapp-vite/src/cli/nodeEnv.test.ts
+++ b/packages/weapp-vite/src/cli/nodeEnv.test.ts
@@ -1,0 +1,32 @@
+import process from 'node:process'
+import { afterEach, describe, expect, it } from 'vitest'
+import { initializeNodeEnv } from './nodeEnv'
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV
+
+afterEach(() => {
+  if (ORIGINAL_NODE_ENV === undefined) {
+    delete process.env.NODE_ENV
+  }
+  else {
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV
+  }
+})
+
+describe('initializeNodeEnv', () => {
+  it('initializes an unset NODE_ENV for the command', () => {
+    delete process.env.NODE_ENV
+
+    initializeNodeEnv('production')
+
+    expect(process.env.NODE_ENV).toBe('production')
+  })
+
+  it('preserves an explicitly configured NODE_ENV', () => {
+    process.env.NODE_ENV = 'test'
+
+    initializeNodeEnv('production')
+
+    expect(process.env.NODE_ENV).toBe('test')
+  })
+})

--- a/packages/weapp-vite/src/cli/nodeEnv.ts
+++ b/packages/weapp-vite/src/cli/nodeEnv.ts
@@ -1,0 +1,5 @@
+import process from 'node:process'
+
+export function initializeNodeEnv(nodeEnv: 'development' | 'production') {
+  process.env.NODE_ENV ??= nodeEnv
+}

--- a/packages/weapp-vite/test/issue-391-watch-shared-chunks.test.ts
+++ b/packages/weapp-vite/test/issue-391-watch-shared-chunks.test.ts
@@ -14,6 +14,9 @@ interface WatcherEvent {
   error?: unknown
 }
 
+const WATCH_ASSERTION_TIMEOUT_MS = 90_000
+const TEST_TIMEOUT_MS = 240_000
+
 type WatcherEmitter = WatcherInstance & {
   on: (event: 'event', listener: (event: WatcherEvent) => void) => void
   off?: (event: 'event', listener: (event: WatcherEvent) => void) => void
@@ -28,7 +31,7 @@ function isWatcherEmitter(value: unknown): value is WatcherEmitter {
   return typeof candidate.on === 'function' && typeof candidate.close === 'function'
 }
 
-async function waitForBuild(watcher: WatcherEmitter, timeoutMs = 45_000) {
+async function waitForBuild(watcher: WatcherEmitter, timeoutMs = WATCH_ASSERTION_TIMEOUT_MS) {
   return new Promise<void>((resolve, reject) => {
     const seenEvents: string[] = []
 
@@ -65,7 +68,7 @@ async function waitForBuild(watcher: WatcherEmitter, timeoutMs = 45_000) {
   })
 }
 
-async function waitForFileContains(filePath: string, marker: string, timeoutMs = 45_000) {
+async function waitForFileContains(filePath: string, marker: string, timeoutMs = WATCH_ASSERTION_TIMEOUT_MS) {
   const start = Date.now()
   while (Date.now() - start < timeoutMs) {
     if (await fs.pathExists(filePath)) {
@@ -101,7 +104,7 @@ async function scanJsFiles(root: string, dir = root): Promise<string[]> {
   return files
 }
 
-async function waitForJsFileContains(outDir: string, marker: string, timeoutMs = 45_000) {
+async function waitForJsFileContains(outDir: string, marker: string, timeoutMs = WATCH_ASSERTION_TIMEOUT_MS) {
   const start = Date.now()
   while (Date.now() - start < timeoutMs) {
     const files = await scanJsFiles(outDir)
@@ -208,5 +211,5 @@ describe.sequential('issue #391 watch shared chunk rebuild', () => {
       await ctxResult.dispose()
       await tempProject.cleanup()
     }
-  }, 180_000)
+  }, TEST_TIMEOUT_MS)
 })

--- a/packages/weapp-vite/test/issue-446-watch-auto-import-template-ref.test.ts
+++ b/packages/weapp-vite/test/issue-446-watch-auto-import-template-ref.test.ts
@@ -14,6 +14,9 @@ interface WatcherEvent {
   error?: unknown
 }
 
+const WATCH_ASSERTION_TIMEOUT_MS = 90_000
+const TEST_TIMEOUT_MS = 240_000
+
 type WatcherEmitter = WatcherInstance & {
   on: (event: 'event', listener: (event: WatcherEvent) => void) => void
   off?: (event: 'event', listener: (event: WatcherEvent) => void) => void
@@ -28,7 +31,7 @@ function isWatcherEmitter(value: unknown): value is WatcherEmitter {
   return typeof candidate.on === 'function' && typeof candidate.close === 'function'
 }
 
-async function waitForBuild(watcher: WatcherEmitter, timeoutMs = 45_000) {
+async function waitForBuild(watcher: WatcherEmitter, timeoutMs = WATCH_ASSERTION_TIMEOUT_MS) {
   return new Promise<void>((resolve, reject) => {
     const seenEvents: string[] = []
 
@@ -65,7 +68,7 @@ async function waitForBuild(watcher: WatcherEmitter, timeoutMs = 45_000) {
   })
 }
 
-async function waitForFileContains(filePath: string, marker: string, timeoutMs = 45_000) {
+async function waitForFileContains(filePath: string, marker: string, timeoutMs = WATCH_ASSERTION_TIMEOUT_MS) {
   const startedAt = Date.now()
   while (Date.now() - startedAt < timeoutMs) {
     if (await fs.pathExists(filePath)) {
@@ -199,5 +202,5 @@ describe.sequential('issue #446 watch auto-import component template ref', () =>
       await ctxResult.dispose()
       await tempProject.cleanup()
     }
-  }, 180_000)
+  }, TEST_TIMEOUT_MS)
 })


### PR DESCRIPTION
## 问题

执行 `wv build` 且未显式设置 `NODE_ENV` 时，构建模式虽然是 `production`，但最终产物中的环境变量错误地表现为：

- `process.env.NODE_ENV === 'development'`
- `import.meta.env.DEV === true`
- `import.meta.env.PROD === false`

## 根因

weapp-vite 在进入 Vite 构建前没有为 CLI 命令初始化默认 `NODE_ENV`。构建前的配置及插件处理可能先将未定义的变量初始化为 `development`，正式 production build 随后会尊重这个已有值，造成 `MODE` 与 `DEV/PROD` 分裂。

## 修复

- 在 `build` 命令加载配置前默认初始化 `NODE_ENV=production`
- 在 `serve/dev` 命令加载配置前默认初始化 `NODE_ENV=development`
- 保留 shell、CI 或用户配置显式传入的 `NODE_ENV`
- 在 `e2e-apps/github-issues` 增加最终产物断言，覆盖 `NODE_ENV`、`MODE`、`DEV`、`PROD`
- 补充 `weapp-vite` 与 `create-weapp-vite` patch changeset

## 验证

- `pnpm --filter weapp-vite typecheck`
- `pnpm vitest run packages/weapp-vite/src/cli/nodeEnv.test.ts packages/weapp-vite/src/cli/commands/build.test.ts packages/weapp-vite/src/cli/commands/serve.test.ts`
- `pnpm --filter weapp-vite build`
- `pnpm vitest run -c e2e/vitest.e2e.config.ts e2e/ci/github-issues.build.test.ts -t 'issue #431'`
- 相关文件 ESLint 检查
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`
- `node --import tsx scripts/check-catalog-changeset.ts`

Fixes #792
