### PR TITLE
fix(weapp-vite): 完善 issue 793 buildScope 回归

### DIFF
--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -15,7 +15,9 @@ const issue642ScopedBuildEnabled = process.env.WEAPP_GITHUB_ISSUE_642_SCOPED ===
 const issue724ProbeEnabled = process.env.WEAPP_GITHUB_ISSUE_724_PROBE === 'true'
 const issue779CssPreEnabled = process.env.WEAPP_GITHUB_ISSUE_779_CSS_PRE === 'true'
 const issue793BuildScope = process.env.WEAPP_GITHUB_ISSUE_793_BUILD_SCOPE
-const issue793BuildScopeEnabled = issue793BuildScope === 'true' || issue793BuildScope === 'subpackage'
+const issue793BuildScopeEnabled = issue793BuildScope === 'true'
+  || issue793BuildScope === 'subpackage'
+  || issue793BuildScope === 'main-with-subpackage'
 const issue651NoExtResolvedId = path.resolve(import.meta.dirname, 'src/issue-fixtures/issue-651/ResolverNoExt/index')
 const issue651WithExtResolvedId = path.resolve(import.meta.dirname, 'src/issue-fixtures/issue-651/ResolverWithExt/index.vue')
 const e2eTargetFile = process.env.WEAPP_VITE_E2E_TARGET_FILE?.replaceAll('\\', '/') ?? ''
@@ -469,7 +471,9 @@ export default defineConfig({
             ...(issue793BuildScope === 'subpackage'
               ? { includeMainPackage: false }
               : {}),
-            include: issue793BuildScope === 'subpackage' ? ['subs'] : ['pages'],
+            include: issue793BuildScope === 'subpackage'
+              ? ['subs']
+              : ['pages', ...(issue793BuildScope === 'main-with-subpackage' ? ['subs'] : [])],
           },
         }
       : {}),

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -419,7 +419,7 @@ async function runSlotFallbackCompilerOffBuild() {
   distVariant = null
 }
 
