### PR TITLE
修复 wevu v-for 嵌套 key 路径被截断

### DIFF
--- a/.changeset/fix-issue-868-nested-key.md
+++ b/.changeset/fix-issue-868-nested-key.md
@@ -1,0 +1,6 @@
+---
+"@wevu/compiler": patch
+"create-weapp-vite": patch
+---
+
+修复 `v-for` 的 `:key` 使用嵌套成员路径时被截断的问题，确保 `entry.item.id` 正确生成 `wx:key="item.id"`。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -22,6 +22,13 @@
     "miniprogram": {
       "list": [
         {
+          "name": "issue 868 nested v-for key",
+          "pathName": "pages/issue-868/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "issue 862 output watcher",
           "pathName": "pages/issue-862/index",
           "query": "",

--- a/e2e-apps/github-issues/src/components/issue-868/GalleryCard/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-868/GalleryCard/index.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+defineProps<{
+  entry: {
+    item: {
+      id: string
+    }
+  }
+}>()
+</script>
+
+<template>
+  <view class="issue868-gallery-card">{{ entry.item.id }}</view>
+</template>
+
+<style>
+.issue868-gallery-card {
+  display: block;
+}
+</style>

--- a/e2e-apps/github-issues/src/pages/issue-868/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-868/index.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import GalleryCard from '../../components/issue-868/GalleryCard/index.vue'
+
+const column = [
+  { item: { id: 'issue-868' } },
+]
+</script>
+
+<template>
+  <view id="issue-868-page">
+    <GalleryCard v-for="entry in column" :key="entry.item.id" :entry="entry" />
+  </view>
+</template>

--- a/e2e/ci/githubIssuesBuild/cases/issue868.case.ts
+++ b/e2e/ci/githubIssuesBuild/cases/issue868.case.ts
@@ -1,0 +1,18 @@
+import type { GithubIssuesBuildCaseContext } from './types'
+import { fs } from '@weapp-core/shared/node'
+import path from 'pathe'
+import { expect, it } from 'vitest'
+
+export function registerGithubIssuesBuildCase(context: GithubIssuesBuildCaseContext) {
+  it('issue #868: preserves nested member paths in v-for keys', async () => {
+    await context.runStandardBuild()
+
+    const pageWxml = await fs.readFile(
+      path.join(context.distRoot, 'pages/issue-868/index.wxml'),
+      'utf8',
+    )
+
+    expect(pageWxml).toContain('wx:key="item.id"')
+    expect(pageWxml).not.toContain('wx:key="item"')
+  })
+}

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template.test.ts
@@ -870,6 +870,19 @@ describe('compileVueTemplateToWxml', () => {
     expect(code).toContain('{{key}} = {{value}}')
   })
 
+  it('preserves nested member paths in v-for keys', () => {
+    const template = `
+<GalleryCard v-for="entry in column" :key="entry.item.id" />
+    `.trim()
+
+    const { code } = compileVueTemplateToWxml(template, '/project/src/pages/issue-868/index.vue')
+
+    expect(code).toContain('wx:for="{{column}}"')
+    expect(code).toContain('wx:for-item="entry"')
+    expect(code).toContain('wx:key="item.id"')
+    expect(code).not.toContain('wx:key="item"')
+  })
+
   it('rewrites component simple event handlers to inline payload handlers', () => {
     const template = `
 <CompatAltPanel @run="onPanelRun" />

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/directives/bind.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/template/directives/bind.ts
@@ -228,8 +228,7 @@ export function transformBindDirective(
     if (forInfo?.item && trimmed.startsWith(`${forInfo.item}.`)) {
       const remainder = trimmed.slice(forInfo.item.length + 1)
       if (isSimpleMemberPath(remainder)) {
-        const firstSegment = remainder.split('.')[0] || remainder
-        return context.platform.keyAttr(firstSegment)
+        return context.platform.keyAttr(remainder)
       }
       warnKeyFallback('不是简单的成员路径')
       return context.platform.keyAttr(context.platform.keyThisValue)


### PR DESCRIPTION
## 背景
修复 issue #868：`v-for` 使用 `:key="entry.item.id"` 时，生成的 WXML 错误为 `wx:key="item"`，触发微信开发者工具警告。

## 变更
- 保留去除循环别名后的完整成员路径，生成 `wx:key="item.id"`。
- 增加 wevu 编译器单元回归测试。
- 增加 `e2e-apps/github-issues` 构建回归页面和断言。

## 验证
- `pnpm --filter @wevu/compiler test`
- `pnpm --filter @wevu/compiler typecheck`
- `pnpm --filter @wevu/compiler lint`
- `pnpm vitest run -c e2e/vitest.e2e.ci.build-only.config.ts e2e/ci/github-issues.build.test.ts -t "issue #868"`

Closes #868