### PR TITLE
fix(weapp-vite): Skyline 模式自动降级 HMR

### DIFF
--- a/.changeset/calm-skyline-hmr.md
+++ b/.changeset/calm-skyline-hmr.md
@@ -1,0 +1,6 @@
+---
+'create-weapp-vite': patch
+'weapp-vite': patch
+---
+
+开发模式检测到 Skyline 渲染配置时，提示微信开发者工具的热重载限制，自动关闭项目私有配置中的热重载并降级为 classic，避免修改源码后预览无响应。

--- a/e2e/ci/skyline-hmr-fallback.test.ts
+++ b/e2e/ci/skyline-hmr-fallback.test.ts
@@ -1,0 +1,114 @@
+import path from 'node:path'
+import { fs } from '@weapp-core/shared/node'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { startDevProcess } from '../utils/dev-process'
+import { cleanupResidualDevProcesses } from '../utils/dev-process-cleanup'
+import { createDevProcessEnv } from '../utils/dev-process-env'
+import { createHmrMarker, replaceFileByRename, waitForFileContains } from '../utils/hmr-helpers'
+import { waitForFile } from '../wevu-runtime.utils'
+
+const ROOT = path.resolve(import.meta.dirname, '../..')
+const SOURCE_ROOT = path.join(ROOT, 'apps/vite-native-skyline')
+const APP_ROOT = path.join(ROOT, '.tmp/e2e/skyline-hmr-fallback')
+const CLI_PATH = path.join(ROOT, 'packages/weapp-vite/bin/weapp-vite.js')
+const PRIVATE_CONFIG_PATH = path.join(APP_ROOT, 'project.private.config.json')
+const SOURCE_WXML_PATH = path.join(APP_ROOT, 'pages/index/index.wxml')
+const DIST_WXML_PATH = path.join(APP_ROOT, 'dist/pages/index/index.wxml')
+const STATEFUL_CONTROL_PATH = path.join(APP_ROOT, 'dist/__weapp_vite_hmr/control.js')
+const COPY_EXCLUDED_ROOTS = new Set(['.weapp-vite', 'dist', 'node_modules'])
+
+async function waitForHotReloadDisabled(timeoutMs = 30_000) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    const config = await fs.readJson(PRIVATE_CONFIG_PATH).catch(() => undefined) as {
+      setting?: { compileHotReLoad?: unknown }
+    } | undefined
+    if (config?.setting?.compileHotReLoad === false) {
+      return config
+    }
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  throw new Error('Timed out waiting for Skyline hot reload fallback config update.')
+}
+
+beforeEach(async () => {
+  await cleanupResidualDevProcesses()
+  await fs.remove(APP_ROOT)
+  await fs.copy(SOURCE_ROOT, APP_ROOT, {
+    filter: (source) => {
+      const relativePath = path.relative(SOURCE_ROOT, source)
+      const [rootSegment] = relativePath.split(path.sep)
+      return !rootSegment || !COPY_EXCLUDED_ROOTS.has(rootSegment)
+    },
+  })
+  await Promise.all([
+    fs.writeFile(path.join(APP_ROOT, 'vite.config.ts'), [
+      'import { defineConfig } from \'weapp-vite/config\'',
+      '',
+      'export default defineConfig({})',
+      '',
+    ].join('\n'), 'utf8'),
+    fs.writeFile(path.join(APP_ROOT, 'app.wxss'), '@import "./common.wxss";\n', 'utf8'),
+    fs.remove(path.join(APP_ROOT, 'postcss.config.js')),
+    fs.remove(path.join(APP_ROOT, 'tailwind.config.js')),
+  ])
+  const privateConfig = await fs.readJson(PRIVATE_CONFIG_PATH) as Record<string, any>
+  privateConfig.setting = {
+    ...(privateConfig.setting ?? {}),
+    compileHotReLoad: true,
+  }
+  await fs.writeJson(PRIVATE_CONFIG_PATH, privateConfig, { spaces: 2 })
+})
+
+afterEach(async () => {
+  await cleanupResidualDevProcesses()
+  await fs.remove(APP_ROOT)
+})
+
+describe.sequential('Skyline HMR compatibility fallback', () => {
+  it('disables DevTools hot reload and keeps classic rebuilds working', async () => {
+    const originalSource = await fs.readFile(SOURCE_WXML_PATH, 'utf8')
+    const marker = createHmrMarker('SKYLINE', 'CLASSIC-FALLBACK')
+    const updatedSource = originalSource.replace('111', marker)
+    const dev = startDevProcess(process.execPath, [
+      CLI_PATH,
+      'dev',
+      APP_ROOT,
+      '--platform',
+      'weapp',
+      '--skipNpm',
+    ], {
+      all: true,
+      cwd: APP_ROOT,
+      env: createDevProcessEnv(),
+      reject: false,
+    })
+
+    try {
+      const output = await dev.waitForOutput(
+        '暂不支持 Skyline 热重载',
+        'Skyline compatibility warning',
+      )
+      expect(output).toContain('并降级为 classic')
+      expect(output).toContain('developers.weixin.qq.com')
+      await dev.waitFor(waitForHotReloadDisabled(), 'project private config hot reload fallback')
+      const privateConfig = await fs.readJson(PRIVATE_CONFIG_PATH) as Record<string, any>
+      expect(privateConfig.setting).toMatchObject({
+        compileHotReLoad: false,
+        skylineRenderEnable: true,
+        urlCheck: false,
+      })
+      await dev.waitFor(waitForFile(path.join(APP_ROOT, 'dist/app.json')), 'Skyline classic initial output')
+      expect(await fs.pathExists(STATEFUL_CONTROL_PATH)).toBe(false)
+
+      await replaceFileByRename(SOURCE_WXML_PATH, updatedSource)
+      await dev.waitFor(
+        waitForFileContains(DIST_WXML_PATH, marker),
+        'Skyline classic rebuilt page output',
+      )
+    }
+    finally {
+      await dev.stop(5_000)
+    }
+  })
+})