-async function runIssue793Build(scope: 'main' | 'subpackage' = 'main') {
+async function runIssue793Build(scope: 'main' | 'main-with-subpackage' | 'subpackage' = 'main') {
   await fs.remove(ISSUE_793_DIST_ROOT)
 
   await execa('node', [
@@ -435,7 +435,7 @@ async function runIssue793Build(scope: 'main' | 'subpackage' = 'main') {
     stdio: 'inherit',
     env: {
       ...sanitizeBuildCommandEnv(),
-      WEAPP_GITHUB_ISSUE_793_BUILD_SCOPE: scope === 'main' ? 'true' : 'subpackage',
+      WEAPP_GITHUB_ISSUE_793_BUILD_SCOPE: scope === 'main' ? 'true' : scope,
     },
   })
 
@@ -487,6 +487,37 @@ describe.sequential('e2e app: github-issues (build)', () => {
     ])
     expect(subpackageAppJson.tabBar).toBeUndefined()
     expect(await fs.pathExists(path.join(ISSUE_793_DIST_ROOT, 'pages'))).toBe(false)
+
+    await runIssue793Build('main-with-subpackage')
+
+    const mainWithSubpackageAppJson = await fs.readJSON(path.join(ISSUE_793_DIST_ROOT, 'app.json')) as {
+      pages?: string[]
+      preloadRule?: Record<string, { packages?: string[] }>
+      subPackages?: Array<{ root?: string, pages?: string[] }>
+      tabBar?: { list?: Array<{ pagePath?: string }> }
+    }
+
+    expect(mainWithSubpackageAppJson.pages).toEqual(expect.arrayContaining([
+      'pages/issue-793/index',
+      'pages/issue-793-settings/index',
+    ]))
+    expect(mainWithSubpackageAppJson.subPackages).toEqual([
+      { root: 'subs', pages: ['issue-793/index'] },
+    ])
+    expect(mainWithSubpackageAppJson.preloadRule).toEqual({
+      'pages/issue-793/index': {
+        packages: ['subs'],
+      },
+      'subs/issue-793/index': {
+        packages: ['__APP__'],
+      },
+    })
+    expect(mainWithSubpackageAppJson.tabBar?.list?.map(item => item.pagePath)).toEqual([
+      'pages/issue-793/index',
+      'pages/issue-793-settings/index',
+    ])
+    expect(await fs.pathExists(path.join(ISSUE_793_DIST_ROOT, 'pages/issue-793/index.js'))).toBe(true)
+    expect(await fs.pathExists(path.join(ISSUE_793_DIST_ROOT, 'subs/issue-793/index.js'))).toBe(true)
   })
 
   it('issue #805: lowers optional chaining inside nullish coalescing expressions', async () => {

--- a/packages/weapp-vite/src/runtime/appConfig.ts
+++ b/packages/weapp-vite/src/runtime/appConfig.ts
@@ -9,12 +9,12 @@ export interface AppConfigBuildOptions {
   routeRules?: WeappRouteRules
 }
 
-export function finalizeAppConfigForBuild(
-  config: Record<string, any>,
+export function finalizeAppConfigForBuild<T extends object>(
+  config: T,
   options: AppConfigBuildOptions,
-) {
+): T {
   const normalizedConfig = normalizeAppJson(config) as BuildScopeAppJson
-  return applyBuildScopeToAppConfig(
+  const finalizedConfig = applyBuildScopeToAppConfig(
     applyPreloadRulesToAppJson(
       normalizedConfig,
       options.routeRules,
@@ -22,4 +22,5 @@ export function finalizeAppConfigForBuild(
     ),
     resolveBuildScope(options.buildScope),
   )
+  return finalizedConfig as T
 }

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.ts
@@ -383,8 +383,12 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
     configured?: HmrRuntimeDecision['configured']
     files: string[]
   }) {
+    const configService = ctx.configService
+    if (!configService) {
+      return false
+    }
     const currentDecision = devHmrDecision ?? resolveHmrRuntimeDecision({
-      platform: ctx.configService.platform,
+      platform: configService.platform,
       configured: options.configured,
       compileHotReLoad: options.compileHotReLoad,
     })
@@ -397,7 +401,7 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
 
     skylineHmrFallbackApplied = true
     devHmrDecision = resolveHmrRuntimeDecision({
-      platform: ctx.configService.platform,
+      platform: configService.platform,
       configured: currentDecision.configured,
       compileHotReLoad: options.compileHotReLoad,
       skyline: true,
@@ -405,9 +409,9 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
 
     const detectedFiles = options.files.slice(0, 3).join('、')
     const detectedSuffix = detectedFiles ? `（${detectedFiles}）` : ''
-    const privateConfigPath = ctx.configService.projectPrivateConfigPath
+    const privateConfigPath = configService.projectPrivateConfigPath
     const privateConfigDisplay = privateConfigPath
-      ? ctx.configService.relativeCwd(privateConfigPath)
+      ? configService.relativeCwd(privateConfigPath)
       : 'project.private.config.json'
 
     if (options.compileHotReLoad === true) {
@@ -416,7 +420,7 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
           throw new Error('无法解析项目私有配置路径')
         }
         await disableProjectPrivateConfigHotReload(privateConfigPath)
-        const privateConfig = ctx.configService.projectPrivateConfig
+        const privateConfig = configService.projectPrivateConfig
         const setting = privateConfig.setting && typeof privateConfig.setting === 'object' && !Array.isArray(privateConfig.setting)
           ? privateConfig.setting as Record<string, unknown>
           : {}

--- a/packages/weapp-vite/src/wxs/index.ts
+++ b/packages/weapp-vite/src/wxs/index.ts
@@ -12,11 +12,16 @@ export interface TransformWxsCodeOptions {
   extension?: string
 }
 
+export interface TransformWxsCodeResult {
+  result: ReturnType<typeof babel.transformSync>
+  importees: Array<{ source: string }>
+}
+
 export {
   normalizeWxsFilename,
 }
 
-export function transformWxsCode(code: string, options?: TransformWxsCodeOptions) {
+export function transformWxsCode(code: string, options?: TransformWxsCodeOptions): TransformWxsCodeResult {
   const filename = options?.filename ?? 'script.ts'
   const extension = options?.extension ?? 'wxs'
   const preserveEsmExports = extension.replace(/^\./, '') === 'sjs'


### PR DESCRIPTION
## 摘要
补充 issue #793 在主包与分包同时参与构建时的端到端回归，锁定生成 app.json 与实际构建范围的一致性。

## 变更
- 增加混合主包/分包 buildScope 场景。
- 校验 preloadRule 的页面与 packages 裁剪。
- 校验无效 tabBar 页面过滤、有效 tabBar 保留及两类产物目录。
- 修复相关构建配置类型检查问题。

## 验证
- `pnpm --filter weapp-vite typecheck`
- `pnpm --filter weapp-vite lint:src`
- `pnpm --filter weapp-vite build`
- `pnpm vitest run packages/weapp-vite/src/runtime/buildScope.test.ts packages/weapp-vite/src/plugins/hooks/useLoadEntry/jsonEmit.test.ts packages/weapp-vite/src/plugins/hooks/useLoadEntry/loadEntry.test.ts`
- `pnpm vitest run -c ./e2e/vitest.e2e.ci.build-only.config.ts e2e/ci/github-issues.build.test.ts -t 'issue #793'`\n\nCloses #793