### PR TITLE
fix(simulator): 完善 headless runtime 与支付宝 SJS 兼容性

### DIFF
--- a/.changeset/steady-headless-runtime.md
+++ b/.changeset/steady-headless-runtime.md
@@ -1,0 +1,7 @@
+---
+'@mpcore/simulator': patch
+'create-weapp-vite': patch
+'weapp-vite': patch
+---
+
+修复 headless simulator 对入口页、ESM/CJS 模块、测试桥接事件与运行时状态的处理，并修复支付宝 SJS 顶层 CommonJS 导出转换，补充对应回归测试。

--- a/mpcore/packages/simulator/src/browser/moduleLoader.ts
+++ b/mpcore/packages/simulator/src/browser/moduleLoader.ts
@@ -12,6 +12,7 @@ import type { BrowserVirtualFiles } from './virtualFiles'
 import { dirname, join, normalize } from 'pathe'
 import {
   createHeadlessWx,
+  normalizeComponentPageDefinition,
   registerAppDefinition,
   registerComponentDefinition,
   registerExportedComponentDefinition,
@@ -188,6 +189,7 @@ export function createBrowserModuleLoader(
         .filter(definition => !registeredDefinitionsBefore.has(definition))
       module.componentDefinitions = [...new Set([
         ...requiredComponentDefinitions,
+        ...(loadContext?.componentDefinitions ?? []),
         ...registeredDefinitions,
       ])]
       return module
@@ -209,8 +211,14 @@ export function createBrowserModuleLoader(
       return registries.appDefinition
     },
     executePageModule(filePath, route) {
-      executeModule(filePath, { kind: 'page', route })
+      const componentDefinitions: HeadlessComponentDefinition[] = []
+      const loadedModule = executeModule(filePath, { kind: 'page', route, componentDefinitions })
+      const fallbackDefinition = loadedModule.componentDefinitions.at(-1)
       const definition = registries.pages.get(route)
+        ?? (fallbackDefinition ? normalizeComponentPageDefinition(fallbackDefinition) : undefined)
+      if (!registries.pages.has(route) && definition) {
+        registerPageDefinition(registries, definition, route)
+      }
       if (!definition) {
         throw new Error(`Page() was not registered for route "${route}" while executing ${normalize(filePath)}.`)
       }

--- a/mpcore/packages/simulator/src/browser/render/component.ts
+++ b/mpcore/packages/simulator/src/browser/render/component.ts
@@ -295,9 +295,16 @@ export function createBrowserComponentInstance(
   nextProperties: Record<string, any>,
   ownerScopeId: string | undefined,
 ) {
+  const isWevuNativeDefinition = Object.keys(componentEntry.definition.methods ?? {}).some(key => key.startsWith('__weapp_vite_'))
+    || Object.hasOwn(componentEntry.definition.properties ?? {}, '__wvSlotOwnerId')
+  const componentProperties = isWevuNativeDefinition
+    ? Object.fromEntries(Object.keys(componentEntry.definition.properties ?? {})
+        .filter(key => Object.hasOwn(nextProperties, key))
+        .map(key => [key, nextProperties[key]]))
+    : nextProperties
   const componentInstance = createComponentInstance({
     definition: componentEntry.definition,
-    properties: nextProperties,
+    properties: componentProperties,
     requestRender: callback => context.session.requestRender(callback),
     triggerEvent: buildComponentTrigger(componentScopeId, context, clonedNode),
   })
@@ -312,7 +319,7 @@ export function createBrowserComponentInstance(
     : null
   context.componentCache.set(componentScopeId, componentInstance)
   runComponentLifecycle(componentInstance, 'created')
-  runComponentObservers(componentInstance.__definition__ ?? componentEntry.definition, componentInstance, Object.keys(nextProperties), {})
+  runComponentObservers(componentInstance.__definition__ ?? componentEntry.definition, componentInstance, Object.keys(componentProperties), {})
   componentInstance.__propertySnapshots = Object.fromEntries(
     Object.entries(componentInstance.properties).map(([key, propertyValue]) => [key, cloneValue(propertyValue)]),
   )

--- a/mpcore/packages/simulator/src/host/globals.ts
+++ b/mpcore/packages/simulator/src/host/globals.ts
@@ -10,6 +10,7 @@ export interface HeadlessBehaviorDefinition extends Record<string, any> {
 
 export interface HeadlessHostLoadContext {
   kind: 'app' | 'page' | 'component'
+  componentDefinitions?: HeadlessComponentDefinition[]
   route?: string
 }
 
@@ -34,7 +35,7 @@ function callDefinitionMethod(
   }
 }
 
-function normalizeComponentPageDefinition(definition: HeadlessComponentDefinition): HeadlessPageDefinition {
+export function normalizeComponentPageDefinition(definition: HeadlessComponentDefinition): HeadlessPageDefinition {
   const {
     lifetimes = {},
     methods = {},
@@ -97,8 +98,8 @@ export function registerAppDefinition(registries: HeadlessHostRegistries, defini
   return definition
 }
 
-export function registerPageDefinition(registries: HeadlessHostRegistries, definition: HeadlessPageDefinition) {
-  const route = registries.currentLoadContext?.route
+export function registerPageDefinition(registries: HeadlessHostRegistries, definition: HeadlessPageDefinition, explicitRoute?: string) {
+  const route = explicitRoute ?? registries.currentLoadContext?.route
   if (!route) {
     throw new Error('Cannot register Page() without an active page load context in headless runtime.')
   }
@@ -111,6 +112,10 @@ export function registerPageDefinition(registries: HeadlessHostRegistries, defin
 
 export function registerComponentDefinition(registries: HeadlessHostRegistries, definition: HeadlessComponentDefinition) {
   if (registries.currentLoadContext?.kind === 'page') {
+    if (registries.currentLoadContext.componentDefinitions) {
+      registries.currentLoadContext.componentDefinitions.push(definition)
+      return definition
+    }
     return registerPageDefinition(registries, normalizeComponentPageDefinition(definition))
   }
   const id = registries.currentLoadContext?.route ?? `anonymous:${registries.components.size}`

--- a/mpcore/packages/simulator/src/kernel/diagnostics.ts
+++ b/mpcore/packages/simulator/src/kernel/diagnostics.ts
@@ -6,6 +6,11 @@ export interface RuntimeDiagnosticEntry {
   timestamp: number
 }
 
+export interface RuntimeConsoleEntry {
+  args: unknown[]
+  level: 'debug' | 'error' | 'info' | 'log' | 'warn'
+}
+
 export class RuntimeDiagnostics {
   private readonly entries: RuntimeDiagnosticEntry[] = []
 
@@ -28,15 +33,23 @@ export class RuntimeDiagnostics {
     })
   }
 
-  createConsole(baseConsole: Console = console): Console {
+  createConsole(baseConsole: Console = console, onConsole?: (entry: RuntimeConsoleEntry) => void): Console {
     const runtimeConsole = Object.create(baseConsole) as Console
+    const wrap = (level: RuntimeConsoleEntry['level'], method: (...args: unknown[]) => void) => (...args: unknown[]) => {
+      if (level === 'error' || level === 'warn') {
+        this.record(level, args)
+      }
+      onConsole?.({ args: [...args], level })
+      method(...args)
+    }
+    runtimeConsole.debug = wrap('debug', baseConsole.debug.bind(baseConsole))
+    runtimeConsole.info = wrap('info', baseConsole.info.bind(baseConsole))
+    runtimeConsole.log = wrap('log', baseConsole.log.bind(baseConsole))
     runtimeConsole.error = (...args: unknown[]) => {
-      this.record('error', args)
-      baseConsole.error(...args)
+      wrap('error', baseConsole.error.bind(baseConsole))(...args)
     }
     runtimeConsole.warn = (...args: unknown[]) => {
-      this.record('warn', args)
-      baseConsole.warn(...args)
+      wrap('warn', baseConsole.warn.bind(baseConsole))(...args)
     }
     return runtimeConsole
   }

--- a/mpcore/packages/simulator/src/runtime/moduleLoader.ts
+++ b/mpcore/packages/simulator/src/runtime/moduleLoader.ts
@@ -14,6 +14,7 @@ import vm from 'node:vm'
 import { normalize } from 'pathe'
 import {
   createHeadlessWx,
+  normalizeComponentPageDefinition,
   registerAppDefinition,
   registerComponentDefinition,
   registerExportedComponentDefinition,
@@ -36,6 +37,146 @@ interface ModuleCacheEntry {
 interface LocalRequire {
   (request: string): any
   async: (request: string) => Promise<any>
+}
+
+const ESM_IMPORT_LINE_RE = /^[ \t]*import[^\n]*$/gm
+const ESM_EXPORT_LIST_RE = /^[ \t]*export[ \t]*\{([^}\n]+)\}[ \t]*;?$/gm
+const ESM_EXPORT_DECLARATION_RE = /\bexport\s+(const|let|var|function|class)\s+([A-Za-z_$][\w$]*)/g
+const ESM_EXPORT_DEFAULT_DECLARATION_RE = /\bexport\s+default\s+(function|class)\s+([A-Za-z_$][\w$]*)/g
+
+function isImportWhitespace(value: string | undefined) {
+  return value === ' ' || value === '\t'
+}
+
+type ParsedEsmImport
+  = | { request: string, sideEffect: true }
+    | { request: string, sideEffect: false, specifier: string }
+
+function parseEsmImportLine(line: string): ParsedEsmImport | undefined {
+  let statement = line.trim().slice('import'.length).trim()
+  if (statement.endsWith(';')) {
+    statement = statement.slice(0, -1).trimEnd()
+  }
+
+  if (statement.startsWith('"') || statement.startsWith('\'')) {
+    const quote = statement[0]
+    if (statement.endsWith(quote) && statement.length > 1) {
+      return {
+        request: statement.slice(1, -1),
+        sideEffect: true,
+      }
+    }
+    return
+  }
+
+  let fromIndex = statement.indexOf('from')
+  while (fromIndex >= 0) {
+    if (isImportWhitespace(statement[fromIndex - 1]) && isImportWhitespace(statement[fromIndex + 4])) {
+      break
+    }
+    fromIndex = statement.indexOf('from', fromIndex + 4)
+  }
+  if (fromIndex < 0) {
+    return
+  }
+
+  const specifier = statement.slice(0, fromIndex).trim()
+  const requestLiteral = statement.slice(fromIndex + 4).trim()
+  const quote = requestLiteral[0]
+  if (
+    !specifier
+    || (quote !== '"' && quote !== '\'')
+    || requestLiteral.length < 2
+    || !requestLiteral.endsWith(quote)
+  ) {
+    return
+  }
+  return {
+    request: requestLiteral.slice(1, -1),
+    sideEffect: false,
+    specifier,
+  }
+}
+
+function createEsmImportBindings(specifier: string, request: string, index: number) {
+  const namespaceName = `__headlessEsmImport${index}`
+  const statements = [`const ${namespaceName} = require(${JSON.stringify(request)});`]
+  const normalizedSpecifier = specifier.trim()
+
+  if (normalizedSpecifier.startsWith('{') && normalizedSpecifier.endsWith('}')) {
+    const entries = normalizedSpecifier.slice(1, -1).split(',')
+    for (const entry of entries) {
+      const [importedName, localName] = entry.trim().split(/\s+as\s+/)
+      if (!importedName) {
+        continue
+      }
+      const bindingName = localName || importedName
+      statements.push(`const ${bindingName} = ${namespaceName}[${JSON.stringify(importedName)}];`)
+    }
+    return statements.join('\n')
+  }
+
+  if (normalizedSpecifier.startsWith('* as ')) {
+    const bindingName = normalizedSpecifier.slice('* as '.length).trim()
+    statements.push(`const ${bindingName} = ${namespaceName};`)
+    return statements.join('\n')
+  }
+
+  const [defaultName, namedPart] = normalizedSpecifier.split(/\s*,\s*/, 2)
+  if (defaultName) {
+    statements.push(`const ${defaultName.trim()} = ${namespaceName}.default ?? ${namespaceName};`)
+  }
+  if (namedPart?.startsWith('{') && namedPart.endsWith('}')) {
+    statements.push(createEsmImportBindings(namedPart, request, index).split('\n').slice(1).join('\n'))
+  }
+  return statements.join('\n')
+}
+
+function transformEsmToCommonJs(source: string) {
+  if (!/^\s*(?:import|export)\b/m.test(source)) {
+    return source
+  }
+
+  let importIndex = 0
+  const exportedNames: Array<{ exported: string, local: string }> = []
+  let transformed = source.replace(ESM_IMPORT_LINE_RE, (line) => {
+    const parsed = parseEsmImportLine(line)
+    if (!parsed) {
+      return line
+    }
+    if (parsed.sideEffect) {
+      return `require(${JSON.stringify(parsed.request)});`
+    }
+    return createEsmImportBindings(parsed.specifier, parsed.request, importIndex++)
+  })
+  transformed = transformed.replace(ESM_EXPORT_LIST_RE, (_match, entries: string) => {
+    for (const entry of entries.split(',')) {
+      const [local, exported] = entry.trim().split(/\s+as\s+/)
+      if (local) {
+        exportedNames.push({
+          exported: exported || local,
+          local,
+        })
+      }
+    }
+    return ''
+  })
+  transformed = transformed.replace(ESM_EXPORT_DEFAULT_DECLARATION_RE, (_match, kind: string, local: string) => {
+    exportedNames.push({ exported: 'default', local })
+    return `${kind} ${local}`
+  })
+  transformed = transformed.replace(ESM_EXPORT_DECLARATION_RE, (_match, kind: string, local: string) => {
+    exportedNames.push({ exported: local, local })
+    return `${kind} ${local}`
+  })
+  transformed = transformed.replace(/\bexport\s+default\s+/g, 'module.exports.default = ')
+
+  if (exportedNames.length > 0) {
+    transformed += `\n${exportedNames
+      .map(({ exported, local }) => `module.exports[${JSON.stringify(exported)}] = ${local};`)
+      .join('\n')}`
+  }
+  return transformed
 }
 
 function createRequireNotFoundError(request: string, importer: string) {
@@ -71,6 +212,7 @@ function createExecutionContext(
   wxDriver: Parameters<typeof createHeadlessWx>[0],
   kernel: RuntimeKernel,
   globals: Record<string, unknown>,
+  onConsole?: (entry: import('../kernel').RuntimeConsoleEntry) => void,
 ) {
   const wx = createHeadlessWx(wxDriver)
 
@@ -90,7 +232,7 @@ function createExecutionContext(
     Page(definition: HeadlessPageDefinition) {
       return registerPageDefinition(registries, definition)
     },
-    console: kernel.diagnostics.createConsole(),
+    console: kernel.diagnostics.createConsole(console, onConsole),
     clearInterval: (handle: ReturnType<typeof setInterval>) => kernel.scheduler.clearInterval(handle),
     clearTimeout: (handle: ReturnType<typeof setTimeout>) => kernel.scheduler.clearTimeout(handle),
     getApp,
@@ -100,6 +242,10 @@ function createExecutionContext(
     require: undefined as any,
     setInterval: kernel.scheduler.setInterval.bind(kernel.scheduler),
     setTimeout: kernel.scheduler.setTimeout.bind(kernel.scheduler),
+    TextDecoder: globalThis.TextDecoder,
+    TextEncoder: globalThis.TextEncoder,
+    URL: globalThis.URL,
+    URLSearchParams: globalThis.URLSearchParams,
     wx,
     ...globals,
   }
@@ -114,6 +260,7 @@ export function createModuleLoader(
     artifactSource: ArtifactSource
     globals?: Record<string, unknown>
     kernel: RuntimeKernel
+    onConsole?: (entry: import('../kernel').RuntimeConsoleEntry) => void
   },
 ): HeadlessModuleLoader {
   const moduleCache = new Map<string, ModuleCacheEntry>()
@@ -124,6 +271,7 @@ export function createModuleLoader(
     wxDriver,
     options.kernel,
     options.globals ?? {},
+    options.onConsole,
   )
   executionContext.globalThis = executionContext
 
@@ -166,7 +314,7 @@ export function createModuleLoader(
 
     try {
       const script = new vm.Script(
-        `(function (exports, module, require, __filename, __dirname) { ${source}\n})`,
+        `(function (exports, module, require, __filename, __dirname) { ${transformEsmToCommonJs(source)}\n})`,
         {
           filename: resolvedPath,
         },
@@ -177,6 +325,7 @@ export function createModuleLoader(
         .filter(definition => !registeredDefinitionsBefore.has(definition))
       module.componentDefinitions = [...new Set([
         ...requiredComponentDefinitions,
+        ...(loadContext?.componentDefinitions ?? []),
         ...registeredDefinitions,
       ])]
       return module
@@ -198,8 +347,14 @@ export function createModuleLoader(
       return registries.appDefinition
     },
     executePageModule(filePath, route) {
-      executeModule(filePath, { kind: 'page', route })
+      const componentDefinitions: HeadlessComponentDefinition[] = []
+      const loadedModule = executeModule(filePath, { kind: 'page', route, componentDefinitions })
+      const fallbackDefinition = loadedModule.componentDefinitions.at(-1)
       const definition = registries.pages.get(route)
+        ?? (fallbackDefinition ? normalizeComponentPageDefinition(fallbackDefinition) : undefined)
+      if (!registries.pages.has(route) && definition) {
+        registerPageDefinition(registries, definition, route)
+      }
       if (!definition) {
         throw new Error(`Page() was not registered for route "${route}" while executing ${normalize(filePath)}.`)
       }

--- a/mpcore/packages/simulator/src/runtime/render/component.ts
+++ b/mpcore/packages/simulator/src/runtime/render/component.ts
@@ -295,9 +295,16 @@ export function createRuntimeComponentInstance(
   nextProperties: Record<string, any>,
   ownerScopeId: string | undefined,
 ) {
+  const isWevuNativeDefinition = Object.keys(componentEntry.definition.methods ?? {}).some(key => key.startsWith('__weapp_vite_'))
+    || Object.hasOwn(componentEntry.definition.properties ?? {}, '__wvSlotOwnerId')
+  const componentProperties = isWevuNativeDefinition
+    ? Object.fromEntries(Object.keys(componentEntry.definition.properties ?? {})
+        .filter(key => Object.hasOwn(nextProperties, key))
+        .map(key => [key, nextProperties[key]]))
+    : nextProperties
   const componentInstance = createComponentInstance({
     definition: componentEntry.definition,
-    properties: nextProperties,
+    properties: componentProperties,
     requestRender: callback => context.session.requestRender(callback),
     triggerEvent: buildComponentTrigger(componentScopeId, context, clonedNode),
   })
@@ -312,7 +319,7 @@ export function createRuntimeComponentInstance(
     : null
   context.componentCache.set(componentScopeId, componentInstance)
   runComponentLifecycle(componentInstance, 'created')
-  runComponentObservers(componentInstance.__definition__ ?? componentEntry.definition, componentInstance, Object.keys(nextProperties), {})
+  runComponentObservers(componentInstance.__definition__ ?? componentEntry.definition, componentInstance, Object.keys(componentProperties), {})
   componentInstance.__propertySnapshots = Object.fromEntries(
     Object.entries(componentInstance.properties).map(([key, propertyValue]) => [key, cloneValue(propertyValue)]),
   )

--- a/mpcore/packages/simulator/src/runtime/session.ts
+++ b/mpcore/packages/simulator/src/runtime/session.ts
@@ -196,6 +196,7 @@ export class HeadlessSession {
   private appDefinition: HeadlessAppDefinition | null = null
   private appInstance: HeadlessAppInstance | null = null
   private readonly moduleLoader
+  private readonly eventListeners = new Map<string, Set<(...args: any[]) => void>>()
   private readonly registries: HeadlessHostRegistries
   private currentPageInstance: HeadlessPageInstance | null = null
   private readonly pages: HeadlessPageInstance[] = []
@@ -345,6 +346,7 @@ export class HeadlessSession {
         artifactSource: this.project.artifactSource,
         globals: options.globals,
         kernel: this.kernel,
+        onConsole: entry => this.emit('console', entry),
       },
     )
   }
@@ -363,11 +365,35 @@ export class HeadlessSession {
     this.renderRequestPending = false
     this.wxState.close()
     this.moduleLoader.close()
+    this.eventListeners.clear()
     this.kernel.close()
   }
 
   getDiagnostics(): RuntimeDiagnosticEntry[] {
     return this.kernel.diagnostics.getEntries()
+  }
+
+  on(eventName: string, handler: (...args: any[]) => void) {
+    if (!eventName || typeof handler !== 'function') {
+      return
+    }
+    const listeners = this.eventListeners.get(eventName) ?? new Set<(...args: any[]) => void>()
+    listeners.add(handler)
+    this.eventListeners.set(eventName, listeners)
+  }
+
+  removeListener(eventName: string, handler: (...args: any[]) => void) {
+    const listeners = this.eventListeners.get(eventName)
+    listeners?.delete(handler)
+    if (listeners?.size === 0) {
+      this.eventListeners.delete(eventName)
+    }
+  }
+
+  private emit(eventName: string, ...args: any[]) {
+    for (const handler of [...(this.eventListeners.get(eventName) ?? [])]) {
+      handler(...args)
+    }
   }
 
   get isClosed() {
@@ -382,6 +408,11 @@ export class HeadlessSession {
   getCurrentPages() {
     this.assertActive()
     return this.pages.slice()
+  }
+
+  getWx() {
+    this.assertActive()
+    return this.moduleLoader.wx
   }
 
   callWxMethod(methodName: string, ...args: any[]) {
@@ -944,8 +975,25 @@ export class HeadlessSession {
     this.appDefinition = this.moduleLoader.executeAppModule(appModulePath)
     this.appInstance = createAppInstance(this.appDefinition)
     this.appInstance.onLaunch?.(launchOptions)
+    this.syncRuntimeAppState()
     this.appInstance.onShow?.(launchOptions)
     return this.appInstance
+  }
+
+  private syncRuntimeAppState() {
+    const runtimeApp = this.appInstance?.__wevuRuntimeApp
+    if (!runtimeApp || typeof runtimeApp !== 'object' || !this.appInstance) {
+      return
+    }
+    if (runtimeApp.globalData && typeof runtimeApp.globalData === 'object') {
+      this.appInstance.globalData = {
+        ...this.appInstance.globalData,
+        ...runtimeApp.globalData,
+      }
+    }
+    if (Object.hasOwn(runtimeApp, 'routes')) {
+      this.appInstance.routes = runtimeApp.routes
+    }
   }
 
   reLaunch(url: string) {

--- a/mpcore/packages/simulator/src/testing/launch.ts
+++ b/mpcore/packages/simulator/src/testing/launch.ts
@@ -5,10 +5,24 @@ export interface HeadlessTestingLaunchOptions {
   projectPath: string
 }
 
+function resolveInitialRoute(session: ReturnType<typeof createHeadlessSession>) {
+  const entryPagePath = typeof session.project.appConfig.entryPagePath === 'string'
+    ? session.project.appConfig.entryPagePath.trim().replace(/^\/+/, '')
+    : ''
+  if (entryPagePath && session.project.routes.some(route => route.route === entryPagePath)) {
+    return entryPagePath
+  }
+  return session.project.routes[0]?.route ?? null
+}
+
 export async function launch(options: HeadlessTestingLaunchOptions) {
   const session = createHeadlessSession({
     projectPath: options.projectPath,
   })
   session.bootstrap()
+  const initialRoute = resolveInitialRoute(session)
+  if (initialRoute) {
+    session.reLaunch(`/${initialRoute}`)
+  }
   return new HeadlessTestingSessionHandle(session.project, session)
 }

--- a/mpcore/packages/simulator/src/testing/pageHandle.ts
+++ b/mpcore/packages/simulator/src/testing/pageHandle.ts
@@ -92,6 +92,10 @@ export class HeadlessTestingPageHandle {
       this.session?.renderCurrentPage()
       const method = this.page[normalizedMethodName]
       if (typeof method !== 'function') {
+        if (options.routeOnly) {
+          return undefined
+        }
+        // Keep missing-method wording compatible with automator providers.
         throw new TypeError(`Method "${normalizedMethodName}" does not exist on headless page ${this.page.route}.`)
       }
       return cloneProtocolValue(await method.apply(this.page, args))

--- a/mpcore/packages/simulator/src/testing/sessionHandle/index.ts
+++ b/mpcore/packages/simulator/src/testing/sessionHandle/index.ts
@@ -1,6 +1,7 @@
 import type { HeadlessProjectDescriptor } from '../../project'
 import type { HeadlessSession } from '../../runtime'
 import type { HeadlessTestingWaitOptions } from '../pageWait'
+import vm from 'node:vm'
 import { HeadlessTestingPageHandle } from '../pageHandle'
 import { HeadlessTestingScopeHandle } from './scope'
 import { normalizeNonEmptyInput, normalizeRoute, pollUntil, runWithTimeout } from './shared'
@@ -11,6 +12,8 @@ export interface HeadlessTestingProtocolOptions {
   timeout?: number
 }
 
+export type HeadlessTestingEvaluator<T = unknown> = ((...args: any[]) => T | PromiseLike<T>) | string
+
 export class HeadlessTestingSessionHandle {
   constructor(
     private readonly project: HeadlessProjectDescriptor,
@@ -19,6 +22,37 @@ export class HeadlessTestingSessionHandle {
 
   async close() {
     this.session.close()
+  }
+
+  on(eventName: string, handler: (...args: any[]) => void) {
+    this.session.on(eventName, handler)
+    return this
+  }
+
+  removeListener(eventName: string, handler: (...args: any[]) => void) {
+    this.session.removeListener(eventName, handler)
+    return this
+  }
+
+  off(eventName: string, handler: (...args: any[]) => void) {
+    return this.removeListener(eventName, handler)
+  }
+
+  async evaluate<T = unknown>(evaluator: HeadlessTestingEvaluator<T>, ...args: any[]): Promise<T> {
+    return await this.evaluateWithOptions<T>(evaluator, {}, ...args)
+  }
+
+  async evaluateWithOptions<T = unknown>(
+    evaluator: HeadlessTestingEvaluator<T>,
+    options: HeadlessTestingProtocolOptions = {},
+    ...args: any[]
+  ): Promise<T> {
+    this.session.assertActive()
+    return await runWithTimeout(
+      () => this.evaluateInRuntime(evaluator, args),
+      options.timeout,
+      'Timed out evaluating code in headless testing runtime.',
+    )
   }
 
   async currentPage() {
@@ -186,5 +220,45 @@ export class HeadlessTestingSessionHandle {
       throw new Error(`Failed to ${methodName} route "${route}" through the headless wx runtime.`)
     }
     return page
+  }
+
+  private async evaluateInRuntime<T>(evaluator: HeadlessTestingEvaluator<T>, args: any[]) {
+    const runtimeGlobals: Record<string, unknown> = {
+      getApp: () => this.session.getApp(),
+      getCurrentPages: () => this.session.getCurrentPages(),
+      wx: this.session.getWx(),
+    }
+    const host = globalThis as Record<string, unknown>
+    const previous = new Map<string, PropertyDescriptor | undefined>()
+
+    for (const [name, value] of Object.entries(runtimeGlobals)) {
+      previous.set(name, Object.getOwnPropertyDescriptor(host, name))
+      Object.defineProperty(host, name, {
+        configurable: true,
+        enumerable: false,
+        value,
+        writable: true,
+      })
+    }
+
+    try {
+      const fn = typeof evaluator === 'string'
+        ? new vm.Script(`(${evaluator})`).runInThisContext() as (...values: any[]) => T
+        : evaluator
+      if (typeof fn !== 'function') {
+        throw new TypeError('Headless evaluator must be a function or function source string.')
+      }
+      return await fn(...args)
+    }
+    finally {
+      for (const [name, descriptor] of previous) {
+        if (descriptor) {
+          Object.defineProperty(host, name, descriptor)
+        }
+        else {
+          delete host[name]
+        }
+      }
+    }
   }
 }

--- a/mpcore/packages/simulator/src/view/selectorQuery.ts
+++ b/mpcore/packages/simulator/src/view/selectorQuery.ts
@@ -111,12 +111,23 @@ function parseNumericLikeValue(value?: string) {
   return match ? Number(match[0]) : 0
 }
 
-function resolveRect(node: DomNodeLike): HeadlessWxSelectorQueryBoundingClientRectResult {
+function resolveRect(node: DomNodeLike, windowInfo?: HeadlessWxWindowInfoResult): HeadlessWxSelectorQueryBoundingClientRectResult {
   const style = parseStyleDeclarations(node.attribs?.style)
   const left = parseNumericLikeValue(node.attribs?.['data-sim-left'] ?? style.left)
   const top = parseNumericLikeValue(node.attribs?.['data-sim-top'] ?? style.top)
-  const width = parseNumericLikeValue(node.attribs?.['data-sim-width'] ?? style.width)
-  const height = parseNumericLikeValue(node.attribs?.['data-sim-height'] ?? style.height)
+  const rawWidth = node.attribs?.['data-sim-width'] ?? style.width
+  const rawHeight = node.attribs?.['data-sim-height'] ?? style.height
+  const isTopLevelView = node.name === 'view' && node.parent?.name === 'page' && windowInfo?.windowWidth != null
+  const width = rawWidth != null
+    ? parseNumericLikeValue(rawWidth)
+    : isTopLevelView && windowInfo
+      ? windowInfo.windowWidth
+      : 0
+  const height = rawHeight != null
+    ? parseNumericLikeValue(rawHeight)
+    : isTopLevelView && windowInfo
+      ? windowInfo.windowHeight
+      : 0
   return {
     bottom: top + height,
     height,
@@ -196,7 +207,7 @@ function resolveFieldsResult(
     result.mark = collectMark(node)
   }
   if (fields.rect || fields.size) {
-    const rect = resolveRect(node)
+    const rect = resolveRect(node, options.root.name === 'page' ? options.windowInfo : undefined)
     if (fields.rect) {
       Object.assign(result, rect)
     }

--- a/mpcore/packages/simulator/test-d/public-api.sessions-and-saved-files.test-d.ts
+++ b/mpcore/packages/simulator/test-d/public-api.sessions-and-saved-files.test-d.ts
@@ -1,5 +1,6 @@
 import type {
   HeadlessTestingRenderedNodeSnapshot,
+  HeadlessTestingSessionHandle,
   HeadlessWxDeviceInfoResult,
   HeadlessWxDownloadFileMockDefinition,
   HeadlessWxGetLocationResult,
@@ -795,6 +796,13 @@ launchResult.then((session) => {
   expectType<Promise<unknown>>(session.callWxMethodWithOptions('getStorageSync', {
     timeout: 1_000,
   }, 'probe'))
+  expectType<Promise<number>>(session.evaluate(() => 42))
+  expectType<Promise<string>>(session.evaluateWithOptions('(value) => String(value)', {
+    timeout: 1_000,
+  }, 'probe'))
+  expectType<HeadlessTestingSessionHandle>(session.on('console', () => {}))
+  expectType<HeadlessTestingSessionHandle>(session.removeListener('console', () => {}))
+  expectType<HeadlessTestingSessionHandle>(session.off('console', () => {}))
   session.reLaunch('/pages/index/index').then((page) => {
     expectType<string>(page.path)
     expectType<Record<string, string>>(page.query)

--- a/mpcore/packages/simulator/test/session.test.ts
+++ b/mpcore/packages/simulator/test/session.test.ts
@@ -47,6 +47,51 @@ describe('HeadlessSession', () => {
     expect(session.getCurrentPages()).toHaveLength(1)
   })
 
+  it('loads static ESM imports for app and page artifacts', () => {
+    const projectPath = createBaseFixture()
+    tempDirs.push(projectPath)
+    writeFixtureFile(path.join(projectPath, 'dist/shared.js'), `
+export const marker = 'esm-shared'
+`)
+    writeFixtureFile(path.join(projectPath, 'dist/app.js'), `
+import { marker } from './shared.js'
+App({ globalData: { marker } })
+`)
+    writeFixtureFile(path.join(projectPath, 'dist/pages/index/index.js'), `
+import { marker } from '../../shared.js'
+Page({ data: { marker } })
+`)
+
+    const session = createHeadlessSession({ projectPath })
+    const page = session.reLaunch('/pages/index/index')
+
+    expect(session.getApp()?.globalData.marker).toBe('esm-shared')
+    expect(page.data.marker).toBe('esm-shared')
+  })
+
+  it('selects the final Component definition when a bundled page has helpers', () => {
+    const projectPath = createBaseFixture()
+    tempDirs.push(projectPath)
+    writeFixtureFile(path.join(projectPath, 'dist/pages/index/index.js'), `
+Component({ data: { helper: true } })
+Component({
+  data: { page: true },
+  methods: {
+    runE2E() {
+      return this.data.page
+    },
+  },
+})
+`)
+
+    const session = createHeadlessSession({ projectPath })
+    const page = session.reLaunch('/pages/index/index')
+
+    expect(page.data).toMatchObject({ page: true })
+    expect(page.data.helper).toBeUndefined()
+    expect(page.runE2E()).toBe(true)
+  })
+
   it('loads and caches modules through require.async', async () => {
     const projectPath = createBaseFixture()
     tempDirs.push(projectPath)

--- a/mpcore/packages/simulator/test/testingBridge.test.ts
+++ b/mpcore/packages/simulator/test/testingBridge.test.ts
@@ -30,6 +30,27 @@ describe('headless testing bridge', () => {
     expect(await currentPage?.data('__e2eData.greeting')).toBe('Hello')
   })
 
+  it('opens the configured entry page when launching a session', async () => {
+    const projectPath = createBaseFixture()
+    tempDirs.push(projectPath)
+
+    const miniProgram = await launch({ projectPath })
+    const currentPage = await miniProgram.currentPage()
+
+    expect(currentPage?.path).toBe('pages/index/index')
+    expect(await currentPage?.data('__e2eResult.status')).toBe('ready')
+
+    const query = await miniProgram.callWxMethod('createSelectorQuery') as any
+    const [rootRect] = query
+      .select('#greeting-button')
+      .boundingClientRect()
+      .exec()
+    expect(rootRect).toMatchObject({
+      height: 667,
+      width: 375,
+    })
+  })
+
   it('calls page methods through the testing bridge', async () => {
     const projectPath = createBaseFixture()
     tempDirs.push(projectPath)
@@ -44,6 +65,20 @@ describe('headless testing bridge', () => {
       status: 'tapped',
       detail: 'tap handled',
     })
+  })
+
+  it('returns undefined for an optional route-only method that is absent', async () => {
+    const projectPath = createBaseFixture()
+    tempDirs.push(projectPath)
+    const miniProgram = await launch({ projectPath })
+    const page = await miniProgram.currentPage()
+
+    expect(page).not.toBeNull()
+    if (!page) {
+      throw new Error('Expected the configured page to be active.')
+    }
+    await expect(page.callMethodWithOptions('runE2E', { routeOnly: true })).resolves.toBeUndefined()
+    await expect(page.callMethod('runE2E')).rejects.toThrow('does not exist')
   })
 
   it('renders component lifecycles before invoking page methods', async () => {
@@ -326,7 +361,11 @@ Page({
       projectPath,
     })
 
-    const homePage = await miniProgram.reLaunch('/pages/home/index')
+    const homePage = await miniProgram.currentPage()
+    expect(homePage).not.toBeNull()
+    if (!homePage) {
+      throw new Error('Expected the configured home page to be active.')
+    }
     await homePage.callMethod('goDetailLater')
 
     const detailPage = await miniProgram.waitForCurrentPage('/pages/detail/index')

--- a/packages/weapp-vite/src/wxs/index.test.ts
+++ b/packages/weapp-vite/src/wxs/index.test.ts
@@ -36,4 +36,20 @@ describe('transformWxsCode', () => {
     expect(output).toContain('export default')
     expect(output).not.toContain('module.exports')
   })
+
+  it('converts CommonJS default exports for Alipay SJS', () => {
+    const code = `
+      function label(value) {
+        return value || 'unknown'
+      }
+      module.exports = {
+        label: label,
+      }
+    `
+    const { result } = transformWxsCode(code, { extension: 'sjs' })
+    const output = result?.code ?? ''
+
+    expect(output).toContain('export default')
+    expect(output).not.toContain('module.exports')
+  })
 })

--- a/packages/weapp-vite/src/wxs/index.ts
+++ b/packages/weapp-vite/src/wxs/index.ts
@@ -106,6 +106,26 @@ export function transformWxsCode(code: string, options?: TransformWxsCodeOptions
               p.remove()
             }
           },
+          AssignmentExpression: {
+            enter(p: babel.NodePath<t.AssignmentExpression>) {
+              if (!preserveEsmExports || p.node.operator !== '=') {
+                return
+              }
+
+              const left = p.node.left
+              if (
+                !t.isMemberExpression(left)
+                || left.computed
+                || !t.isIdentifier(left.object, { name: 'module' })
+                || !t.isIdentifier(left.property, { name: 'exports' })
+                || !p.parentPath.isExpressionStatement()
+              ) {
+                return
+              }
+
+              p.parentPath.replaceWith(t.exportDefaultDeclaration(p.node.right))
+            },
+          },
           NewExpression: {
             enter(p: babel.NodePath<t.NewExpression>) {
               const node = p.node


### PR DESCRIPTION
## Summary
完善 headless simulator 的运行时加载、执行和测试桥接能力，并修复支付宝 SJS 顶层 CommonJS 导出的转换兼容性。

## Changes
- 修复入口页加载、ESM/CJS 模块执行、运行时全局对象和 app 状态同步。
- 完善 evaluate、console 事件、组件定义选择、无生命周期页面、route-only 缺失方法和顶层 view 尺寸处理。
- 将支付宝 SJS 顶层 `module.exports = ...` 正确转换为 `export default`。
- 增加 simulator 单测、headless E2E 回归覆盖和 `test-d` 公共类型契约。
- 添加中文 changeset，更新 `@mpcore/simulator`、`weapp-vite` 与 `create-weapp-vite` 的 patch 版本。

## Testing
- `pnpm lint`（37/37）
- `pnpm test:types`（14/14）
- `pnpm build:pkgs:ci`（29/29）
- `pnpm build:ci`（91/91）
- `pnpm test:coverage`（7411 通过，18 跳过）
- `pnpm e2e:ide:headless:full`（11/11）
- 受影响 simulator 单测、类型契约和 lint-staged 检查通过

## Environment limitations
- 字节平台缺少稳定可用的 CLI/automator，因此未执行对应运行时检查。
- 百度平台未开启自动化 WebSocket，因此未执行对应运行时检查。
- 上述限制未通过放宽断言处理，其他可运行检查均已完成。