### PR TITLE
refactor(weapp-ide-cli): use blazediff for compare

### DIFF
--- a/.changeset/blazediff-image-compare.md
+++ b/.changeset/blazediff-image-compare.md
@@ -1,0 +1,5 @@
+---
+'weapp-ide-cli': patch
+---
+
+将 `weapp compare` 的像素对比引擎从 `pixelmatch` 换成 `@blazediff/core`，对比参数与结果语义保持不变，同一份截图基准的判定行为一致。

--- a/apps/weapp-vite-web-demo/scripts/generate-product-detail-iteration-report.mjs
+++ b/apps/weapp-vite-web-demo/scripts/generate-product-detail-iteration-report.mjs
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
-import pixelmatch from 'pixelmatch'
+import { diff as blazediff } from '@blazediff/core'
 import { chromium } from 'playwright'
 import { PNG } from 'pngjs'
 import sharp from 'sharp'
@@ -122,7 +122,7 @@ async function compareScreenshots(targetPath, actualPath, diffPath) {
   actualCropped.data.fill(255)
   PNG.bitblt(actual, actualCropped, 0, 0, Math.min(target.width, actual.width), Math.min(target.height, actual.height), 0, 0)
   const diff = new PNG({ width, height })
-  const mismatched = pixelmatch(target.data, actualCropped.data, diff.data, width, height, {
+  const mismatched = blazediff(target.data, actualCropped.data, diff.data, width, height, {
     threshold: 0.16,
     alpha: 0.45,
     includeAA: true,
@@ -337,7 +337,7 @@ async function writeReport(rows) {
   const lines = [
     '# NOVA X1 商品详情页 TDesign 基准迭代截图报告',
     '',
-    '基准采用 `apps/tdesign-miniprogram-starter-retail/pages/goods/details` 的详情页信息结构和本地真实商品图；Diff 由 `pixelmatch` 逐像素生成。',
+    '基准采用 `apps/tdesign-miniprogram-starter-retail/pages/goods/details` 的详情页信息结构和本地真实商品图；Diff 由 `@blazediff/core` 逐像素生成。',
     '',
     `视口：${viewport.width}x${viewport.height}`,
     '',
@@ -389,7 +389,7 @@ async function main() {
       await normalizeReportFrame(paddedScreenshotPath, croppedScreenshotPath, targetSize.width - 24)
       await normalizeCanvas(croppedScreenshotPath, normalizedScreenshotPath, targetSize)
       const similarity = await compareScreenshots(targetPath, normalizedScreenshotPath, rawDiffPath)
-      const label = `pixelmatch ${similarity}%`
+      const label = `blazediff ${similarity}%`
       await Promise.all([
         addSimilarityOverlay(normalizedScreenshotPath, screenshotPath, label),
         addSimilarityOverlay(rawDiffPath, diffPath, label),

--- a/packages/weapp-ide-cli/README.md
+++ b/packages/weapp-ide-cli/README.md
@@ -190,7 +190,7 @@ weapp cache --clean all
 | 命令                             | 说明                           |
 | -------------------------------- | ------------------------------ |
 | `weapp screenshot`               | 截图（支持 base64 / 文件输出） |
-| `weapp compare`                  | 截图对比（pixelmatch）         |
+| `weapp compare`                  | 截图对比（blazediff）          |
 | `weapp navigate <url>`           | 保留栈跳转页面                 |
 | `weapp redirect <url>`           | 重定向页面                     |
 | `weapp back`                     | 页面返回                       |

--- a/packages/weapp-ide-cli/package.json
+++ b/packages/weapp-ide-cli/package.json
@@ -87,6 +87,7 @@
     }
   },
   "dependencies": {
+    "@blazediff/core": "^1.10.0",
     "@modelcontextprotocol/server": "^2.0.0",
     "@weapp-core/logger": "workspace:*",
     "@weapp-core/shared": "workspace:*",
@@ -95,7 +96,6 @@
     "cac": "^7.0.0",
     "execa": "10.0.1",
     "pathe": "catalog:",
-    "pixelmatch": "^7.2.0",
     "pngjs": "^7.0.0",
     "zod": "catalog:"
   },

--- a/packages/weapp-ide-cli/src/cli/compare.ts
+++ b/packages/weapp-ide-cli/src/cli/compare.ts
@@ -89,7 +89,7 @@ ${colors.bold('参数:')}
       --diff-output <path>       diff 图片输出路径
       --page <path>              对比前先跳转页面
       --full-page                对比时使用整页长截图
-      --threshold <number>       pixelmatch threshold（默认：0.1）
+      --threshold <number>       blazediff threshold（默认：0.1）
       --max-diff-pixels <count>  最大允许差异像素数
       --max-diff-ratio <number>  最大允许差异占比（0-1）
   -t, --timeout <ms>             连接超时时间（默认：30000）
@@ -118,7 +118,7 @@ ${colors.bold('Options:')}
       --diff-output <path>       Output file path for diff image
       --page <path>              Navigate to page before comparison
       --full-page                Use stitched full-page screenshots for comparison
-      --threshold <number>       Pixelmatch threshold (default: 0.1)
+      --threshold <number>       Blazediff threshold (default: 0.1)
       --max-diff-pixels <count>  Maximum allowed diff pixels
       --max-diff-ratio <number>  Maximum allowed diff ratio (0-1)
   -t, --timeout <ms>             Connection timeout in milliseconds (default: 30000)

--- a/packages/weapp-ide-cli/src/cli/imageDiff.ts
+++ b/packages/weapp-ide-cli/src/cli/imageDiff.ts
@@ -1,6 +1,6 @@
 import type { Buffer } from 'node:buffer'
 import fs from 'node:fs/promises'
-import pixelmatch from 'pixelmatch'
+import { diff as blazediff } from '@blazediff/core'
 import { PNG } from 'pngjs'
 import { i18nText } from '../i18n'
 
@@ -66,7 +66,7 @@ export async function comparePngWithBaseline(
   }
 
   const diffPng = new PNG({ width: currentPng.width, height: currentPng.height })
-  const diffPixels = pixelmatch(
+  const diffPixels = blazediff(
     baselinePng.data,
     currentPng.data,
     diffPng.data,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2709,6 +2709,9 @@ importers:
 
   packages/weapp-ide-cli:
     dependencies:
+      '@blazediff/core':
+        specifier: ^1.10.0
+        version: 1.10.0
       '@modelcontextprotocol/server':
         specifier: ^2.0.0
         version: 2.0.0
@@ -2733,9 +2736,6 @@ importers:
       pathe:
         specifier: 'catalog:'
         version: 2.0.3
-      pixelmatch:
-        specifier: ^7.2.0
-        version: 7.2.0
       pngjs:
         specifier: ^7.0.0
         version: 7.0.0
@@ -4610,6 +4610,9 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@blazediff/core@1.10.0':
+    resolution: {integrity: sha512-AOQff0zgR7cGsZL+4E7hVkmujoPUpm0J9xzWGWZj5wCjd3gmxESXAPfKyuzs93VdpQNFhHlBhfOjrcZ+XTERtQ==}
 
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
@@ -14934,10 +14937,6 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
-  pixelmatch@7.2.0:
-    resolution: {integrity: sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==}
-    hasBin: true
-
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
@@ -18717,6 +18716,8 @@ snapshots:
       '@babel/helper-validator-identifier': 8.0.4
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@blazediff/core@1.10.0': {}
 
   '@blazediff/core@1.9.1': {}
 
@@ -29771,10 +29772,6 @@ snapshots:
   pinyin-firstletter@1.0.2: {}
 
   pirates@4.0.7: {}
-
-  pixelmatch@7.2.0:
-    dependencies:
-      pngjs: 7.0.0
 
   pkce-challenge@5.0.1: {}
 

--- a/website/guide/cli.md
+++ b/website/guide/cli.md
@@ -479,17 +479,17 @@ wv compare --project ./dist/build/mp-weixin --page pages/index/index --baseline 
 
 关键参数：
 
-| 参数                        | 说明                             |
-| --------------------------- | -------------------------------- |
-| `--project <path>`          | 小程序项目目录                   |
-| `--baseline <path>`         | baseline 图片，必填              |
-| `--page <path>`             | 对比前先跳转页面                 |
-| `--current-output <path>`   | 保存当前截图                     |
-| `--diff-output <path>`      | 保存 diff 图                     |
-| `--threshold <number>`      | pixelmatch threshold，默认 `0.1` |
-| `--max-diff-pixels <count>` | 最大允许差异像素数               |
-| `--max-diff-ratio <number>` | 最大允许差异占比                 |
-| `--json`                    | JSON 输出                        |
+| 参数                        | 说明                            |
+| --------------------------- | ------------------------------- |
+| `--project <path>`          | 小程序项目目录                  |
+| `--baseline <path>`         | baseline 图片，必填             |
+| `--page <path>`             | 对比前先跳转页面                |
+| `--current-output <path>`   | 保存当前截图                    |
+| `--diff-output <path>`      | 保存 diff 图                    |
+| `--threshold <number>`      | blazediff threshold，默认 `0.1` |
+| `--max-diff-pixels <count>` | 最大允许差异像素数              |
+| `--max-diff-ratio <number>` | 最大允许差异占比                |
+| `--json`                    | JSON 输出                       |
 
 使用约束：
 

--- a/website/packages/mcp.md
+++ b/website/packages/mcp.md
@@ -181,7 +181,7 @@ pnpm --filter @weapp-vite/mcp start
 | `page`              | 可选；对比前先跳转页面                                                    |
 | `currentOutputPath` | 可选；保存当前截图                                                        |
 | `diffOutputPath`    | 可选；保存 diff 图                                                        |
-| `threshold`         | 可选；pixelmatch threshold，范围 `0-1`                                    |
+| `threshold`         | 可选；blazediff threshold，范围 `0-1`                                     |
 | `maxDiffPixels`     | 可选；最大允许差异像素数                                                  |
 | `maxDiffRatio`      | 可选；最大允许差异占比，范围 `0-1`                                        |
 | `timeoutMs`         | 可选；命令超时                                                            |

--- a/website/packages/weapp-ide-cli.md
+++ b/website/packages/weapp-ide-cli.md
@@ -119,7 +119,7 @@ weapp cache --clean all
 | 命令                             | 说明                      |
 | -------------------------------- | ------------------------- |
 | `weapp screenshot`               | 截图（base64 / 文件输出） |
-| `weapp compare`                  | 截图对比（pixelmatch）    |
+| `weapp compare`                  | 截图对比（blazediff）     |
 | `weapp navigate <url>`           | 保留栈跳转页面            |
 | `weapp redirect <url>`           | 重定向页面                |
 | `weapp back`                     | 页面返回                  |
@@ -162,19 +162,19 @@ weapp compare --baseline .screenshots/baseline/home.png --max-diff-pixels 100 --
 
 #### `weapp compare` 选项
 
-| 参数                        | 说明                             |
-| --------------------------- | -------------------------------- |
-| `-p, --project <path>`      | 项目路径，默认当前目录           |
-| `--baseline <path>`         | baseline 图片路径，必填          |
-| `--current-output <path>`   | 保存当前截图                     |
-| `--diff-output <path>`      | 保存 diff 图                     |
-| `--page <path>`             | 对比前先跳转页面                 |
-| `--threshold <number>`      | pixelmatch threshold，默认 `0.1` |
-| `--max-diff-pixels <count>` | 最大允许差异像素数               |
-| `--max-diff-ratio <number>` | 最大允许差异占比，范围 `0-1`     |
-| `-t, --timeout <ms>`        | 连接超时，默认 `30000`           |
-| `--json`                    | JSON 输出                        |
-| `--lang <lang>`             | 语言切换：`zh` / `en`            |
+| 参数                        | 说明                            |
+| --------------------------- | ------------------------------- |
+| `-p, --project <path>`      | 项目路径，默认当前目录          |
+| `--baseline <path>`         | baseline 图片路径，必填         |
+| `--current-output <path>`   | 保存当前截图                    |
+| `--diff-output <path>`      | 保存 diff 图                    |
+| `--page <path>`             | 对比前先跳转页面                |
+| `--threshold <number>`      | blazediff threshold，默认 `0.1` |
+| `--max-diff-pixels <count>` | 最大允许差异像素数              |
+| `--max-diff-ratio <number>` | 最大允许差异占比，范围 `0-1`    |
+| `-t, --timeout <ms>`        | 连接超时，默认 `30000`          |
+| `--json`                    | JSON 输出                       |
+| `--lang <lang>`             | 语言切换：`zh` / `en`           |
 
 对比规则：
 


### PR DESCRIPTION
**What:** Swap `pixelmatch` for `@blazediff/core` as the pixel engine behind `weapp compare` / `compare_weapp_screenshot`.

**Why:** Same YIQ algorithm and anti-aliasing detection, ~62% faster on average and up to ~90% faster on identical screenshots — the common case in visual regression runs. [Benchmarks](https://github.com/teimurjan/blazediff/blob/main/benchmarks/pixel-by-pixel.md) (M1 Max, Node 22, 50 iterations).

**How:** Drop-in — identical `(img1, img2, output, width, height, options)` signature and return value, so `threshold`, `diffPixels` and `diffRatio` semantics are unchanged. `weapp-ide-cli`'s 311 tests pass untouched.

**Notes:** Already used by Vitest, Shopify (react-native-skia), Ant Design, AntV G, Ant Design X, GPT-Vis, Vega and ApexCharts. Background: [block-level optimization](https://dev.to/teimurjan/building-blazediff-how-i-made-the-fastest-image-diff-up-to-60-faster-with-block-level-optimization-ok7), [porting the MATLAB algorithms](https://hackernoon.com/porting-scientific-algorithms-from-matlab-to-javascript), [Rust + N-API](https://hackernoon.com/beating-javascript-performance-limits-with-rust-and-n-api-building-a-faster-image-diff-tool).