--- a/e2e/scripts/hmr-guard-manifest.test.ts
+++ b/e2e/scripts/hmr-guard-manifest.test.ts
@@ -53,6 +53,7 @@ describe('hmr-guard manifest', () => {
       'ci/e2e-app-tailwind-memory-guard.test.ts',
       'ci/external-linked-vue-component.hmr.test.ts',
       'ci/issue-340-comment.hmr.test.ts',
+      'ci/skyline-hmr-fallback.test.ts',
       'ci/style-import-vue.test.ts',
       'ci/template-tailwind-hmr.test.ts',
       'ci/wevu-root-import-hmr.test.ts',

--- a/e2e/scripts/hmr-guard-manifest.ts
+++ b/e2e/scripts/hmr-guard-manifest.ts
@@ -20,6 +20,7 @@ export const HMR_GUARD_TEST_GROUPS = {
     'hmr-delete.test.ts',
     'hmr-app-config.test.ts',
     'hmr-package-scripts.test.ts',
+    'skyline-hmr-fallback.test.ts',
     'issue-340-comment.hmr.test.ts',
     'wevu-router-hmr.test.ts',
   ]),

--- a/packages/weapp-vite/README.md
+++ b/packages/weapp-vite/README.md
@@ -47,7 +47,7 @@ export default defineConfig({
 })
 ```
 
-未配置 `weapp.hmr.runtime` 时，`wv dev` 会在启动时读取 `project.private.config.json.setting.compileHotReLoad`：开启时使用 `stateful-experimental`，关闭或无法确认时使用 `classic`。启动日志会以 `HMR 模式` 和 `HMR 切换` 两行显示最终模式、选择来源和切换方法。显式设置 `classic` 或 `stateful-experimental` 会覆盖自动选择。修改 DevTools 设置后请重启 `wv dev`；CSS、资源、配置和不兼容更新会自动回退完整构建与当前路由重载。
+未配置 `weapp.hmr.runtime` 时，`wv dev` 会在启动时读取 `project.private.config.json.setting.compileHotReLoad`：开启时使用 `stateful-experimental`，关闭或无法确认时使用 `classic`。启动日志会以 `HMR 模式` 和 `HMR 切换` 两行显示最终模式、选择来源和切换方法。显式设置 `classic` 或 `stateful-experimental` 会覆盖自动选择，但 Skyline 例外：微信开发者工具暂不支持 Skyline 热重载，首次编译检测到任意应用或页面配置使用 `renderer: 'skyline'` 时，会显示兼容性警告、自动将项目私有配置中的 `compileHotReLoad` 设为 `false`，并强制降级到 `classic`。切回 WebView 后可按需手动重新开启热重载。修改 DevTools 设置后请重启 `wv dev`；CSS、资源、配置和不兼容更新会自动回退完整构建与当前路由重载。
 
 > 说明：CLI 同时支持完整命令 `weapp-vite` 与简写命令 `wv`，两者等价。下面的示例默认使用 `weapp-vite`，你也可以按个人习惯替换成 `wv`。
 

--- a/packages/weapp-vite/docs/packaged/weapp-config.md
+++ b/packages/weapp-vite/docs/packaged/weapp-config.md
@@ -344,9 +344,9 @@ export default defineConfig({
 
 安全的 JavaScript/Vue 更新会保留当前 Page/Component 实例、route/query、输入和可序列化 data/setup ref，并替换原生 Page、原生 Component 与 wevu 方法。CSS、资源、JSON/配置、不兼容模块图或补丁失败会回退完整构建与当前路由重载。
 
-`auto` 在 `project.private.config.json` 的 `setting.compileHotReLoad` 严格为 `true` 时选择 `stateful-experimental`，否则选择 `classic`；非微信平台也会回退到 `classic`。该判断只在启动时执行，修改开发者工具设置后需要重启 `wv dev`。启动日志会以 `HMR 模式` 和 `HMR 切换` 两行显示最终模式、选择来源，以及通过 DevTools 热重载开关或 `weapp.hmr.runtime` 切换模式的方法。显式配置 `classic` 或 `stateful-experimental` 始终优先。
+`auto` 在 `project.private.config.json` 的 `setting.compileHotReLoad` 严格为 `true` 时选择 `stateful-experimental`，否则选择 `classic`；非微信平台也会回退到 `classic`。该判断只在启动时执行，修改开发者工具设置后需要重启 `wv dev`。启动日志会以 `HMR 模式` 和 `HMR 切换` 两行显示最终模式、选择来源，以及通过 DevTools 热重载开关或 `weapp.hmr.runtime` 切换模式的方法。显式配置通常优先，但 Skyline 兼容降级不受显式配置覆盖。
 
-状态保持模式目前只支持微信小程序，需要微信开发者工具开启服务端口和热重载。需要既有写盘/刷新行为时显式配置 `classic`。
+状态保持模式目前只支持微信小程序 WebView，需要微信开发者工具开启服务端口和热重载。微信开发者工具暂不支持 Skyline 热重载；首次编译检测到任意生成的应用或页面 JSON 使用 `renderer: 'skyline'` 时，`wv dev` 会输出带官方兼容文档链接的警告，将当前项目私有配置中的 `setting.compileHotReLoad` 持久化为 `false`，并强制使用 `classic`，包括显式配置 `stateful-experimental` 的场景。其他私有配置字段不会改变，切回 WebView 后也不会自动重新开启热重载。需要既有写盘/刷新行为时显式配置 `classic`。
 
 ### `hmr.logLevel` / `hmr.profileJson`
 

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
@@ -22,6 +22,7 @@ const createCompilerContextMock = vi.hoisted(() => vi.fn(async () => ({
     closeAll: vi.fn(),
   },
 })))
+const disableProjectPrivateConfigHotReloadMock = vi.hoisted(() => vi.fn(async () => true))
 const syncProjectConfigToOutputMock = vi.hoisted(() => vi.fn(async () => {}))
 const generateLibDtsMock = vi.hoisted(() => vi.fn(async () => {}))
 const createSharedBuildConfigMock = vi.hoisted(() => vi.fn(() => ({ shared: true })))
@@ -105,6 +106,7 @@ vi.mock('../../createContext', () => ({
 }))
 
 vi.mock('../../utils/projectConfig', () => ({
+  disableProjectPrivateConfigHotReload: disableProjectPrivateConfigHotReloadMock,
   syncProjectConfigToOutput: syncProjectConfigToOutputMock,
 }))
 
@@ -322,6 +324,8 @@ describe('runtime buildPlugin service', () => {
     devBuildWatcherQueue.length = 0
     vi.clearAllMocks()
     buildMock.mockReset()
+    disableProjectPrivateConfigHotReloadMock.mockReset()
+    disableProjectPrivateConfigHotReloadMock.mockResolvedValue(true)
     runStatefulHmrDevMock.mockReset()
     resetEmittedOutputCachesMock.mockReset()
     isOutputRootInsideOutDirMock.mockImplementation((outDir: string, pluginOutputRoot: string) => {
@@ -420,6 +424,73 @@ describe('runtime buildPlugin service', () => {
     expect(loggerInfoMock).toHaveBeenCalledWith(expect.stringContaining('HMR 切换：关闭微信开发者工具“热重载”后重启 wv dev'))
   })
 
+  it.each([
+    { configured: undefined, compileHotReLoad: true },
+    { configured: 'auto' as const, compileHotReLoad: true },
+    { configured: 'stateful-experimental' as const, compileHotReLoad: false },
+  ])('forces classic dev for Skyline ($configured, hot reload: $compileHotReLoad)', async ({ configured, compileHotReLoad }) => {
+    const watcher = createManualWatcher()
+    buildMock
+      .mockResolvedValueOnce({
+        output: [{ fileName: 'app.json', source: JSON.stringify({ renderer: 'skyline' }), type: 'asset' }],
+      })
+      .mockResolvedValueOnce(watcher)
+    const ctx = createMockContext()
+    if (configured) {
+      ctx.configService.weappViteConfig.hmr = { runtime: configured }
+    }
+    ctx.configService.projectPrivateConfig = {
+      setting: { compileHotReLoad },
+    }
+
+    const buildPromise = createBuildService(ctx).build({ skipNpm: true })
+    await watcher.subscribed
+    watcher.emit('START')
+    watcher.emit('END')
+    await buildPromise
+
+    expect(runStatefulHmrDevMock).not.toHaveBeenCalled()
+    expect(ctx.watcherService.setRollupWatcher).toHaveBeenCalledWith(watcher, '/')
+    expect(loggerWarnMock).toHaveBeenCalledWith(expect.stringContaining('app.json'))
+    expect(loggerWarnMock).toHaveBeenCalledWith(expect.stringContaining('developers.weixin.qq.com'))
+    expect(loggerInfoMock).toHaveBeenCalledWith('HMR 模式：classic（自动降级：Skyline 暂不支持微信开发者工具热重载）')
+    if (compileHotReLoad) {
+      expect(disableProjectPrivateConfigHotReloadMock).toHaveBeenCalledWith('/project/project.private.config.json')
+      expect(ctx.configService.projectPrivateConfig.setting.compileHotReLoad).toBe(false)
+    }
+    else {
+      expect(disableProjectPrivateConfigHotReloadMock).not.toHaveBeenCalled()
+    }
+  })
+
+  it('keeps the Skyline classic fallback when private config writeback fails', async () => {
+    const watcher = createManualWatcher()
+    buildMock
+      .mockResolvedValueOnce({
+        output: [
+          { fileName: 'app.json', source: JSON.stringify({ pages: ['pages/skyline/index'] }), type: 'asset' },
+          { fileName: 'pages/skyline/index.json', source: JSON.stringify({ renderer: 'skyline' }), type: 'asset' },
+        ],
+      })
+      .mockResolvedValueOnce(watcher)
+    disableProjectPrivateConfigHotReloadMock.mockRejectedValueOnce(new Error('read-only config'))
+    const ctx = createMockContext()
+    ctx.configService.projectPrivateConfig = {
+      setting: { compileHotReLoad: true },
+    }
+
+    const buildPromise = createBuildService(ctx).build({ skipNpm: true })
+    await watcher.subscribed
+    watcher.emit('START')
+    watcher.emit('END')
+    await buildPromise
+
+    expect(runStatefulHmrDevMock).not.toHaveBeenCalled()
+    expect(loggerWarnMock).toHaveBeenCalledWith(expect.stringContaining('无法自动关闭'))
+    expect(loggerWarnMock).toHaveBeenCalledWith(expect.stringContaining('read-only config'))
+    expect(loggerInfoMock).toHaveBeenCalledWith('HMR 模式：classic（自动降级：Skyline 暂不支持微信开发者工具热重载）')
+  })
+
   it('keeps stateful snapshot builds in memory until the session writer commits them', async () => {
     const watcher = { close: vi.fn(async () => {}) }
     buildMock
@@ -478,7 +549,6 @@ describe('runtime buildPlugin service', () => {
     runStatefulHmrDevMock.mockRejectedValueOnce(new StatefulHmrRuntimeCompatibilityError('missing DevRuntime'))
     buildMock.mockResolvedValueOnce(watcher)
     const ctx = createMockContext()
-    ctx.configService.weappViteConfig.hmr = { runtime: 'auto' }
     ctx.configService.projectPrivateConfig = {
       setting: { compileHotReLoad: true },
     }

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.ts
@@ -7,6 +7,7 @@ import type {
 import type { InlineConfig } from 'vite'
 import type { BuildTarget, MutableCompilerContext } from '../../context'
 import type { ChangeEvent, SubPackageMetaValue } from '../../types'
+import type { HmrRuntimeDecision } from '../hmrRuntime'
 import type { StatefulHmrOutputFile } from '../statefulHmr/outputWriter'
 import { appendFile, mkdir } from 'node:fs/promises'
 import process from 'node:process'
@@ -32,9 +33,9 @@ import { isLayoutSourcePath } from '../../plugins/utils/layoutSourcePath'
 import { touch } from '../../utils/file'
 import { createHmrProfileEventId, recordHmrProfileDuration, resolveHmrProfileJsonEnvOption, resolveHmrProfileJsonPath as resolveHmrProfileJsonOutputPath } from '../../utils/hmrProfile'
 import { resolveCompilerOutputExtensions } from '../../utils/outputExtensions'
-import { syncProjectConfigToOutput } from '../../utils/projectConfig'
+import { disableProjectPrivateConfigHotReload, syncProjectConfigToOutput } from '../../utils/projectConfig'
 import { normalizeFsResolvedId } from '../../utils/resolvedId'
-import { formatHmrRuntimeStartupMessages, resolveHmrRuntime } from '../hmrRuntime'
+import { findSkylineRendererFiles, formatHmrRuntimeStartupMessages, resolveHmrRuntimeDecision } from '../hmrRuntime'
 import { generateLibDts } from '../libDts'
 import { resetRuntimeStateForFreshBuild } from '../resetRuntimeState'
 import { createSharedBuildConfig } from '../sharedBuildConfig'
@@ -361,8 +362,76 @@ function createSnapshotSidecarIgnoredMatcher(ctx: MutableCompilerContext) {
 
 export function createBuildService(ctx: MutableCompilerContext): BuildService {
   let lastHmrSlowTipProfileCount = 0
-  let devHmrRuntime: ReturnType<typeof resolveHmrRuntime> | undefined
+  let devHmrDecision: HmrRuntimeDecision | undefined
   let devHmrRuntimeNoticeLogged = false
+  let skylineHmrFallbackApplied = false
+
+  const SKYLINE_HMR_COMPATIBILITY_URL = 'https://developers.weixin.qq.com/miniprogram/dev/framework/runtime/skyline/migration/compatibility.html#%E5%B8%B8%E8%A7%81%E7%9A%84%E5%85%BC%E5%AE%B9%E9%97%AE%E9%A2%98'
+
+  function logHmrRuntimeDecision(decision: HmrRuntimeDecision) {
+    if (devHmrRuntimeNoticeLogged) {
+      return
+    }
+    devHmrRuntimeNoticeLogged = true
+    for (const message of formatHmrRuntimeStartupMessages(decision)) {
+      logger.info(message)
+    }
+  }
+
+  async function applySkylineHmrFallback(options: {
+    compileHotReLoad?: unknown
+    configured?: HmrRuntimeDecision['configured']
+    files: string[]
+  }) {
+    const currentDecision = devHmrDecision ?? resolveHmrRuntimeDecision({
+      platform: ctx.configService.platform,
+      configured: options.configured,
+      compileHotReLoad: options.compileHotReLoad,
+    })
+    if (
+      skylineHmrFallbackApplied
+      || (currentDecision.runtime === 'classic' && options.compileHotReLoad !== true)
+    ) {
+      return false
+    }
+
+    skylineHmrFallbackApplied = true
+    devHmrDecision = resolveHmrRuntimeDecision({
+      platform: ctx.configService.platform,
+      configured: currentDecision.configured,
+      compileHotReLoad: options.compileHotReLoad,
+      skyline: true,
+    })
+
+    const detectedFiles = options.files.slice(0, 3).join('、')
+    const detectedSuffix = detectedFiles ? `（${detectedFiles}）` : ''
+    const privateConfigPath = ctx.configService.projectPrivateConfigPath
+    const privateConfigDisplay = privateConfigPath
+      ? ctx.configService.relativeCwd(privateConfigPath)
+      : 'project.private.config.json'
+
+    if (options.compileHotReLoad === true) {
+      try {
+        if (!privateConfigPath) {
+          throw new Error('无法解析项目私有配置路径')
+        }
+        await disableProjectPrivateConfigHotReload(privateConfigPath)
+        const privateConfig = ctx.configService.projectPrivateConfig
+        const setting = privateConfig.setting && typeof privateConfig.setting === 'object' && !Array.isArray(privateConfig.setting)
+          ? privateConfig.setting as Record<string, unknown>
+          : {}
+        privateConfig.setting = { ...setting, compileHotReLoad: false }
+        logger.warn(`检测到 Skyline 渲染配置${detectedSuffix}。微信开发者工具暂不支持 Skyline 热重载，已将 ${privateConfigDisplay} 中的 setting.compileHotReLoad 设为 false，并降级为 classic。详情：${SKYLINE_HMR_COMPATIBILITY_URL}`)
+      }
+      catch (error) {
+        logger.warn(`检测到 Skyline 渲染配置${detectedSuffix}。已降级为 classic，但无法自动关闭 ${privateConfigDisplay} 中的 setting.compileHotReLoad：${error instanceof Error ? error.message : String(error)}。请手动关闭微信开发者工具“热重载”。详情：${SKYLINE_HMR_COMPATIBILITY_URL}`)
+      }
+    }
+    else {
+      logger.warn(`检测到 Skyline 渲染配置${detectedSuffix}。微信开发者工具暂不支持 Skyline 热重载，weapp.hmr.runtime="stateful-experimental" 已自动降级为 classic。详情：${SKYLINE_HMR_COMPATIBILITY_URL}`)
+    }
+    return true
+  }
 
   function createHmrProfileJsonSample(totalMs: number): HmrProfileJsonSample {
     const profile = ctx.runtimeState.build.hmr.profile
@@ -1169,42 +1238,60 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
     }
     debug?.(`[${target}] dev build watcher start`)
     const { hasWorkersDir, workersDir } = checkWorkersOptions(target, configService, scanService)
-    // eslint-disable-next-line ts/no-use-before-define
-    const createDevBuildOptions = () => appendHmrMetricsPlugin(applyTargetBuildOverride(
-      configService.merge(
+    const configuredHmrRuntime = configService.weappViteConfig.hmr?.runtime
+    const compileHotReLoad = configService.projectPrivateConfig.setting?.compileHotReLoad
+    devHmrDecision ??= resolveHmrRuntimeDecision({
+      platform: configService.platform,
+      configured: configuredHmrRuntime,
+      compileHotReLoad,
+    })
+    const createDevBuildOptions = () => {
+      // eslint-disable-next-line ts/no-use-before-define
+      const options = applyTargetBuildOverride(configService.merge(
         undefined,
         createSharedBuildConfig(configService, scanService),
         // eslint-disable-next-line ts/no-use-before-define
         resolveTargetBuildOverride(target),
-      ),
-      target,
-    ))
+      ), target)
+      if (target === 'app' && devHmrDecision?.runtime === 'classic') {
+        let skylineFiles: string[] = []
+        options.plugins = [
+          ...(options.plugins ?? []),
+          {
+            name: 'weapp-vite:skyline-hmr-compatibility',
+            enforce: 'post',
+            generateBundle(_options, bundle) {
+              skylineFiles = findSkylineRendererFiles(Object.values(bundle))
+            },
+            writeBundle() {
+              if (skylineFiles.length === 0) {
+                return
+              }
+              const detectedFiles = skylineFiles
+              skylineFiles = []
+              setTimeout(() => {
+                void applySkylineHmrFallback({
+                  compileHotReLoad,
+                  configured: devHmrDecision?.configured,
+                  files: detectedFiles,
+                })
+              }, 0)
+            },
+          },
+        ]
+      }
+      return appendHmrMetricsPlugin(options)
+    }
     let buildOptions = createDevBuildOptions()
     buildOptions.build = {
       ...(buildOptions.build ?? {}),
       write: true,
     }
-    const configuredHmrRuntime = configService.weappViteConfig.hmr?.runtime
-    const compileHotReLoad = configService.projectPrivateConfig.setting?.compileHotReLoad
-    devHmrRuntime ??= resolveHmrRuntime({
-      platform: configService.platform,
-      configured: configuredHmrRuntime,
-      compileHotReLoad,
-    })
-    const hmrRuntime = devHmrRuntime
-    if (target === 'app' && !devHmrRuntimeNoticeLogged) {
-      devHmrRuntimeNoticeLogged = true
-      const messages = formatHmrRuntimeStartupMessages({
-        platform: configService.platform,
-        configured: configuredHmrRuntime,
-        compileHotReLoad,
-        runtime: hmrRuntime,
-      })
-      for (const message of messages) {
-        logger.info(message)
-      }
+    const hmrDecision = devHmrDecision
+    if (target === 'app' && hmrDecision.runtime !== 'stateful-experimental') {
+      logHmrRuntimeDecision(hmrDecision)
     }
-    if (target === 'app' && hmrRuntime === 'stateful-experimental') {
+    if (target === 'app' && hmrDecision.runtime === 'stateful-experimental') {
       try {
         const snapshotBuildOptions: InlineConfig = {
           ...buildOptions,
@@ -1215,6 +1302,22 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
           },
         }
         const initialSnapshot = toStatefulHmrOutput(await build(snapshotBuildOptions))
+        const skylineFiles = findSkylineRendererFiles(initialSnapshot)
+        if (skylineFiles.length > 0) {
+          await applySkylineHmrFallback({
+            compileHotReLoad,
+            configured: hmrDecision.configured,
+            files: skylineFiles,
+          })
+        }
+        if (devHmrDecision?.runtime === 'classic') {
+          resetRuntimeStateForFreshBuild(ctx.runtimeState)
+          await configService.load(configService.loadOptions)
+          await scanService.loadAppEntry()
+          scanService.loadSubPackages()
+          return await runDev(target)
+        }
+        logHmrRuntimeDecision(hmrDecision)
         await configService.load(configService.loadOptions)
         resetRuntimeStateForFreshBuild(ctx.runtimeState)
         await scanService.loadAppEntry()
@@ -1279,12 +1382,16 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
         return watcher
       }
       catch (error) {
-        if (configuredHmrRuntime !== 'auto' || !isStatefulHmrRuntimeCompatibilityError(error)) {
+        if (hmrDecision.configured !== 'auto' || !isStatefulHmrRuntimeCompatibilityError(error)) {
           throw error
         }
-        devHmrRuntime = 'classic'
+        devHmrDecision = {
+          configured: hmrDecision.configured,
+          reason: 'runtime-compatibility-fallback',
+          runtime: 'classic',
+        }
         logger.warn(`微信状态保持 HMR 运行时不可用，已自动降级为 classic：${error instanceof Error ? error.message : String(error)}`)
-        logger.info('HMR 模式：classic（自动降级：stateful HMR 运行时兼容性检查失败）')
+        logger.info(formatHmrRuntimeStartupMessages(devHmrDecision)[0])
         resetRuntimeStateForFreshBuild(ctx.runtimeState)
         await configService.load(configService.loadOptions)
         await scanService.loadAppEntry()

--- a/packages/weapp-vite/src/runtime/hmrRuntime.test.ts
+++ b/packages/weapp-vite/src/runtime/hmrRuntime.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, it } from 'vitest'
-import { formatHmrRuntimeStartupMessages, resolveHmrRuntime } from './hmrRuntime'
+import {
+  findSkylineRendererFiles,
+  formatHmrRuntimeStartupMessages,
+  resolveHmrRuntime,
+  resolveHmrRuntimeDecision,
+} from './hmrRuntime'
 
 describe('resolveHmrRuntime', () => {
-  it('uses stateful runtime when WeChat hot reload is enabled', () => {
-    expect(resolveHmrRuntime({ platform: 'weapp', configured: 'auto', compileHotReLoad: true })).toBe('stateful-experimental')
+  it.each(['auto', undefined] as const)('uses stateful runtime when WeChat hot reload is enabled (%s)', (configured) => {
+    expect(resolveHmrRuntime({ platform: 'weapp', configured, compileHotReLoad: true })).toBe('stateful-experimental')
+    expect(resolveHmrRuntimeDecision({ platform: 'weapp', configured, compileHotReLoad: true })).toEqual({
+      configured: 'auto',
+      reason: 'auto-stateful',
+      runtime: 'stateful-experimental',
+    })
   })
 
   it.each([false, undefined, 'true', 1])('uses classic when hot reload is not confirmed (%s)', (compileHotReLoad) => {
@@ -11,53 +21,117 @@ describe('resolveHmrRuntime', () => {
   })
 
   it('uses classic for auto on non-WeChat platforms', () => {
-    expect(resolveHmrRuntime({ platform: 'alipay', configured: 'auto', compileHotReLoad: true })).toBe('classic')
+    expect(resolveHmrRuntimeDecision({ platform: 'alipay', configured: 'auto', compileHotReLoad: true })).toEqual({
+      configured: 'auto',
+      reason: 'auto-non-wechat',
+      runtime: 'classic',
+    })
   })
 
-  it('keeps explicit runtime settings authoritative', () => {
+  it('keeps explicit runtime settings authoritative outside Skyline', () => {
     expect(resolveHmrRuntime({ platform: 'weapp', configured: 'classic', compileHotReLoad: true })).toBe('classic')
     expect(resolveHmrRuntime({ platform: 'weapp', configured: 'stateful-experimental', compileHotReLoad: false })).toBe('stateful-experimental')
   })
 
+  it.each(['auto', 'classic', 'stateful-experimental', undefined] as const)('forces classic for Skyline (%s)', (configured) => {
+    expect(resolveHmrRuntimeDecision({
+      platform: 'weapp',
+      configured,
+      compileHotReLoad: true,
+      skyline: true,
+    })).toEqual({
+      configured: configured ?? 'auto',
+      reason: 'skyline-fallback',
+      runtime: 'classic',
+    })
+  })
+
   it('explains the auto stateful selection and how to switch to classic', () => {
-    expect(formatHmrRuntimeStartupMessages({
+    const decision = resolveHmrRuntimeDecision({
       platform: 'weapp',
       configured: 'auto',
       compileHotReLoad: true,
-      runtime: 'stateful-experimental',
-    })).toEqual([
+    })
+    expect(formatHmrRuntimeStartupMessages(decision)).toEqual([
       'HMR 模式：stateful-experimental（自动检测：微信开发者工具热重载已开启）',
       'HMR 切换：关闭微信开发者工具“热重载”后重启 wv dev，或通过 weapp.hmr.runtime 显式配置。',
     ])
   })
 
   it('explains the auto classic selection and how to switch to stateful HMR', () => {
-    expect(formatHmrRuntimeStartupMessages({
+    const decision = resolveHmrRuntimeDecision({
       platform: 'weapp',
-      configured: undefined,
       compileHotReLoad: false,
-      runtime: 'classic',
-    })).toEqual([
+    })
+    expect(formatHmrRuntimeStartupMessages(decision)).toEqual([
       'HMR 模式：classic（自动检测：微信开发者工具热重载未开启或无法确认）',
       'HMR 切换：开启微信开发者工具“热重载”后重启 wv dev，或通过 weapp.hmr.runtime 显式配置。',
     ])
   })
 
-  it('explains explicit and non-WeChat runtime selections', () => {
-    expect(formatHmrRuntimeStartupMessages({
+  it('explains explicit, non-WeChat, and Skyline selections', () => {
+    const explicit = resolveHmrRuntimeDecision({
       platform: 'weapp',
       configured: 'classic',
       compileHotReLoad: true,
-      runtime: 'classic',
-    })[1]).toContain('auto 或 stateful-experimental')
-    expect(formatHmrRuntimeStartupMessages({
+    })
+    expect(formatHmrRuntimeStartupMessages(explicit)[1]).toContain('auto 或 stateful-experimental')
+
+    const nonWeChat = resolveHmrRuntimeDecision({
       platform: 'alipay',
       configured: 'auto',
       compileHotReLoad: true,
-      runtime: 'classic',
-    })).toEqual([
+    })
+    expect(formatHmrRuntimeStartupMessages(nonWeChat)).toEqual([
       'HMR 模式：classic（自动检测：仅微信小程序支持 stateful-experimental）',
       'HMR 切换：可通过 weapp.hmr.runtime 显式配置 classic。',
     ])
+
+    const skyline = resolveHmrRuntimeDecision({
+      platform: 'weapp',
+      configured: 'stateful-experimental',
+      skyline: true,
+    })
+    expect(formatHmrRuntimeStartupMessages(skyline)[0]).toContain('Skyline')
+  })
+})
+
+describe('findSkylineRendererFiles', () => {
+  it('finds app, page, and subpackage Skyline json assets', () => {
+    expect(findSkylineRendererFiles([
+      {
+        type: 'asset',
+        fileName: 'app.json',
+        source: JSON.stringify({
+          pages: ['pages/home/index', 'pages/skyline/index'],
+          renderer: 'skyline',
+          subPackages: [{ root: 'package-a', pages: ['pages/index'] }],
+        }),
+      },
+      { type: 'asset', fileName: 'pages/home/index.json', source: JSON.stringify({ renderer: 'webview' }) },
+      { type: 'asset', fileName: 'pages/skyline/index.json', source: new TextEncoder().encode(JSON.stringify({ renderer: 'skyline' })) },
+      { type: 'asset', fileName: 'package-a\\pages\\index.json', source: JSON.stringify({ renderer: 'skyline' }) },
+    ])).toEqual([
+      'app.json',
+      'pages/skyline/index.json',
+      'package-a/pages/index.json',
+    ])
+  })
+
+  it('ignores WebView, non-page json, missing renderer, invalid json, and non-json output', () => {
+    expect(findSkylineRendererFiles([
+      { type: 'asset', fileName: 'app.json', source: JSON.stringify({ pages: ['pages/index/index'], renderer: 'webview' }) },
+      { type: 'asset', fileName: 'pages/index/index.json', source: '{}' },
+      { type: 'asset', fileName: 'pages/broken/index.json', source: '{invalid' },
+      { type: 'asset', fileName: 'data/renderer.json', source: JSON.stringify({ renderer: 'skyline' }) },
+      { type: 'asset', fileName: 'app.js', source: JSON.stringify({ renderer: 'skyline' }) },
+      { type: 'chunk', fileName: 'page.json', source: JSON.stringify({ renderer: 'skyline' }) },
+    ])).toEqual([])
+  })
+
+  it('requires an emitted app config to identify page json assets', () => {
+    expect(findSkylineRendererFiles([
+      { type: 'asset', fileName: 'pages/index/index.json', source: JSON.stringify({ renderer: 'skyline' }) },
+    ])).toEqual([])
   })
 })

--- a/packages/weapp-vite/src/runtime/hmrRuntime.ts
+++ b/packages/weapp-vite/src/runtime/hmrRuntime.ts
@@ -2,44 +2,147 @@ import type { MpPlatform } from '../types'
 
 export type HmrRuntime = 'classic' | 'stateful-experimental'
 export type HmrRuntimeSetting = 'auto' | HmrRuntime | undefined
+export type HmrRuntimeDecisionReason
+  = | 'auto-classic'
+    | 'auto-non-wechat'
+    | 'auto-stateful'
+    | 'explicit'
+    | 'runtime-compatibility-fallback'
+    | 'skyline-fallback'
 
-interface HmrRuntimeStartupMessageOptions {
-  platform: MpPlatform
-  configured?: HmrRuntimeSetting
-  compileHotReLoad?: unknown
+export interface HmrRuntimeDecision {
+  configured: Exclude<HmrRuntimeSetting, undefined>
+  reason: HmrRuntimeDecisionReason
   runtime: HmrRuntime
 }
 
-export function resolveHmrRuntime(options: {
+interface HmrRuntimeOutputFile {
+  fileName: string
+  source?: unknown
+  type: string
+}
+
+interface EmittedAppConfig {
+  pages?: unknown
+  renderer?: unknown
+  subPackages?: unknown
+  subpackages?: unknown
+}
+
+export function resolveHmrRuntimeDecision(options: {
   platform: MpPlatform
   configured?: HmrRuntimeSetting
   compileHotReLoad?: unknown
-}): HmrRuntime {
-  if (options.configured === 'classic' || options.configured === 'stateful-experimental') {
-    return options.configured
+  skyline?: boolean
+}): HmrRuntimeDecision {
+  const configured = options.configured ?? 'auto'
+  if (options.platform === 'weapp' && options.skyline === true) {
+    return { configured, reason: 'skyline-fallback', runtime: 'classic' }
+  }
+  if (configured === 'classic' || configured === 'stateful-experimental') {
+    return { configured, reason: 'explicit', runtime: configured }
   }
   if (options.platform === 'weapp' && options.compileHotReLoad === true) {
-    return 'stateful-experimental'
+    return { configured, reason: 'auto-stateful', runtime: 'stateful-experimental' }
   }
-  return 'classic'
+  return {
+    configured,
+    reason: options.platform === 'weapp' ? 'auto-classic' : 'auto-non-wechat',
+    runtime: 'classic',
+  }
 }
 
-export function formatHmrRuntimeStartupMessages(options: HmrRuntimeStartupMessageOptions): [string, string] {
-  const isExplicit = options.configured === 'classic' || options.configured === 'stateful-experimental'
-  if (isExplicit) {
-    const alternative = options.runtime === 'classic' ? 'stateful-experimental' : 'classic'
+export function resolveHmrRuntime(options: Parameters<typeof resolveHmrRuntimeDecision>[0]): HmrRuntime {
+  return resolveHmrRuntimeDecision(options).runtime
+}
+
+export function findSkylineRendererFiles(output: Iterable<HmrRuntimeOutputFile>): string[] {
+  const jsonConfigs = new Map<string, Record<string, unknown>>()
+  for (const item of output) {
+    if (item.type !== 'asset' || !item.fileName.endsWith('.json')) {
+      continue
+    }
+    const source = typeof item.source === 'string'
+      ? item.source
+      : item.source instanceof Uint8Array
+        ? new TextDecoder().decode(item.source)
+        : undefined
+    if (!source) {
+      continue
+    }
+    try {
+      const config = JSON.parse(source) as unknown
+      if (config && typeof config === 'object' && !Array.isArray(config)) {
+        jsonConfigs.set(item.fileName.replaceAll('\\', '/'), config as Record<string, unknown>)
+      }
+    }
+    catch {}
+  }
+
+  const appConfig = jsonConfigs.get('app.json') as EmittedAppConfig | undefined
+  if (!appConfig) {
+    return []
+  }
+
+  const configFiles = new Set(['app.json'])
+  if (Array.isArray(appConfig.pages)) {
+    for (const page of appConfig.pages) {
+      if (typeof page === 'string') {
+        configFiles.add(`${page}.json`)
+      }
+    }
+  }
+  const subPackages = Array.isArray(appConfig.subPackages)
+    ? appConfig.subPackages
+    : Array.isArray(appConfig.subpackages)
+      ? appConfig.subpackages
+      : []
+  for (const subPackage of subPackages) {
+    if (!subPackage || typeof subPackage !== 'object' || Array.isArray(subPackage)) {
+      continue
+    }
+    const { pages, root } = subPackage as { pages?: unknown, root?: unknown }
+    if (typeof root !== 'string' || !Array.isArray(pages)) {
+      continue
+    }
+    const normalizedRoot = root.replaceAll('\\', '/').replace(/^\/+|\/+$/g, '')
+    for (const page of pages) {
+      if (typeof page === 'string') {
+        configFiles.add(`${normalizedRoot}/${page}.json`)
+      }
+    }
+  }
+
+  return [...configFiles].filter(fileName => jsonConfigs.get(fileName)?.renderer === 'skyline')
+}
+
+export function formatHmrRuntimeStartupMessages(decision: HmrRuntimeDecision): [string, string] {
+  if (decision.reason === 'skyline-fallback') {
     return [
-      `HMR 模式：${options.runtime}（显式配置）`,
+      'HMR 模式：classic（自动降级：Skyline 暂不支持微信开发者工具热重载）',
+      'HMR 切换：切回 WebView 后可手动重新开启微信开发者工具“热重载”。',
+    ]
+  }
+  if (decision.reason === 'runtime-compatibility-fallback') {
+    return [
+      'HMR 模式：classic（自动降级：stateful HMR 运行时兼容性检查失败）',
+      'HMR 切换：修复兼容性问题后重启 wv dev，或通过 weapp.hmr.runtime 显式配置 classic。',
+    ]
+  }
+  if (decision.reason === 'explicit') {
+    const alternative = decision.runtime === 'classic' ? 'stateful-experimental' : 'classic'
+    return [
+      `HMR 模式：${decision.runtime}（显式配置）`,
       `HMR 切换：修改 weapp.hmr.runtime 为 auto 或 ${alternative} 后重启 wv dev。`,
     ]
   }
-  if (options.platform !== 'weapp') {
+  if (decision.reason === 'auto-non-wechat') {
     return [
       'HMR 模式：classic（自动检测：仅微信小程序支持 stateful-experimental）',
       'HMR 切换：可通过 weapp.hmr.runtime 显式配置 classic。',
     ]
   }
-  if (options.compileHotReLoad === true) {
+  if (decision.reason === 'auto-stateful') {
     return [
       'HMR 模式：stateful-experimental（自动检测：微信开发者工具热重载已开启）',
       'HMR 切换：关闭微信开发者工具“热重载”后重启 wv dev，或通过 weapp.hmr.runtime 显式配置。',

--- a/packages/weapp-vite/src/utils/projectConfig.test.ts
+++ b/packages/weapp-vite/src/utils/projectConfig.test.ts
@@ -4,6 +4,7 @@ import { fs } from '@weapp-core/shared/fs'
 import path from 'pathe'
 import { describe, expect, it, vi } from 'vitest'
 import {
+  disableProjectPrivateConfigHotReload,
   getProjectConfig,
   getProjectConfigFileName,
   getProjectConfigRootKeys,
@@ -103,6 +104,40 @@ describe('projectConfig utils', () => {
     expect(readJsonSpy).toHaveBeenCalledWith(basePath)
     expect(readJsonSpy).toHaveBeenCalledWith(privatePath)
     readJsonSpy.mockRestore()
+  })
+
+  it('disables project private hot reload without changing unrelated settings', async () => {
+    const root = await createTempDir()
+    const privatePath = path.join(root, 'config', 'weapp', 'project.private.config.weapp.json')
+    await fs.ensureDir(path.dirname(privatePath))
+    await fs.writeJson(privatePath, {
+      projectname: 'skyline-demo',
+      setting: {
+        compileHotReLoad: true,
+        skylineRenderEnable: true,
+        urlCheck: false,
+      },
+    }, { spaces: 2 })
+
+    await expect(disableProjectPrivateConfigHotReload(privatePath)).resolves.toBe(true)
+    expect(await fs.readJson(privatePath)).toEqual({
+      projectname: 'skyline-demo',
+      setting: {
+        compileHotReLoad: false,
+        skylineRenderEnable: true,
+        urlCheck: false,
+      },
+    })
+    await expect(disableProjectPrivateConfigHotReload(privatePath)).resolves.toBe(false)
+  })
+
+  it('reports missing and invalid private config files when disabling hot reload', async () => {
+    const root = await createTempDir()
+    const privatePath = path.join(root, 'project.private.config.json')
+    await expect(disableProjectPrivateConfigHotReload(privatePath)).rejects.toThrow('找不到项目配置文件')
+
+    await fs.writeFile(privatePath, '{invalid', 'utf8')
+    await expect(disableProjectPrivateConfigHotReload(privatePath)).rejects.toThrow('非法的 json 格式')
   })
 
   it('allows missing private config file when private merge is enabled', async () => {

--- a/packages/weapp-vite/src/utils/projectConfig.ts
+++ b/packages/weapp-vite/src/utils/projectConfig.ts
@@ -63,6 +63,22 @@ export async function getProjectPrivateConfig(root: string, options?: Pick<Proje
   return await readProjectConfigFile(privateJsonPath, false) as Record<string, any>
 }
 
+export async function disableProjectPrivateConfigHotReload(filePath: string): Promise<boolean> {
+  const config = await readProjectConfigFile(filePath, true) as Record<string, any>
+  const setting = config.setting && typeof config.setting === 'object' && !Array.isArray(config.setting)
+    ? config.setting as Record<string, unknown>
+    : {}
+  if (setting.compileHotReLoad === false) {
+    return false
+  }
+  config.setting = {
+    ...setting,
+    compileHotReLoad: false,
+  }
+  await fs.writeFile(filePath, `${JSON.stringify(config, null, 2)}\n`, 'utf8')
+  return true
+}
+
 export function resolveProjectConfigSyncDirs(options: {
   outDir: string
   projectConfigPath: string

--- a/skills/weapp-vite-best-practices/SKILL.md
+++ b/skills/weapp-vite-best-practices/SKILL.md
@@ -48,7 +48,7 @@ description: 面向采用 weapp-vite 项目布局仓库或已安装 `weapp-vite`
    - `weapp.routeRules`
    - `weapp.buildScope` / `wv dev|build --scope`：限定页面或分包构建时保持 autoRoutes 的主包/分包归属
    - `weapp.typescript`
-   - `weapp.hmr.runtime`：显式配置优先；未配置时结合工作区 `compileHotReLoad` 选择 classic 或实验性 stateful 模式
+   - `weapp.hmr.runtime`：显式配置优先；未配置时结合工作区 `compileHotReLoad` 选择 classic 或实验性 stateful 模式；实际 bundle 含 Skyline renderer 时强制关闭 DevTools 热重载并降级 classic
    - `weapp.vue.template.slotFallbackWrapperStrategy`：微信平台默认使用内部 `virtualHost` 组件承载转发 `<slot />` 的具名插槽 fallback；需要旧版真实节点行为时显式设为 `view`
    - `weapp.vue.template.slotFallbackWrapper`：普通具名插槽 fallback 的真实 wrapper，可用全局默认、按模板标签名 `component`、子组件静态 `defineOptions({ name })` 的 `componentName`、slot 规则和组件内 `slot-wrapper` / `slot-wrapper-footer` / `slot-wrapper-class` / `slot-wrapper-footer-class` 静态覆盖；显式配置后优先于默认策略；不要把 `block` 当作转发 `<slot />` 的 wrapper
 3. 按目标启用能力：
@@ -73,7 +73,7 @@ description: 面向采用 weapp-vite 项目布局仓库或已安装 `weapp-vite`
    - Wot UI / uview-plus / uni-app 组件库异常：同时检查 `weapp.uniApp.include`、resolver 的真实 `resolvedId` / `sourceType: 'wevu-sfc'`，以及目标端条件分支
    - AI 无法稳定操作：查 `AGENTS.md`、`dist/docs`、CLI 路由、MCP
    - 分包体积或 HMR 变慢：先跑 `wv analyze --markdown` / `wv analyze --budget-check`，HMR profile 已开启时再跑 `wv analyze --hmr-profile`
-   - 状态保持 HMR 不生效：确认平台为微信、DevTools 开启服务端口与热重载、`compileHotReLoad: true`，并区分安全 JS/Vue 补丁与 CSS/资源/配置的完整重载回退
+   - 状态保持 HMR 不生效：先确认生成的应用/页面 JSON 未使用 Skyline；WebView 项目再确认平台为微信、DevTools 开启服务端口与热重载、`compileHotReLoad: true`，并区分安全 JS/Vue 补丁与 CSS/资源/配置的完整重载回退
    - sourcemap 漂移：检查 CLI `--sourcemap` 透传和构建后 npm、平台 API、shared chunk 重写是否组合原 map，不接受只保留旧 map
 6. 评估 Rust/native 加速时，先看真实 profile 和跨边界调用次数：
    - 默认把 JS ↔ Rust 往返、序列化/反序列化和 AST 数据搬运视为热路径成本。
@@ -85,10 +85,10 @@ description: 面向采用 weapp-vite 项目布局仓库或已安装 `weapp-vite`
 ## 近期能力决策
 
 - 插件项目先确认 `weapp.pluginRoot`，结构变化必须同时检查主应用 `dist/` 和插件 `dist-plugin/`；不要只验证 host 产物。
-- 状态保持 HMR 仅适用于微信小程序：需要 DevTools 服务端口、热重载和 `setting.compileHotReLoad: true`。JS/Vue 安全补丁可保留实例状态；CSS、资源、JSON、配置、边界不兼容或补丁失败时应接受完整构建回退。
+- 状态保持 HMR 仅适用于微信小程序 WebView：需要 DevTools 服务端口、热重载和 `setting.compileHotReLoad: true`。实际 bundle 检测到 Skyline renderer 时，即使显式选择 stateful 也会输出官方兼容性警告、关闭项目私有配置中的热重载并降级 classic；切回 WebView 后不自动重新开启。JS/Vue 安全补丁可保留实例状态；CSS、资源、JSON、配置、边界不兼容或补丁失败时应接受完整构建回退。
 - Web runtime 只验证 Web 语义，不把它当成小程序真机等价环境；请求 globals、URL 和平台 API 兼容问题要分别在目标 runtime 验证。
 - 小程序单测不使用 jsdom；`@mpcore/test` 只暴露逻辑 WXML 树。测试产物必须通过 `weapp-vite/test` 交给 Vite/Rolldown emit，不能由适配器手写 bundle。
-- uni-app 兼容层默认关闭，只转换项目源码与 `include` 白名单依赖；Wot UI 与 uview-plus 分别以 `@wot-ui/ui@2.2.0`、`uview-plus@3.8.108` 的 npm 发布包 SFC 清单为兼容基线，不把它们泛化成完整 uni-app runtime。
+- uni-app 兼容层默认关闭，只转换项目源码与 `include` 白名单依赖；Wot UI 与 uview-plus 分别以 `@wot-ui/ui@2.2.0`、`uview-plus@3.8.86` 的 npm 发布包 SFC 清单为兼容基线，不把它们泛化成完整 uni-app runtime。
 - 分包、插件、worker 和 lib mode 的性能判断都先看产物结构与 `wv analyze`，再改 chunk/shared 策略。
 
 ## 参考决策表

--- a/skills/weapp-vite-best-practices/references/stateful-hmr-playbook.md
+++ b/skills/weapp-vite-best-practices/references/stateful-hmr-playbook.md
@@ -2,8 +2,9 @@
 
 ## 前提
 
-- 只支持微信小程序；确认 `DevTools` 服务端口、热重载和 `setting.compileHotReLoad: true`。
-- 显式 `weapp.hmr.runtime` 优先；未配置时核对工作区 `compileHotReLoad` 自动选择结果。
+- 只支持微信小程序 WebView；确认 `DevTools` 服务端口、热重载和 `setting.compileHotReLoad: true`。
+- 先检查实际 bundle 中的应用/页面 JSON 是否使用 Skyline；命中时工具会关闭项目私有配置中的热重载并强制降级 classic。
+- 显式 `weapp.hmr.runtime` 通常优先；Skyline 兼容降级会覆盖显式 stateful，其他场景未配置时核对工作区 `compileHotReLoad` 自动选择结果。
 - 排障时先用 `classic` 建立行为基线，再显式启用 `stateful-experimental`。
 
 ## 判断

--- a/website/config/hmr.md
+++ b/website/config/hmr.md
@@ -42,15 +42,18 @@ export default defineConfig({
 })
 ```
 
-`auto` 会在 `wv dev` 启动时读取微信项目的 `project.private.config.json`：当 `setting.compileHotReLoad` 严格为 `true` 时使用 `stateful-experimental`，否则使用 `classic`。非微信平台也会回退到 `classic`。该判断只发生在启动阶段，修改微信开发者工具设置后需要重启 `wv dev` 才会重新选择模式。启动日志会显示最终模式、选择来源，以及通过 DevTools 热重载开关或 `weapp.hmr.runtime` 切换模式的方法。显式配置 `classic` 或 `stateful-experimental` 时始终优先于自动判断。
+`auto` 会在 `wv dev` 启动时读取微信项目的 `project.private.config.json`：当 `setting.compileHotReLoad` 严格为 `true` 时使用 `stateful-experimental`，否则使用 `classic`。非微信平台也会回退到 `classic`。该判断只发生在启动阶段，修改微信开发者工具设置后需要重启 `wv dev` 才会重新选择模式。启动日志会显示最终模式、选择来源，以及通过 DevTools 热重载开关或 `weapp.hmr.runtime` 切换模式的方法。显式配置通常优先，但 Skyline 兼容降级不受显式配置覆盖。
 
 `stateful-experimental` 目前只支持微信小程序平台。它使用 Vite bundled dev graph 和微信 App Service 内的增量补丁协议，JavaScript/Vue 安全更新会在现有实例上替换方法并恢复状态。CSS、静态资源、JSON/配置变化、模块边界不兼容、补丁积压超过保留上限或补丁执行失败时，会回退到完整构建并通过 `wx.reLaunch` 恢复当前 route/query。
+
+微信开发者工具[暂不支持 Skyline 热重载](https://developers.weixin.qq.com/miniprogram/dev/framework/runtime/skyline/migration/compatibility.html#%E5%B8%B8%E8%A7%81%E7%9A%84%E5%85%BC%E5%AE%B9%E9%97%AE%E9%A2%98)。首次编译检测到任意生成的应用或页面 JSON 使用 `renderer: 'skyline'` 时，`wv dev` 会输出兼容性警告，将当前项目私有配置中的 `setting.compileHotReLoad` 持久化为 `false`，并强制使用 `classic`，即使用户显式配置了 `stateful-experimental`。其他私有配置字段不会改变；切回 WebView 后需要由开发者按需重新开启热重载。
 
 使用前请确认：
 
 - 微信开发者工具已开启服务端口，并在项目设置中启用热重载。
 - `project.private.config.json` 的 `setting.compileHotReLoad` 为 `true`。
-- 这是实验能力；需要完全沿用既有写盘/刷新语义时保持默认 `classic`。
+- 当前项目没有使用 Skyline；Skyline 会自动关闭 DevTools 热重载并降级为 `classic`。
+- 这是实验能力；需要完全沿用既有写盘/刷新语义时显式配置 `classic`。
 - 状态恢复只覆盖可序列化的小程序 data 和 wevu setup ref；定时器、网络连接、原生句柄等副作用仍应由应用生命周期管理。
 
 ## `weapp.hmr.sharedChunks` {#weapp-hmr-sharedchunks}


### PR DESCRIPTION
## 背景

微信开发者工具暂不支持 Skyline 热重载。此前在 Skyline 项目中开启 compileHotReLoad 后，开发态可能表现为修改源码但预览无响应。

## 变更

- 从首次开发态 bundle 的 app.json 及其声明的主包、分包页面 JSON 检测 renderer: "skyline"，避免依赖 DevTools UI 状态或误判业务 JSON。
- 将 HMR 选择收敛为结构化决策；未配置 runtime 与显式 auto 使用同一逻辑，Skyline 优先于显式 stateful-experimental 并强制降级 classic。
- 当 compileHotReLoad 为 true 时，结构化更新对应项目私有配置，仅持久化为 false；写回失败仍保持 classic，并提示手动关闭热重载。
- 补充单元测试、串行 CLI E2E、HMR guard 清单、README、随包文档、网站配置页和公开 best-practices skill。
- 添加 weapp-vite 与 create-weapp-vite patch changeset。

## 验证

- pnpm vitest run packages/weapp-vite/src/runtime/hmrRuntime.test.ts packages/weapp-vite/src/utils/projectConfig.test.ts packages/weapp-vite/src/runtime/buildPlugin/service.test.ts（85 tests）
- pnpm --filter weapp-vite typecheck
- pnpm --filter weapp-vite build
- pnpm vitest run -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/skyline-hmr-fallback.test.ts
- pnpm --filter website-weapp-vite build
- pnpm build
- pnpm test（849 files / 7437 tests passed，12 files / 18 tests skipped）
- pnpm e2e:ci（65/65 tasks passed；随后收紧页面 JSON 识别边界，并重新通过目标单测、完整单测及 Skyline E2E）
- node --import tsx scripts/check-create-weapp-vite-changeset.ts
- node --import tsx scripts/check-catalog-changeset.ts
- 路径级 ESLint、pre-commit、git diff --check

## 结构说明

service.ts 原本已超过 300 行。本次逻辑需要直接协调初始 snapshot、watcher 启动和 classic/stateful 会话切换，因此继续保留在现有构建服务编排边界；可复用的 renderer 检测与私有配置持久化分别放在 hmrRuntime.ts 和 projectConfig.ts，避免继续扩大编排模块中的数据处理职责。