### PR TITLE
docs: 修复 Star History 图表显示

### DIFF
--- a/README.en-US.md
+++ b/README.en-US.md
@@ -117,7 +117,7 @@ Thanks to [all contributors](https://github.com/weapp-vite/weapp-vite/graphs/con
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=weapp-vite/weapp-vite&type=Date)](https://star-history.com/#weapp-vite/weapp-vite&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=weapp-vite/weapp-vite&type=Date)](https://star-history.dera.page/#weapp-vite/weapp-vite&Date)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ pnpm build:docs
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=weapp-vite/weapp-vite&type=Date)](https://star-history.com/#weapp-vite/weapp-vite&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=weapp-vite/weapp-vite&type=Date)](https://star-history.dera.page/#weapp-vite/weapp-vite&Date)
 
 ## 许可证
 


### PR DESCRIPTION
当前 README 中的 Star History 图表已经无法正常加载，原因是 GitHub stargazer API 的限制。我们将图表切换到可用的数据源 star-history.dera.page，该方案无需 API token，已有多仓库采用，可稳定展示 star 增长曲线。

同步更新了 README.md 与 README.en-US.md 中的图表链接。