### PR TITLE
fix(wevu): 隔离 test-utils 组件运行时上下文

### DIFF
--- a/.changeset/quiet-wrappers-isolate.md
+++ b/.changeset/quiet-wrappers-isolate.md
@@ -1,0 +1,7 @@
+---
+"wevu": patch
+"@wevu/test-utils": patch
+"create-weapp-vite": patch
+---
+
+隔离 `@wevu/test-utils` 每次组件挂载的应用上下文，避免 provide、插件、mocks 和卸载状态跨 wrapper 泄漏；同时允许测试页面目录内的普通组件，并支持自定义页面文件判定。

--- a/packages-runtime/wevu-test-utils/README.md
+++ b/packages-runtime/wevu-test-utils/README.md
@@ -51,6 +51,16 @@ export default defineConfig({
 })
 ```
 
+默认情况下，`wevuSfc()` 会拒绝 `app.vue` 和 `pages/**` 下的页面文件，但允许 `pages/**/components/**` 中的普通组件。项目使用自定义页面目录时，可传入同步或异步的 `isPage(filename)` 判定；回调收到的是移除查询参数并统一为 `/` 分隔符的文件名：
+
+```ts
+export default defineConfig({
+  plugins: [wevuSfc({
+    isPage: filename => filename.includes('/routes/'),
+  })],
+})
+```
+
 ```ts
 import { mountComponent } from '@wevu/test-utils'
 import Counter from './Counter.vue'
@@ -69,7 +79,7 @@ expect(wrapper.vm.count.value).toBe(2)
 wrapper.unmount()
 ```
 
-`mountComponent()` 接收编译后的 SFC 默认导出、组件选项或 Wevu component definition，不接收源码路径或字符串。它复用组件自身的 props 默认值、data、computed、methods、watch、setup、Options API provide/inject、emits 和生命周期，挂载顺序为 `created -> attached -> ready`，卸载时调用 `detached`。
+`mountComponent()` 接收编译后的 SFC 默认导出、组件选项或 Wevu component definition，不接收源码路径或字符串。它复用组件自身的 props 默认值、data、computed、methods、watch、setup、Options API provide/inject、emits 和生命周期，挂载顺序为 `created -> attached -> ready`，卸载时调用 `detached`。每次挂载都会创建独立的 Wevu app context，因此 `global.provide`、插件、mocks、全局属性和卸载状态不会在 wrapper 之间共享。
 
 `app.vue` 和页面组件不属于该入口的测试对象；需要验证完整编译产物、WXML 查询、组件树、宿主 mock 或交互时，请使用 `@mpcore/test`。
 

--- a/packages-runtime/wevu-test-utils/src/mount.test.ts
+++ b/packages-runtime/wevu-test-utils/src/mount.test.ts
@@ -95,6 +95,27 @@ describe('@wevu/test-utils', () => {
     expect(observed).toEqual([1, 3])
   })
 
+  it('isolates app provides between composable wrappers', () => {
+    const token = Symbol('isolated-composable-token')
+    const first = mountComposable(() => ({
+      injected: inject(token, 'missing'),
+    }), {
+      global: {
+        provide: { [token]: 'first' },
+      },
+    })
+
+    expect(first.vm.injected).toBe('first')
+    first.unmount()
+
+    const second = mountComposable(() => ({
+      injected: inject(token, 'missing'),
+    }))
+
+    expect(second.vm.injected).toBe('missing')
+    second.unmount()
+  })
+
   it('updates runtime data through the wrapper and records emitted details', async () => {
     const wrapper = mountComposable((_props, { emit }) => {
       const count = ref(0)

--- a/packages-runtime/wevu-test-utils/src/mountComponent.ts
+++ b/packages-runtime/wevu-test-utils/src/mountComponent.ts
@@ -9,6 +9,7 @@ import type {
 import { nextTick } from 'wevu'
 import {
   callHookList,
+  createIsolatedWevuComponentDefinition,
   createWevuComponentDefinition,
   getWevuComponentLifecycleDefinition,
 } from 'wevu/internal-runtime'
@@ -66,7 +67,7 @@ export function isComponentSubject(value: unknown): value is Record<string, any>
 
 function resolveComponentDefinition(component: unknown): ComponentDefinitionLike {
   if (isComponentDefinition(component)) {
-    return component
+    return createIsolatedWevuComponentDefinition(component) as ComponentDefinitionLike
   }
   if (!component || typeof component !== 'object') {
     throw new TypeError('mountComponent() 需要接收编译后的 Vue SFC、组件选项或 Wevu 组件定义')

--- a/packages-runtime/wevu-test-utils/src/sfc.test.ts
+++ b/packages-runtime/wevu-test-utils/src/sfc.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { watch } from 'wevu'
+import { inject, watch } from 'wevu'
 import OptionsLogic from './fixtures/OptionsLogic.vue'
 import { mount, mountComponent } from './index'
 
@@ -90,5 +90,51 @@ describe('Vue SFC logic mounting', () => {
     await wrapper.setProps({ value: 2 })
     expect(calls).toEqual(['observer:2', 'watch:2'])
     wrapper.unmount()
+  })
+
+  it('isolates app context between live component wrappers', () => {
+    const token = Symbol('isolated-component-token')
+    const cleanup = vi.fn()
+    const install = vi.fn((app: { onUnmount: (cleanup: () => void) => void }) => {
+      app.onUnmount(cleanup)
+    })
+    const component = {
+      setup() {
+        return {
+          injected: inject(token, 'missing'),
+        }
+      },
+    }
+
+    const first = mountComponent(component, {
+      global: {
+        mocks: { $mountName: 'first' },
+        plugins: [{ install }],
+        provide: { [token]: 'first' },
+      },
+    })
+    expect(first.vm.injected).toBe('first')
+    expect(first.vm.$mountName).toBe('first')
+
+    const second = mountComponent(component, {
+      global: {
+        mocks: { $mountName: 'second' },
+        plugins: [{ install }],
+        provide: { [token]: 'second' },
+      },
+    })
+    expect(second.vm.injected).toBe('second')
+    expect(second.vm.$mountName).toBe('second')
+    expect(first.vm.injected).toBe('first')
+    expect(first.vm.$mountName).toBe('first')
+    expect(install).toHaveBeenCalledTimes(2)
+
+    second.unmount()
+    expect(cleanup).toHaveBeenCalledTimes(1)
+    expect(first.isUnmounted).toBe(false)
+    expect(first.vm.$mountName).toBe('first')
+
+    first.unmount()
+    expect(cleanup).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages-runtime/wevu-test-utils/src/vitest.test.ts
+++ b/packages-runtime/wevu-test-utils/src/vitest.test.ts
@@ -32,4 +32,34 @@ describe('wevuSfc()', () => {
     await expect(transform.call({}, '', '/virtual/app.vue')).rejects.toThrow('@mpcore/test')
     await expect(transform.call({}, '', '/virtual/pages/index.vue')).rejects.toThrow('@mpcore/test')
   })
+
+  it('allows ordinary components nested below a pages directory', async () => {
+    const plugin = wevuSfc()
+    const transform = plugin.transform as any
+    const result = await transform.call(
+      {},
+      '<script setup>const label = \'nested component\'</script>',
+      '/virtual/pages/home/components/Panel.vue',
+    )
+
+    expect(result.code).toContain('nested component')
+  })
+
+  it('supports project-aware page matching for nonstandard routes', async () => {
+    const filenames: string[] = []
+    const plugin = wevuSfc({
+      async isPage(filename) {
+        filenames.push(filename)
+        return filename.endsWith('/routes/home.vue')
+      },
+    })
+    const transform = plugin.transform as any
+
+    await expect(transform.call(
+      {},
+      '<script setup>const route = \'home\'</script>',
+      '/virtual/routes/home.vue?vue&type=script',
+    )).rejects.toThrow('@mpcore/test')
+    expect(filenames).toEqual(['/virtual/routes/home.vue'])
+  })
 })

--- a/packages-runtime/wevu-test-utils/src/vitest.ts
+++ b/packages-runtime/wevu-test-utils/src/vitest.ts
@@ -18,14 +18,25 @@ export interface WevuSfcPlugin {
   transform: (code: string, id: string) => undefined | { code: string, map: any } | Promise<undefined | { code: string, map: any }>
 }
 
+export interface WevuSfcOptions {
+  isPage?: (filename: string) => boolean | Promise<boolean>
+}
+
 function isVueFile(id: string) {
   return /\.vue(?:$|\?)/.test(id)
 }
 
-function isAppOrPageFile(id: string) {
-  const filename = id.split('?')[0].replaceAll('\\', '/')
+function normalizeFilename(id: string) {
+  return id.split('?')[0].replaceAll('\\', '/')
+}
+
+function isAppFile(filename: string) {
   return /(?:^|\/)app\.vue$/.test(filename)
-    || /(?:^|\/)pages?(?:\/|$)/.test(filename)
+}
+
+function isLikelyPageFile(filename: string) {
+  return /(?:^|\/)pages?(?:\/|$)/.test(filename)
+    && !/(?:^|\/)components?(?:\/|$)/.test(filename)
 }
 
 /**
@@ -33,7 +44,7 @@ function isAppOrPageFile(id: string) {
  *
  * 该插件只输出 SFC script，不加载 Vue Web runtime，也不渲染模板、样式或 WXML。
  */
