### PR TITLE
fix(weapp-vite): 修复 Web Runtime 自定义组件模块导出

### DIFF
--- a/.changeset/fixed-issue-804-web-runtime.md
+++ b/.changeset/fixed-issue-804-web-runtime.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复开发模式启用 Web Runtime 后使用自定义组件时运行时共享模块导出缺失的问题，避免微信开发者工具加载组件时报 `resolveMiniProgramPlatform is not a function`。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -701,6 +701,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-804/index",
+          "pathName": "pages/issue-804/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "subs/issue-793/index",
           "pathName": "subs/issue-793/index",
           "query": "",

--- a/e2e-apps/github-issues/src/components/issue-804/Pressable/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-804/Pressable/index.vue
@@ -1,0 +1,11 @@
+<template>
+  <view class="issue804-pressable">
+    <slot />
+  </view>
+</template>
+
+<style scoped>
+.issue804-pressable {
+  transition: opacity 0.15s;
+}
+</style>

--- a/e2e-apps/github-issues/src/pages/issue-804/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-804/index.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import Pressable from '@/components/issue-804/Pressable/index.vue'
+
+definePageJson({
+  navigationBarTitleText: 'issue-804',
+})
+
+definePageMeta({
+  layout: false,
+})
+</script>
+
+<template>
+  <view id="issue804-page" class="issue804-page">
+    <text>web runtime custom component</text>
+    <Pressable>
+      <text>ready</text>
+    </Pressable>
+  </view>
+</template>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -27,6 +27,7 @@ const issue547AugmentedEnabled = issue547AugmentedEnvEnabled || e2eTargetFile.en
 const issue558AugmentedEnabled = issue558AugmentedEnvEnabled || e2eTargetFile.endsWith('github-issues.runtime.issue558.test.ts')
 const issue564AugmentedEnabled = issue564AugmentedEnvEnabled || e2eTargetFile.endsWith('github-issues.runtime.issue564.test.ts')
 const issue615AugmentedEnabled = issue615AugmentedEnvEnabled || e2eTargetFile.endsWith('github-issues.runtime.issue615.test.ts')
