### PR TITLE
fix(miniprogram-automator): route fallback 元素补齐只读能力(offset/size/style/attribute)

### DIFF
--- a/.changeset/route-fallback-element-reads.md
+++ b/.changeset/route-fallback-element-reads.md
@@ -2,4 +2,4 @@
 "@weapp-vite/miniprogram-automator": patch
 ---
 
-App-Service route 降级元素补齐只读能力：`offset()`/`size()`/`style()`/`attribute()` 经 `createSelectorQuery` 实时读取快照（每次读取重新查询，滚动/重渲染后仍新鲜），证据截图高亮框与可见性断言在 page-frame 协议失效的 DevTools 版本（如 2.01.2510290）上恢复可用；`text()`/`value()`/`property()`/`wxml()` 与交互方法改为带替代建议的明确报错，不再挂起 30s 才超时。
+App-Service route 降级元素补齐只读能力：`offset()`/`size()`/`style()`/`attribute()` 经 `createSelectorQuery` 按原始组件作用域实时读取快照（每次读取重新查询，滚动/重渲染后仍新鲜），证据截图高亮框与可见性断言在 page-frame 协议失效的 DevTools 版本（如 2.01.2510290）上恢复可用；`text()`/`value()`/`property()`/`wxml()`、元素级查询与交互方法改为带替代建议的明确报错，不再等待失效协议超时。

--- a/.changeset/route-fallback-element-reads.md
+++ b/.changeset/route-fallback-element-reads.md
@@ -1,0 +1,5 @@
+---
+"@weapp-vite/miniprogram-automator": patch
+---
+
+App-Service route 降级元素补齐只读能力：`offset()`/`size()`/`style()`/`attribute()` 经 `createSelectorQuery` 实时读取快照（每次读取重新查询，滚动/重渲染后仍新鲜），证据截图高亮框与可见性断言在 page-frame 协议失效的 DevTools 版本（如 2.01.2510290）上恢复可用；`text()`/`value()`/`property()`/`wxml()` 与交互方法改为带替代建议的明确报错，不再挂起 30s 才超时。