-export function wevuSfc(): WevuSfcPlugin {
+export function wevuSfc(options: WevuSfcOptions = {}): WevuSfcPlugin {
   return {
     name: 'wevu-test-utils:sfc',
     enforce: 'pre',
@@ -49,10 +60,14 @@ export function wevuSfc(): WevuSfcPlugin {
       if (!isVueFile(id)) {
         return undefined
       }
-      if (isAppOrPageFile(id)) {
+      const filename = normalizeFilename(id)
+      const isPage = options.isPage
+        ? await options.isPage(filename)
+        : isLikelyPageFile(filename)
+      if (isAppFile(filename) || isPage) {
         throw new Error(`@wevu/test-utils/vitest 不支持 app.vue 或页面组件：${id}，请改用 @mpcore/test`)
       }
-      const result = await compileVueFile(code, id.split('?')[0], {
+      const result = await compileVueFile(code, filename, {
         skipComponentTransform: true,
         sourceMap: true,
       })

--- a/packages-runtime/wevu-test-utils/test-d/index.test-d.ts
+++ b/packages-runtime/wevu-test-utils/test-d/index.test-d.ts
@@ -1,5 +1,6 @@
 import type { Ref } from 'wevu'
 import { mount, mountComponent, mountComposable } from '@wevu/test-utils'
+import { wevuSfc } from '@wevu/test-utils/vitest'
 import { expectType } from 'tsd'
 
 const wrapper = mountComposable<{ count: Ref<number>, increment: () => void }, { initial: number }>((props) => {
@@ -34,3 +35,11 @@ const optionsWrapper = mount<{ label: string }, { label: string }>({
   setup: (props: { label: string }) => ({ label: props.label }),
 })
 expectType<string>(optionsWrapper.vm.label)
+
+const sfcPlugin = wevuSfc({
+  async isPage(filename) {
+    expectType<string>(filename)
+    return filename.endsWith('.page.vue')
+  },
+})
+expectType<'pre'>(sfcPlugin.enforce)

--- a/packages-runtime/wevu/src/internal-runtime.ts
+++ b/packages-runtime/wevu/src/internal-runtime.ts
@@ -6,6 +6,7 @@ export {
   setWevuDefaults,
 } from './runtime/defaults'
 export {
+  createIsolatedWevuComponentDefinition,
   createWevuComponent,
   createWevuComponentDefinition,
   createWevuScopedSlotComponent,

--- a/packages-runtime/wevu/src/runtime/app.ts
+++ b/packages-runtime/wevu/src/runtime/app.ts
@@ -65,7 +65,9 @@ export function createApp<D extends object, C extends ComputedDefinitions, M ext
       return runtimeApp
     },
     provide(key: any, value: any) {
-      setRuntimeAppProvidedValue(runtimeApp, key, value)
+      setRuntimeAppProvidedValue(runtimeApp, key, value, {
+        syncGlobal: defaultsScope !== 'component',
+      })
       return runtimeApp
     },
     onUnmount(cleanup: () => void) {

--- a/packages-runtime/wevu/src/runtime/define.ts
+++ b/packages-runtime/wevu/src/runtime/define.ts
@@ -1,3 +1,4 @@
+import type { RuntimeComponentDefinitionOptions } from './define/componentDefinition'
 import type { InlineExpressionMap } from './register/inline'
 import type { TemplateRefBinding } from './templateRefs'
 import type {
@@ -20,8 +21,10 @@ import {
   WEVU_SLOT_SCOPE_KEY,
 } from '@weapp-core/constants'
 import { hasOwn } from '../utils'
-import { createApp } from './app'
-import { applyWevuComponentDefaults, INTERNAL_DEFAULTS_SCOPE_KEY } from './defaults'
+import { applyWevuComponentDefaults } from './defaults'
+import {
+  createRuntimeComponentDefinition,
+} from './define/componentDefinition'
 import { resolveNativeInitialData } from './define/initialComputed'
 import { resolveVueComponentOptions } from './define/options'
 import { applyOptionsApiProvide, resolveOptionsApiInjections } from './define/optionsApi'
@@ -29,7 +32,7 @@ import { normalizeProps } from './define/props'
 import { createScopedSlotOptions } from './define/scopedSlotOptions'
 import { applySetupResult } from './define/setupResult'
 import { getScopedSlotHostGlobalObject } from './platform'
-import { registerComponent, runSetupFunction } from './register'
+import { runSetupFunction } from './register'
 import { allocateOwnerId } from './scopedSlots'
 
 let scopedSlotCreator: (() => void) | undefined
@@ -127,6 +130,19 @@ export interface ComponentDefinition<
     setup: ((props: any, ctx: any) => any) | undefined
     mpOptions: MiniProgramComponentRawOptions
   }
+}
+
+function materializeComponentDefinition(
+  componentOptions: RuntimeComponentDefinitionOptions,
+  registerNative = false,
+) {
+  const { lifecycleDefinition, runtimeApp } = createRuntimeComponentDefinition(componentOptions, registerNative)
+  const definition: ComponentDefinition<any, any, any> = {
+    __wevu_runtime: runtimeApp as any,
+    __wevu_options: componentOptions as ComponentDefinition<any, any, any>['__wevu_options'],
+  }
+  componentLifecycleDefinitions.set(definition, lifecycleDefinition)
+  return definition
 }
 
 type SetupBindings<S> = Exclude<S, void> extends never ? Record<string, never> : Exclude<S, void>
@@ -273,14 +289,6 @@ function createComponentDefinition(
     ? () => data.call(initialDataContext)
     : data
 
-  const runtimeApp = createApp({
-    data: resolvedData,
-    computed,
-    methods,
-    setData: resolvedSetData,
-    [INTERNAL_DEFAULTS_SCOPE_KEY]: 'component',
-  } as any)
-
   const hasOptionsApiContext = injectOptions != null || provideOptions != null
   const setupWrapper = typeof setup === 'function' || hasOptionsApiContext
     ? ((props, ctx) => {
@@ -326,31 +334,17 @@ function createComponentDefinition(
       }
     : normalizedMpOptions
 
-  const componentOptions = {
+  const componentOptions: RuntimeComponentDefinitionOptions = {
     data: resolvedData as () => Record<string, any>,
     computed: computed as ComputedDefinitions,
     methods: methods as MethodDefinitions,
     setData: resolvedSetData,
     watch,
     setup: setupWrapper,
-    mpOptions: mpOptionsWithProps,
+    mpOptions: mpOptionsWithProps as MiniProgramComponentRawOptions,
   }
 
-  const lifecycleDefinition = registerComponent(
-    runtimeApp as any,
-    methods ?? {},
-    watch as any,
-    setupWrapper as any,
-    mpOptionsWithProps as any,
-    { registerNative },
-  )
-
-  // 返回组件定义，便于外部自行注册
-  const definition: ComponentDefinition<any, any, any> = {
-    __wevu_runtime: runtimeApp as any,
-    __wevu_options: componentOptions as ComponentDefinition<any, any, any>['__wevu_options'],
-  }
-  componentLifecycleDefinitions.set(definition, lifecycleDefinition)
+  const definition = materializeComponentDefinition(componentOptions, registerNative)
 
   return definition as unknown as WevuComponentConstructor<
     ResolveProps<ComponentPropsOptions>,
@@ -371,6 +365,20 @@ export function createWevuComponentDefinition(
   options: DefineComponentOptions<any, any, any, any, any>,
 ) {
   return createComponentDefinition(options, false)
+}
+
+/**
+ * 从现有组件定义派生拥有独立应用上下文的组件定义。
+ *
+ * @param definition 已解析的 Wevu 组件定义
+ * @internal
+ */
+export function createIsolatedWevuComponentDefinition(definition: object) {
+  const componentOptions = (definition as ComponentDefinition<any, any, any>).__wevu_options
+  if (!componentOptions) {
+    throw new TypeError('无法从非 Wevu 组件定义创建独立运行时')
+  }
+  return materializeComponentDefinition(componentOptions)
 }
 
 /**

--- a/packages-runtime/wevu/src/runtime/define/componentDefinition.ts
+++ b/packages-runtime/wevu/src/runtime/define/componentDefinition.ts
@@ -1,0 +1,49 @@
+import type { WatchMap } from '../register/watch'
+import type {
+  ComputedDefinitions,
+  MethodDefinitions,
+  MiniProgramComponentRawOptions,
+  SetDataSnapshotOptions,
+} from '../types'
+import { createApp } from '../app'
+import { INTERNAL_DEFAULTS_SCOPE_KEY } from '../defaults'
+import { registerComponent } from '../register'
+
+export interface RuntimeComponentDefinitionOptions {
+  data: (() => Record<string, any>) | undefined
+  computed: ComputedDefinitions
+  methods: MethodDefinitions
+  setData: SetDataSnapshotOptions | undefined
+  watch: WatchMap | undefined
+  setup: ((props: any, ctx: any) => any) | undefined
+  mpOptions: MiniProgramComponentRawOptions
+}
+
+/**
+ * 从稳定的组件选项快照创建独立运行时和宿主生命周期定义。
+ */
+export function createRuntimeComponentDefinition(
+  options: RuntimeComponentDefinitionOptions,
+  registerNative = false,
+) {
+  const runtimeApp = createApp({
+    data: options.data,
+    computed: options.computed,
+    methods: options.methods,
+    setData: options.setData,
+    [INTERNAL_DEFAULTS_SCOPE_KEY]: 'component',
+  } as any)
+  const lifecycleDefinition = registerComponent(
+    runtimeApp as any,
+    options.methods,
+    options.watch,
+    options.setup,
+    options.mpOptions,
+    { registerNative },
+  )
+
+  return {
+    lifecycleDefinition,
+    runtimeApp,
+  }
+}

--- a/packages-runtime/wevu/src/runtime/provide.test.ts
+++ b/packages-runtime/wevu/src/runtime/provide.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { setCurrentInstance } from './hooks'
 import {
   inject,
+  injectGlobal,
   provide,
 } from './provide'
 import {
@@ -108,5 +109,17 @@ describe('runtime provide/inject', () => {
       expect(inject('layout')).toBe('layout-value')
       expect(inject('page')).toBe('page-value')
     })
+  })
+
+  it('keeps component-scoped app provides out of the global fallback store', () => {
+    const runtimeApp = createRuntimeApp()
+    const token = Symbol('component-scoped-provide')
+    setRuntimeAppProvidedValue(runtimeApp, token, 'local-value', { syncGlobal: false })
+
+    const component = createRuntimeState(undefined, runtimeApp)
+    runWithInstance(component, () => {
+      expect(inject(token)).toBe('local-value')
+    })
+    expect(injectGlobal(token, 'missing')).toBe('missing')
   })
 })

--- a/packages-runtime/wevu/src/runtime/provideContext.ts
+++ b/packages-runtime/wevu/src/runtime/provideContext.ts
@@ -80,9 +80,16 @@ export function ensureRuntimeAppProvides(runtimeApp: RuntimeApp<any, any, any>):
   return getRuntimeAppProvides(runtimeApp)
 }
 
-export function setRuntimeAppProvidedValue<T>(runtimeApp: RuntimeApp<any, any, any>, key: any, value: T): void {
+export function setRuntimeAppProvidedValue<T>(
+  runtimeApp: RuntimeApp<any, any, any>,
+  key: any,
+  value: T,
+  options: { syncGlobal?: boolean } = {},
+): void {
   getRuntimeAppProvides(runtimeApp)[key as PropertyKey] = value
-  setGlobalProvidedValue(key, value)
+  if (options.syncGlobal !== false) {
+    setGlobalProvidedValue(key, value)
+  }
 }
 
 export function attachRuntimeProvideContext(

--- a/packages-runtime/wevu/test/runtime-component-definition.test.ts
+++ b/packages-runtime/wevu/test/runtime-component-definition.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  createIsolatedWevuComponentDefinition,
   createWevuComponentDefinition,
   getWevuComponentLifecycleDefinition,
 } from '@/internal-runtime'
@@ -25,5 +26,24 @@ describe('runtime: component definition factory', () => {
     expect(lifecycleDefinition?.lifetimes.attached).toBeTypeOf('function')
     expect(lifecycleDefinition?.lifetimes.ready).toBeTypeOf('function')
     expect(lifecycleDefinition?.lifetimes.detached).toBeTypeOf('function')
+  })
+
+  it('derives equivalent lifecycle definitions with isolated runtime apps', () => {
+    const definition = createWevuComponentDefinition({
+      props: { count: { type: Number, default: 1 } },
+      setup: props => ({ count: props.count }),
+    })
+    const isolated = createIsolatedWevuComponentDefinition(definition)
+    const lifecycleDefinition = getWevuComponentLifecycleDefinition(definition)
+    const isolatedLifecycleDefinition = getWevuComponentLifecycleDefinition(isolated)
+
+    expect(isolated.__wevu_runtime).not.toBe(definition.__wevu_runtime)
+    expect(isolated.__wevu_options).toBe(definition.__wevu_options)
+    expect(isolatedLifecycleDefinition).not.toBe(lifecycleDefinition)
+    expect(Object.keys(isolatedLifecycleDefinition ?? {}).sort()).toEqual(
+      Object.keys(lifecycleDefinition ?? {}).sort(),
+    )
+    expect(isolatedLifecycleDefinition?.properties.count.value).toBe(1)
+    expect(isolatedLifecycleDefinition?.lifetimes.created).toBeTypeOf('function')
   })
 })

--- a/packages/weapp-vite/docs/packaged/testing.md
+++ b/packages/weapp-vite/docs/packaged/testing.md
@@ -13,7 +13,9 @@ export default defineConfig({
 })
 ```
 
-该入口只编译并执行 SFC script，不渲染模板、WXML、CSS 或 DOM；`app.vue` 和页面组件也不属于测试对象。完整编译产物、WXML 查询、组件树、宿主 mock 和用户交互仍使用 `@mpcore/test`。
+每次 `mountComponent()` 都会创建独立的 Wevu app context，因此 `global.provide`、插件、mocks、全局属性和卸载状态不会在 wrapper 之间共享。
+
+该入口只编译并执行 SFC script，不渲染模板、WXML、CSS 或 DOM；`app.vue` 和页面组件也不属于测试对象。默认页面判定允许 `pages/**/components/**` 中的普通组件；使用自定义页面目录时，可通过 `wevuSfc({ isPage: filename => boolean })` 提供同步或异步判定。完整编译产物、WXML 查询、组件树、宿主 mock 和用户交互仍使用 `@mpcore/test`。
 
 ## 接入
 

--- a/website/packages/wevu-test-utils.md
+++ b/website/packages/wevu-test-utils.md
@@ -68,6 +68,16 @@ export default defineConfig({
 })
 ```
 
+默认页面判定会拒绝 `app.vue` 和 `pages/**` 下的页面文件，同时允许 `pages/**/components/**` 中的普通组件。自定义路由目录可通过同步或异步 `isPage(filename)` 覆盖页面判定；回调收到的文件名已移除查询参数并统一为 `/` 分隔符：
+
+```ts
+export default defineConfig({
+  plugins: [wevuSfc({
+    isPage: filename => filename.includes('/routes/'),
+  })],
+})
+```
+
 ```ts
 import { mountComponent } from '@wevu/test-utils'
 import Counter from './Counter.vue'
@@ -82,7 +92,7 @@ wrapper.unmount()
 
 `wevuSfc()` 只把 `@wevu/compiler` 生成的 script 交给 Vitest，保留 source map，并把 `virtual:weapp-vite/runtime`、`/reactivity`、`/template` 映射到 Wevu internal runtime。它不使用 `@vitejs/plugin-vue`，不渲染模板、WXML、CSS 或 DOM。
 
-`mountComponent()` 可接收编译后的 SFC 默认导出、`DefineComponentOptions` 或 Wevu component definition。它复用组件 props 默认值、data、computed、methods、watch、setup、Options API provide/inject、emits 和生命周期，执行 `created -> attached -> ready`，卸载时调用 `detached`。`mount()` 会自动识别组件定义；需要保持 `{ setup }` composable 的明确语义时可继续使用 `mountComposable()`。
+`mountComponent()` 可接收编译后的 SFC 默认导出、`DefineComponentOptions` 或 Wevu component definition。它复用组件 props 默认值、data、computed、methods、watch、setup、Options API provide/inject、emits 和生命周期，执行 `created -> attached -> ready`，卸载时调用 `detached`。每个 wrapper 都拥有独立的 Wevu app context，`global.provide`、插件、mocks、全局属性和卸载状态不会跨挂载共享。`mount()` 会自动识别组件定义；需要保持 `{ setup }` composable 的明确语义时可继续使用 `mountComposable()`。
 
 app/page SFC、完整构建产物、逻辑 WXML、选择器、布局、宿主 mock 和真实交互不属于 `mountComponent()`；这些场景使用 [`@mpcore/test`](/packages/mpcore-test)。`onUpdated` 仍沿用 Wevu runtime 语义，本工具不会伪造生产更新。
 


### PR DESCRIPTION
## 背景

跟进 [Discussion #338](https://github.com/weapp-vite/weapp-vite/discussions/338#discussioncomment-18103910) 对 `@wevu/test-utils` 的复核：编译后的组件定义会复用 runtime app，导致测试级 provide、mocks、插件和卸载状态可能在重复或并发挂载间残留；同时，`wevuSfc()` 原有的路径判断会误伤页面目录内的普通组件。

## 改动

- 从稳定的组件选项快照为每次组件挂载派生独立 runtime app，隔离 provide、mocks、插件与卸载清理。
- 组件作用域的 app provide 不再写入进程级兼容存储，同时保留正常 App 的全局兼容行为。
- `wevuSfc()` 允许 `pages/**/components/**` 普通组件，并新增同步或异步 `isPage(filename)` 判定。
- 补充同时存活 wrapper、重复挂载、卸载清理、页面目录组件及公开类型回归。
- 同步包 README、website、随包测试文档和中文 changeset。

## 兼容性边界

`@wevu/test-utils` 继续只验证 Wevu 逻辑层，不引入 Vue Web runtime，也不模拟 WXML、DOM 或小程序宿主。完整编译产物与交互仍由 `@mpcore/test` 覆盖。

## Changeset

- `wevu`: patch
- `@wevu/test-utils`: patch
- `create-weapp-vite`: patch

## 验证

- `pnpm --filter wevu test`（77 个文件，875 项测试）
- `pnpm -C packages-runtime/wevu-test-utils test`（3 个文件，16 项测试）
- `pnpm -C packages-runtime/wevu typecheck`
- `pnpm -C packages-runtime/wevu test:types`
- `pnpm -C packages-runtime/wevu lint`
- `pnpm -C packages-runtime/wevu-test-utils typecheck`
- `pnpm -C packages-runtime/wevu-test-utils test:types`
- `pnpm -C packages-runtime/wevu-test-utils lint`
- `pnpm --filter weapp-vite build`
- `pnpm --filter website-weapp-vite build`
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`
- `node --import tsx scripts/check-catalog-changeset.ts`