### PR TITLE
feat(website): 增加赞助广告侧栏

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -630,6 +630,7 @@ const configSidebarItems: DefaultTheme.SidebarItem[] = [
 // https://github.com/emersonbottero/vitepress-plugin-mermaid/issues/47
 export default withMermaid(
   defineConfig({
+    lang: 'zh-CN',
     title: 'Weapp-vite',
     description:
       '面向小程序的现代工程化工具链，覆盖开发、构建、Vue SFC、Wevu、自动化、MCP 与多平台能力。',

--- a/website/.vitepress/theme/Layout.vue
+++ b/website/.vitepress/theme/Layout.vue
@@ -3,6 +3,7 @@ import { useToggleTheme } from 'theme-transition'
 import { useData } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
 import { nextTick, onBeforeUnmount, onMounted, provide } from 'vue'
+import SponsorAd from './SponsorAd.vue'
 
 const { isDark } = useData()
 const { toggleTheme } = useToggleTheme({
@@ -33,5 +34,9 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <DefaultTheme.Layout />
+  <DefaultTheme.Layout>
+    <template #aside-ads-after>
+      <SponsorAd />
+    </template>
+  </DefaultTheme.Layout>
 </template>

--- a/website/.vitepress/theme/SponsorAd.vue
+++ b/website/.vitepress/theme/SponsorAd.vue
@@ -1,0 +1,179 @@
+<script lang="ts" setup>
+import type { CampaignLocale } from './sponsorCampaigns'
+import { useData } from 'vitepress'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import {
+  fallbackCampaign,
+  paidCampaigns,
+  selectDisplayCampaign,
+} from './sponsorCampaigns'
+
+const CAMPAIGN_REFRESH_INTERVAL = 60_000
+const { lang } = useData()
+const now = ref<Date>()
+let refreshTimer: ReturnType<typeof setInterval> | undefined
+
+const locale = computed<CampaignLocale>(() => (
+  lang.value.toLowerCase().startsWith('en') ? 'en' : 'zh-cn'
+))
+const campaign = computed(() => selectDisplayCampaign(
+  paidCampaigns,
+  'weapp-vite',
+  fallbackCampaign,
+  now.value,
+))
+const creative = computed(() => campaign.value.creative[locale.value])
+const campaignHref = computed(() => {
+  if (campaign.value.id !== fallbackCampaign.id || locale.value === 'zh-cn') {
+    return campaign.value.href
+  }
+  return 'https://github.com/sonofmagic/sponsors/issues/new?template=business-sponsorship-en.yml'
+})
+
+onMounted(() => {
+  now.value = new Date()
+  refreshTimer = setInterval(() => {
+    now.value = new Date()
+  }, CAMPAIGN_REFRESH_INTERVAL)
+})
+
+onBeforeUnmount(() => {
+  if (refreshTimer) {
+    clearInterval(refreshTimer)
+  }
+})
+</script>
+
+<template>
+  <div
+    class="sponsor-ad-slot"
+    :data-sponsor-campaign="campaign.id"
+  >
+    <a
+      class="sponsor-ad"
+      :href="campaignHref"
+      target="_blank"
+      rel="noopener sponsored nofollow"
+      :aria-label="`${creative.brand}: ${creative.copy}`"
+    >
+      <span class="sponsor-ad__label">
+        {{ campaign.id === 'weapp-vite-house-ad' ? (locale === 'en' ? 'Partner with us' : '赞助合作') : (locale === 'en' ? 'Sponsored' : '赞助商') }}
+      </span>
+      <span class="sponsor-ad__logo-frame">
+        <img
+          class="sponsor-ad__logo"
+          :class="{ 'sponsor-ad__logo--light': creative.logoDarkSrc }"
+          :src="creative.logoSrc"
+          :alt="creative.logoAlt"
+          width="48"
+          height="48"
+        >
+        <img
+          v-if="creative.logoDarkSrc"
+          class="sponsor-ad__logo sponsor-ad__logo--dark"
+          :src="creative.logoDarkSrc"
+          :alt="creative.logoAlt"
+          width="48"
+          height="48"
+        >
+      </span>
+      <strong class="sponsor-ad__brand">{{ creative.brand }}</strong>
+      <span class="sponsor-ad__copy">{{ creative.copy }}</span>
+    </a>
+  </div>
+</template>
+
+<style scoped>
+.sponsor-ad-slot {
+  width: 100%;
+  height: 196px;
+  margin-top: 20px;
+}
+
+.sponsor-ad {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 196px;
+  padding: 18px 14px;
+  color: var(--vp-c-text-1);
+  text-align: center;
+  text-decoration: none;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease;
+}
+
+.sponsor-ad:hover {
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg-alt);
+  border-color: var(--vp-c-brand-1);
+}
+
+.sponsor-ad__label {
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 16px;
+  color: var(--vp-c-text-2);
+  text-transform: uppercase;
+}
+
+.sponsor-ad__logo-frame {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 48px;
+}
+
+.sponsor-ad__logo {
+  width: auto;
+  max-width: 160px;
+  height: 48px;
+  object-fit: contain;
+}
+
+.sponsor-ad__logo--dark {
+  display: none;
+}
+
+:global(.dark) .sponsor-ad__logo--light {
+  display: none;
+}
+
+:global(.dark) .sponsor-ad__logo--dark {
+  display: block;
+}
+
+.sponsor-ad__brand {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 13px;
+  line-height: 20px;
+  white-space: nowrap;
+}
+
+.sponsor-ad__copy {
+  display: -webkit-box;
+  min-height: 36px;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--vp-c-text-2);
+}
+
+@media (max-width: 1279px) {
+  .sponsor-ad-slot {
+    display: none;
+  }
+}
+</style>

--- a/website/.vitepress/theme/sponsorCampaigns.test.ts
+++ b/website/.vitepress/theme/sponsorCampaigns.test.ts
@@ -1,0 +1,76 @@
+import type { PaidCampaign } from './sponsorCampaigns'
+import { describe, expect, it } from 'vitest'
+import {
+  assertNoCampaignOverlaps,
+  fallbackCampaign,
+  selectActiveCampaign,
+  selectDisplayCampaign,
+} from './sponsorCampaigns'
+
+function createCampaign(
+  id: string,
+  startsAt: string,
+  endsAt: string,
+  site: PaidCampaign['site'] = 'weapp-vite',
+): PaidCampaign {
+  return {
+    creative: fallbackCampaign.creative,
+    endsAt,
+    href: `https://example.com/${id}`,
+    id,
+    site,
+    startsAt,
+  }
+}
+
+describe('sponsor campaign scheduling', () => {
+  const monthly = createCampaign(
+    'monthly',
+    '2026-09-01T00:00:00.000Z',
+    '2026-10-01T00:00:00.000Z',
+  )
+  const quarterly = createCampaign(
+    'quarterly',
+    '2026-09-01T00:00:00.000Z',
+    '2026-11-30T00:00:00.000Z',
+    'weapp-tailwindcss',
+  )
+
+  it('uses the house ad before and after a paid campaign', () => {
+    expect(selectDisplayCampaign([monthly], monthly.site, fallbackCampaign, new Date('2026-08-31T23:59:59.999Z'))).toBe(fallbackCampaign)
+    expect(selectDisplayCampaign([monthly], monthly.site, fallbackCampaign, new Date('2026-10-01T00:00:00.000Z'))).toBe(fallbackCampaign)
+  })
+
+  it('treats the start as inclusive and the end as exclusive for 30-day campaigns', () => {
+    expect(selectActiveCampaign([monthly], monthly.site, new Date('2026-09-01T00:00:00.000Z'))).toBe(monthly)
+    expect(selectActiveCampaign([monthly], monthly.site, new Date('2026-09-30T23:59:59.999Z'))).toBe(monthly)
+    expect(selectActiveCampaign([monthly], monthly.site, new Date('2026-10-01T00:00:00.000Z'))).toBeUndefined()
+  })
+
+  it('keeps the same boundary rules for 90-day campaigns', () => {
+    expect(selectActiveCampaign([quarterly], quarterly.site, new Date('2026-09-01T00:00:00.000Z'))).toBe(quarterly)
+    expect(selectActiveCampaign([quarterly], quarterly.site, new Date('2026-11-29T23:59:59.999Z'))).toBe(quarterly)
+    expect(selectActiveCampaign([quarterly], quarterly.site, new Date('2026-11-30T00:00:00.000Z'))).toBeUndefined()
+  })
+
+  it('rejects overlapping campaigns on the same site', () => {
+    const overlapping = createCampaign(
+      'overlapping',
+      '2026-09-30T12:00:00.000Z',
+      '2026-10-30T12:00:00.000Z',
+    )
+
+    expect(() => assertNoCampaignOverlaps([monthly, overlapping])).toThrow(/overlap/)
+    expect(() => selectActiveCampaign([monthly, overlapping], monthly.site, new Date('2026-09-30T18:00:00.000Z'))).toThrow(/Multiple active/)
+  })
+
+  it('allows adjacent campaigns and independent schedules on different sites', () => {
+    const adjacent = createCampaign(
+      'adjacent',
+      monthly.endsAt,
+      '2026-10-31T00:00:00.000Z',
+    )
+
+    expect(() => assertNoCampaignOverlaps([monthly, adjacent, quarterly])).not.toThrow()
+  })
+})

--- a/website/.vitepress/theme/sponsorCampaigns.ts
+++ b/website/.vitepress/theme/sponsorCampaigns.ts
@@ -1,0 +1,118 @@
+export type CampaignLocale = 'en' | 'zh-cn'
+export type CampaignSite = 'weapp-tailwindcss' | 'weapp-vite'
+
+export interface CampaignCreative {
+  brand: string
+  copy: string
+  logoAlt: string
+  logoDarkSrc?: string
+  logoSrc: string
+}
+
+export interface DisplayCampaign {
+  creative: Record<CampaignLocale, CampaignCreative>
+  href: string
+  id: string
+  site: CampaignSite
+}
+
+export interface PaidCampaign extends DisplayCampaign {
+  endsAt: string
+  startsAt: string
+}
+
+export const paidCampaigns: PaidCampaign[] = []
+
+export const fallbackCampaign: DisplayCampaign = {
+  creative: {
+    'en': {
+      brand: 'Advertise on weapp-vite',
+      copy: 'Exclusive desktop documentation placement for developer tools',
+      logoAlt: 'weapp-vite logo',
+      logoSrc: '/logo.svg',
+    },
+    'zh-cn': {
+      brand: '在 weapp-vite 投放广告',
+      copy: '面向开发者工具的桌面文档侧栏独占广告位',
+      logoAlt: 'weapp-vite 标志',
+      logoSrc: '/logo.svg',
+    },
+  },
+  href: 'https://github.com/sonofmagic/sponsors/issues/new?template=business-sponsorship-zh.yml',
+  id: 'weapp-vite-house-ad',
+  site: 'weapp-vite',
+}
+
+function toTimestamp(value: string, campaignId: string, field: 'startsAt' | 'endsAt'): number {
+  const timestamp = Date.parse(value)
+  if (!Number.isFinite(timestamp)) {
+    throw new TypeError(`Campaign "${campaignId}" has an invalid ${field}`)
+  }
+  return timestamp
+}
+
+function getCampaignInterval(campaign: PaidCampaign): [number, number] {
+  const startsAt = toTimestamp(campaign.startsAt, campaign.id, 'startsAt')
+  const endsAt = toTimestamp(campaign.endsAt, campaign.id, 'endsAt')
+  if (startsAt >= endsAt) {
+    throw new RangeError(`Campaign "${campaign.id}" must end after it starts`)
+  }
+  return [startsAt, endsAt]
+}
+
+export function assertNoCampaignOverlaps(campaigns: readonly PaidCampaign[]): void {
+  const campaignsBySite = new Map<CampaignSite, Array<{ campaign: PaidCampaign, endsAt: number, startsAt: number }>>()
+
+  for (const campaign of campaigns) {
+    const [startsAt, endsAt] = getCampaignInterval(campaign)
+    const siteCampaigns = campaignsBySite.get(campaign.site) ?? []
+    siteCampaigns.push({ campaign, endsAt, startsAt })
+    campaignsBySite.set(campaign.site, siteCampaigns)
+  }
+
+  for (const siteCampaigns of campaignsBySite.values()) {
+    siteCampaigns.sort((left, right) => left.startsAt - right.startsAt)
+    for (let index = 1; index < siteCampaigns.length; index += 1) {
+      const previous = siteCampaigns[index - 1]
+      const current = siteCampaigns[index]
+      if (current.startsAt < previous.endsAt) {
+        throw new RangeError(`Campaigns "${previous.campaign.id}" and "${current.campaign.id}" overlap on ${current.campaign.site}`)
+      }
+    }
+  }
+}
+
+export function selectActiveCampaign(
+  campaigns: readonly PaidCampaign[],
+  site: CampaignSite,
+  now: Date = new Date(),
+): PaidCampaign | undefined {
+  const timestamp = now.getTime()
+  if (!Number.isFinite(timestamp)) {
+    throw new TypeError('Campaign selection requires a valid date')
+  }
+
+  const activeCampaigns = campaigns.filter((campaign) => {
+    if (campaign.site !== site) {
+      return false
+    }
+    const [startsAt, endsAt] = getCampaignInterval(campaign)
+    return startsAt <= timestamp && timestamp < endsAt
+  })
+
+  if (activeCampaigns.length > 1) {
+    throw new RangeError(`Multiple active campaigns found for ${site}`)
+  }
+  return activeCampaigns[0]
+}
+
+export function selectDisplayCampaign(
+  campaigns: readonly PaidCampaign[],
+  site: CampaignSite,
+  fallback: DisplayCampaign,
+  now: Date = new Date(),
+): DisplayCampaign {
+  return selectActiveCampaign(campaigns, site, now) ?? fallback
+}
+
+assertNoCampaignOverlaps(paidCampaigns)


### PR DESCRIPTION
## 变更内容

- 通过 VitePress `aside-ads-after` slot 增加桌面文档侧栏广告卡
- 新增带站点、起止时间、中英文素材和链接信息的 campaign 配置
- 采用 `[startsAt, endsAt)` 时间边界，并在配置加载及运行时阻止同站重叠排期
- 无付费排期时展示项目自有的广告申请卡，付费 campaign 生效后自动替换
- 支持浅色/深色模式、固定高度、Logo、两行文案截断、移动隐藏和安全外链属性
- 明确站点语言为 `zh-CN`，使页面语义和广告文案选择一致

## 验证

- campaign 单测：生效前、生效中、到期后、兜底、30/90 天边界与排期冲突
- `pnpm --filter website-weapp-vite test`（22 项通过）
- `pnpm --filter website-weapp-vite build`
- 相关文件 ESLint 与 SponsorAd 样式 Stylelint 通过
- Playwright 检查 slot 桌面展示、移动隐藏、浅色/深色、长文案、Logo、固定高度与横向溢出

## 补充

仓库当前单独运行全量 `vue-tsc` 仍会命中既有的 Dashboard、SEO、主题和第三方组件类型错误；本次新增文件不在错误列表中，VitePress 生产构建已通过。

## Changeset

纯网站展示改动，不涉及包发布，无需 changeset。