--- a/e2e/ide/github-issues.runtime.issue706.test.ts
+++ b/e2e/ide/github-issues.runtime.issue706.test.ts
@@ -46,6 +46,10 @@ describe.sequential('e2e app: github-issues / issue #706', () => {
       const startedAt = Date.now()
       const helloElements = await issuePage.$$('.hello', { timeout: 5_000 })
       const hello = await issuePage.$('.hello', { timeout: 5_000 })
+      const helloOffset = await hello?.offset()
+      const helloSize = await hello?.size()
+      const helloDisplay = await hello?.style('display')
+      const helloStatus = await hello?.attribute('data-issue706-status')
       const status = await issuePage.data('probeStatus', { timeout: 5_000 })
       await issuePage.setData({ probeStatus: 'updated' })
       const updatedStatus = await issuePage.data('probeStatus', { timeout: 5_000 })
@@ -53,6 +57,18 @@ describe.sequential('e2e app: github-issues / issue #706', () => {
 
       expect(helloElements.length).toBeGreaterThan(0)
       expect(hello).not.toBeNull()
+      expect(helloOffset).toEqual(expect.objectContaining({
+        height: expect.any(Number),
+        left: expect.any(Number),
+        top: expect.any(Number),
+        width: expect.any(Number),
+      }))
+      expect(helloSize).toEqual({
+        height: helloOffset?.height,
+        width: helloOffset?.width,
+      })
+      expect(helloDisplay).toEqual(expect.any(String))
+      expect(helloStatus).toBe('ready')
       expect(status).toBe('ready')
       expect(updatedStatus).toBe('updated')
       expect(runtime).toMatchObject({ ok: false, status: 'method' })

--- a/packages/miniprogram-automator/README.md
+++ b/packages/miniprogram-automator/README.md
@@ -107,6 +107,24 @@ await button?.tap()
 await page.waitFor(500)
 ```
 
+### 4.5 App-Service 降级（route fallback）能力边界
+
+部分 DevTools 版本（如 `2.01.2510290`）的 page-frame 定向协议失效，表现为 `Page.*` RPC 全部超时。此时本库自动切换到 App-Service 降级通道（`App.callFunction` + `wx.createSelectorQuery`），无需任何配置。
+
+降级模式下各能力可用性：
+
+| 能力                                                      | 状态        | 说明                                                                                           |
+| --------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------- |
+| `page.$` / `page.$$`                                      | ✅          | 经 route 查询返回降级元素                                                                      |
+| `page.data()` / `page.setData()` / `page.callMethod()`    | ✅          | 经 App-Service 读写页面数据、调用页面方法                                                      |
+| `element.offset()` / `element.size()` / `element.style()` | ✅          | 实时经 `createSelectorQuery` 读取 rect 与 computedStyle（每次读取都重新查询，不缓存）          |
+| `element.attribute('id')` / `element.attribute('data-*')` | ✅          | 经快照读取 id 与 dataset                                                                       |
+| `element.text()`                                          | ❌ 明确报错 | `SelectorQuery` 无法读取 `innerText`；请改用 `page.data()` 或 `page.callMethod()` 断言文案来源 |
+| `element.tap()` / `trigger()` 等真实交互                  | ❌ 明确报错 | AppService 无法合成真实触摸事件；请改用 `page.callMethod()` 或 `evaluate` 间接触发页面逻辑     |
+| `scroll-view` 容器滚动                                    | ❌          | 需 page-frame 协议支持，降级模式不可用                                                         |
+
+> 降级元素上的不支持操作会**立即抛出带替代建议的错误**，不会再像旧版那样挂起 30s 才超时。
+
 ## 5. 主要导出
 
 | 导出                      | 说明                                     |

--- a/packages/miniprogram-automator/README.md
+++ b/packages/miniprogram-automator/README.md
@@ -119,6 +119,7 @@ await page.waitFor(500)
 | `page.data()` / `page.setData()` / `page.callMethod()`    | ✅          | 经 App-Service 读写页面数据、调用页面方法                                                      |
 | `element.offset()` / `element.size()` / `element.style()` | ✅          | 实时经 `createSelectorQuery` 读取 rect 与 computedStyle（每次读取都重新查询，不缓存）          |
 | `element.attribute('id')` / `element.attribute('data-*')` | ✅          | 经快照读取 id 与 dataset                                                                       |
+| `element.$()` / `element.$$()`                            | ❌ 明确报错 | 元素级查询依赖 page-frame 协议；请改用 `page.$()` / `page.$$()`                                |
 | `element.text()`                                          | ❌ 明确报错 | `SelectorQuery` 无法读取 `innerText`；请改用 `page.data()` 或 `page.callMethod()` 断言文案来源 |
 | `element.tap()` / `trigger()` 等真实交互                  | ❌ 明确报错 | AppService 无法合成真实触摸事件；请改用 `page.callMethod()` 或 `evaluate` 间接触发页面逻辑     |
 | `scroll-view` 容器滚动                                    | ❌          | 需 page-frame 协议支持，降级模式不可用                                                         |

--- a/packages/miniprogram-automator/src/Element.ts
+++ b/packages/miniprogram-automator/src/Element.ts
@@ -17,6 +17,7 @@ export interface IElementOptions {
   routeFallbackIndex?: number
   routeFallbackRoute?: string
   routeFallbackQuery?: Record<string, any>
+  routeFallbackScopeSelectors?: string[]
   tagName: string
 }
 /** ITouch 的类型定义。 */
@@ -261,6 +262,7 @@ export class RouteFallbackElement extends Element {
   private readonly routeIndex?: number
   private readonly routeRoute?: string
   private readonly routeQuery?: Record<string, any>
+  private readonly routeScopeSelectors: string[]
 
   constructor(connection: Connection, options: IElementOptions, elementMap: Map<string, Element>) {
     super(connection, options, elementMap)
@@ -268,6 +270,7 @@ export class RouteFallbackElement extends Element {
     this.routeIndex = options.routeFallbackIndex
     this.routeRoute = options.routeFallbackRoute
     this.routeQuery = options.routeFallbackQuery
+    this.routeScopeSelectors = options.routeFallbackScopeSelectors ?? []
   }
 
   /**
@@ -284,12 +287,21 @@ export class RouteFallbackElement extends Element {
       this.routeQuery ?? {},
       this.routeSelector,
       this.routeIndex,
+      this.routeScopeSelectors,
       styleNames,
     )
   }
 
   private missingSnapshot(what: string): Error {
     return new Error(`route fallback 元素未取到${what}: ${this.routeSelector ?? '(未知选择器)'}(页面已切换或元素已卸载)`)
+  }
+
+  async $(selector: string, _options: ElementQueryOptions = {}) {
+    return this.unsupported(`Element.$(${selector})`)
+  }
+
+  async $$(selector: string, _options: ElementQueryOptions = {}) {
+    return this.unsupported(`Element.$$(${selector})`)
   }
 
   async offset() {

--- a/packages/miniprogram-automator/src/Element.ts
+++ b/packages/miniprogram-automator/src/Element.ts
@@ -2,7 +2,9 @@
  * @file 页面元素能力封装。
  */
 import type Connection from './Connection'
+import type { RouteElementSnapshot } from './pageRouteSnapshot'
 import { isStr, isUndef, sleep } from './internal/compat'
+import { readRouteElementSnapshot } from './pageRouteSnapshot'
 /** IElementOptions 的类型定义。 */
 export interface IElementOptions {
   elementId: string
@@ -10,6 +12,11 @@ export interface IElementOptions {
   videoId?: string
   pageId: number
   routeFallback?: boolean
+  /** route 降级元素的定位信息:用于只读方法经 App-service 实时重查快照。 */
+  routeFallbackSelector?: string
+  routeFallbackIndex?: number
+  routeFallbackRoute?: string
+  routeFallbackQuery?: Record<string, any>
   tagName: string
 }
 /** ITouch 的类型定义。 */
@@ -47,7 +54,7 @@ export default class Element {
   private id: string
   private pageId: number
   private publicProps?: Record<string, any>
-  constructor(private connection: Connection, options: IElementOptions, private elementMap: ElementMap) {
+  constructor(protected readonly connection: Connection, options: IElementOptions, private elementMap: ElementMap) {
     this.id = options.elementId
     this.pageId = options.pageId
     this.nodeId = options.nodeId || null
@@ -250,8 +257,112 @@ export default class Element {
 }
 /** App-Service 路由降级元素仅用于只读查询，不能伪装成交互协议元素。 */
 export class RouteFallbackElement extends Element {
+  private readonly routeSelector?: string
+  private readonly routeIndex?: number
+  private readonly routeRoute?: string
+  private readonly routeQuery?: Record<string, any>
+
+  constructor(connection: Connection, options: IElementOptions, elementMap: Map<string, Element>) {
+    super(connection, options, elementMap)
+    this.routeSelector = options.routeFallbackSelector
+    this.routeIndex = options.routeFallbackIndex
+    this.routeRoute = options.routeFallbackRoute
+    this.routeQuery = options.routeFallbackQuery
+  }
+
+  /**
+   * 经 App-service SelectorQuery 实时重查元素快照(rect/size/dataset/computedStyle)。
+   * 每次读取都重新查询,保证滚动/重渲染后拿到的是当前值;未命中返回 null。
+   */
+  private async readSnapshot(styleNames: string[] = []): Promise<RouteElementSnapshot | null> {
+    if (!this.routeSelector || this.routeIndex === undefined || !this.routeRoute) {
+      return null
+    }
+    return await readRouteElementSnapshot(
+      this.connection,
+      this.routeRoute,
+      this.routeQuery ?? {},
+      this.routeSelector,
+      this.routeIndex,
+      styleNames,
+    )
+  }
+
+  private missingSnapshot(what: string): Error {
+    return new Error(`route fallback 元素未取到${what}: ${this.routeSelector ?? '(未知选择器)'}(页面已切换或元素已卸载)`)
+  }
+
+  async offset() {
+    const snapshot = await this.readSnapshot()
+    if (snapshot?.left === undefined || snapshot.top === undefined) {
+      throw this.missingSnapshot('坐标')
+    }
+    return { left: snapshot.left, top: snapshot.top, width: snapshot.width, height: snapshot.height }
+  }
+
+  async size() {
+    const snapshot = await this.readSnapshot()
+    if (snapshot?.width === undefined || snapshot.height === undefined) {
+      throw this.missingSnapshot('尺寸')
+    }
+    return { width: snapshot.width, height: snapshot.height }
+  }
+
+  async style(name: string) {
+    if (!isStr(name)) {
+      throw new Error('name must be a string')
+    }
+    const snapshot = await this.readSnapshot([name])
+    const value = snapshot?.[name]
+    if (value === undefined) {
+      throw this.missingSnapshot(`样式 ${name}`)
+    }
+    return value as string
+  }
+
+  async attribute(name: string) {
+    if (!isStr(name)) {
+      throw new Error('name must be a string')
+    }
+    const snapshot = await this.readSnapshot()
+    if (name === 'id') {
+      return snapshot?.id as string | undefined
+    }
+    if (name.startsWith('data-')) {
+      const key = name.slice(5).replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase())
+      return snapshot?.dataset?.[key] as string | undefined
+    }
+    throw new Error(`route fallback 元素仅支持读取 id 与 data-* 属性,不支持 attribute(${name})`)
+  }
+
   private unsupported(method: string): never {
-    throw new Error(`App-Service route fallback 元素不支持 ${method}`)
+    throw new Error(
+      `App-Service route fallback 元素不支持 ${method}(真实交互依赖已失效的 page-frame 协议);`
+      + '可改用 page.callMethod()/evaluate 间接触发页面逻辑',
+    )
+  }
+
+  async text() {
+    throw new Error(
+      'App-Service route fallback 元素不支持 text(SelectorQuery 无法读取 innerText);'
+      + '请改用 page.data() 断言数据源,或 page.callMethod()/evaluate 读取',
+    )
+  }
+
+  async value() {
+    this.unsupported('Element.value')
+  }
+
+  async property(name: string) {
+    this.unsupported(`Element.property(${name})`)
+  }
+
+  async wxml() {
+    this.unsupported('Element.wxml')
+  }
+
+  async outerWxml() {
+    this.unsupported('Element.outerWxml')
   }
 
   async tap() {

--- a/packages/miniprogram-automator/src/Page.ts
+++ b/packages/miniprogram-automator/src/Page.ts
@@ -958,6 +958,7 @@ export default class Page {
       index,
       this.path,
       this.query,
+      options.componentSelectors,
     ))
   }
 

--- a/packages/miniprogram-automator/src/Page.ts
+++ b/packages/miniprogram-automator/src/Page.ts
@@ -956,6 +956,8 @@ export default class Page {
       selector,
       node,
       index,
+      this.path,
+      this.query,
     ))
   }
 

--- a/packages/miniprogram-automator/src/objects.test.ts
+++ b/packages/miniprogram-automator/src/objects.test.ts
@@ -237,6 +237,119 @@ describe('Page', () => {
     expect(send).not.toHaveBeenCalledWith('Element.tap', expect.anything())
   })
 
+  it('reads offset/size/style/attributes on route fallback elements via app-service snapshot', async () => {
+    const timeoutError = Object.assign(
+      new Error('DevTools did not respond to protocol method Page.getElement within 2500ms'),
+      {
+        code: 'DEVTOOLS_PROTOCOL_TIMEOUT',
+        method: 'Page.getElement',
+      },
+    )
+    const send = vi.fn(async (method: string, params?: Record<string, any>) => {
+      if (method === 'Page.getElement') {
+        throw timeoutError
+      }
+      if (method === 'App.callFunction') {
+        const declaration = params?.functionDeclaration as string
+        // 快照读取(functionDeclaration 带 computedStyle 字段)
+        if (declaration.includes('computedStyle')) {
+          return {
+            result: {
+              id: 'hero',
+              dataset: { type: 'banner' },
+              left: 12,
+              top: 34,
+              width: 100,
+              height: 40,
+              display: 'block',
+            },
+          }
+        }
+        // renderedNodes 元素查询
+        return { result: [{ id: 'hero' }] }
+      }
+      throw new Error(`${method} should not be called`)
+    })
+    const page = new Page(createConnection(send), { id: 7, path: '/pages/index', query: {} })
+    const element = await page.$('.hero')
+
+    await expect(element?.offset()).resolves.toEqual({ left: 12, top: 34, width: 100, height: 40 })
+    await expect(element?.size()).resolves.toEqual({ width: 100, height: 40 })
+    await expect(element?.style('display')).resolves.toBe('block')
+    await expect(element?.attribute('id')).resolves.toBe('hero')
+    await expect(element?.attribute('data-type')).resolves.toBe('banner')
+
+    const snapshotCalls = vi.mocked(send).mock.calls.filter(
+      ([method, params]) => method === 'App.callFunction'
+        && (params?.functionDeclaration as string).includes('computedStyle'),
+    )
+    // offset/size/attribute 不带 styleNames;style 调用携带请求的样式名
+    expect(snapshotCalls[0]?.[1]?.args).toEqual(['/pages/index', {}, '.hero', 0, []])
+    expect(
+      snapshotCalls.some(([, params]) => JSON.stringify(params?.args?.[4]) === JSON.stringify(['display'])),
+    ).toBe(true)
+  })
+
+  it('re-queries the snapshot on every read so values stay fresh', async () => {
+    const timeoutError = Object.assign(
+      new Error('DevTools did not respond to protocol method Page.getElement within 2500ms'),
+      {
+        code: 'DEVTOOLS_PROTOCOL_TIMEOUT',
+        method: 'Page.getElement',
+      },
+    )
+    const rects = [
+      { left: 0, top: 0, width: 10, height: 10 },
+      { left: 0, top: 200, width: 10, height: 10 },
+    ]
+    let snapshotReads = 0
+    const send = vi.fn(async (method: string, params?: Record<string, any>) => {
+      if (method === 'Page.getElement') {
+        throw timeoutError
+      }
+      if (method === 'App.callFunction') {
+        const declaration = params?.functionDeclaration as string
+        if (declaration.includes('computedStyle')) {
+          const result = rects[Math.min(snapshotReads, rects.length - 1)]
+          snapshotReads += 1
+          return { result }
+        }
+        return { result: [{ id: 'hero' }] }
+      }
+      throw new Error(`${method} should not be called`)
+    })
+    const page = new Page(createConnection(send), { id: 7, path: '/pages/index', query: {} })
+    const element = await page.$('.hero')
+
+    await expect(element?.offset()).resolves.toMatchObject({ top: 0 })
+    await expect(element?.offset()).resolves.toMatchObject({ top: 200 })
+    expect(snapshotReads).toBe(2)
+  })
+
+  it('throws a clear error for text() on route fallback elements', async () => {
+    const timeoutError = Object.assign(
+      new Error('DevTools did not respond to protocol method Page.getElement within 2500ms'),
+      {
+        code: 'DEVTOOLS_PROTOCOL_TIMEOUT',
+        method: 'Page.getElement',
+      },
+    )
+    const send = vi.fn(async (method: string) => {
+      if (method === 'Page.getElement') {
+        throw timeoutError
+      }
+      if (method === 'App.callFunction') {
+        return { result: [{ id: 'hero' }] }
+      }
+      throw new Error(`${method} should not be called`)
+    })
+    const page = new Page(createConnection(send), { id: 7, path: '/pages/index', query: {} })
+    const element = await page.$('.hero')
+
+    await expect(element?.text()).rejects.toThrow('route fallback 元素不支持 text')
+    expect(send).not.toHaveBeenCalledWith('Element.getDOMProperties', expect.anything(), expect.anything())
+  })
+
   it('forces native Page RPC when fallback is disabled after a prior protocol timeout', async () => {
     const timeoutError = Object.assign(
       new Error('DevTools did not respond to protocol method Page.getElements within 2500ms'),

--- a/packages/miniprogram-automator/src/objects.test.ts
+++ b/packages/miniprogram-automator/src/objects.test.ts
@@ -271,7 +271,7 @@ describe('Page', () => {
       throw new Error(`${method} should not be called`)
     })
     const page = new Page(createConnection(send), { id: 7, path: '/pages/index', query: {} })
-    const element = await page.$('.hero')
+    const element = await page.$('.hero', { componentSelectors: ['weapp-layout-admin'] })
 
     await expect(element?.offset()).resolves.toEqual({ left: 12, top: 34, width: 100, height: 40 })
     await expect(element?.size()).resolves.toEqual({ width: 100, height: 40 })
@@ -284,9 +284,16 @@ describe('Page', () => {
         && (params?.functionDeclaration as string).includes('computedStyle'),
     )
     // offset/size/attribute 不带 styleNames;style 调用携带请求的样式名
-    expect(snapshotCalls[0]?.[1]?.args).toEqual(['/pages/index', {}, '.hero', 0, []])
+    expect(snapshotCalls[0]?.[1]?.args).toEqual([
+      '/pages/index',
+      {},
+      '.hero',
+      0,
+      ['weapp-layout-admin'],
+      [],
+    ])
     expect(
-      snapshotCalls.some(([, params]) => JSON.stringify(params?.args?.[4]) === JSON.stringify(['display'])),
+      snapshotCalls.some(([, params]) => JSON.stringify(params?.args?.[5]) === JSON.stringify(['display'])),
     ).toBe(true)
   })
 
@@ -348,6 +355,32 @@ describe('Page', () => {
 
     await expect(element?.text()).rejects.toThrow('route fallback 元素不支持 text')
     expect(send).not.toHaveBeenCalledWith('Element.getDOMProperties', expect.anything(), expect.anything())
+  })
+
+  it('rejects nested queries on app-service route fallback elements without page-frame RPCs', async () => {
+    const timeoutError = Object.assign(
+      new Error('DevTools did not respond to protocol method Page.getElement within 2500ms'),
+      {
+        code: 'DEVTOOLS_PROTOCOL_TIMEOUT',
+        method: 'Page.getElement',
+      },
+    )
+    const send = vi.fn(async (method: string) => {
+      if (method === 'Page.getElement') {
+        throw timeoutError
+      }
+      if (method === 'App.callFunction') {
+        return { result: [{ id: 'hero' }] }
+      }
+      throw new Error(`${method} should not be called for route fallback nested queries`)
+    })
+    const page = new Page(createConnection(send), { id: 7, path: '/pages/index', query: {} })
+    const element = await page.$('.hero')
+
+    await expect(element?.$('.label')).rejects.toThrow('route fallback 元素不支持 Element.$')
+    await expect(element?.$$('.label')).rejects.toThrow('route fallback 元素不支持 Element.$$')
+    expect(send).not.toHaveBeenCalledWith('Element.getElement', expect.anything(), expect.anything())
+    expect(send).not.toHaveBeenCalledWith('Element.getElements', expect.anything(), expect.anything())
   })
 
   it('forces native Page RPC when fallback is disabled after a prior protocol timeout', async () => {

--- a/packages/miniprogram-automator/src/pageRouteFallback.ts
+++ b/packages/miniprogram-automator/src/pageRouteFallback.ts
@@ -28,6 +28,8 @@ export function createRouteFallbackElement(
   selector: string,
   node: RouteRenderedNode,
   index: number,
+  route: string,
+  query: Record<string, any>,
 ) {
   const nodeId = typeof node.id === 'string' && node.id
     ? normalizeFallbackIdPart(node.id)
@@ -38,5 +40,9 @@ export function createRouteFallbackElement(
     pageId,
     routeFallback: true,
     tagName: resolveFallbackTagName(selector),
+    routeFallbackSelector: selector,
+    routeFallbackIndex: index,
+    routeFallbackRoute: route,
+    routeFallbackQuery: query,
   }, elementMap)
 }

--- a/packages/miniprogram-automator/src/pageRouteFallback.ts
+++ b/packages/miniprogram-automator/src/pageRouteFallback.ts
@@ -30,6 +30,7 @@ export function createRouteFallbackElement(
   index: number,
   route: string,
   query: Record<string, any>,
+  scopeSelectors: string[] = [],
 ) {
   const nodeId = typeof node.id === 'string' && node.id
     ? normalizeFallbackIdPart(node.id)
@@ -44,5 +45,6 @@ export function createRouteFallbackElement(
     routeFallbackIndex: index,
     routeFallbackRoute: route,
     routeFallbackQuery: query,
+    routeFallbackScopeSelectors: [...scopeSelectors],
   }, elementMap)
 }

--- a/packages/miniprogram-automator/src/pageRouteSnapshot.ts
+++ b/packages/miniprogram-automator/src/pageRouteSnapshot.ts
@@ -1,0 +1,232 @@
+/**
+ * @file 页面 route 降级元素的只读快照读取(rect/size/dataset/computedStyle)。
+ *
+ * 背景:部分 DevTools 版本(如 2.01.2510290)的 page-frame 定向协议失效,
+ * `Element.getDOMProperties`/`Element.getOffset` 等 RPC 全部超时。本模块复用
+ * route 降级思路,把只读信息经 `App.callFunction` + `wx.createSelectorQuery`
+ * 在 AppService 内实时取回——每次读取都重新查询,避免滚动/重渲染后拿到过期快照。
+ */
+import type Connection from './Connection'
+
+/** 降级元素只读快照(rect 字段平铺在节点上;computedStyle 按请求的属性名平铺)。 */
+export interface RouteElementSnapshot {
+  bottom?: number
+  dataset?: Record<string, unknown>
+  height?: number
+  id?: string
+  left?: number
+  right?: number
+  top?: number
+  width?: number
+  [styleName: string]: unknown
+}
+
+const ROUTE_ELEMENT_SNAPSHOT_TIMEOUT = 5_000
+
+/**
+ * 页面定位 + 组件作用域遍历逻辑与 Page.renderedNodes 保持一致:
+ * 先按 route/query 找到目标页面,再逐层进入自定义组件作用域查询,
+ * 返回首个命中作用域里 selectAll(selector)[index] 的快照;未命中返回 null。
+ */
+const ROUTE_ELEMENT_SNAPSHOT_FUNCTION_DECLARATION = `function (route, query, selector, index, styleNames) {
+  function normalizeRoute(value) {
+    return String(value || '').replace(/^\\/+/, '').replace(/\\/+$/g, '');
+  }
+  function matchesQuery(page, expectedQuery) {
+    if (!expectedQuery || !Object.keys(expectedQuery).length) {
+      return true;
+    }
+    var actualQuery = page && (page.options || page.query || {});
+    return Object.keys(expectedQuery).every(function (key) {
+      var actualValue = String(actualQuery[key] == null ? '' : actualQuery[key]);
+      var expectedValue = String(expectedQuery[key]);
+      var decodedActualValue = actualValue;
+      try {
+        decodedActualValue = decodeURIComponent(actualValue);
+      }
+      catch (_) {
+      }
+      return actualValue === expectedValue
+        || decodedActualValue === expectedValue
+        || actualValue === encodeURIComponent(expectedValue);
+    });
+  }
+  var pages = typeof getCurrentPages === 'function' ? getCurrentPages() : [];
+  var expectedRoute = normalizeRoute(route);
+  var page = null;
+  for (var pageIndex = pages.length - 1; pageIndex >= 0; pageIndex -= 1) {
+    var candidate = pages[pageIndex];
+    var candidateRoute = normalizeRoute(candidate && (candidate.path || candidate.route || candidate.__route__));
+    if ((!expectedRoute || candidateRoute === expectedRoute) && matchesQuery(candidate, query)) {
+      page = candidate;
+      break;
+    }
+  }
+  if (!page) {
+    return null;
+  }
+  function createSelectorQuery(scope) {
+    var selectorQuery = null;
+    var createdFromScope = false;
+    if (scope && typeof scope.createSelectorQuery === 'function') {
+      selectorQuery = scope.createSelectorQuery();
+      createdFromScope = true;
+    }
+    else if (typeof wx !== 'undefined' && wx && typeof wx.createSelectorQuery === 'function') {
+      selectorQuery = wx.createSelectorQuery();
+    }
+    else if (typeof page.createSelectorQuery === 'function') {
+      selectorQuery = page.createSelectorQuery();
+    }
+    if (!selectorQuery) {
+      return null;
+    }
+    if (!createdFromScope && typeof selectorQuery.in === 'function') {
+      try {
+        selectorQuery = selectorQuery.in(scope || page);
+      }
+      catch (_) {
+      }
+    }
+    return selectorQuery;
+  }
+  function pushUnique(list, seen, item) {
+    if (!item) {
+      return;
+    }
+    var id = item.is || item.id || item.__wxWebviewId__ || item.__wxExparserNodeId__ || String(list.length);
+    if (seen[id]) {
+      return;
+    }
+    seen[id] = true;
+    list.push(item);
+  }
+  function collectScopes(root) {
+    var scopes = [];
+    var seen = {};
+    var queue = [];
+    pushUnique(scopes, seen, root);
+    queue.push(root);
+    for (var queueIndex = 0; queueIndex < queue.length && queueIndex < 60; queueIndex += 1) {
+      var scope = queue[queueIndex];
+      if (!scope || typeof scope.selectAllComponents !== 'function') {
+        continue;
+      }
+      var children = [];
+      var componentSelectors = [selector, '*', 'weapp-app-shell', 'weapp-layout-default'];
+      for (var selectorIndex = 0; selectorIndex < componentSelectors.length; selectorIndex += 1) {
+        if (!componentSelectors[selectorIndex]) {
+          continue;
+        }
+        try {
+          var selected = scope.selectAllComponents(componentSelectors[selectorIndex]);
+          if (Array.isArray(selected)) {
+            children = children.concat(selected);
+          }
+        }
+        catch (_) {
+        }
+      }
+      for (var childIndex = 0; childIndex < children.length; childIndex += 1) {
+        var child = children[childIndex];
+        var previousLength = scopes.length;
+        pushUnique(scopes, seen, child);
+        if (scopes.length > previousLength) {
+          queue.push(child);
+        }
+      }
+    }
+    return scopes;
+  }
+  function queryScope(scope) {
+    return new Promise(function (resolve) {
+      var settled = false;
+      var timer = setTimeout(function () {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        resolve([]);
+      }, 800);
+      function finish(nodes) {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        resolve(Array.isArray(nodes) ? nodes : nodes ? [nodes] : []);
+      }
+      try {
+        var selectorQuery = createSelectorQuery(scope);
+        if (!selectorQuery) {
+          finish([]);
+          return;
+        }
+        selectorQuery
+          .selectAll(selector)
+          .fields({
+            id: true,
+            dataset: true,
+            rect: true,
+            size: true,
+            computedStyle: Array.isArray(styleNames) ? styleNames : []
+          }, function (nodes) {
+            finish(nodes);
+          })
+          .exec();
+      }
+      catch (_) {
+        finish([]);
+      }
+    });
+  }
+  return new Promise(function (resolve) {
+    try {
+      var scopes = collectScopes(page);
+      var scopeIndex = 0;
+      function next() {
+        if (scopeIndex >= scopes.length) {
+          resolve(null);
+          return;
+        }
+        var scope = scopes[scopeIndex];
+        scopeIndex += 1;
+        queryScope(scope).then(function (nodes) {
+          if (nodes.length > 0) {
+            resolve(nodes[index] || null);
+            return;
+          }
+          next();
+        }, function () {
+          next();
+        });
+      }
+      next();
+    }
+    catch (_) {
+      resolve(null);
+    }
+  });
+}`
+
+/**
+ * 读取降级元素快照。未找到(页面不在/选择器无命中/索引越界)返回 null,
+ * 由调用方决定抛错文案;永不因为协议失效而长时间挂起。
+ */
+export async function readRouteElementSnapshot(
+  connection: Connection,
+  route: string,
+  query: Record<string, any>,
+  selector: string,
+  index: number,
+  styleNames: string[] = [],
+  timeout = ROUTE_ELEMENT_SNAPSHOT_TIMEOUT,
+): Promise<RouteElementSnapshot | null> {
+  const { result } = await connection.send('App.callFunction', {
+    functionDeclaration: ROUTE_ELEMENT_SNAPSHOT_FUNCTION_DECLARATION,
+    args: [route, query, selector, index, styleNames],
+  }, {
+    timeout,
+  }) as { result?: RouteElementSnapshot | null }
+  return result ?? null
+}

--- a/packages/miniprogram-automator/src/pageRouteSnapshot.ts
+++ b/packages/miniprogram-automator/src/pageRouteSnapshot.ts
@@ -28,7 +28,7 @@ const ROUTE_ELEMENT_SNAPSHOT_TIMEOUT = 5_000
  * 先按 route/query 找到目标页面,再逐层进入自定义组件作用域查询,
  * 返回首个命中作用域里 selectAll(selector)[index] 的快照;未命中返回 null。
  */
-const ROUTE_ELEMENT_SNAPSHOT_FUNCTION_DECLARATION = `function (route, query, selector, index, styleNames) {
+const ROUTE_ELEMENT_SNAPSHOT_FUNCTION_DECLARATION = `function (route, query, selector, index, scopeSelectors, styleNames) {
   function normalizeRoute(value) {
     return String(value || '').replace(/^\\/+/, '').replace(/\\/+$/g, '');
   }
@@ -101,7 +101,7 @@ const ROUTE_ELEMENT_SNAPSHOT_FUNCTION_DECLARATION = `function (route, query, sel
     seen[id] = true;
     list.push(item);
   }
-  function collectScopes(root) {
+  function collectScopes(root, scopeSelectors) {
     var scopes = [];
     var seen = {};
     var queue = [];
@@ -113,7 +113,8 @@ const ROUTE_ELEMENT_SNAPSHOT_FUNCTION_DECLARATION = `function (route, query, sel
         continue;
       }
       var children = [];
-      var componentSelectors = [selector, '*', 'weapp-app-shell', 'weapp-layout-default'];
+      var componentSelectors = Array.isArray(scopeSelectors) ? scopeSelectors.slice() : [];
+      componentSelectors.push(selector, '*', 'weapp-app-shell', 'weapp-layout-default');
       for (var selectorIndex = 0; selectorIndex < componentSelectors.length; selectorIndex += 1) {
         if (!componentSelectors[selectorIndex]) {
           continue;
@@ -182,7 +183,7 @@ const ROUTE_ELEMENT_SNAPSHOT_FUNCTION_DECLARATION = `function (route, query, sel
   }
   return new Promise(function (resolve) {
     try {
-      var scopes = collectScopes(page);
+      var scopes = collectScopes(page, scopeSelectors);
       var scopeIndex = 0;
       function next() {
         if (scopeIndex >= scopes.length) {
@@ -219,12 +220,13 @@ export async function readRouteElementSnapshot(
   query: Record<string, any>,
   selector: string,
   index: number,
+  scopeSelectors: string[] = [],
   styleNames: string[] = [],
   timeout = ROUTE_ELEMENT_SNAPSHOT_TIMEOUT,
 ): Promise<RouteElementSnapshot | null> {
   const { result } = await connection.send('App.callFunction', {
     functionDeclaration: ROUTE_ELEMENT_SNAPSHOT_FUNCTION_DECLARATION,
-    args: [route, query, selector, index, styleNames],
+    args: [route, query, selector, index, scopeSelectors, styleNames],
   }, {
     timeout,
   }) as { result?: RouteElementSnapshot | null }


### PR DESCRIPTION
## 摘要

关联 #706（`Page.*` 降级初版见 #712/#713）。`Page.*` 域降级（App-Service route fallback）目前只覆盖 `Page` 级 API：降级元素（`RouteFallbackElement`）只携带合成 `elementId` 与 `tagName`，没有节点数据——`offset()`/`size()`/`style()` 等只读方法继承自 `Element` 基类，仍把 `Element.getDOMProperties`/`Element.getOffset` 等 RPC 发往已失效的 page-frame 通道，在 DevTools `2.01.2510290` 上全部 30s 超时；`text()`/交互方法行为也不一致。本 PR 让降级元素的只读方法经 App-Service `createSelectorQuery` 实时读取快照，不可实现的能力收敛为带替代建议的明确报错。


**失效范围补充（渲染器差异）**：经同机同版本对照实测，该协议失效是 **glass-easel 渲染器特有**——`"componentFramework": "glass-easel"` 的原生工程下 `Page.*`/`Element.*` 全部超时；经典 webview（exparser）渲染器工程（无 `componentFramework` 字段的编译产物）下协议正常。#706 的最小复现之所以「全员复现」，是因为新版 DevTools 新建项目默认开启 glass-easel。也就是说本 PR 的受益面 = 所有 glass-easel 工程（微信官方推的新渲染器，新项目默认开启，影响面会持续扩大）。

## 改动

- 新增 `src/pageRouteSnapshot.ts`：经 `App.callFunction` + `wx.createSelectorQuery` 在 AppService 内读取元素快照（`rect`/`size`/`dataset`/`computedStyle`）。页面定位与组件作用域遍历逻辑与 `Page.renderedNodes` 保持一致，避免两套口径漂移。
- `RouteFallbackElement` 覆写 `offset()`/`size()`/`style(name)`/`attribute()`：每次读取都重新查询快照（不缓存），滚动/重渲染后仍新鲜；`attribute` 支持 `id` 与 `data-*`（dataset）。
- `text()`/`value()`/`property()`/`wxml()` 与 `tap()`/`trigger()` 等交互方法，由「继承基类走失效 RPC、30s 后才超时」改为**立即抛出带替代建议的错误**（如 `page.data()`、`page.callMethod()`）。
- `Element` 基类 `connection` 由 `private` 放宽为 `protected readonly`（子类重查快照需要）。
- `Page.queryRouteElements` 向降级元素透传 `route`/`query`/`selector`/`index`，供只读方法自定位。
- 新增 3 个单测（快照读取、逐次重查的新鲜度、明确报错语义）；README 增加「App-Service 降级能力边界」一节；添加 patch changeset。

## 验证

- `pnpm --filter @weapp-vite/miniprogram-automator test`（127 全过，含新增 3 个）
- `pnpm --filter @weapp-vite/miniprogram-automator lint`
- `pnpm --filter @weapp-vite/miniprogram-automator build`
- `pnpm --filter @weapp-vite/miniprogram-automator typecheck`：仅存的 `mpcore/packages/simulator` 引用 `@weapp-core/constants` 报错在上游 main 上同样存在（本地未构建该包所致），与本改动无关。
- 真机实测（DevTools 2.01.2510290 + 真实小程序模拟器）：`el.offset()` 31ms 返回 `{left:16.5, top:163, width:357, height:388.625}`，`el.style('display')` 返回 `"block"`，`el.attribute('id')` 正常；`el.text()`/`el.tap()` 由原来 30s 挂死变为 1ms 内明确报错。

## 取舍

- `text()`（innerText）与真实 `tap()` 在 App-Service 降级下协议层不可实现（`SelectorQuery` 无 innerText 读取能力，AppService 无法合成触摸事件），本 PR 不伪装成完整协议替代，而是收敛为「快速失败 + 替代路径指引」，并在 README 写清边界。
- 快照每次读取都重新查询而非缓存：单次读取多一次 AppService 往返（实测约 30ms），换取滚动/重渲染后的数据准确性。
- 仅扩展降级元素的只读能力，未触碰正常协议路径与既有 `Page` 级降级逻辑。
