### PR TITLE
fix(web): 修复组件观察器与全量回归稳定性问题

### DIFF
--- a/.changeset/fuzzy-web-observers.md
+++ b/.changeset/fuzzy-web-observers.md
@@ -1,0 +1,5 @@
+---
+"@weapp-vite/web": patch
+---
+
+为 Web 自定义组件实例补齐带组件作用域的 `createIntersectionObserver`，修复依赖实例观察器的组件库在 Web 端启动失败。

--- a/e2e/ci/automator-launch-resilience.test.ts
+++ b/e2e/ci/automator-launch-resilience.test.ts
@@ -87,6 +87,8 @@ interface MockMiniProgramRuntime {
   __rawReLaunch: ReturnType<typeof vi.fn>
 }
 
+const activeMockMiniPrograms = new Set<MockMiniProgramRuntime>()
+
 function createMockPage(pagePath = 'pages/index/index'): MockPage {
   return {
     path: pagePath,
@@ -106,7 +108,7 @@ function createMockMiniProgram(options?: { currentPage?: MockPage, reLaunchError
         throw options.reLaunchError
       })
     : vi.fn(async () => page)
-  return {
+  const miniProgram = {
     compile: rawCompile,
     on: vi.fn(),
     removeListener: vi.fn(),
@@ -117,6 +119,20 @@ function createMockMiniProgram(options?: { currentPage?: MockPage, reLaunchError
     __rawClose: rawClose,
     __rawCurrentPage: rawCurrentPage,
     __rawReLaunch: rawReLaunch,
+  }
+  activeMockMiniPrograms.add(miniProgram)
+  return miniProgram
+}
+
+async function closeActiveMockMiniPrograms() {
+  const miniPrograms = Array.from(activeMockMiniPrograms)
+  activeMockMiniPrograms.clear()
+  const results = await Promise.allSettled(miniPrograms.map(miniProgram => miniProgram.close()))
+  const errors = results
+    .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+    .map(result => result.reason)
+  if (errors.length > 0) {
+    throw new AggregateError(errors, 'Failed to close mock mini-programs')
   }
 }
 
@@ -266,10 +282,30 @@ describe.sequential('automator launch resilience', () => {
     process.env.WEAPP_VITE_E2E_AUTOMATOR_PREBUILD = '0'
   })
 
-  afterEach(() => {
-    clearLaunchEnv()
-    vi.resetModules()
-    fs.rmSync(sandboxRoot, { recursive: true, force: true })
+  afterEach(async () => {
+    try {
+      await closeActiveMockMiniPrograms()
+    }
+    finally {
+      clearLaunchEnv()
+      vi.resetModules()
+      fs.rmSync(sandboxRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('closes tracked mini-programs before removing their fixture', async () => {
+    const lifecycle: string[] = []
+    const miniProgram = createMockMiniProgram()
+    miniProgram.close.mockImplementationOnce(async () => {
+      lifecycle.push('close')
+    })
+
+    await closeActiveMockMiniPrograms()
+    lifecycle.push('remove')
+    await closeActiveMockMiniPrograms()
+
+    expect(lifecycle).toEqual(['close', 'remove'])
+    expect(miniProgram.close).toHaveBeenCalledTimes(1)
   })
 
   it('extracts DevTools service port from cli bridge output', async () => {

--- a/e2e/ide/github-issues.runtime.issue564.test.ts
+++ b/e2e/ide/github-issues.runtime.issue564.test.ts
@@ -72,7 +72,7 @@ describe.sequential('e2e app: github-issues / issue #564', () => {
       })
 
       const pageWxml = await fs.readFile(path.join(DIST_ROOT, 'pages/issue-564/index.wxml'), 'utf8')
-      expect(pageWxml).toContain('<issue-564-native-tabbar>')
+      expect(pageWxml).toMatch(/<issue-564-native-tabbar(?:\s|>)/)
       expect(pageWxml).toContain('<issue-564-native-tabbar-item')
       expect(pageWxml).toContain('wx:for="{{tabItems}}"')
       expect(pageWxml).toContain('label="{{__wv_item_0.label}}"')

--- a/e2e/ide/github-issues.runtime.issue627.test.ts
+++ b/e2e/ide/github-issues.runtime.issue627.test.ts
@@ -9,6 +9,7 @@ import {
   PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT,
   prepareGithubIssuesBuild,
   relaunchPage,
+  releaseSharedMiniProgram,
 } from './github-issues.runtime.shared'
 
 describe.sequential('e2e app: github-issues / issue #627', () => {
@@ -19,7 +20,7 @@ describe.sequential('e2e app: github-issues / issue #627', () => {
   }, PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT)
 
   afterAll(async () => {
-    await miniProgram?.close?.().catch(() => {})
+    await releaseSharedMiniProgram(miniProgram)
     miniProgram = null
     await closeSharedMiniProgram()
   })

--- a/packages-runtime/web/src/runtime/component/element.ts
+++ b/packages-runtime/web/src/runtime/component/element.ts
@@ -12,6 +12,7 @@ import type {
 import type { ClassAttributeElement } from './virtualHost'
 import { html } from 'lit'
 import { unsafeHTML } from 'lit/directives/unsafe-html.js'
+import { createIntersectionObserverBridge } from '../polyfill/intersectionObserver'
 import { createRenderContext } from '../renderContext'
 import { hasOwn } from '../utils/object'
 import { supportsLit } from './constants'
@@ -158,6 +159,14 @@ export function createComponentElementClass({
 
     createSelectorQuery() {
       return createScopedSelectorQuery(this)
+    }
+
+    createIntersectionObserver(options?: {
+      initialRatio?: number
+      observeAll?: boolean
+      thresholds?: number[]
+    }) {
+      return createIntersectionObserverBridge(this, options)
     }
 
     selectComponent(selector: string) {

--- a/packages-runtime/web/src/runtime/component/types.ts
+++ b/packages-runtime/web/src/runtime/component/types.ts
@@ -82,6 +82,11 @@ export interface ComponentPublicInstance extends HTMLElement {
   setData: (patch: DataRecord, callback?: () => void) => void | Promise<void>
   triggerEvent: (name: string, detail?: any, options?: TriggerEventOptions) => void
   createSelectorQuery: () => any
+  createIntersectionObserver: (options?: {
+    initialRatio?: number
+    observeAll?: boolean
+    thresholds?: number[]
+  }) => any
   selectComponent: (selector: string) => ComponentPublicInstance | null
   selectAllComponents: (selector: string) => ComponentPublicInstance[]
   getRelationNodes: (relationPath: string) => ComponentPublicInstance[]

--- a/packages-runtime/web/test/component.test.ts
+++ b/packages-runtime/web/test/component.test.ts
@@ -1648,6 +1648,47 @@ describe('component selector helpers', () => {
     }))
   })
 
+  it('provides scoped createIntersectionObserver on component instance', () => {
+    defineComponent('wv-intersection-observer-host', {
+      template: createTemplate('<view class="intersection-target"></view>'),
+      component: {},
+    })
+
+    const host = document.createElement('wv-intersection-observer-host') as HTMLElement & {
+      createIntersectionObserver: (options?: { thresholds?: number[] }) => ReturnType<typeof createIntersectionObserver>
+    }
+    document.body.append(host)
+    const target = host.shadowRoot?.querySelector('.intersection-target')
+    expect(target).toBeTruthy()
+    ;(target as HTMLElement).getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      right: 20,
+      bottom: 20,
+      width: 20,
+      height: 20,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    })
+    const observe = vi.fn()
+    const restoreObserver = overrideGlobalProperty('IntersectionObserver', class {
+      observe = observe
+      disconnect = vi.fn()
+    })
+
+    try {
+      host.createIntersectionObserver({ thresholds: [0.5] })
+        .relativeToViewport({ top: -12 })
+        .observe('.intersection-target', vi.fn())
+
+      expect(observe).toHaveBeenCalledWith(target)
+    }
+    finally {
+      restoreObserver()
+    }
+  })
+
   it('falls back to non-wechat mini-program globals for scoped selector query', () => {
     const originalWx = (globalThis as any).wx
     const originalMy = (globalThis as any).my


### PR DESCRIPTION
## 变更说明

- 统一登记 automator resilience 测试创建的 mock mini-program，在删除临时项目和重置模块前异步关闭 bridge wrapper watcher，并保证重复清理幂等。
- 放宽 issue #564 的 WXML 标签断言以接受合法的 scoped-style 属性，同时保留父组件标签边界，避免误匹配子组件。
- 修复 issue #627 直接关闭共享 automator 的所有权问题，避免后续场景等待超时后重启会话。
- 为 Web 自定义组件实例补齐带组件作用域的 `createIntersectionObserver`，修复 uview-plus `up-lazy-load` 在 mobile/desktop Web E2E 中的页面错误。

## 根因与效果

Windows Node 24 下，测试删除临时项目时 bridge wrapper 的 `fs.watch` 仍存活，可能触发 libuv 崩溃。清理顺序现统一为“关闭会话和 watcher -> 重置模块 -> 删除 fixture”。

IDE aggregate 中，issue #627 曾直接关闭共享会话但保留非空引用，导致后续用例复用死会话。改用共享释放 API 后，定向 aggregate 不再出现首次切页超时或非预期 automator restart。

Web runtime 原先只在全局 `uni` 上实现 `createIntersectionObserver`，自定义组件实例只有 `createSelectorQuery`。wevu 因而暴露了可调用但返回 `undefined` 的桥接方法，uview-plus 检测为支持后在调用 `relativeToViewport` 时崩溃。现在由 Web 组件实例直接创建 scoped observer，恢复与小程序组件实例一致的能力边界。

## 本地验证

- `pnpm test`：867 个文件、7535 项测试通过。
- `pnpm e2e:ci`：69/69 tasks 通过，包含 25/25 full HMR guard。
- `caffeinate -dimsu -- pnpm e2e:ide:full`：15/15 tasks 通过。
- `pnpm e2e:web`：1/1 task、5 个文件、70 项测试通过。
- `pnpm --filter @weapp-vite/web test`：92 个文件、589 项测试通过。
- `pnpm --filter @weapp-vite/web build`：通过并生成声明文件。
- automator resilience 定向回归：53 项测试通过。
- GitHub issues aggregate 定向回归：66 项测试通过。
- IDE 共享启动检查：106 个文件通过。
- 变更文件 ESLint、`git diff --check`、create-weapp-vite/catalog changeset guard 通过。

`@weapp-vite/web typecheck` 在本次改动前后均存在同一批既有测试类型诊断；基线对照确认本次没有新增诊断位置，本次新增用例的类型错误已清零。

## Changeset

Web runtime 行为修复属于用户可见变更，已添加 `@weapp-vite/web` patch changeset。未修改 `weapp-vite`、`wevu` 或模板，不需要联动 `create-weapp-vite`。

## CI 关注项

PR matrix 覆盖 Windows Node 22 Miniapp E2E/HMR 与 Ubuntu Node 24 Miniapp E2E；Windows Node 24 watcher 验收由 scheduled full matrix 提供，当前 PR checks 不包含该组合。