+const issue804WebRuntimeEnabled = e2eTargetFile.endsWith('github-issues.runtime.web-runtime.test.ts')
 const githubIssuesWarmupRoutes = ['pages/block-slot/**']
 const githubIssuesRouteGroups: Record<string, string[]> = {
   'github-issues.runtime.app-shell.test.ts': [
@@ -167,6 +168,8 @@ const githubIssuesRouteGroups: Record<string, string[]> = {
   'github-issues.runtime.web-runtime.test.ts': [
     'pages/issue-448/**',
     'pages/issue-459/**',
+    'pages/issue-804/**',
+    'components/issue-804/**',
   ],
 }
 const githubIssuesAggregateRouteGroupFiles = [
@@ -527,6 +530,13 @@ export default defineConfig({
       },
     },
     npm: resolveGithubIssuesNpm(),
+    ...(issue804WebRuntimeEnabled
+      ? {
+          appPrelude: {
+            webRuntime: true,
+          },
+        }
+      : {}),
     chunks: {
       dynamicImports: issue393ChunkModeEnabled ? 'preserve' : 'native',
       ...(issue393ChunkModeEnabled

--- a/e2e/ide/github-issues.runtime.web-runtime.test.ts
+++ b/e2e/ide/github-issues.runtime.web-runtime.test.ts
@@ -52,4 +52,20 @@ describe.sequential('github-issues runtime web runtime globals', () => {
     expect(pageJs).toContain('Object.keys(response).join(",")')
     expect(pageJs).toContain('_runE2E')
   })
+
+  it('issue #804: keeps web runtime platform exports available to custom components', async () => {
+    const pageWxml = await readDistFile('pages/issue-804/index.wxml')
+    const vendorRoot = path.join(DIST_ROOT, 'weapp-vendors')
+    const vendorFiles = await fs.readdir(vendorRoot)
+    const vendorJs = (await Promise.all(
+      vendorFiles
+        .filter(file => file.endsWith('.js'))
+        .map(file => fs.readFile(path.join(vendorRoot, file), 'utf8')),
+    )).join('\n')
+
+    expect(pageWxml).toContain('id="issue804-page"')
+    expect(pageWxml).toContain('<Pressable')
+    expect(vendorJs).toContain('resolveMiniProgramPlatform')
+    expect(vendorJs).not.toContain('request-globals-wevu-web-apis-fetch.js')
+  })
 })

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts
@@ -2215,6 +2215,63 @@ describe('core lifecycle emit hook extra branches', () => {
     expect(bundle['app.js'].code).toContain('require("./weapp-vendors/request-globals-runtime.js")')
   })
 
+  it('collapses hashed web-apis support chunks and rewrites runtime consumers', async () => {
+    const state = createState({
+      subPackageMeta: null,
+      entriesMap: new Map([
+        ['app', { type: 'app', path: 'app' }],
+      ]),
+      ctx: {
+        configService: {
+          packageJson: {
+            dependencies: {
+              axios: '^1.8.0',
+            },
+          },
+          weappViteConfig: {},
+        },
+      },
+    })
+    const hook = createGenerateBundleHook(state, false)
+    const bundle = {
+      'weapp-vendors/request-globals-runtime.js': {
+        type: 'chunk',
+        fileName: 'weapp-vendors/request-globals-runtime.js',
+        code: 'const require_fetch = require("./request-globals-wevu-web-apis-fetch.js"); function installWebRuntimeGlobals(){return require_fetch} Object.defineProperty(exports,"installWebRuntimeGlobals",{get:function(){return installWebRuntimeGlobals}})',
+        imports: ['weapp-vendors/request-globals-wevu-web-apis-fetch.js'],
+        dynamicImports: [],
+      },
+      'weapp-vendors/request-globals-wevu-web-apis-fetch.js': {
+        type: 'chunk',
+        fileName: 'weapp-vendors/request-globals-wevu-web-apis-fetch.js',
+        code: 'function resolveMiniProgramPlatform(){return "weapp"} Object.defineProperty(exports,"resolveMiniProgramPlatform",{get:function(){return resolveMiniProgramPlatform}})',
+        imports: [],
+        dynamicImports: [],
+      },
+      'weapp-vendors/wevu-reactivity.js': {
+        type: 'chunk',
+        fileName: 'weapp-vendors/wevu-reactivity.js',
+        code: 'const require_fetch = require("./request-globals-wevu-web-apis-fetch.js"); require_fetch.resolveMiniProgramPlatform()',
+        imports: ['weapp-vendors/request-globals-wevu-web-apis-fetch.js'],
+        dynamicImports: [],
+      },
+      'app.js': {
+        type: 'chunk',
+        fileName: 'app.js',
+        code: 'App({})',
+        imports: [],
+        dynamicImports: [],
+      },
+    } as any
+
+    await hook.call({}, {}, bundle)
+
+    expect(bundle['weapp-vendors/request-globals-wevu-web-apis-fetch.js']).toBeUndefined()
+    expect(bundle['weapp-vendors/request-globals-runtime.js'].code).toContain('resolveMiniProgramPlatform')
+    expect(bundle['weapp-vendors/wevu-reactivity.js'].code).toContain('require("./request-globals-runtime.js")')
+    expect(bundle['weapp-vendors/wevu-reactivity.js'].code).not.toContain('request-globals-wevu-web-apis-fetch.js')
+  })
+
   it('registers request globals installer chunks from app.js for page-only usage', async () => {
     const state = createState({
       subPackageMeta: null,

--- a/packages/weapp-vite/src/plugins/core/lifecycle/emit/requestGlobals.ts
+++ b/packages/weapp-vite/src/plugins/core/lifecycle/emit/requestGlobals.ts
@@ -453,6 +453,12 @@ function toRequireRequestPath(fromFileName: string, toFileName: string) {
   return relativePath.startsWith('.') ? relativePath : `./${relativePath}`
 }
 
+function isRequestGlobalsSupportChunkFileName(fileName: string) {
+  const baseName = path.basename(toPosixPath(fileName))
+  return baseName.startsWith('request-globals-')
+    || baseName === 'web-apis-shared.js'
+}
+
 function rewriteChunkRequireLiteral(
   chunk: OutputChunk,
   fromFileName: string,
@@ -690,7 +696,7 @@ export function collapseRequestGlobalsRuntimeSupportChunk(bundle: OutputBundle) 
     }
     if (
       resolvedImport === REQUEST_GLOBAL_RUNTIME_CHUNK_FILE_BASENAME
-      || (!resolvedImport.startsWith('request-globals-') && !resolvedImport.endsWith('web-apis-shared.js'))
+      || !isRequestGlobalsSupportChunkFileName(resolvedImport)
     ) {
       continue
     }


### PR DESCRIPTION
## 背景
启用 `appPrelude.webRuntime` 后，开发模式产物中的自定义组件可能触发 `resolveMiniProgramPlatform is not a function`。

## 根因
`collapseRequestGlobalsRuntimeSupportChunk` 以完整路径判断 `request-globals-*` support chunk，无法识别 `weapp-vendors/request-globals-*.js`，导致 support chunk 未合并回 runtime，相关 consumer 继续引用已被错误拆分的模块。

## 修复
- 按 POSIX basename 识别 request-globals support chunk，避免绑定具体 vendor 目录。
- 增加 chunk 合并和 consumer 引用重写的单元回归测试。
- 增加 GitHub issue #804 的自定义组件 Web Runtime IDE 场景。
- 增加 `weapp-vite` 与 `create-weapp-vite` patch changeset。

## 验证
- `pnpm --filter weapp-vite typecheck`
- `pnpm vitest run packages/weapp-vite/src/plugins/core/lifecycle/emit.more.test.ts`
- `pnpm vitest run -c ./e2e/vitest.e2e.devtools.config.ts e2e/ide/github-issues.runtime.web-runtime.test.ts`
- changeset、ESLint、Stylelint 检查通过

Closes #804