### PR TITLE
test(e2e): 稳定 issue 829 真实 IDE 可见性验证

### DIFF
--- a/e2e-apps/github-issues/src/components/issue-829/Query/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-829/Query/index.vue
@@ -11,17 +11,6 @@ const data = ref<string[]>()
 onAttached(async () => {
   data.value = await props.queryFn?.()
 })
-
-function _runE2E() {
-  return {
-    hasQueryFn: typeof props.queryFn === 'function',
-    result: data.value,
-  }
-}
-
-defineExpose({
-  _runE2E,
-})
 </script>
 
 <template>

--- a/e2e-apps/github-issues/src/pages/issue-829/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-829/index.vue
@@ -1,37 +1,21 @@
 <script setup lang="ts">
-import { ref, useNativeInstance } from 'wevu'
+import { ref } from 'wevu'
 import Card from '../../components/issue-829/Card/index.vue'
 import Query from '../../components/issue-829/Query/index.vue'
 
-const nativeInstance = useNativeInstance()
-const queryCallCount = ref(0)
+const queryResolveCount = ref(0)
 
 async function queryFn() {
-  queryCallCount.value += 1
-  return new Promise<string[]>((resolve) => {
+  const result = await new Promise<string[]>((resolve) => {
     setTimeout(resolve, 1_000, ['foo', 'bar'])
   })
+  queryResolveCount.value += 1
+  return result
 }
-
-function readQuery(selector: string) {
-  const query = (nativeInstance as any).selectComponent?.(selector)
-  return typeof query?._runE2E === 'function' ? query._runE2E() : null
-}
-
-function _runE2E() {
-  return {
-    direct: readQuery('#issue-829-direct-query'),
-    queryCallCount: queryCallCount.value,
-  }
-}
-
-defineExpose({
-  _runE2E,
-})
 </script>
 
 <template>
-  <view id="issue-829-page">
+  <view id="issue-829-page" :data-query-resolve-count="queryResolveCount">
     <Card title="nested">
       <Query id="issue-829-nested-query" v-slot="{ label, data }" :query-fn="queryFn" label="Result">
         <view class="issue829-nested-result">{{ label }}: {{ data }}</view>

--- a/e2e/ide/github-issues.runtime.issue829.test.ts
+++ b/e2e/ide/github-issues.runtime.issue829.test.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs/promises'
 import path from 'pathe'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import {
-  callRoutePageMethodWithOptions,
   closeSharedMiniProgram,
   DIST_ROOT,
   getSharedMiniProgram,
@@ -48,26 +47,25 @@ describe.sequential('e2e app: github-issues / issue #829', () => {
         throw new Error('Failed to launch issue-829 page')
       }
 
-      await expect.poll(
-        async () => await callRoutePageMethodWithOptions<Record<string, any>>(
-          miniProgram,
-          ISSUE_ROUTE,
-          '_runE2E',
-          {
-            readiness: 'route',
-            protocolTimeoutMs: 12_000,
-            recoveryAttempts: 3,
-            retries: 10,
-          },
-        ).catch(() => null),
-        { timeout: 15_000, interval: 250 },
-      ).toMatchObject({
-        direct: {
-          hasQueryFn: true,
-          result: ['foo', 'bar'],
-        },
-        queryCallCount: 2,
-      })
+      const renderedOptions = {
+        dataset: { queryResolveCount: 2 },
+        timeout: 15_000,
+      }
+      await issuePage.waitForRendered({ ...renderedOptions, selector: '#issue-829-page' })
+
+      const pageNodes = await issuePage.renderedNodes('#issue-829-page', renderedOptions)
+      expect(pageNodes).toHaveLength(1)
+      const pageNode = pageNodes[0]
+      expect(pageNode).toEqual(expect.objectContaining({
+        dataset: expect.objectContaining({ queryResolveCount: 2 }),
+        height: expect.any(Number),
+        width: expect.any(Number),
+      }))
+      expect(pageNode!.height).toBeGreaterThan(0)
+      expect(pageNode!.width).toBeGreaterThan(0)
+
+      const runtimeEntries = miniProgram?.__weappViteRuntimeLogMeta?.entries ?? []
+      expect(runtimeEntries.filter((entry: { level?: string }) => entry.level === 'error' || entry.level === 'exception')).toEqual([])
 
       const pageWxml = await readDistText('pages/issue-829/index.wxml')
       expect(pageWxml).toContain('query-fn="{{queryFn}}"')


### PR DESCRIPTION
## 背景

#829 的运行时根因已由 #831 修复并随 6.20.5 发布。现有真实 IDE 回归通过页面私有方法读取组件状态，在微信开发者工具协议不稳定时会超时，即使模拟器页面已经正确渲染。

关联 #829。

## 变更

- 移除 issue fixture 中仅供 Automator 调用的 `_runE2E` 私有探针
- 在页面根节点暴露两条异步查询均已完成的稳定 dataset
- 通过 `renderedNodes` 验证页面可见尺寸、函数调用完成次数以及零 runtime error/exception
- 保留直接与嵌套 scoped-slot 的编译产物绑定断言

## 验证

- `pnpm exec eslint e2e-apps/github-issues/src/components/issue-829/Query/index.vue e2e-apps/github-issues/src/pages/issue-829/index.vue e2e/ide/github-issues.runtime.issue829.test.ts`
- `pnpm exec stylelint e2e-apps/github-issues/src/components/issue-829/Query/index.vue e2e-apps/github-issues/src/pages/issue-829/index.vue`
- `pnpm exec vitest run test/runtime-scoped-slots.test.ts --coverage.enabled=false`（`packages-runtime/wevu`）
- `pnpm exec vitest run test/pageInstance.test.ts --coverage.enabled=false`（`mpcore/packages/simulator`）
- `node --import tsx scripts/check-e2e-ide-shared-launch.ts`
- `caffeinate -dimsu -- pnpm exec cross-env WEAPP_VITE_E2E_TARGET_FILE=ide/github-issues.runtime.issue829.test.ts vitest run -c e2e/vitest.e2e.devtools.config.ts`

真实微信开发者工具 Stable v2.01.2510290 中，`pages/issue-829/index` 首屏可见 `nested` 与 `Result: foo,bar`，运行时统计为 `warn=0 error=0 exception=0`。