### PR TITLE
fix(e2e): 兼容不同版本微信开发者工具自动化接口

### DIFF
--- a/e2e/ci/automator-launch-resilience.test.ts
+++ b/e2e/ci/automator-launch-resilience.test.ts
@@ -208,9 +208,9 @@ function clearLaunchEnv() {
   delete process.env.WEAPP_VITE_E2E_AUTOMATOR_BRIDGE_WRAPPER
 }
 
-function readBridgePayloadFromFirstExecaCall() {
-  const firstCall = execaMock.mock.calls[0]
-  const args = firstCall?.[1] as string[] | undefined
+function readBridgePayloadFromExecaCall(index = 0) {
+  const call = execaMock.mock.calls[index]
+  const args = call?.[1] as string[] | undefined
   const rawPayload = args?.find(arg => arg.startsWith('{'))
   return rawPayload ? JSON.parse(rawPayload) as { projectPath?: string } : undefined
 }
@@ -1435,7 +1435,7 @@ describe.sequential('automator launch resilience', () => {
 
     expect(launchMock).not.toHaveBeenCalled()
     expect(execaMock).toHaveBeenCalledTimes(1)
-    expectBridgeWrapperProjectPath(sandboxRoot, readBridgePayloadFromFirstExecaCall()?.projectPath)
+    expectBridgeWrapperProjectPath(sandboxRoot, readBridgePayloadFromExecaCall()?.projectPath)
     expect(connectMock).toHaveBeenCalledWith({
       wsEndpoint: 'ws://127.0.0.1:9420',
     })
@@ -1474,12 +1474,12 @@ describe.sequential('automator launch resilience', () => {
       wrapperProjectPath = payload.projectPath
       expect(readJson(path.join(wrapperProjectPath, 'project.config.json'))).toMatchObject({
         setting: {
-          es6: true,
           packNpmManually: false,
           packNpmRelationList: [],
           postcss: true,
         },
       })
+      expect(readJson(path.join(wrapperProjectPath, 'project.config.json')).setting).not.toHaveProperty('es6')
       expect(readJson(path.join(wrapperProjectPath, 'project.config.json'))).toMatchObject({ simulatorType: 'wechat' })
       expect(readJson(path.join(wrapperProjectPath, 'app.json'))).toEqual({
         pages: ['pages/index/index'],
@@ -1502,10 +1502,10 @@ describe.sequential('automator launch resilience', () => {
     connectedMiniProgram.__rawReLaunch.mockImplementationOnce(async () => {
       expect(readJson(path.join(wrapperProjectPath, 'project.config.json'))).toMatchObject({
         setting: {
-          es6: true,
           postcss: true,
         },
       })
+      expect(readJson(path.join(wrapperProjectPath, 'project.config.json')).setting).not.toHaveProperty('es6')
       expect(readJson(path.join(wrapperProjectPath, 'project.config.json'))).toMatchObject({ simulatorType: 'wechat' })
       expect(readJson(path.join(wrapperProjectPath, 'app.json'))).toMatchObject({
         window: {
@@ -1571,7 +1571,7 @@ describe.sequential('automator launch resilience', () => {
     const { launchAutomator } = await import('../utils/automator')
     await launchAutomator({ projectPath: sandboxRoot, timeout: 12_345, warmupAllowRelaunch: false })
 
-    const payload = readBridgePayloadFromFirstExecaCall()
+    const payload = readBridgePayloadFromExecaCall()
     expect(payload?.projectPath).toBe(sandboxRoot)
     expect(readJson(path.join(payload!.projectPath!, 'project.config.json'))).toMatchObject({
       compileType: 'plugin',
@@ -1608,7 +1608,7 @@ describe.sequential('automator launch resilience', () => {
     const { launchAutomator } = await import('../utils/automator')
     const launchedMiniProgram = await launchAutomator({ projectPath: sandboxRoot, timeout: 12_345 })
 
-    const wrapperProjectPath = readBridgePayloadFromFirstExecaCall()?.projectPath
+    const wrapperProjectPath = readBridgePayloadFromExecaCall()?.projectPath
     expectBridgeWrapperProjectPath(sandboxRoot, wrapperProjectPath)
     expect(rmSyncSpy.mock.calls.some(([target]) => String(target) === path.join(wrapperProjectPath!, 'pages'))).toBe(false)
 
@@ -1689,7 +1689,9 @@ describe.sequential('automator launch resilience', () => {
     connectMock.mockResolvedValueOnce(reconnectedMiniProgram)
 
     await launchAutomator({ projectPath: sandboxRoot, timeout: 12_345 })
-    expect(readJson(wrapperAppJsonPath)).toMatchObject({
+    const reconnectedWrapperProjectPath = readBridgePayloadFromExecaCall(1)?.projectPath
+    expect(reconnectedWrapperProjectPath).not.toBe(wrapperProjectPath)
+    expect(readJson(path.join(reconnectedWrapperProjectPath!, 'app.json'))).toMatchObject({
       pages: ['pages/changed/index'],
     })
     await reconnectedMiniProgram.disconnect?.()
@@ -1717,7 +1719,7 @@ describe.sequential('automator launch resilience', () => {
     const { launchAutomator } = await import('../utils/automator')
     await launchAutomator({ projectPath: sandboxRoot, timeout: 12_345 })
 
-    expect(readBridgePayloadFromFirstExecaCall()?.projectPath).toBe(sandboxRoot)
+    expect(readBridgePayloadFromExecaCall()?.projectPath).toBe(sandboxRoot)
     expect(connectedMiniProgram.__rawCurrentPage).toHaveBeenCalled()
   })
 
@@ -1964,7 +1966,7 @@ describe.sequential('automator launch resilience', () => {
     const { launchAutomator } = await import('../utils/automator')
     await launchAutomator({ projectPath: sandboxRoot, timeout: 12_345 })
 
-    const firstWrapperProjectPath = (readBridgePayloadFromFirstExecaCall()?.projectPath)
+    const firstWrapperProjectPath = (readBridgePayloadFromExecaCall()?.projectPath)
     expect(connectMock).toHaveBeenCalledTimes(2)
     expect(openWechatIdeProjectByHttpMock).toHaveBeenCalledTimes(2)
     expect(openWechatIdeProjectByHttpMock).toHaveBeenNthCalledWith(1, firstWrapperProjectPath, {

--- a/e2e/utils/automator.cli-bridge.test.ts
+++ b/e2e/utils/automator.cli-bridge.test.ts
@@ -220,9 +220,66 @@ describe('enableAutomatorViaHttp', () => {
     expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({
       account: 'test-account',
       autoPort: '45678',
+      port: '45678',
       project: '/repo/demo app',
       ticket: 'ignored-ticket',
     })
+  })
+
+  it.each(['s0', 's1'])('uses the requested port for the new DevTools status response %s', async (status) => {
+    const server = net.createServer((socket) => {
+      socket.once('data', () => {
+        socket.end([
+          'HTTP/1.1 200 OK',
+          'Content-Type: application/json',
+          'Connection: close',
+          '',
+          JSON.stringify(status),
+        ].join('\r\n'))
+      })
+    })
+    servers.push(server)
+    const servicePort = await new Promise<number>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', () => {
+        const address = server.address()
+        resolve(typeof address === 'object' && address ? address.port : 0)
+      })
+    })
+
+    await expect(enableAutomatorViaHttp({
+      autoPort: 45678,
+      projectPath: '/repo/demo app',
+      servicePort,
+    })).resolves.toBe(45678)
+  })
+
+  it('rejects an unknown successful response shape', async () => {
+    const server = net.createServer((socket) => {
+      socket.once('data', () => {
+        socket.end([
+          'HTTP/1.1 200 OK',
+          'Content-Type: application/json',
+          'Connection: close',
+          '',
+          JSON.stringify({ status: 'ok' }),
+        ].join('\r\n'))
+      })
+    })
+    servers.push(server)
+    const servicePort = await new Promise<number>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', () => {
+        const address = server.address()
+        resolve(typeof address === 'object' && address ? address.port : 0)
+      })
+    })
+
+    await expect(enableAutomatorViaHttp({
+      autoPort: 45678,
+      projectPath: '/repo/demo app',
+      servicePort,
+    })).rejects.toThrow('unsupported response')
   })
 })
 

--- a/e2e/utils/automator.cli-bridge.ts
+++ b/e2e/utils/automator.cli-bridge.ts
@@ -150,6 +150,7 @@ function readCliArgument(args: string[] | undefined, names: string[]) {
 export async function enableAutomatorViaHttp(options: EnableAutomatorViaHttpOptions) {
   const endpoint = new URL('/auto', `http://127.0.0.1:${options.servicePort}`)
   endpoint.searchParams.set('project', options.projectPath)
+  endpoint.searchParams.set('port', String(options.autoPort))
   endpoint.searchParams.set('autoPort', String(options.autoPort))
 
   const account = readCliArgument(options.args, ['--auto-account', '--autoAccount'])
@@ -181,14 +182,19 @@ export async function enableAutomatorViaHttp(options: EnableAutomatorViaHttpOpti
       cause: error as Error,
     })
   }
-  if (!result || typeof result !== 'object' || !('autoPort' in result)) {
-    throw new Error('WeChat DevTools HTTP automator fallback returned no autoPort')
+  if (result && typeof result === 'object' && 'autoPort' in result) {
+    const autoPort = Number(result.autoPort)
+    if (!Number.isInteger(autoPort) || autoPort <= 0 || autoPort > 65535) {
+      throw new Error(`WeChat DevTools HTTP automator fallback returned invalid autoPort: ${String(result.autoPort)}`)
+    }
+    return autoPort
   }
-  const autoPort = Number(result.autoPort)
-  if (!Number.isInteger(autoPort) || autoPort <= 0 || autoPort > 65535) {
-    throw new Error(`WeChat DevTools HTTP automator fallback returned invalid autoPort: ${String(result.autoPort)}`)
+
+  if (typeof result === 'string' && /^s\d+$/.test(result)) {
+    return options.autoPort
   }
-  return autoPort
+
+  throw new Error(`WeChat DevTools HTTP automator fallback returned unsupported response: ${summarizeTextOutput(body)}`)
 }
 
 const AUTOMATOR_VALUE_OPTIONS = new Set([

--- a/packages/miniprogram-automator/src/launcher.test.ts
+++ b/packages/miniprogram-automator/src/launcher.test.ts
@@ -456,6 +456,7 @@ describe('Launcher', () => {
     expect(Object.fromEntries(endpoint.searchParams)).toEqual({
       account: 'tester',
       autoPort: '9420',
+      port: '9420',
       project: '/tmp/project',
       ticket: 'test-ticket',
       trustProject: 'true',

--- a/packages/miniprogram-automator/src/launcher/wechatCliFallback.test.ts
+++ b/packages/miniprogram-automator/src/launcher/wechatCliFallback.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+import { enableAutomatorViaHttp } from './wechatCliFallback'
+
+describe('enableAutomatorViaHttp', () => {
+  const options = {
+    autoPort: 45678,
+    projectPath: '/repo/demo app',
+    servicePort: 20023,
+  }
+
+  it('supports the legacy autoPort response and sends both port query names', async () => {
+    const fetchMock = vi.fn(async (_input: string | URL) => new Response(JSON.stringify({ autoPort: 45679 })))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(enableAutomatorViaHttp(options)).resolves.toBe(45679)
+
+    const endpoint = new URL(String(fetchMock.mock.calls[0]?.[0]))
+    expect(Object.fromEntries(endpoint.searchParams)).toMatchObject({
+      autoPort: '45678',
+      port: '45678',
+      project: '/repo/demo app',
+    })
+  })
+
+  it.each(['s0', 's1'])('supports the new DevTools status response %s', async (status) => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(status))))
+
+    await expect(enableAutomatorViaHttp(options)).resolves.toBe(45678)
+  })
+
+  it('rejects an unknown successful response shape', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ status: 'ok' }))))
+
+    await expect(enableAutomatorViaHttp(options)).rejects.toThrow('unsupported response')
+  })
+
+  it('surfaces DevTools HTTP errors', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ code: 31 }), { status: 400 })))
+
+    await expect(enableAutomatorViaHttp(options)).rejects.toThrow('status 400')
+  })
+})

--- a/packages/miniprogram-automator/src/launcher/wechatCliFallback.ts
+++ b/packages/miniprogram-automator/src/launcher/wechatCliFallback.ts
@@ -15,6 +15,7 @@ export async function enableAutomatorViaHttp(options: {
 }) {
   const endpoint = new URL('/auto', `http://127.0.0.1:${options.servicePort}`)
   endpoint.searchParams.set('project', options.projectPath)
+  endpoint.searchParams.set('port', String(options.autoPort))
   endpoint.searchParams.set('autoPort', String(options.autoPort))
   if (options.account) {
     endpoint.searchParams.set('account', options.account)
@@ -41,14 +42,19 @@ export async function enableAutomatorViaHttp(options: {
       cause: error as Error,
     })
   }
-  if (!result || typeof result !== 'object' || !('autoPort' in result)) {
-    throw new Error('WeChat DevTools HTTP automator fallback returned no autoPort')
+  if (result && typeof result === 'object' && 'autoPort' in result) {
+    const autoPort = Number(result.autoPort)
+    if (!Number.isInteger(autoPort) || autoPort <= 0 || autoPort > 65535) {
+      throw new Error(`WeChat DevTools HTTP automator fallback returned invalid autoPort: ${String(result.autoPort)}`)
+    }
+    return autoPort
   }
-  const autoPort = Number(result.autoPort)
-  if (!Number.isInteger(autoPort) || autoPort <= 0 || autoPort > 65535) {
-    throw new Error(`WeChat DevTools HTTP automator fallback returned invalid autoPort: ${String(result.autoPort)}`)
+
+  if (typeof result === 'string' && /^s\d+$/.test(result)) {
+    return options.autoPort
   }
-  return autoPort
+
+  throw new Error(`WeChat DevTools HTTP automator fallback returned unsupported response: ${body.trim().slice(0, 400)}`)
 }
 
 const AUTOMATOR_VALUE_OPTIONS = new Set([


### PR DESCRIPTION
## 根因

微信开发者工具的 `/v2/auto` 接口存在两代协议：
- 旧版使用 `autoPort` 参数并返回 `{ autoPort }`
- 新版使用 `port` 参数并返回项目窗口状态字符串（如 `s0`、`s1`），实际 automator 端口就是请求端口

## 修复

- bridge 与 `@weapp-vite/miniprogram-automator` 启动链路同时发送 `port` / `autoPort`
- 保留旧版 JSON 端口响应，兼容新版状态字符串响应
- 对未知响应、非法端口和 HTTP 错误保留明确失败
- 新增两侧协议回归测试，覆盖旧版响应、新版 `s0`/`s1`、查询参数和错误响应
- 复用现有 `.changeset/clean-dialog-package-files.md` 中的 automator 发布意图

## 验证

- `pnpm --filter @weapp-vite/miniprogram-automator typecheck`：通过
- `pnpm --filter @weapp-vite/miniprogram-automator test`：138/138 通过
- `pnpm --filter @weapp-vite/miniprogram-automator build`：通过
- bridge 定向测试：16/16 通过
- automator launch resilience：54/54 通过
- `pnpm test`：875 个测试文件通过，7635 个测试通过
- `pnpm e2e:ci`：70/70 通过
- `node --import tsx scripts/check-e2e-ide-shared-launch.ts`：109 个文件通过
- 受影响文件 ESLint：通过

## IDE 环境说明

`pnpm e2e:ide:full` 已在干净 DevTools 进程下启动并验证 bridge 可建立 WebSocket 连接，但 GitHub issues 聚合 suite 在页面切换阶段持续触发当前 DevTools `2.02.2608040` 的 `routeTo appLaunch timeout`，automator 收到 `Uncaught [object Object]` 并进入既有恢复重试；DevTools 日志同时报告 `appid missing`。该失败发生在模拟器启动/账号环境层，未进入业务断言，也不是 automator HTTP 端口握手失败。
