### PR TITLE
fix: 完善 buildScope 应用配置裁剪

### DIFF
--- a/.changeset/calm-build-scope-app-config.md
+++ b/.changeset/calm-build-scope-app-config.md
@@ -1,0 +1,6 @@
+---
+'weapp-vite': patch
+'create-weapp-vite': patch
+---
+
+修复局部构建后 `preloadRule`、`tabBar` 与默认启动页仍引用未参与构建页面或分包的问题，确保生成的 `app.json` 与本次构建范围保持一致。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -701,6 +701,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-793-settings/index",
+          "pathName": "pages/issue-793-settings/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-805/index",
           "pathName": "pages/issue-805/index",
           "query": "",

--- a/e2e-apps/github-issues/src/app.vue
+++ b/e2e-apps/github-issues/src/app.vue
@@ -3,7 +3,7 @@ import routes from 'weapp-vite/auto-routes'
 import { onLaunch } from 'wevu'
 import { ensureGithubIssuesRouter } from './shared/appRouter'
 
-const tabBarList = [
+const defaultTabBarList = [
   {
     pagePath: 'pages/issue-705/index',
     text: 'issue-705',
@@ -22,15 +22,50 @@ const tabBarList = [
   },
 ].filter(item => routes.pages.includes(item.pagePath))
 
+const issue793BuildScopeEnabled = routes.pages.includes('pages/issue-793/index')
+  || routes.subPackages.some(subPackage => subPackage.root === 'subs')
+const tabBarList = issue793BuildScopeEnabled
+  ? [
+      {
+        pagePath: 'pages/issue-793/index',
+        text: 'issue-793',
+      },
+      {
+        pagePath: 'pages/issue-793-settings/index',
+        text: 'issue-793-settings',
+      },
+      {
+        pagePath: 'subs/issue-793/index',
+        text: 'issue-793-subpackage',
+      },
+    ]
+  : defaultTabBarList
+
 defineAppJson({
   pages: routes.pages,
   subPackages: routes.subPackages,
   subpackages: routes.subPackages,
+  ...(issue793BuildScopeEnabled
+    ? {
+        entryPagePath: 'pages/issue-793/index',
+        preloadRule: {
+          'pages/issue-793/index': {
+            packages: ['subs', 'missing'],
+          },
+          'subs/issue-793/index': {
+            packages: ['__APP__'],
+          },
+        },
+      }
+    : {}),
   ...(tabBarList.length >= 2
     ? {
         tabBar: {
+          backgroundColor: '#ffffff',
+          color: '#000000',
           custom: true,
           list: tabBarList,
+          selectedColor: '#000000',
         },
       }
     : {}),

--- a/e2e-apps/github-issues/src/pages/issue-793-settings/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-793-settings/index.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+definePageJson({
+  navigationBarTitleText: 'issue-793-settings',
+})
+</script>
+
+<template>
+  <view>issue-793-settings</view>
+</template>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -14,7 +14,8 @@ const issue595ScopedBuildEnabled = process.env.WEAPP_GITHUB_ISSUE_595_SCOPED ===
 const issue642ScopedBuildEnabled = process.env.WEAPP_GITHUB_ISSUE_642_SCOPED === 'true'
 const issue724ProbeEnabled = process.env.WEAPP_GITHUB_ISSUE_724_PROBE === 'true'
 const issue779CssPreEnabled = process.env.WEAPP_GITHUB_ISSUE_779_CSS_PRE === 'true'
-const issue793BuildScopeEnabled = process.env.WEAPP_GITHUB_ISSUE_793_BUILD_SCOPE === 'true'
+const issue793BuildScope = process.env.WEAPP_GITHUB_ISSUE_793_BUILD_SCOPE
+const issue793BuildScopeEnabled = issue793BuildScope === 'true' || issue793BuildScope === 'subpackage'
 const issue651NoExtResolvedId = path.resolve(import.meta.dirname, 'src/issue-fixtures/issue-651/ResolverNoExt/index')
 const issue651WithExtResolvedId = path.resolve(import.meta.dirname, 'src/issue-fixtures/issue-651/ResolverWithExt/index.vue')
 const e2eTargetFile = process.env.WEAPP_VITE_E2E_TARGET_FILE?.replaceAll('\\', '/') ?? ''
@@ -203,6 +204,7 @@ function resolveGithubIssuesAutoRoutes() {
     return {
       include: [
         'pages/issue-793/**',
+        'pages/issue-793-settings/**',
         'subs/issue-793/**',
       ],
     }
@@ -464,7 +466,10 @@ export default defineConfig({
     ...(issue793BuildScopeEnabled
       ? {
           buildScope: {
-            include: ['pages'],
+            ...(issue793BuildScope === 'subpackage'
+              ? { includeMainPackage: false }
+              : {}),
+            include: issue793BuildScope === 'subpackage' ? ['subs'] : ['pages'],
           },
         }
       : {}),

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -419,7 +419,7 @@ async function runSlotFallbackCompilerOffBuild() {
   distVariant = null
 }
 
-async function runIssue793Build() {
+async function runIssue793Build(scope: 'main' | 'subpackage' = 'main') {
   await fs.remove(ISSUE_793_DIST_ROOT)
 
   await execa('node', [
@@ -435,7 +435,7 @@ async function runIssue793Build() {
     stdio: 'inherit',
     env: {
       ...sanitizeBuildCommandEnv(),
-      WEAPP_GITHUB_ISSUE_793_BUILD_SCOPE: 'true',
+      WEAPP_GITHUB_ISSUE_793_BUILD_SCOPE: scope === 'main' ? 'true' : 'subpackage',
     },
   })
 
@@ -444,17 +444,49 @@ async function runIssue793Build() {
 }
 
 describe.sequential('e2e app: github-issues (build)', () => {
-  it('issue #793: excludes out-of-scope subpackages from routes and output', async () => {
+  it('issue #793: keeps derived app config aligned with the scoped routes', async () => {
     await runIssue793Build()
 
     const appJson = await fs.readJSON(path.join(ISSUE_793_DIST_ROOT, 'app.json')) as {
+      entryPagePath?: string
       pages?: string[]
+      preloadRule?: Record<string, unknown>
       subPackages?: Array<{ root?: string, pages?: string[] }>
+      tabBar?: { list?: Array<{ pagePath?: string }> }
     }
 
-    expect(appJson.pages).toEqual(['pages/issue-793/index'])
+    expect(appJson.entryPagePath).toBe('pages/issue-793/index')
+    expect(appJson.pages).toHaveLength(2)
+    expect(appJson.pages).toEqual(expect.arrayContaining([
+      'pages/issue-793/index',
+      'pages/issue-793-settings/index',
+    ]))
+    expect(appJson.preloadRule).toBeUndefined()
     expect(appJson.subPackages).toEqual([])
+    expect(appJson.tabBar?.list?.map(item => item.pagePath)).toEqual([
+      'pages/issue-793/index',
+      'pages/issue-793-settings/index',
+    ])
     expect(await fs.pathExists(path.join(ISSUE_793_DIST_ROOT, 'subs'))).toBe(false)
+
+    await runIssue793Build('subpackage')
+
+    const subpackageAppJson = await fs.readJSON(path.join(ISSUE_793_DIST_ROOT, 'app.json')) as {
+      entryPagePath?: string
+      pages?: string[]
+      preloadRule?: Record<string, unknown>
+      subPackages?: Array<{ root?: string, pages?: string[] }>
+      tabBar?: unknown
+    }
+
+    expect(subpackageAppJson.entryPagePath).toBeUndefined()
+    expect(subpackageAppJson.pages).toEqual([])
+    expect(subpackageAppJson.preloadRule).toBeUndefined()
+    expect(subpackageAppJson.subPackages).toEqual([
+      { root: 'subs', pages: ['issue-793/index'] },
+    ])
+    expect(subpackageAppJson.tabBar).toBeUndefined()
+    expect(await fs.pathExists(path.join(ISSUE_793_DIST_ROOT, 'pages'))).toBe(false)
   })
 
   it('issue #805: lowers optional chaining inside nullish coalescing expressions', async () => {

--- a/packages/weapp-vite/docs/packaged/weapp-config.md
+++ b/packages/weapp-vite/docs/packaged/weapp-config.md
@@ -46,7 +46,7 @@ export default defineConfig({
 })
 ```
 
-`main` 表示主包，`packages/order` 匹配 `app.json.subPackages[].root`。启用后，产物 `app.json.subPackages` 只保留参与 scope 的分包，`preloadRule`、自动路由和 typed router 也会按同一范围裁剪。发布前建议再跑不带 scope 的完整构建。
+`main` 表示主包，`packages/order` 匹配 `app.json.subPackages[].root`。启用后，产物 `app.json.subPackages` 只保留参与 scope 的分包，`preloadRule`、`tabBar`、`entryPagePath`、自动路由和 typed router 也会按同一注册图裁剪。`preloadRule.packages` 支持分包 `root`、`name` 和主包标记 `__APP__`；`tabBar.list` 不足微信要求的 2 项时会删除整个 `tabBar`。发布前建议再跑不带 scope 的完整构建。
 
 ### 分包异步模块
 

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/jsonEmit.test.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/jsonEmit.test.ts
@@ -106,6 +106,58 @@ describe('createJsonEmitManager', () => {
     })
   })
 
+  it('applies build scope whenever the final app json asset is registered', () => {
+    const manager = createJsonEmitManager({
+      platform: 'weapp',
+      relativeOutputPath(filePath: string) {
+        return filePath.replace('/project/src/', '')
+      },
+      weappViteConfig: {
+        buildScope: {
+          include: [],
+        },
+      },
+    } as any)
+
+    manager.register({
+      type: 'app',
+      json: {
+        pages: ['pages/home/index', 'pages/profile/index'],
+        preloadRule: {
+          'pages/home/index': {
+            packages: ['packages/excluded'],
+          },
+        },
+        subPackages: [
+          { root: 'packages/excluded', pages: ['index'] },
+        ],
+        tabBar: {
+          color: '#000000',
+          selectedColor: '#ffffff',
+          backgroundColor: '#ffffff',
+          list: [
+            { pagePath: 'pages/home/index', text: 'home' },
+            { pagePath: 'pages/profile/index', text: 'profile' },
+            { pagePath: 'pages/missing/index', text: 'missing' },
+          ],
+        },
+      },
+      jsonPath: '/project/src/app.json',
+    })
+
+    expect(manager.map.get('app.json')?.entry.json).toMatchObject({
+      pages: ['pages/home/index', 'pages/profile/index'],
+      subPackages: [],
+      tabBar: {
+        list: [
+          { pagePath: 'pages/home/index', text: 'home' },
+          { pagePath: 'pages/profile/index', text: 'profile' },
+        ],
+      },
+    })
+    expect(manager.map.get('app.json')?.entry.json.preloadRule).toBeUndefined()
+  })
+
   it('does not normalize app side json files as app config', () => {
     const manager = createJsonEmitManager({
       relativeOutputPath(filePath: string) {

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/jsonEmit.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/jsonEmit.ts
@@ -1,5 +1,5 @@
 import type { CompilerContext } from '../../../context'
-import { normalizeAppJson } from '../../../utils'
+import { finalizeAppConfigForBuild } from '../../../runtime/appConfig'
 import { resolveRelativeJsonOutputFileName } from '../../utils/outputFileName'
 
 export interface JsonEmitFileEntry {
@@ -26,10 +26,15 @@ export function createJsonEmitManager(
 
     const fileName = entry.fileName ?? resolveRelativeJsonOutputFileName(configService, entry.jsonPath!)
     const shouldNormalizeAppJson = entry.type === 'app' && fileName === 'app.json'
+    const weappViteConfig = configService.weappViteConfig ?? {}
     const normalizedEntry = shouldNormalizeAppJson
       ? {
           ...entry,
-          json: normalizeAppJson(entry.json),
+          json: finalizeAppConfigForBuild(entry.json, {
+            buildScope: weappViteConfig.buildScope,
+            platform: configService.platform,
+            routeRules: weappViteConfig.routeRules,
+          }),
         }
       : entry
 

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry.test.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry.test.ts
@@ -462,6 +462,69 @@ describe('createEntryLoader', () => {
     })
   })
 
+  it('applies build scope to the final app json asset', async () => {
+    const { loader, jsonService, registerJsonAsset } = createLoader({
+      weappViteConfig: {
+        buildScope: {
+          include: ['packages/order'],
+        },
+      },
+    })
+    const pluginCtx = createPluginContext()
+
+    mockFindJsonEntry.mockImplementation(async (filepath: string) => {
+      if (filepath === '/project/src/app.ts') {
+        return { path: '/project/src/app.json', predictions: [] }
+      }
+      return { path: undefined, predictions: [] }
+    })
+    jsonService.read.mockResolvedValue({
+      pages: ['pages/home/index', 'pages/profile/index'],
+      subPackages: [
+        { root: 'packages/order', pages: ['index'] },
+        { root: 'packages/user', pages: ['index'] },
+      ],
+      preloadRule: {
+        'pages/home/index': {
+          packages: ['packages/order', 'packages/user'],
+        },
+      },
+      tabBar: {
+        color: '#000000',
+        selectedColor: '#ffffff',
+        backgroundColor: '#ffffff',
+        list: [
+          { pagePath: 'pages/home/index', text: 'home' },
+          { pagePath: 'pages/profile/index', text: 'profile' },
+          { pagePath: 'pages/missing/index', text: 'missing' },
+        ],
+      },
+    })
+
+    await loader.call(pluginCtx, '/project/src/app.ts', 'app')
+
+    const appAsset = registerJsonAsset.mock.calls
+      .map(([entry]) => entry)
+      .find(entry => entry.type === 'app')
+    expect(appAsset?.json).toMatchObject({
+      pages: ['pages/home/index', 'pages/profile/index'],
+      subPackages: [
+        { root: 'packages/order', pages: ['index'] },
+      ],
+      preloadRule: {
+        'pages/home/index': {
+          packages: ['packages/order'],
+        },
+      },
+      tabBar: {
+        list: [
+          { pagePath: 'pages/home/index', text: 'home' },
+          { pagePath: 'pages/profile/index', text: 'profile' },
+        ],
+      },
+    })
+  })
+
   it('registers app side json files without app config normalization', async () => {
     const { loader, jsonService, registerJsonAsset } = createLoader()
     const pluginCtx = createPluginContext()

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/app.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry/app.ts
@@ -7,7 +7,7 @@ import type { ResolvedEntryRecord } from './resolve'
 import { createHash } from 'node:crypto'
 import { get, removeExtensionDeep } from '@weapp-core/shared'
 import path from 'pathe'
-import { applyPreloadRulesToAppJson, normalizeAppJson } from '../../../../utils'
+import { finalizeAppConfigForBuild } from '../../../../runtime/appConfig'
 import { normalizeWatchPath } from '../../../../utils/path'
 import { analyzeAppJson, analyzePluginJson } from '../../../utils/analyze'
 import { collectAppSideFiles, collectMiniappConfigFile } from './watch'
@@ -149,11 +149,11 @@ export async function collectAppEntries(options: CollectAppEntriesOptions): Prom
   }
 
   if (!isPluginBuild) {
-    appJson = applyPreloadRulesToAppJson(
-      normalizeAppJson(json),
-      configService.weappViteConfig.routeRules,
-      configService.platform,
-    )
+    appJson = finalizeAppConfigForBuild(json, {
+      buildScope: configService.weappViteConfig.buildScope,
+      platform: configService.platform,
+      routeRules: configService.weappViteConfig.routeRules,
+    })
     entries.push(...analyzeAppJson(appJson))
   }
 

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/shared.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/shared.test.ts
@@ -609,6 +609,9 @@ describe('emitSharedVueEntryAssets', () => {
       isPage: false,
       configService: {
         weappViteConfig: {
+          buildScope: {
+            include: ['subs'],
+          },
           json: {
             defaults: {
               app: {
@@ -651,10 +654,62 @@ describe('emitSharedVueEntryAssets', () => {
         mergeExistingAsset: true,
         mergeStrategy: 'override',
         defaults: { lazyCodeLoading: 'requiredComponents' },
+        finalizeConfig: expect.any(Function),
         kind: 'app',
         extension: 'json',
       },
     )
+    const finalizeConfig = emitSfcJsonAssetMock.mock.calls[0][4].finalizeConfig
+    expect(finalizeConfig({
+      pages: [
+        'pages/issue-793/index',
+        'pages/issue-793-settings/index',
+      ],
+      preloadRule: {
+        'pages/issue-793/index': {
+          packages: ['subs', 'missing'],
+        },
+      },
+      subPackages: [
+        {
+          root: 'subs',
+          pages: ['issue-793/index'],
+        },
+        {
+          root: 'excluded',
+          pages: ['index'],
+        },
+      ],
+      tabBar: {
+        list: [
+          { pagePath: 'pages/issue-793/index', text: '首页' },
+          { pagePath: 'pages/issue-793-settings/index', text: '设置' },
+          { pagePath: 'subs/issue-793/index', text: '分包' },
+        ],
+      },
+    })).toEqual({
+      pages: [
+        'pages/issue-793/index',
+        'pages/issue-793-settings/index',
+      ],
+      preloadRule: {
+        'pages/issue-793/index': {
+          packages: ['subs'],
+        },
+      },
+      subPackages: [
+        {
+          root: 'subs',
+          pages: ['issue-793/index'],
+        },
+      ],
+      tabBar: {
+        list: [
+          { pagePath: 'pages/issue-793/index', text: '首页' },
+          { pagePath: 'pages/issue-793-settings/index', text: '设置' },
+        ],
+      },
+    })
     expect(result).toEqual({
       isAppVue: true,
       shouldEmitComponentJson: false,

--- a/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/assets.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/bundle/shared/assets.ts
@@ -3,6 +3,7 @@ import type { CompilerContext } from '../../../../../context'
 import type { JsonMergeStrategy } from '../../../../../types'
 import type { ClassStyleWxsAsset } from './types'
 import { getClassStyleWxsSource } from 'wevu/compiler'
+import { finalizeAppConfigForBuild } from '../../../../../runtime/appConfig'
 import { normalizeFsResolvedId } from '../../../../../utils/resolvedId'
 import { processCssWithCache } from '../../../../css/shared/preprocessor'
 import { resolveClassStyleWxsLocationForBase } from '../../classStyle'
@@ -58,6 +59,7 @@ export function emitSharedVueEntryJsonAsset(options: {
     defaultConfig?: Record<string, any>
     mergeExistingAsset?: boolean
     defaults?: Record<string, any>
+    finalizeConfig?: (config: Record<string, any>) => Record<string, any>
     mergeStrategy?: JsonMergeStrategy
     kind: 'app' | 'page' | 'component'
     extension: string
@@ -404,6 +406,14 @@ export async function emitCompiledEntryBundleAssets(options: {
     )
   }
 
+  const finalizeJsonConfig = isAppVue
+    ? (config: Record<string, any>) => finalizeAppConfigForBuild(config, {
+        buildScope: options.configService.weappViteConfig?.buildScope,
+        platform: options.configService.platform,
+        routeRules: options.configService.weappViteConfig?.routeRules,
+      })
+    : undefined
+
   if (options.result.config || shouldEmitComponentJson) {
     emitSharedVueEntryJsonAsset({
       bundle: options.bundle,
@@ -417,6 +427,7 @@ export async function emitCompiledEntryBundleAssets(options: {
         mergeExistingAsset: shouldMergeJsonAsset,
         mergeStrategy: jsonConfig?.mergeStrategy,
         defaults: jsonConfig?.defaults?.[jsonKind],
+        ...(finalizeJsonConfig ? { finalizeConfig: finalizeJsonConfig } : {}),
         kind: jsonKind,
         extension: options.jsonExtension,
       },

--- a/packages/weapp-vite/src/plugins/vue/transform/emitAssets.test.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/emitAssets.test.ts
@@ -63,6 +63,40 @@ describe('emitAssets', () => {
     ])
   })
 
+  it('finalizes merged json config after combining the existing asset', () => {
+    const emitter = createEmitter()
+    const bundle: Record<string, any> = {
+      'app.json': {
+        type: 'asset',
+        fileName: 'app.json',
+        source: JSON.stringify({ fromExisting: true }),
+      },
+    }
+    const finalizeConfig = vi.fn(config => ({
+      ...config,
+      finalized: true,
+    }))
+
+    emitSfcJsonAsset(emitter.ctx, bundle, 'app', {
+      config: JSON.stringify({ fromVue: true }),
+    }, {
+      finalizeConfig,
+      kind: 'app',
+      mergeExistingAsset: true,
+    })
+
+    expect(finalizeConfig).toHaveBeenCalledWith({
+      fromExisting: true,
+      fromVue: true,
+    })
+    expect(JSON.parse(bundle['app.json'].source)).toEqual({
+      finalized: true,
+      fromExisting: true,
+      fromVue: true,
+    })
+    expect(emitter.emitFile).not.toHaveBeenCalled()
+  })
+
   it('replaces an existing script chunk code without emitting a duplicate file', () => {
     const emitter = createEmitter()
     const existingChunk = {

--- a/packages/weapp-vite/src/plugins/vue/transform/emitAssets.ts
+++ b/packages/weapp-vite/src/plugins/vue/transform/emitAssets.ts
@@ -118,6 +118,7 @@ export function emitSfcJsonAsset(
     emitIfMissingOnly?: boolean
     mergeStrategy?: JsonMergeStrategy
     defaults?: Record<string, any>
+    finalizeConfig?: (config: Record<string, any>) => Record<string, any>
     kind?: 'app' | 'page' | 'component'
     extension?: string
   },
@@ -160,6 +161,7 @@ export function emitSfcJsonAsset(
 
   if (options.emitIfMissingOnly) {
     if (!bundle[jsonFileName]) {
+      nextConfig = options.finalizeConfig?.(nextConfig) ?? nextConfig
       const nextSource = JSON.stringify(nextConfig, null, 2)
       if (emittedAssetSourceCache.get(cacheKey) !== nextSource) {
         ctx.emitFile({ type: 'asset', fileName: jsonFileName, source: nextSource })
@@ -172,16 +174,19 @@ export function emitSfcJsonAsset(
   if (options.mergeExistingAsset && existing && existing.type === 'asset') {
     try {
       const existingConfig = JSON.parse(existing.source.toString())
-      const merged = mergeJson(existingConfig, nextConfig, 'merge-existing')
+      const mergedConfig = mergeJson(existingConfig, nextConfig, 'merge-existing')
+      const merged = options.finalizeConfig?.(mergedConfig) ?? mergedConfig
       existing.source = JSON.stringify(merged, null, 2)
     }
     catch {
+      nextConfig = options.finalizeConfig?.(nextConfig) ?? nextConfig
       existing.source = JSON.stringify(nextConfig, null, 2)
     }
     return
   }
 
   if (existing && existing.type === 'asset') {
+    nextConfig = options.finalizeConfig?.(nextConfig) ?? nextConfig
     const nextSource = JSON.stringify(nextConfig, null, 2)
     const current = existing.source?.toString?.() ?? ''
     if (current !== nextSource) {
@@ -191,6 +196,7 @@ export function emitSfcJsonAsset(
     return
   }
 
+  nextConfig = options.finalizeConfig?.(nextConfig) ?? nextConfig
   const nextSource = JSON.stringify(nextConfig, null, 2)
   if (emittedAssetSourceCache.get(cacheKey) === nextSource) {
     return

--- a/packages/weapp-vite/src/runtime/appConfig.ts
+++ b/packages/weapp-vite/src/runtime/appConfig.ts
@@ -1,0 +1,25 @@
+import type { MpPlatform, WeappBuildScopeConfig, WeappRouteRules } from '../types'
+import type { BuildScopeAppJson } from './buildScope'
+import { applyPreloadRulesToAppJson, normalizeAppJson } from '../utils'
+import { applyBuildScopeToAppConfig, resolveBuildScope } from './buildScope'
+
+export interface AppConfigBuildOptions {
+  buildScope?: WeappBuildScopeConfig
+  platform?: MpPlatform
+  routeRules?: WeappRouteRules
+}
+
+export function finalizeAppConfigForBuild(
+  config: Record<string, any>,
+  options: AppConfigBuildOptions,
+) {
+  const normalizedConfig = normalizeAppJson(config) as BuildScopeAppJson
+  return applyBuildScopeToAppConfig(
+    applyPreloadRulesToAppJson(
+      normalizedConfig,
+      options.routeRules,
+      options.platform,
+    ),
+    resolveBuildScope(options.buildScope),
+  )
+}

--- a/packages/weapp-vite/src/runtime/buildScope.test.ts
+++ b/packages/weapp-vite/src/runtime/buildScope.test.ts
@@ -1,3 +1,4 @@
+import type { BuildScopeAppJson } from './buildScope'
 import { describe, expect, it } from 'vitest'
 import {
   applyBuildScopeToAppConfig,
@@ -69,9 +70,78 @@ describe('buildScope', () => {
     })
   })
 
-  it('can build only a target subpackage when main package is disabled', () => {
+  it('keeps scoped package names and the main package preload marker', () => {
     const appConfig = {
       pages: ['pages/home/index'],
+      subPackages: [
+        {
+          root: 'packages/independent',
+          name: 'independent',
+          pages: ['index'],
+          independent: true,
+        },
+        {
+          root: 'packages/user',
+          name: 'user',
+          pages: ['index'],
+        },
+      ],
+      preloadRule: {
+        'pages/home/index': {
+          packages: ['packages/independent', 'independent', 'packages/user', 'user'],
+        },
+        'packages/independent/index': {
+          packages: ['__APP__', 'packages/user'],
+        },
+      },
+    }
+
+    applyBuildScopeToAppConfig(appConfig, resolveBuildScope({
+      include: ['packages/independent'],
+    }))
+
+    expect(appConfig.preloadRule).toEqual({
+      'pages/home/index': {
+        packages: ['packages/independent', 'independent'],
+      },
+      'packages/independent/index': {
+        packages: ['__APP__'],
+      },
+    })
+  })
+
+  it('filters tab bar pages and removes an invalid short tab bar', () => {
+    const appConfig: BuildScopeAppJson = {
+      pages: ['pages/home/index', 'pages/profile/index'],
+      tabBar: {
+        color: '#000000',
+        selectedColor: '#ffffff',
+        backgroundColor: '#ffffff',
+        list: [
+          { pagePath: 'pages/home/index', text: 'home' },
+          { pagePath: 'pages/profile/index', text: 'profile' },
+          { pagePath: 'pages/missing/index', text: 'missing' },
+        ],
+      },
+    }
+
+    applyBuildScopeToAppConfig(appConfig, resolveBuildScope({ include: [] }))
+
+    expect(appConfig.tabBar?.list).toEqual([
+      { pagePath: 'pages/home/index', text: 'home' },
+      { pagePath: 'pages/profile/index', text: 'profile' },
+    ])
+
+    appConfig.pages = ['pages/home/index']
+    applyBuildScopeToAppConfig(appConfig, resolveBuildScope({ include: [] }))
+
+    expect(appConfig.tabBar).toBeUndefined()
+  })
+
+  it('can build only a target subpackage when main package is disabled', () => {
+    const appConfig: BuildScopeAppJson = {
+      pages: ['pages/home/index'],
+      entryPagePath: 'pages/home/index',
       subpackages: [
         { root: 'packages/order', pages: ['pages/list/index'] },
         { root: 'packages/user', pages: ['pages/profile/index'] },
@@ -83,6 +153,15 @@ describe('buildScope', () => {
         'packages/order/pages/list/index': {
           packages: ['packages/user'],
         },
+      },
+      tabBar: {
+        color: '#000000',
+        selectedColor: '#ffffff',
+        backgroundColor: '#ffffff',
+        list: [
+          { pagePath: 'pages/home/index', text: 'home' },
+          { pagePath: 'pages/profile/index', text: 'profile' },
+        ],
       },
     }
 
@@ -96,6 +175,8 @@ describe('buildScope', () => {
       { root: 'packages/order', pages: ['pages/list/index'] },
     ])
     expect(appConfig.preloadRule).toBeUndefined()
+    expect(appConfig.tabBar).toBeUndefined()
+    expect(appConfig.entryPagePath).toBeUndefined()
   })
 
   it('filters auto-routes module snapshot by build scope', () => {

--- a/packages/weapp-vite/src/runtime/buildScope.ts
+++ b/packages/weapp-vite/src/runtime/buildScope.ts
@@ -104,23 +104,18 @@ function normalizeScopedSubPackage<T extends { root?: string, pages?: string[] }
 
 function filterPreloadRule(
   preloadRule: Record<string, unknown> | undefined,
-  scope: ResolvedBuildScope,
-  allSubPackageRoots: ReadonlySet<string>,
+  scopedPages: ReadonlySet<string>,
+  scopedPackageIdentifiers: ReadonlySet<string>,
+  includeMainPackage: boolean,
 ) {
   if (!preloadRule || typeof preloadRule !== 'object') {
     return preloadRule
   }
 
-  const scopedRoots = new Set(scope.subPackageRoots)
   const scopedPreloadRule: Record<string, unknown> = {}
   for (const [pagePath, rule] of Object.entries(preloadRule)) {
     const normalizedPagePath = normalizeRoot(pagePath)
-    const pageSubPackageRoot = [...allSubPackageRoots]
-      .find(root => normalizedPagePath === root || normalizedPagePath.startsWith(`${root}/`))
-    const isPageInScope = pageSubPackageRoot
-      ? scopedRoots.has(pageSubPackageRoot)
-      : scope.includeMainPackage
-    if (!isPageInScope) {
+    if (!scopedPages.has(normalizedPagePath)) {
       continue
     }
 
@@ -136,7 +131,13 @@ function filterPreloadRule(
     }
 
     const filteredPackages = packages.filter((packageRoot) => {
-      return typeof packageRoot === 'string' && scopedRoots.has(normalizeRoot(packageRoot))
+      if (typeof packageRoot !== 'string') {
+        return false
+      }
+      const normalizedPackageRoot = normalizeRoot(packageRoot)
+      return normalizedPackageRoot === '__APP__'
+        ? includeMainPackage
+        : scopedPackageIdentifiers.has(normalizedPackageRoot)
     })
     if (filteredPackages.length > 0) {
       scopedPreloadRule[pagePath] = {
@@ -147,6 +148,53 @@ function filterPreloadRule(
   }
 
   return Object.keys(scopedPreloadRule).length > 0 ? scopedPreloadRule : undefined
+}
+
+function collectScopedAppGraph(
+  pages: string[],
+  subPackages: BuildScopeSubPackage[],
+) {
+  const mainPages = new Set(pages.map(page => normalizeRoot(page)))
+  const allPages = new Set(mainPages)
+  const packageIdentifiers = new Set<string>()
+
+  for (const subPackage of subPackages) {
+    const root = normalizeRoot(subPackage.root ?? '')
+    if (!root) {
+      continue
+    }
+    packageIdentifiers.add(root)
+    if (typeof subPackage.name === 'string' && subPackage.name.trim()) {
+      packageIdentifiers.add(normalizeRoot(subPackage.name))
+    }
+    for (const page of subPackage.pages ?? []) {
+      allPages.add(normalizeRoot(`${root}/${page}`))
+    }
+  }
+
+  return {
+    allPages,
+    mainPages,
+    packageIdentifiers,
+  }
+}
+
+function filterTabBar(tabBar: AppJson['tabBar'], mainPages: ReadonlySet<string>) {
+  if (!tabBar || !Array.isArray(tabBar.list)) {
+    return tabBar
+  }
+
+  const list = tabBar.list.filter((item) => {
+    return typeof item.pagePath === 'string' && mainPages.has(normalizeRoot(item.pagePath))
+  })
+  if (list.length < 2) {
+    return undefined
+  }
+
+  return {
+    ...tabBar,
+    list,
+  } as NonNullable<AppJson['tabBar']>
 }
 
 export function applyBuildScopeToAppConfig(
@@ -163,11 +211,6 @@ export function applyBuildScopeToAppConfig(
     : Array.isArray(config.subpackages)
       ? config.subpackages
       : []
-  const allSubPackageRoots = new Set(
-    sourceSubPackages
-      .map(subPackage => subPackage.root ? normalizeRoot(subPackage.root) : undefined)
-      .filter((root): root is string => Boolean(root)),
-  )
   const scopedSubPackages = sourceSubPackages
     .filter(subPackage => isSubPackageInScope(subPackage, scopedRoots))
     .map(normalizeScopedSubPackage)
@@ -178,12 +221,33 @@ export function applyBuildScopeToAppConfig(
   ;(config as { subPackages: BuildScopeSubPackage[] }).subPackages = scopedSubPackages
   delete config.subpackages
 
-  const preloadRule = filterPreloadRule(config.preloadRule, scope, allSubPackageRoots)
+  const scopedGraph = collectScopedAppGraph(config.pages, scopedSubPackages)
+  const preloadRule = filterPreloadRule(
+    config.preloadRule,
+    scopedGraph.allPages,
+    scopedGraph.packageIdentifiers,
+    scope.includeMainPackage,
+  )
   if (preloadRule) {
     config.preloadRule = preloadRule
   }
   else {
     delete config.preloadRule
+  }
+
+  const tabBar = filterTabBar(config.tabBar, scopedGraph.mainPages)
+  if (tabBar) {
+    config.tabBar = tabBar
+  }
+  else {
+    delete config.tabBar
+  }
+
+  if (
+    typeof config.entryPagePath === 'string'
+    && !scopedGraph.mainPages.has(normalizeRoot(config.entryPagePath))
+  ) {
+    delete config.entryPagePath
   }
 
   return config

--- a/packages/weapp-vite/src/runtime/scanPlugin/service/app.ts
+++ b/packages/weapp-vite/src/runtime/scanPlugin/service/app.ts
@@ -4,8 +4,8 @@ import type { AppEntry, SubPackage } from '../../../types'
 import type { ScanServiceStateLike } from './shared'
 import { isObject } from '@weapp-core/shared'
 import path from 'pathe'
-import { applyPreloadRulesToAppJson, findJsEntry, findJsonEntry, findVueEntry, normalizeAppJson } from '../../../utils'
-import { applyBuildScopeToAppConfig, resolveBuildScope } from '../../buildScope'
+import { findJsEntry, findJsonEntry, findVueEntry, normalizeAppJson } from '../../../utils'
+import { finalizeAppConfigForBuild } from '../../appConfig'
 import { createWarnOnce, mergeAutoRoutePages } from './shared'
 
 export function resolveScanAppBasename(absoluteSrcRoot: string) {
@@ -243,15 +243,13 @@ export async function loadAppEntry(ctx: MutableCompilerContext, scanState: ScanS
       }
     }
     await applyAutoRoutesToAppConfigIfNeeded(ctx, config)
-    applyPreloadRulesToAppJson(
-      config,
-      ctx.configService.weappViteConfig.routeRules,
-      ctx.configService.platform,
-    )
-    applyBuildScopeToAppConfig(config, resolveBuildScope(ctx.configService.weappViteConfig.buildScope))
+    config = finalizeAppConfigForBuild(config, {
+      buildScope: ctx.configService.weappViteConfig.buildScope,
+      platform: ctx.configService.platform,
+      routeRules: ctx.configService.weappViteConfig.routeRules,
+    })
 
     if (isObject(config)) {
-      normalizeAppConfigSubPackages(config)
       const finalEntryPath = appEntryPath || vueAppPath!
       const resolvedAppEntry: AppEntry = {
         path: finalEntryPath,

--- a/packages/weapp-vite/test/wevu-app-runtime-hmr.test.ts
+++ b/packages/weapp-vite/test/wevu-app-runtime-hmr.test.ts
@@ -200,17 +200,11 @@ describe.sequential('wevu app runtime HMR', () => {
           [
             'import { onLaunch, ref } from \'wevu\'',
             'import { normalizeClass } from \'wevu/internal-template\'',
-          ].join('\n'),
-        )
-        .replace(
-          'const tabBarList = [',
-          [
+            '',
             'const hmrProbeRef = ref(0)',
             'const hmrProbeClass = normalizeClass([\'wevu-hmr-probe\'])',
             'void hmrProbeRef',
             'void hmrProbeClass',
-            '',
-            'const tabBarList = [',
           ].join('\n'),
         ),
       'utf8',

--- a/website/config/build-and-output.md
+++ b/website/config/build-and-output.md
@@ -162,7 +162,9 @@ wv build --scope packages/order
 
 - 产物 `app.json.pages` 只在包含主包时保留。
 - 产物 `app.json.subPackages` 只保留参与 scope 的分包。
-- `preloadRule` 会同步过滤到参与 scope 的页面和分包。
+- `preloadRule` 只保留参与 scope 的触发页，并按分包 `root` / `name` 过滤 `packages`；`__APP__` 仅在主包参与构建时保留。
+- `tabBar.list` 只保留仍在本次主包中的页面；过滤后少于微信要求的 2 项时会删除整个 `tabBar`。
+- `entryPagePath` 指向被排除的主包页面时会删除，由本次主包 `pages` 的第一项接管默认启动页。
 - 开启 `weapp.autoRoutes` 时，`weapp-vite/auto-routes` 导出的 `pages`、`subPackages`、typed router 也会基于 scope 后的结果生成。
 - 开发态 watcher 会收窄到主包 `pages/**` 与参与 scope 的分包 root。
 

--- a/website/guide/cli.md
+++ b/website/guide/cli.md
@@ -117,7 +117,7 @@ wv build --scope main,packages/order --analyze
 - CLI `--scope` 的优先级高于配置文件中的 `weapp.buildScope`。
 - 不传 `--scope` 时保持完整构建行为。
 - 传入 `--scope packages/order` 时默认仍包含主包，因此最终产物会包含主包页面和 `packages/order` 分包。
-- 生成的 `app.json` 会同步裁剪 `subPackages` 与 `preloadRule`，未参与 scope 的分包不会被注册到本次产物。
+- 生成的 `app.json` 会同步裁剪 `subPackages`、`preloadRule`、`tabBar` 与失效的 `entryPagePath`，未参与 scope 的页面和分包不会被派生配置继续引用。
 
 ### 3) `analyze`
 

--- a/website/guide/subpackage.md
+++ b/website/guide/subpackage.md
@@ -217,6 +217,8 @@ wv build --scope packages/order
 - `wv build --scope packages/order` 默认仍包含主包。
 - 最终产物 `app.json.subPackages` 只包含参与 scope 的分包。
 - 未参与 scope 的分包页面不会被注册到本次产物。
+- `preloadRule.packages` 会按参与 scope 的分包 `root` / `name` 裁剪；主包标记 `__APP__` 也会跟随主包范围。
+- `tabBar.list` 会删除未注册的页面，剩余不足 2 项时直接删除整个 `tabBar`，避免生成微信无法加载的配置。
 - 开启 `autoRoutes` 时，`weapp-vite/auto-routes` 也只导出参与 scope 的主包页面和分包页面。
 
 也可以把常用 scope 固化到配置里：


### PR DESCRIPTION
## 问题

Issue #793 的原始分包误入主包问题已修复，但后续反馈暴露出应用配置没有统一按最终构建注册图投影：

- `preloadRule` 的触发页和 `packages` 未完整跟随 scope，且未覆盖分包 `name` 与 `__APP__`
- `tabBar.list` 仍可能引用未构建页面，过滤后不足 2 项会生成微信无法加载的配置
- `entryPagePath` 可能引用被排除的主包页面
- Vue SFC 的最终 `app.json` 合并发射会覆盖前面已经裁剪的结果

## 修改

- 新增共享应用配置终结器，统一执行规范化、路由预下载规则合成和 `buildScope` 投影
- 在扫描、入口分析、普通 JSON 注册和 Vue SFC 最终发射边界复用同一终结器
- 按最终页面注册图过滤 `preloadRule`、`tabBar` 和 `entryPagePath`
- `tabBar.list` 少于 2 项时自动删除整个 `tabBar`，不新增额外开关
- 扩展 issue #793 夹具，覆盖主包构建和仅分包构建
- 将 HMR 测试 probe 收敛到稳定 import 锚点，避免夹具局部变量改名导致测试未实际注入 probe
- 同步配置、CLI、分包指南与随包文档，并补充 `weapp-vite` / `create-weapp-vite` patch changeset

## 验证

- `pnpm vitest run -c packages/weapp-vite/vitest.config.ts ... --configLoader bundle`：14 个测试文件、312 项断言通过
- `pnpm vitest run -c packages/weapp-vite/vitest.config.ts packages/weapp-vite/test/wevu-app-runtime-hmr.test.ts --configLoader bundle`
- `pnpm --filter weapp-vite typecheck`
- `pnpm --filter weapp-vite build`
- `pnpm vitest run -c e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #793"`
- `pnpm --filter website-weapp-vite build`
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`
- `node --import tsx scripts/check-catalog-changeset.ts`
- changed-file ESLint 与 pre-commit hooks

## 文件拆分评估

`plugins/vue/transform/bundle/shared/assets.ts` 为既有的 Vue bundle asset 协调模块，目前 441 行。本次只在其现有 JSON 发射职责中注入最终配置终结器；此处拆分会扩大与问题无关的变更面，因此保留现有结构。新增的配置投影逻辑已独立收敛到 `runtime/appConfig.ts`。

Fixes #793