### PR TITLE
fix(ci): 增加 Release 工作流超时保护

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout Repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## 摘要
为 Release job 增加明确的 30 分钟超时，避免 `repo release ci` 异常挂起时永久占用 release 并阻塞后续队列。

## 背景
`main` 的 Release run `32435963422` 在依赖安装完成后长时间停留于 `pnpm exec repo release ci`，该 job 原先没有 `timeout-minutes`，且 GitHub 无法提供运行中日志。

## 变更
- 为 `.github/workflows/release.yml` 的 `release` job 增加 `timeout-minutes: 30`。
- 不改变发布命令、权限或失败处理逻辑；超时仍会让 workflow 失败并暴露问题。

## 验证
- `pnpm exec eslint --no-warn-ignored .github/workflows/release.yml`
- `git diff --check`

相关运行： https://github.com/weapp-vite/weapp-vite/actions/runs/32435963422