### PR TITLE
fix(weapp-vite): 彻底修复 CLI 构建环境变量冲突

### DIFF
--- a/.changeset/fix-build-node-env.md
+++ b/.changeset/fix-build-node-env.md
@@ -3,4 +3,4 @@
 'weapp-vite': patch
 ---
 
-修复生产构建未显式设置 `NODE_ENV` 时错误继承开发环境，确保 `process.env.NODE_ENV` 与 `import.meta.env.DEV`、`import.meta.env.PROD` 和构建模式保持一致。
+修复 CLI 构建模式与外部 `NODE_ENV` 冲突时环境变量错误的问题，确保 `process.env.NODE_ENV` 与 `import.meta.env.DEV`、`import.meta.env.PROD` 和命令模式保持一致。

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -66,6 +66,20 @@ async function runBuildWithSourcemap() {
   distVariant = 'sourcemap'
 }
 
+async function runBuildWithNodeEnv(nodeEnv: string) {
+  await fs.remove(DIST_ROOT)
+
+  await runWeappViteBuildWithLogCapture({
+    cliPath: CLI_PATH,
+    projectRoot: APP_ROOT,
+    platform: 'weapp',
+    cwd: APP_ROOT,
+    env: { NODE_ENV: nodeEnv },
+    label: `ci:github-issues-node-env-${nodeEnv}`,
+    skipNpm: true,
+  })
+}
+
 async function scanFiles(root: string) {
   // eslint-disable-next-line new-cap
   const fd = new fdir({
@@ -103,6 +117,10 @@ function findGeneratedPosition(code: string, needle: string) {
 
 function createObjectPropertyPattern(property: string, value: string) {
   return new RegExp(`${escapeRegex(JSON.stringify(property))}\\s*:\\s*${escapeRegex(JSON.stringify(value))}`)
+}
+
+function expectProductionEnvironment(pageJs: string) {
+  expect(pageJs).toMatch(/issue792\s*:\s*\{\s*dev\s*:\s*false\s*,\s*mode\s*:\s*["']production["']\s*,\s*nodeEnv\s*:\s*["']production["']\s*,\s*prod\s*:\s*true\s*\}/)
 }
 
 function expectSetDataPickKeys(code: string, keys: string[]) {
@@ -562,10 +580,18 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(pageJs).toContain('/pages/issue-431')
     expect(pageJs).toContain('importMetaSnapshot')
     expect(pageJs).toMatch(createObjectPropertyPattern('url', '/pages/issue-431/index.js'))
-    expect(pageJs).toMatch(/issue792\s*:\s*\{\s*dev\s*:\s*false\s*,\s*mode\s*:\s*["']production["']\s*,\s*nodeEnv\s*:\s*["']production["']\s*,\s*prod\s*:\s*true\s*\}/)
+    expectProductionEnvironment(pageJs)
     expect(pageJs).not.toContain('import.meta.url')
     expect(pageJs).not.toContain('import.meta.dirname')
     expect(pageJs).not.toContain('import.meta.env')
+  })
+
+  it('issue #792: production build overrides an inherited development NODE_ENV', async () => {
+    await runBuildWithNodeEnv('development')
+
+    const pageJs = await fs.readFile(path.join(DIST_ROOT, 'pages/issue-431/index.js'), 'utf-8')
+
+    expectProductionEnvironment(pageJs)
   })
 
   it('issue #429: prefers local component auto import and warns when name collides with a builtin component tag', async () => {

--- a/packages/weapp-vite/src/cli/commands/build.ts
+++ b/packages/weapp-vite/src/cli/commands/build.ts
@@ -13,7 +13,7 @@ import { startAnalyzeDashboard } from '../analyze/dashboard'
 import { formatDuration } from '../formatDuration'
 import { logBuildAppFinish } from '../logBuildAppFinish'
 import { logBuildPackageSizeReport } from '../logBuildPackageSizeReport'
-import { initializeNodeEnv } from '../nodeEnv'
+import { setCommandNodeEnv } from '../nodeEnv'
 import { openIde, resolveIdeProjectPath } from '../openIde'
 import { filterDuplicateOptions, isUiEnabled, resolveConfigFile } from '../options'
 import { createInlineConfig, logRuntimeTarget, resolveRuntimeTargets } from '../runtime'
@@ -154,7 +154,7 @@ export function registerBuildCommand(cli: CAC) {
       let buildCompleted = false
       try {
         filterDuplicateOptions(options)
-        initializeNodeEnv('production')
+        setCommandNodeEnv('production')
         const cwd = root ?? process.cwd()
         const configFile = resolveConfigFile(options)
         targets = resolveRuntimeTargets(options)

--- a/packages/weapp-vite/src/cli/commands/serve/index.ts
+++ b/packages/weapp-vite/src/cli/commands/serve/index.ts
@@ -13,7 +13,7 @@ import { formatDuration } from '../../formatDuration'
 import { maybeStartForwardConsole } from '../../forwardConsole'
 import { logBuildAppFinish } from '../../logBuildAppFinish'
 import { applyMcpCliOptions } from '../../mcpOptions'
-import { initializeNodeEnv } from '../../nodeEnv'
+import { setCommandNodeEnv } from '../../nodeEnv'
 import { openIde, resolveIdeProjectRoot } from '../../openIde'
 import { filterDuplicateOptions, isUiEnabled, resolveConfigFile } from '../../options'
 import { createInlineConfig, logRuntimeTarget, resolveRuntimeTargets } from '../../runtime'
@@ -46,7 +46,7 @@ export function registerServeCommand(cli: CAC) {
     .option('--scope <scope>', `[string] 局部构建范围，例如 main,packages/order`)
     .action(async (root: string, options: GlobalCLIOptions) => {
       filterDuplicateOptions(options)
-      initializeNodeEnv('development')
+      setCommandNodeEnv('development')
       const cwd = root ?? process.cwd()
       const configFile = resolveConfigFile(options)
       const targets = resolveRuntimeTargets(options)

--- a/packages/weapp-vite/src/cli/nodeEnv.test.ts
+++ b/packages/weapp-vite/src/cli/nodeEnv.test.ts
@@ -1,6 +1,6 @@
 import process from 'node:process'
 import { afterEach, describe, expect, it } from 'vitest'
-import { initializeNodeEnv } from './nodeEnv'
+import { setCommandNodeEnv } from './nodeEnv'
 
 const ORIGINAL_NODE_ENV = process.env.NODE_ENV
 
@@ -13,20 +13,28 @@ afterEach(() => {
   }
 })
 
-describe('initializeNodeEnv', () => {
+describe('setCommandNodeEnv', () => {
   it('initializes an unset NODE_ENV for the command', () => {
     delete process.env.NODE_ENV
 
-    initializeNodeEnv('production')
+    setCommandNodeEnv('production')
 
     expect(process.env.NODE_ENV).toBe('production')
   })
 
-  it('preserves an explicitly configured NODE_ENV', () => {
-    process.env.NODE_ENV = 'test'
+  it('overrides development NODE_ENV for the build command', () => {
+    process.env.NODE_ENV = 'development'
 
-    initializeNodeEnv('production')
+    setCommandNodeEnv('production')
 
-    expect(process.env.NODE_ENV).toBe('test')
+    expect(process.env.NODE_ENV).toBe('production')
+  })
+
+  it('overrides production NODE_ENV for the dev command', () => {
+    process.env.NODE_ENV = 'production'
+
+    setCommandNodeEnv('development')
+
+    expect(process.env.NODE_ENV).toBe('development')
   })
 })

--- a/packages/weapp-vite/src/cli/nodeEnv.ts
+++ b/packages/weapp-vite/src/cli/nodeEnv.ts
@@ -1,5 +1,5 @@
 import process from 'node:process'
 
-export function initializeNodeEnv(nodeEnv: 'development' | 'production') {
-  process.env.NODE_ENV ??= nodeEnv
+export function setCommandNodeEnv(nodeEnv: 'development' | 'production') {
+  process.env.NODE_ENV = nodeEnv
 }


### PR DESCRIPTION
## 问题

此前的修复仅在 `NODE_ENV` 未设置时初始化命令环境。当外部显式设置 `NODE_ENV=development` 后执行 `wv build`，产物仍会出现 `MODE=production`，但 `DEV=true`、`PROD=false`、`process.env.NODE_ENV=development` 的分裂状态。

## 修复

- 将 CLI 命令模式作为环境变量的唯一来源：`build` 强制使用 `production`，`dev` 强制使用 `development`
- 调整 helper 命名，明确其设置命令环境的职责
- 增加显式继承 `NODE_ENV=development` 的真实 CLI 构建回归
- 同步更新 changeset 描述

## 验证

- `pnpm --filter weapp-vite run build`
- `pnpm vitest run packages/weapp-vite/src/cli/nodeEnv.test.ts packages/weapp-vite/src/cli/commands/build.test.ts`
- `pnpm --filter weapp-vite run typecheck`
- 定向 ESLint 检查
- `pnpm vitest run -c ./e2e/vitest.e2e.ci.build-only.config.ts e2e/ci/github-issues.build.test.ts -t "issue #(431|792)"`

Closes #792