### PR TITLE
fix(weapp-vite): 修复纯模板 SFC 属性解析

### DIFF
--- a/.changeset/quiet-vue-props.md
+++ b/.changeset/quiet-vue-props.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复 `wv prepare` 扫描不含脚本块的 Vue SFC 时误用 JSX 解析模板的问题，纯模板组件现在可以正常生成自动导入与类型支持文件，不再输出相邻 JSX 元素或 Vue 绑定语法解析错误。

--- a/packages/weapp-vite/src/runtime/autoImport/dtsProps.test.ts
+++ b/packages/weapp-vite/src/runtime/autoImport/dtsProps.test.ts
@@ -2,14 +2,12 @@ import { describe, expect, it } from 'vitest'
 import { extractInlinePropsTypeFromCode } from './dtsProps'
 
 describe('extractInlinePropsTypeFromCode', () => {
-  it('extracts defineProps type literal members from script setup source', () => {
+  it('extracts defineProps type literal members from TypeScript source', () => {
     const result = extractInlinePropsTypeFromCode(`
-<script setup lang="ts">
 defineProps<{
   sidebar?: boolean
   title?: string
 }>()
-</script>
     `.trim())
 
     expect([...result.entries()]).toEqual([

--- a/packages/weapp-vite/src/runtime/autoImport/dtsProps.ts
+++ b/packages/weapp-vite/src/runtime/autoImport/dtsProps.ts
@@ -1,6 +1,5 @@
 import type * as t from '@weapp-vite/ast/babelTypes'
 import type { ComponentPropMap } from '../componentProps'
-import { parse as parseSfc } from 'vue/compiler-sfc'
 import { BABEL_TS_MODULE_PARSER_OPTIONS, generate, getVisitorKeys, parse, traverse } from '../../utils/babel'
 import { mapConstructorName } from '../utils/constructorType'
 
@@ -243,14 +242,8 @@ export function extractComponentPropsFromDts(code: string): ComponentPropMap {
 }
 
 export function extractInlinePropsTypeFromCode(code: string): ComponentPropMap {
-  const source = code.includes('<script')
-    ? (() => {
-        const parsed = parseSfc(code, { filename: 'layout.vue' })
-        return parsed.descriptor.scriptSetup?.content ?? parsed.descriptor.script?.content ?? code
-      })()
-    : code
   const props: ComponentPropMap = new Map()
-  const ast = parse(source, {
+  const ast = parse(code, {
     ...BABEL_TS_MODULE_PARSER_OPTIONS,
     errorRecovery: true,
   })

--- a/packages/weapp-vite/src/runtime/autoImport/service/outputs/sync.ts
+++ b/packages/weapp-vite/src/runtime/autoImport/service/outputs/sync.ts
@@ -153,14 +153,13 @@ async function collectLayoutSyncState(ctx: MutableCompilerContext): Promise<Layo
       else {
         try {
           const source = await fs.readFile(full, 'utf8')
-          const inlineProps = extractInlinePropsTypeFromCode(source)
-          if (inlineProps.size > 0) {
-            propMap = inlineProps
-          }
-          else {
+          if (ext === '.vue') {
             propMap = extractVueComponentProps(source, full, {
               astEngine: resolveAstEngine(configService.weappViteConfig),
             })
+          }
+          else {
+            propMap = extractInlinePropsTypeFromCode(source)
           }
         }
         catch {

--- a/packages/weapp-vite/src/runtime/autoImport/vueProps.test.ts
+++ b/packages/weapp-vite/src/runtime/autoImport/vueProps.test.ts
@@ -2,6 +2,25 @@ import { describe, expect, it } from 'vitest'
 import { extractVueComponentProps } from './vueProps'
 
 describe('extractVueComponentProps', () => {
+  it('returns empty props for template-only components with sibling SFC blocks', () => {
+    expect(extractVueComponentProps(`
+<template>
+  <view><slot /></view>
+</template>
+<style scoped>
+view { display: block; }
+</style>
+    `.trim(), '/project/src/components/card/index.vue')).toEqual(new Map())
+  })
+
+  it('returns empty props for template-only components with Vue bindings', () => {
+    expect(extractVueComponentProps(`
+<template>
+  <slot :value="1" />
+</template>
+    `.trim(), '/project/src/components/cell/index.vue')).toEqual(new Map())
+  })
+
   it('extracts inline defineProps type members without full SFC compilation', () => {
     const props = extractVueComponentProps(`
 <template><view /></template>

--- a/packages/weapp-vite/src/runtime/autoImport/vueProps.ts
+++ b/packages/weapp-vite/src/runtime/autoImport/vueProps.ts
@@ -7,14 +7,15 @@ import { extractInlinePropsTypeFromCode } from './dtsProps'
 export function extractVueComponentProps(source: string, filename: string, options: {
   astEngine?: 'babel' | 'oxc'
 } = {}): ComponentPropMap {
-  const inlineProps = extractInlinePropsTypeFromCode(source)
-  if (inlineProps.size > 0) {
-    return inlineProps
-  }
-
   const { descriptor, errors } = parse(source, { filename })
   if (errors.length || (!descriptor.script && !descriptor.scriptSetup)) {
     return new Map()
+  }
+
+  const scriptSource = descriptor.scriptSetup?.content ?? descriptor.script?.content ?? ''
+  const inlineProps = extractInlinePropsTypeFromCode(scriptSource)
+  if (inlineProps.size > 0) {
+    return inlineProps
   }
 
   const compiled = compileScript(descriptor, {


### PR DESCRIPTION
## 问题

`wv prepare` 扫描不含 `<script>` 的 Vue SFC 时，会把完整模板交给 Babel TypeScript/JSX parser，导致合法的多 SFC block 或 Vue `:prop` 语法被误报为 JSX 解析错误。

## 修复

- 由 Vue SFC props 解析器统一解析 descriptor，无脚本组件直接返回空 props
- inline props helper 只处理 JavaScript/TypeScript，不再隐式解析完整 SFC
- layout props 扫描按 `.vue` 与 TSX/JSX 明确分流，避免重复解析
- 补充纯模板、多 SFC block 和 Vue 属性绑定回归测试
- 增加 `weapp-vite` 与 `create-weapp-vite` patch changeset

## 验证

- `pnpm vitest run packages/weapp-vite/src/runtime/autoImport/service/registry.test.ts packages/weapp-vite/src/runtime/autoImport/service/outputs/sync.test.ts packages/weapp-vite/src/runtime/autoImport/vueProps.test.ts packages/weapp-vite/src/runtime/autoImport/dtsProps.test.ts`
- `pnpm --dir packages/weapp-vite typecheck`
- `pnpm --filter weapp-vite build`
- `pnpm --filter e2e-app-github-issues exec wv prepare`
- `pnpm exec eslint packages/weapp-vite/src/runtime/autoImport/vueProps.ts packages/weapp-vite/src/runtime/autoImport/dtsProps.ts packages/weapp-vite/src/runtime/autoImport/service/outputs/sync.ts packages/weapp-vite/src/runtime/autoImport/vueProps.test.ts packages/weapp-vite/src/runtime/autoImport/dtsProps.test.ts`
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`
- `node --import tsx scripts/check-catalog-changeset.ts`

全包测试中唯一失败来自隔离环境未预构建 `@weapp-vite/react`；补构建后对应 React benchmark 用例定向重跑通过。