### PR TITLE
fix(wevu): 修复模板空值合并中的可选链转换

### DIFF
--- a/.changeset/fix-issue-805.md
+++ b/.changeset/fix-issue-805.md
@@ -1,0 +1,8 @@
+---
+"@wevu/compiler": patch
+"wevu": patch
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复 Vue 模板中 optional chaining 嵌套在空值合并表达式时未被降级的问题，确保生成的 WXML 不再包含小程序不支持的 `?.`。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -701,6 +701,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-805/index",
+          "pathName": "pages/issue-805/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "subs/issue-793/index",
           "pathName": "subs/issue-793/index",
           "query": "",

--- a/e2e-apps/github-issues/src/pages/issue-805/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-805/index.vue
@@ -1,0 +1,10 @@
+<script setup>
+const a = {
+  b: {},
+}
+</script>
+
+<template>
+  <view id="issue-805-nullish">{{ a?.b?.d ?? 4 }}</view>
+  <view id="issue-805-logical">{{ a?.b?.d || 4 }}</view>
+</template>

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -457,6 +457,18 @@ describe.sequential('e2e app: github-issues (build)', () => {
     expect(await fs.pathExists(path.join(ISSUE_793_DIST_ROOT, 'subs'))).toBe(false)
   })
 
+  it('issue #805: lowers optional chaining inside nullish coalescing expressions', async () => {
+    await runBuild()
+
+    const pageWxml = await fs.readFile(path.join(DIST_ROOT, 'pages/issue-805/index.wxml'), 'utf-8')
+
+    expect(pageWxml).not.toContain('?.')
+    expect(pageWxml).not.toContain('??')
+    expect(pageWxml).toContain('a==null?undefined:a.b==null?undefined:a.b.d')
+    expect(pageWxml).toContain('!=null?')
+    expect(pageWxml).toContain(':4')
+  })
+
   it('issue #724: keeps Vue SFC script, template, and style requests isolated', async () => {
     await runIssue724Build()
 

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
@@ -68,6 +68,22 @@ describe('compileVueTemplateToWxml', () => {
     expect(code).not.toContain('??')
   })
 
+  it('rewrites optional chaining nested in nullish coalescing bindings', () => {
+    const template = `
+<view>{{ a?.b?.d ?? 4 }}</view>
+<view>{{ a?.b?.d || 4 }}</view>
+    `.trim()
+
+    const { code } = compileVueTemplateToWxml(template, '/project/src/pages/issue-805/index.vue')
+
+    const normalized = code.replace(WHITESPACE_RE, '')
+    expect(normalized).not.toContain('?.')
+    expect(normalized).not.toContain('??')
+    expect(normalized).toContain('a==null?undefined:a.b==null?undefined:a.b.d')
+    expect(normalized).toContain('!=null?')
+    expect(normalized).toContain(':4')
+  })
+
   it('rewrites optional chaining in template expressions', () => {
     const template = `
 <view :title="routeMeta?.title || '首页'">{{ routeMeta?.group || '模块' }}</view>

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/expression/wxml.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/expression/wxml.ts
@@ -245,15 +245,17 @@ export function normalizeWxmlExpression(exp: string): string {
           path.skip()
         },
       },
-      LogicalExpression(path) {
-        if (path.node.operator !== '??') {
-          return
-        }
-        const left = path.node.left
-        const right = path.node.right
-        const test = t.binaryExpression('!=', t.cloneNode(left), t.nullLiteral())
-        path.replaceWith(t.conditionalExpression(test, t.cloneNode(left), t.cloneNode(right)))
-        path.skip()
+      LogicalExpression: {
+        exit(path) {
+          if (path.node.operator !== '??') {
+            return
+          }
+          const left = path.node.left
+          const right = path.node.right
+          const test = t.binaryExpression('!=', t.cloneNode(left), t.nullLiteral())
+          path.replaceWith(t.conditionalExpression(test, t.cloneNode(left), t.cloneNode(right)))
+          path.skip()
+        },
       },
       TemplateLiteral(path) {
         if (t.isTaggedTemplateExpression(path.parent)) {


### PR DESCRIPTION
## 变更

修复 Vue 模板表达式中 optional chaining 嵌套在 `??` 时未被降级的问题。`??` 转换现在在子表达式完成 optional-chain 降级后执行，生成的 WXML 不再包含小程序不支持的 `?.`。

新增 issue 805 的编译器单测、github-issues 构建回归页面与产物断言，并补充 `@wevu/compiler`、`wevu`、`weapp-vite` 和 `create-weapp-vite` 的 patch changeset。

Closes #805

## 验证

- `pnpm --filter @wevu/compiler typecheck`
- `pnpm --filter @wevu/compiler test`
- `vitest run -c e2e/vitest.e2e.ci.build-only.config.ts e2e/ci/github-issues.build.test.ts -t "issue #805"`
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`
- `node --import tsx scripts/check-catalog-changeset.ts`