### PR TITLE
fix(weapp-vite): 修复 app.vue 共享样式注入

### DIFF
--- a/.changeset/tidy-app-vue-styles.md
+++ b/.changeset/tidy-app-vue-styles.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复 `weapp.styles.include` 显式匹配 `app.vue` 时未向 `app.wxss` 注入共享样式的问题，同时保持默认配置不修改应用级样式入口。

--- a/docs/subpackages.md
+++ b/docs/subpackages.md
@@ -133,7 +133,7 @@ export default defineConfig({
 
 > 提示：`styles` 支持 `wxss/css/scss/less/stylus` 等格式，`weapp-vite` 会统一转换为目标平台后缀并按作用域注入。
 
-> 主包入口：顶层 `weapp.styles` 会生成独立样式资产，并注入主包与普通分包中命中的页面或组件，但不会修改 `app.wxss`。独立分包不能依赖主包资源，仍需使用自己的 `subPackages.<root>.styles`。对象配置设为 `inject: false` 时只生成文件，不自动注入。
+> 主包入口：顶层 `weapp.styles` 会生成独立样式资产，并注入主包与普通分包中命中的样式。默认不修改 `app.wxss`；对象配置通过 `include: 'app.vue'` 等显式匹配应用入口时，可以向 `app.wxss` 注入。独立分包不能依赖主包资源，仍需使用自己的 `subPackages.<root>.styles`。对象配置设为 `inject: false` 时只生成文件，不自动注入。
 
 > 路径解析说明：`styles.source` 以“分包根目录”为基准。以上示例里，`packages/order` 访问 `src/shared/styles/components.scss` 需要写成 `../../shared/styles/components.scss`，而不是 `../shared/styles/components.scss`。
 

--- a/e2e-apps/github-issues/src/styles/issue-838-app-vue.scss
+++ b/e2e-apps/github-issues/src/styles/issue-838-app-vue.scss
@@ -1,0 +1,3 @@
+.issue-838-app-vue-shared-style {
+  color: #123456;
+}

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -18,6 +18,7 @@ const issue779CssPreEnabled = process.env.WEAPP_GITHUB_ISSUE_779_CSS_PRE === 'tr
 const e2eTargetFile = process.env.WEAPP_VITE_E2E_TARGET_FILE?.replaceAll('\\', '/') ?? ''
 const issue826PreserveEnabled = process.env.WEAPP_GITHUB_ISSUE_826_PRESERVE === 'true'
   || e2eTargetFile.endsWith('github-issues.runtime.issue826.test.ts')
+const issue838AppVueStylesEnabled = process.env.WEAPP_GITHUB_ISSUE_838_APP_VUE_STYLES === 'true'
 const issue845I18nEnabled = process.env.WEAPP_GITHUB_ISSUE_845_I18N === 'true'
 const issue850OutputReplayEnabled = process.env.WEAPP_GITHUB_ISSUE_850_OUTPUT_REPLAY === 'true'
 const issue793BuildScope = process.env.WEAPP_GITHUB_ISSUE_793_BUILD_SCOPE
@@ -502,6 +503,9 @@ const issue850OutputReplayPlugin = issue850OutputReplayEnabled
   : undefined
 
 function resolveGithubIssuesBuildConfig() {
+  if (issue838AppVueStylesEnabled) {
+    return { outDir: 'dist-issue-838', minify: false }
+  }
   if (issue850OutputReplayEnabled) {
     return { outDir: 'dist-issue-850', minify: false }
   }
@@ -566,6 +570,14 @@ export default defineConfig({
       profileJson: true,
     },
     srcRoot: 'src',
+    ...(issue838AppVueStylesEnabled
+      ? {
+          styles: {
+            source: 'styles/issue-838-app-vue.scss',
+            include: 'app.vue',
+          },
+        }
+      : {}),
     autoRoutes: resolveGithubIssuesAutoRoutes(),
     subPackages: issue850OutputReplayEnabled
       ? {

--- a/e2e/ci/github-issues.build.test.ts
+++ b/e2e/ci/github-issues.build.test.ts
@@ -18,6 +18,7 @@ const ISSUE_595_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-595')
 const ISSUE_642_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-642')
 const ISSUE_724_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-724')
 const ISSUE_793_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-793')
+const ISSUE_838_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-838')
 const ISSUE_845_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-845')
 const ISSUE_850_DIST_ROOT = path.join(APP_ROOT, 'dist-issue-850')
 const issue826DistRoot = (jsFormat: 'cjs' | 'esm') => path.join(APP_ROOT, `dist-issue-826-${jsFormat}`)
@@ -78,6 +79,21 @@ async function runIssue845Build() {
     skipNpm: true,
     env: {
       WEAPP_GITHUB_ISSUE_845_I18N: 'true',
+    },
+  })
+}
+
+async function runIssue838Build() {
+  await fs.remove(ISSUE_838_DIST_ROOT)
+  await runWeappViteBuildWithLogCapture({
+    cliPath: CLI_PATH,
+    projectRoot: APP_ROOT,
+    platform: 'weapp',
+    cwd: APP_ROOT,
+    label: 'ci:github-issues:issue838',
+    skipNpm: true,
+    env: {
+      WEAPP_GITHUB_ISSUE_838_APP_VUE_STYLES: 'true',
     },
   })
 }
@@ -523,6 +539,19 @@ async function runIssue826Build(jsFormat: 'cjs' | 'esm') {
 }
 
 describe.sequential('e2e app: github-issues (build)', () => {
+  it('PR #838: injects explicitly included shared styles into app.vue', async () => {
+    await runIssue838Build()
+
+    const appStyle = await fs.readFile(path.join(ISSUE_838_DIST_ROOT, 'app.wxss'), 'utf8')
+    const sharedStyle = await fs.readFile(
+      path.join(ISSUE_838_DIST_ROOT, 'styles/issue-838-app-vue.wxss'),
+      'utf8',
+    )
+
+    expect(appStyle).toContain('@import \'./styles/issue-838-app-vue.wxss\';')
+    expect(sharedStyle).toContain('color: #123456;')
+  })
+
   it('issue #850: processes completed independent outputs only once', async () => {
     await runIssue850Build()
 

--- a/packages/weapp-vite/docs/packaged/weapp-config.md
+++ b/packages/weapp-vite/docs/packaged/weapp-config.md
@@ -155,7 +155,7 @@ export default defineConfig({
 
 ### `styles`
 
-用于生成主包独立样式入口，并按规则向主包与普通分包的页面或组件样式注入相对 `@import`，不会把内容合并进 `app.wxss`：
+用于生成主包独立样式入口，并按规则向主包与普通分包的样式注入相对 `@import`。默认不会修改 `app.wxss`；对象配置的 `include` 显式匹配 `app.vue` 等应用入口时，可以向 `app.wxss` 注入：
 
 ```ts
 export default defineConfig({
@@ -169,12 +169,16 @@ export default defineConfig({
         source: 'styles/manual.less',
         inject: false,
       },
+      {
+        source: 'styles/app-theme.scss',
+        include: 'app.vue',
+      },
     ],
   },
 })
 ```
 
-`inject: false` 只生成目标平台样式文件，适合由源码手动 `@import`。独立分包不能依赖主包资源，不会收到 `weapp.styles` 的自动注入；需要在 `weapp.subPackages.<root>.styles` 中声明分包自己的入口。
+`inject: false` 只生成目标平台样式文件，适合由源码手动 `@import`。未显式配置 `include` 时仍默认排除 app，避免意外把共享样式提升为全局样式。独立分包不能依赖主包资源，不会收到 `weapp.styles` 的自动注入；需要在 `weapp.subPackages.<root>.styles` 中声明分包自己的入口。
 
 ### `routeRules`
 

--- a/packages/weapp-vite/src/plugins/css/shared/sharedStyles.test.ts
+++ b/packages/weapp-vite/src/plugins/css/shared/sharedStyles.test.ts
@@ -66,29 +66,47 @@ describe('sharedStyles helpers', () => {
     expect(Array.from(onlyPkgB.keys())).toEqual(['pkgB'])
   })
 
-  it('injects main-package styles into pages but not app styles', () => {
+  it('injects default main-package styles into pages but not app styles', () => {
     const sharedStyles = new Map<string, SubPackageStyleEntry[]>([
       ['', [createStyleEntry({
+        include: ['pages/**', 'components/**'],
         outputRelativePath: 'styles/main.wxss',
       })]],
     ])
-    const configService = createConfigService(id => id.includes('/app.') ? 'app.ts' : 'pkgA/pages/foo.ts')
+    const configService = createConfigService(id => id.includes('/app.') ? 'app.vue' : 'pages/foo.ts')
 
     expect(injectSharedStyleImports(
       '.page{}',
-      '/abs/pkgA/pages/foo.ts',
-      'pkgA/pages/foo.wxss',
+      '/abs/pages/foo.ts',
+      'pages/foo.wxss',
       sharedStyles,
       configService,
-    )).toBe('@import \'../../styles/main.wxss\';\n.page{}')
+    )).toBe('@import \'../styles/main.wxss\';\n.page{}')
 
     expect(injectSharedStyleImports(
       '.app{}',
-      '/abs/app.ts',
+      '/abs/app.vue',
       'app.wxss',
       sharedStyles,
       configService,
     )).toBe('.app{}')
+  })
+
+  it('injects main-package styles explicitly included for app.vue', () => {
+    const sharedStyles = new Map<string, SubPackageStyleEntry[]>([
+      ['', [createStyleEntry({
+        include: ['app.vue'],
+        outputRelativePath: 'styles/main.wxss',
+      })]],
+    ])
+
+    expect(injectSharedStyleImports(
+      '.app{}',
+      '/abs/app.vue',
+      'app.wxss',
+      sharedStyles,
+      createConfigService(() => 'app.vue'),
+    )).toBe('@import \'./styles/main.wxss\';\n.app{}')
   })
 
   it('emits but does not inject entries configured with inject false', () => {

--- a/packages/weapp-vite/src/plugins/css/shared/sharedStyles.ts
+++ b/packages/weapp-vite/src/plugins/css/shared/sharedStyles.ts
@@ -69,10 +69,6 @@ function relativeToRoot(pathname: string, root: string) {
   }
 }
 
-function isMainAppStyleFile(fileName: string) {
-  return !fileName.includes('/') && path.posix.basename(fileName, path.posix.extname(fileName)) === 'app'
-}
-
 function getStyleMatcher(entry: StyleEntry): StyleMatcher {
   const cached = styleMatcherCache.get(entry)
   if (cached) {
@@ -134,9 +130,6 @@ function findSharedStylesForModule(
   for (const [root, entries] of sharedStyles.entries()) {
     const normalizedRoot = normalizeRoot(root)
     if (root && !normalizedRoot) {
-      continue
-    }
-    if (!normalizedRoot && isMainAppStyleFile(sanitizedFile)) {
       continue
     }
     if (!isWithinRoot(sanitizedFile, normalizedRoot)) {

--- a/packages/weapp-vite/src/runtime/scanPlugin/styleEntries/index.test.ts
+++ b/packages/weapp-vite/src/runtime/scanPlugin/styleEntries/index.test.ts
@@ -145,4 +145,33 @@ describe('normalizeSubPackageStyleEntries', () => {
     expect(entries).toHaveLength(2)
     expect(entries?.some(entry => entry.source === 'components.scss')).toBe(false)
   })
+
+  it('excludes app by default but preserves an explicit app.vue include', async () => {
+    await fs.writeFile(path.join(tempRoot, 'main.scss'), '.shared {}')
+
+    const defaultEntries = normalizeMainPackageStyleEntries(
+      'main.scss',
+      createConfigService(tempRoot),
+    )
+    const explicitEntries = normalizeMainPackageStyleEntries(
+      {
+        source: 'main.scss',
+        include: 'app.vue',
+      },
+      createConfigService(tempRoot),
+    )
+
+    expect(defaultEntries).toEqual([
+      expect.objectContaining({
+        include: ['**/*'],
+        exclude: ['app.*'],
+      }),
+    ])
+    expect(explicitEntries).toEqual([
+      expect.objectContaining({
+        include: ['app.vue'],
+        exclude: [],
+      }),
+    ])
+  })
 })

--- a/packages/weapp-vite/src/runtime/scanPlugin/styleEntries/index.ts
+++ b/packages/weapp-vite/src/runtime/scanPlugin/styleEntries/index.ts
@@ -20,11 +20,32 @@ import {
   SUPPORTED_SHARED_STYLE_EXTS,
 } from './config'
 import { addStyleEntry, appendDefaultScopedStyleEntries } from './entries'
+import { normalizePattern } from './patterns'
 import {
   getRelativePathWithinSubPackage,
   inferScopeFromRelativePath,
   resolveStyleEntryAbsolutePath,
 } from './resolve'
+
+function hasExplicitIncludePattern(
+  include: string | string[] | undefined,
+  normalizedRoot: string,
+) {
+  const patterns = include === undefined
+    ? []
+    : Array.isArray(include) ? include : [include]
+  return patterns.some(pattern => normalizePattern(pattern, normalizedRoot) !== undefined)
+}
+
+function appendExcludePattern(
+  exclude: string | string[] | undefined,
+  pattern: string,
+) {
+  if (exclude === undefined) {
+    return [pattern]
+  }
+  return Array.isArray(exclude) ? [...exclude, pattern] : [exclude, pattern]
+}
 
 export function isSupportedSharedStyleExtension(absolutePath: string) {
   return SUPPORTED_SHARED_STYLE_EXTS.has(path.extname(absolutePath).toLowerCase())
@@ -50,6 +71,7 @@ function normalizeStyleEntries(
   options: {
     warningPrefix: string
     appendDefaultEntries: boolean
+    excludeRootAppByDefault: boolean
   },
 ): StyleEntry[] | undefined {
   const service = configService
@@ -97,6 +119,10 @@ function normalizeStyleEntries(
     const posixOutput = toPosixPath(outputRelativePath)
     const resolvedDescriptor: ResolvedStyleConfig = {
       ...descriptor,
+      exclude: options.excludeRootAppByDefault
+        && !hasExplicitIncludePattern(descriptor.include, normalizedRoot)
+        ? appendExcludePattern(descriptor.exclude, 'app.*')
+        : descriptor.exclude,
       scope: resolveStyleEntryScope(descriptor, posixOutput, normalizedRoot),
     }
 
@@ -123,6 +149,7 @@ export function normalizeSubPackageStyleEntries(
   return normalizeStyleEntries(styles, root, configService, {
     warningPrefix: `[分包] 分包 ${root} `,
     appendDefaultEntries: true,
+    excludeRootAppByDefault: false,
   })
 }
 
@@ -137,5 +164,6 @@ export function normalizeMainPackageStyleEntries(
   return normalizeStyleEntries(styles, '', configService, {
     warningPrefix: '[样式] 主包 ',
     appendDefaultEntries: false,
+    excludeRootAppByDefault: true,
   })
 }

--- a/packages/weapp-vite/src/types/config/foundation.ts
+++ b/packages/weapp-vite/src/types/config/foundation.ts
@@ -92,7 +92,7 @@ export interface StyleConfigObject {
    * @description 作用范围快捷配置
    */
   scope?: StyleScope
-  /** 自定义包含路径，支持传入单个 glob 或数组，默认覆盖当前包内所有文件 */
+  /** 自定义包含路径，支持传入单个 glob 或数组；主包默认不包含 app，需显式匹配 `app.vue` 等应用入口 */
   include?: string | string[]
   /** 自定义排除路径，支持传入单个 glob 或数组 */
   exclude?: string | string[]

--- a/skills/weapp-vite-best-practices/SKILL.md
+++ b/skills/weapp-vite-best-practices/SKILL.md
@@ -47,7 +47,7 @@ description: 面向采用 weapp-vite 项目布局仓库或已安装 `weapp-vite`
    - `weapp.i18n`：基于 `@weapp-vite/i18n` 的微信平台 locale JSON 编译与运行时切换；`defaultLocale` 必填，默认扫描 `**/i18n/*.json`
    - `weapp.uniApp`：实验性外部 uni-app Vue SFC 转换；npm 包必须显式加入 `include` 白名单
    - `weapp.routeRules`
-   - `weapp.styles`：生成主包独立样式入口并按规则注入主包与普通分包；不修改 `app.wxss`，也不跨入独立分包
+   - `weapp.styles`：生成主包独立样式入口并按规则注入主包与普通分包；默认不修改 `app.wxss`，显式 `include: 'app.vue'` 时可注入，也不跨入独立分包
    - `weapp.buildScope` / `wv dev|build --scope`：限定页面或分包构建时保持 autoRoutes 的主包/分包归属
    - `weapp.typescript`
    - `weapp.hmr.runtime`：显式配置优先；未配置时结合工作区 `compileHotReLoad` 选择 classic 或实验性 stateful 模式；实际 bundle 含 Skyline renderer 时强制关闭 DevTools 热重载并降级 classic
@@ -95,7 +95,7 @@ description: 面向采用 weapp-vite 项目布局仓库或已安装 `weapp-vite`
 - 小程序单测不使用 jsdom；`@mpcore/test` 只暴露逻辑 WXML 树。测试产物必须通过 `weapp-vite/test` 交给 Vite/Rolldown emit，不能由适配器手写 bundle。
 - uni-app 兼容层默认关闭，只转换项目源码与 `include` 白名单依赖；Wot UI 与 uview-plus 分别以 `@wot-ui/ui@2.2.0`、`uview-plus@3.8.86` 的 npm 发布包 SFC 清单为兼容基线，不把它们泛化成完整 uni-app runtime。
 - 分包、插件、worker 和 lib mode 的性能判断都先看产物结构与 `wv analyze`，再改 chunk/shared 策略。
-- 主包共享样式优先使用 `weapp.styles` 保持独立产物；`inject: false` 只 emit，独立分包必须通过自己的 `subPackages.<root>.styles` 持有副本。
+- 主包共享样式优先使用 `weapp.styles` 保持独立产物；默认排除 app，只有显式 `include: 'app.vue'` 等应用入口时才注入 `app.wxss`；`inject: false` 只 emit，独立分包必须通过自己的 `subPackages.<root>.styles` 持有副本。
 - 内置 i18n v1 只支持 `{name}` / `{user.name}` 插值，不提供 ICU、复数、日期/数字格式化或自动 storage 持久化；非微信平台不要启用。
 
 ## 参考决策表

--- a/website/config/subpackages.md
+++ b/website/config/subpackages.md
@@ -26,7 +26,7 @@ keywords:
 - **类型**：`StyleConfigEntry | StyleConfigEntry[]`
 - **默认值**：`undefined`
 
-用于把主包源码目录中的样式编译为独立产物，并按规则向主包与普通分包的页面或组件样式注入相对 `@import`。它不会把内容合并进 `app.wxss`。
+用于把主包源码目录中的样式编译为独立产物，并按规则向主包与普通分包的样式注入相对 `@import`。默认不会修改 `app.wxss`；`include` 显式匹配 `app.vue` 等应用入口时，可以向 `app.wxss` 注入。
 
 ```ts
 import { defineConfig } from 'weapp-vite/config'
@@ -42,6 +42,10 @@ export default defineConfig({
         source: 'styles/manual.less',
         inject: false,
       },
+      {
+        source: 'styles/app-theme.scss',
+        include: 'app.vue',
+      },
     ],
   },
 })
@@ -51,11 +55,12 @@ export default defineConfig({
 
 - `theme.wxss` 会被命中的主包、普通分包页面或组件引用。
 - `manual.wxss` 只生成文件，供源码使用 `@wv-keep-import` 或其他原生方式手动引用。
-- `app.wxss` 不会被自动修改。
+- 未显式配置 `include` 时，app 默认被排除，避免共享样式意外变成全局样式。
+- `include: 'app.vue'` 会让生成的 `app.wxss` 引用对应共享样式资产。
 - 独立分包不能依赖主包资源，因此不会注入这些入口。需要在独立分包使用同一主题时，应在对应的 `weapp.subPackages.<root>.styles` 中显式声明一份分包内入口。
 
 > [!NOTE]
-> `weapp.styles` 的 `include` / `exclude` 相对 `srcRoot` 匹配。`scope: 'pages'` 和 `scope: 'components'` 的默认规则分别是根级 `pages/**` 与 `components/**`；要覆盖分包目录，请使用显式 glob。
+> `weapp.styles` 的 `include` / `exclude` 相对 `srcRoot` 匹配。`scope: 'pages'` 和 `scope: 'components'` 的默认规则分别是根级 `pages/**` 与 `components/**`；要覆盖分包目录或 app，请使用显式 glob。
 
 ## `weapp.subPackages` {#weapp-subpackages}
 


### PR DESCRIPTION
## 背景

跟进 PR #838 的用户反馈：`weapp.styles.include` 显式匹配 `app.vue` 时，共享样式文件会生成，但产物 `app.wxss` 没有对应的 `@import`。

## 根因

主包共享样式注入器在执行 include/exclude glob 匹配之前，无条件跳过了 `app.wxss`。这保住了默认配置不修改应用级样式的旧语义，但也让用户显式配置 `include: "app.vue"` 永远无法生效。

## 修复

- 将“默认排除 app”迁移到主包样式配置归一化层：未显式配置有效 include 时追加 `app.*` exclude
- 移除注入器中不可覆盖的 app 硬跳过，让显式 include 与 exclude 成为唯一匹配依据
- 在 `e2e-apps/github-issues` 增加隔离构建场景，验证 `app.vue -> app.wxss` 的共享样式注入
- 补充 helper、归一化和集成回归，确保默认配置仍不修改 `app.wxss`
- 同步类型注释、packaged docs、website、公开 skill 与中文 changeset

## 验证

- `pnpm vitest run packages/weapp-vite/src/runtime/scanPlugin/styleEntries/index.test.ts packages/weapp-vite/src/plugins/css/shared/sharedStyles.test.ts packages/weapp-vite/src/plugins/css.test.ts packages/weapp-vite/test/subPackages-shared-styles.test.ts`
- `pnpm --filter weapp-vite typecheck`
- `pnpm --filter weapp-vite test:types`
- `pnpm --filter weapp-vite build`
- `pnpm vitest run -c e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "PR #838"`
- 改动范围 ESLint 与 Stylelint
- `pnpm skills:check`
- `pnpm --filter website-weapp-vite build`
- `node --import tsx scripts/check-create-weapp-vite-changeset.ts`
- `node --import tsx scripts/check-catalog-changeset.ts`

## 维护性说明

默认行为现在由归一化后的 include/exclude 数据表达，注入器只负责统一匹配，避免后续再出现显式配置被隐藏分支覆盖的问题。相关源码文件仍低于 300 行，本次无需拆分。