### PR TITLE
feat(api): 新增类型安全的 Vitest mock 工具

### DIFF
--- a/.changeset/typed-wpi-vitest-mocks.md
+++ b/.changeset/typed-wpi-vitest-mocks.md
@@ -1,0 +1,8 @@
+---
+"@weapp-core/api": minor
+"@wevu/api": minor
+"wevu": minor
+"create-weapp-vite": patch
+---
+
+新增类型安全的 Vitest API mock：支持通过 setup 子路径一次替换 `api` / `wpi`，也可使用独立 factory 与局部 reset；Promise、回调、同步和事件 API 均保留原类型契约，并同步提供 `@wevu/api` 与 `wevu/api` 兼容入口。

--- a/@weapp-core/api/README.md
+++ b/@weapp-core/api/README.md
@@ -338,6 +338,53 @@ const api = createApi({
 await api.getSystemInfo()
 ```
 
+## Vitest mock
+
+在 Vitest 配置中注册一次 setup，业务模块静态导入的 `api` / `wpi` 会被替换为同一个类型安全 mock，包内其他导出保持真实实现：
+
+```ts
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    setupFiles: ['@weapp-core/api/vitest/setup'],
+  },
+})
+```
+
+```ts
+import { wpi } from '@weapp-core/api'
+import { wpiMock } from '@weapp-core/api/vitest'
+import { expect, test } from 'vitest'
+
+test('loads user data', async () => {
+  wpiMock.request.mockResolvedValue(responseFixture)
+
+  await loadUser()
+
+  expect(wpi.request).toHaveBeenCalledWith({
+    url: '/api/user',
+  })
+})
+```
+
+`mockImplementation()` 同时保留 Promise 风格与原始 callback options 类型；`mockResolvedValue()`、同步 API、事件 API 和内部辅助方法也沿用 `wpi` 的原始契约。setup 会在每个测试前只重置已经创建的 API mock，不调用全局 `vi.resetAllMocks()`。
+
+需要独立实例时，可以直接使用 factory：
+
+```ts
+import { createWpiMock, resetApiMock } from '@weapp-core/api/vitest'
+
+const localWpi = createWpiMock({
+  platform: 'wx',
+})
+
+localWpi.getSystemInfoSync.mockReturnValue(systemInfoFixture)
+resetApiMock(localWpi)
+```
+
+未配置的方法默认返回 `undefined`，不会伪造宿主行为。该测试子路径依赖 Vitest，但不会进入 `@weapp-core/api` 的生产入口或小程序 bundle。若要测试页面、组件、WXML 查询、交互或真实宿主 mock，请使用 `@mpcore/test`；这里的工具只负责隔离 `api` / `wpi` 调用。
+
 ## 行为说明
 
 - **只在不传回调时返回 Promise**

--- a/@weapp-core/api/package.json
+++ b/@weapp-core/api/package.json
@@ -22,12 +22,22 @@
     "adapter",
     "weapp"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/vitest/setup.mjs"
+  ],
   "weapp-vite-dev": {
     "exports": {
       ".": {
         "types": "./src/index.ts",
         "default": "./src/index.ts"
+      },
+      "./vitest": {
+        "types": "./src/vitest/index.ts",
+        "default": "./src/vitest/index.ts"
+      },
+      "./vitest/setup": {
+        "types": "./src/vitest/setup.ts",
+        "default": "./src/vitest/setup.ts"
       }
     },
     "main": "./src/index.ts",
@@ -41,6 +51,14 @@
         "types": "./types/index.d.ts",
         "default": "./dist/index.mjs"
       }
+    },
+    "./vitest": {
+      "types": "./dist/vitest.d.mts",
+      "import": "./dist/vitest.mjs"
+    },
+    "./vitest/setup": {
+      "types": "./dist/vitest/setup.d.mts",
+      "import": "./dist/vitest/setup.mjs"
     }
   },
   "main": "./dist/index.mjs",
@@ -78,10 +96,24 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "typecheck:test": "tsc --noEmit -p tsconfig.test.json"
   },
+  "peerDependencies": {
+    "vitest": ">=4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vitest": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@douyin-microapp/typings": "catalog:",
     "@mini-types/alipay": "catalog:",
     "miniprogram-api-typings": "catalog:"
+  },
+  "tsd": {
+    "compilerOptions": {
+      "module": "NodeNext",
+      "moduleResolution": "NodeNext"
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/@weapp-core/api/src/vitest/index.test.ts
+++ b/@weapp-core/api/src/vitest/index.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  apiMock,
+  createApiMock,
+  createWpiMock,
+  resetApiMock,
+  wpiMock,
+} from './index'
+
+describe('api Vitest mock', () => {
+  it('creates method mocks lazily and keeps stable references', () => {
+    const mock = createApiMock()
+
+    expect(Reflect.ownKeys(mock)).toEqual([])
+    expect(mock.request).toBe(mock.request)
+    expect(vi.isMockFunction(mock.request)).toBe(true)
+    expect(mock.request.getMockName()).toBe('api.request')
+    expect(Reflect.ownKeys(mock)).toEqual(['request'])
+    expect(Reflect.get(mock, 'then')).toBeUndefined()
+  })
+
+  it('keeps factories isolated and resets only the selected mock', () => {
+    const first = createApiMock()
+    const second = createApiMock()
+    const unrelated = vi.fn()
+
+    first.showToast({ title: 'first' })
+    second.showToast({ title: 'second' })
+    unrelated()
+    resetApiMock(first)
+
+    expect(first.showToast).not.toHaveBeenCalled()
+    expect(second.showToast).toHaveBeenCalledOnce()
+    expect(unrelated).toHaveBeenCalledOnce()
+  })
+
+  it('wraps method overrides and preserves non-function overrides', () => {
+    const requestTask = { abort: vi.fn() }
+    const mock = createApiMock({
+      platform: 'wx',
+      request: () => requestTask as any,
+    })
+
+    expect(mock.platform).toBe('wx')
+    expect(vi.isMockFunction(mock.request)).toBe(true)
+    expect(mock.request({ url: 'https://example.com' })).toBe(requestTask)
+
+    resetApiMock(mock)
+    expect(mock.request({ url: 'https://example.com' })).toBe(requestTask)
+  })
+
+  it('shares the documented compatibility aliases', () => {
+    expect(wpiMock).toBe(apiMock)
+    expect(createWpiMock).toBe(createApiMock)
+  })
+
+  it('supports custom adapter methods without mocking value members', () => {
+    interface CustomAdapter {
+      readSync: (key: string) => number
+    }
+
+    const lazyMock = createApiMock<CustomAdapter>()
+    const overrideMock = createApiMock<CustomAdapter>({
+      readSync: key => key.length,
+    })
+
+    expect(vi.isMockFunction(lazyMock.readSync)).toBe(true)
+    expect(vi.isMockFunction(overrideMock.readSync)).toBe(true)
+    expect(overrideMock.readSync('token')).toBe(5)
+    expect(lazyMock.platform).toBeUndefined()
+    expect(lazyMock.raw).toBeUndefined()
+  })
+})

--- a/@weapp-core/api/src/vitest/index.ts
+++ b/@weapp-core/api/src/vitest/index.ts
@@ -1,0 +1,210 @@
+import type { Mock } from 'vitest'
+import type {
+  WeapiAdapter,
+  WeapiCrossPlatformRawAdapter,
+  WeapiInstance,
+} from '../core/types'
+import { beforeEach, vi } from 'vitest'
+import {
+  WEAPI_ALIPAY_METHODS,
+  WEAPI_DOUYIN_METHODS,
+  WEAPI_WECHAT_METHODS,
+} from '../core/apiCatalog'
+
+type Procedure = (...args: any[]) => any
+type ApiMockKey = string | symbol
+type MockImplementation<T extends Procedure> = (...args: Parameters<T>) => ReturnType<T>
+
+type ApiMockFunction<
+  TPublic extends Procedure,
+  TRaw extends Procedure = TPublic,
+> = Omit<Mock<TPublic>, 'mockImplementation' | 'mockImplementationOnce' | 'withImplementation'>
+  & TPublic
+  & {
+    mockImplementation: {
+      (implementation: MockImplementation<TRaw>): ApiMockFunction<TPublic, TRaw>
+      (implementation: MockImplementation<TPublic>): ApiMockFunction<TPublic, TRaw>
+    }
+    mockImplementationOnce: {
+      (implementation: MockImplementation<TRaw>): ApiMockFunction<TPublic, TRaw>
+      (implementation: MockImplementation<TPublic>): ApiMockFunction<TPublic, TRaw>
+    }
+    withImplementation: {
+      (implementation: MockImplementation<TRaw>, callback: () => Promise<unknown>): Promise<ApiMockFunction<TPublic, TRaw>>
+      (implementation: MockImplementation<TRaw>, callback: () => unknown): ApiMockFunction<TPublic, TRaw>
+      (implementation: MockImplementation<TPublic>, callback: () => Promise<unknown>): Promise<ApiMockFunction<TPublic, TRaw>>
+      (implementation: MockImplementation<TPublic>, callback: () => unknown): ApiMockFunction<TPublic, TRaw>
+    }
+  }
+
+type RawMethod<TAdapter extends WeapiAdapter, TKey extends PropertyKey, TFallback extends Procedure>
+  = TKey extends keyof TAdapter
+    ? TAdapter[TKey] extends Procedure
+      ? TAdapter[TKey]
+      : TFallback
+    : TFallback
+
+/**
+ * @description 与 API 实例方法签名对齐的 Vitest mock 对象。
+ */
+export type ApiMock<TAdapter extends WeapiAdapter = WeapiCrossPlatformRawAdapter> = {
+  [TKey in keyof WeapiInstance<TAdapter>]: WeapiInstance<TAdapter>[TKey] extends Procedure
+    ? ApiMockFunction<
+      WeapiInstance<TAdapter>[TKey],
+      RawMethod<TAdapter, TKey, WeapiInstance<TAdapter>[TKey]>
+    >
+    : WeapiInstance<TAdapter>[TKey]
+}
+
+/**
+ * @description 创建 API mock 时预设的属性或方法实现。
+ */
+export type ApiMockOverrides<TAdapter extends WeapiAdapter = WeapiCrossPlatformRawAdapter>
+  = Partial<WeapiInstance<TAdapter>>
+
+interface ApiMockState {
+  mocks: Set<Mock>
+  values: Map<ApiMockKey, unknown>
+}
+
+const INTERNAL_METHOD_NAMES = [
+  'getAdapter',
+  'resolveTarget',
+  'setAdapter',
+  'supports',
+] as const
+
+const API_METHOD_NAMES = new Set<ApiMockKey>([
+  ...WEAPI_WECHAT_METHODS,
+  ...WEAPI_ALIPAY_METHODS,
+  ...WEAPI_DOUYIN_METHODS,
+  ...INTERNAL_METHOD_NAMES,
+])
+
+const API_VALUE_NAMES = new Set<ApiMockKey>([
+  'platform',
+  'raw',
+])
+
+const API_MOCK_STATES = new WeakMap<object, ApiMockState>()
+
+function createNamedMock(name: ApiMockKey, implementation?: Procedure) {
+  const mock = implementation ? vi.fn(implementation) : vi.fn()
+  return mock.mockName(`api.${String(name)}`)
+}
+
+function materializeOverride(state: ApiMockState, key: ApiMockKey, value: unknown) {
+  if (typeof value === 'function') {
+    const mock = vi.isMockFunction(value)
+      ? value as Mock
+      : createNamedMock(key, value as Procedure)
+    state.mocks.add(mock)
+    state.values.set(key, mock)
+    return
+  }
+  state.values.set(key, value)
+}
+
+/**
+ * @description 创建与 API 类型对齐、按访问惰性生成方法的 Vitest mock。
+ */
+export function createApiMock<TAdapter extends WeapiAdapter = WeapiCrossPlatformRawAdapter>(
+  overrides: ApiMockOverrides<NoInfer<TAdapter>> = {},
+): ApiMock<TAdapter> {
+  const state: ApiMockState = {
+    mocks: new Set(),
+    values: new Map(),
+  }
+
+  for (const key of Reflect.ownKeys(overrides)) {
+    materializeOverride(state, key, Reflect.get(overrides, key))
+  }
+
+  const proxy = new Proxy(Object.create(null) as object, {
+    get(_target, key) {
+      if (key === Symbol.toStringTag) {
+        return 'ApiMock'
+      }
+      if (key === 'then') {
+        return undefined
+      }
+      if (state.values.has(key)) {
+        return state.values.get(key)
+      }
+      if (API_VALUE_NAMES.has(key) || (typeof key !== 'string' && !API_METHOD_NAMES.has(key))) {
+        return undefined
+      }
+      const mock = createNamedMock(key)
+      state.mocks.add(mock)
+      state.values.set(key, mock)
+      return mock
+    },
+    getOwnPropertyDescriptor(_target, key) {
+      if (!state.values.has(key)) {
+        return undefined
+      }
+      return {
+        configurable: true,
+        enumerable: true,
+        value: state.values.get(key),
+        writable: true,
+      }
+    },
+    has(_target, key) {
+      return state.values.has(key) || API_METHOD_NAMES.has(key)
+    },
+    ownKeys() {
+      return [...state.values.keys()]
+    },
+    set(_target, key, value) {
+      materializeOverride(state, key, value)
+      return true
+    },
+  }) as ApiMock<TAdapter>
+
+  API_MOCK_STATES.set(proxy, state)
+  return proxy
+}
+
+/**
+ * @description 默认 API Vitest mock 单例。
+ */
+export const apiMock = createApiMock()
+
+/**
+ * @description 默认 API Vitest mock 单例的兼容名称。
+ */
+export const wpiMock = apiMock
+
+/**
+ * @description 创建 API Vitest mock 的兼容名称。
+ */
+export const createWpiMock = createApiMock
+
+/**
+ * @description 重置指定 API mock 自身已创建的方法，不影响其他 Vitest mocks。
+ */
+export function resetApiMock(mock: ApiMock<any> = apiMock): void {
+  const state = API_MOCK_STATES.get(mock)
+  state?.mocks.forEach(item => item.mockReset())
+}
+
+/**
+ * @description 在 Vitest setup 文件中注册需要替换 API 实例的模块入口。
+ */
+export function setupApiMock(moduleIds: readonly string[]): void {
+  for (const moduleId of moduleIds) {
+    vi.doMock(moduleId, async () => {
+      const actual = await vi.importActual<Record<string, unknown>>(moduleId)
+      return {
+        ...actual,
+        api: apiMock,
+        wpi: apiMock,
+      }
+    })
+  }
+
+  beforeEach(() => {
+    resetApiMock(apiMock)
+  })
+}

--- a/@weapp-core/api/src/vitest/setup.ts
+++ b/@weapp-core/api/src/vitest/setup.ts
@@ -1,0 +1,3 @@
+import { setupApiMock } from './index'
+
+setupApiMock(['@weapp-core/api'])

--- a/@weapp-core/api/test-d/vitest.test-d.ts
+++ b/@weapp-core/api/test-d/vitest.test-d.ts
@@ -1,0 +1,54 @@
+import type {
+  WeapiMiniProgramRequestOption,
+  WeapiMiniProgramRequestSuccessResult,
+  WeapiMiniProgramRequestTask,
+  WeapiMiniProgramSystemInfo,
+  WeapiResolvedTarget,
+} from '@weapp-core/api'
+import type { ApiMock } from '@weapp-core/api/vitest'
+import {
+  apiMock,
+  createApiMock,
+  createWpiMock,
+  resetApiMock,
+  setupApiMock,
+  wpiMock,
+} from '@weapp-core/api/vitest'
+import { expectType } from 'tsd'
+
+expectType<ApiMock>(apiMock)
+expectType<ApiMock>(wpiMock)
+expectType<typeof createApiMock>(createWpiMock)
+expectType<void>(resetApiMock())
+expectType<void>(setupApiMock(['@weapp-core/api']))
+
+wpiMock.request.mockImplementation((options) => {
+  expectType<WeapiMiniProgramRequestOption>(options)
+  options.success?.({} as WeapiMiniProgramRequestSuccessResult)
+  return {} as WeapiMiniProgramRequestTask
+})
+wpiMock.request.mockImplementation(async (options) => {
+  expectType<string>(options.url)
+  return {} as WeapiMiniProgramRequestSuccessResult
+})
+wpiMock.request.mockResolvedValue({} as WeapiMiniProgramRequestSuccessResult)
+wpiMock.getSystemInfoSync.mockReturnValue({} as WeapiMiniProgramSystemInfo)
+wpiMock.onMemoryWarning.mockImplementation((callback) => {
+  callback({ level: 10 })
+})
+wpiMock.supports.mockReturnValue(true)
+wpiMock.resolveTarget.mockImplementation((method) => {
+  expectType<string>(method)
+  return {} as WeapiResolvedTarget
+})
+
+interface CustomAdapter {
+  readSync: (key: string) => number
+}
+
+const customMock = createApiMock<CustomAdapter>()
+customMock.readSync.mockImplementation((key) => {
+  expectType<string>(key)
+  return 1
+})
+expectType<number>(customMock.readSync('key'))

--- a/@weapp-core/api/tsdown.config.ts
+++ b/@weapp-core/api/tsdown.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['./src/index.ts'],
+  entry: {
+    'index': './src/index.ts',
+    'vitest': './src/vitest/index.ts',
+    'vitest/setup': './src/vitest/setup.ts',
+  },
   format: ['esm'],
   dts: true,
   clean: true,

--- a/packages-runtime/weapi/README.md
+++ b/packages-runtime/weapi/README.md
@@ -28,3 +28,27 @@ import { createWeapi, wpi } from '@wevu/api'
 ```
 
 `@wevu/api` 不再维护独立实现，所有能力、平台适配、类型声明与兼容性修复均由 `@weapp-core/api` 提供。
+
+## Vitest mock
+
+兼容入口提供同一套类型安全 mock。Vitest 配置使用对应 setup 子路径：
+
+```ts
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    setupFiles: ['@wevu/api/vitest/setup'],
+  },
+})
+```
+
+```ts
+import { wpiMock } from '@wevu/api/vitest'
+
+wpiMock.request.mockResolvedValue(responseFixture)
+```
+
+`@wevu/api/vitest/setup` 会同时替换 `@weapp-core/api` 与 `@wevu/api` 导入的 `api` / `wpi`，两层入口共享同一单例。也可以使用 `createApiMock()` / `createWpiMock()` 创建隔离实例，或用 `resetApiMock()` 手动重置指定实例。
+
+该能力只 mock API 门面；页面、组件、WXML 与宿主运行时行为仍由 `@mpcore/test` 覆盖。

--- a/packages-runtime/weapi/package.json
+++ b/packages-runtime/weapi/package.json
@@ -14,7 +14,9 @@
     "url": "https://github.com/weapp-vite/weapp-vite/issues"
   },
   "keywords": [],
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/vitest/setup.mjs"
+  ],
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
@@ -22,6 +24,14 @@
         "types": "./types/index.d.ts",
         "default": "./dist/index.mjs"
       }
+    },
+    "./vitest": {
+      "types": "./dist/vitest.d.mts",
+      "import": "./dist/vitest.mjs"
+    },
+    "./vitest/setup": {
+      "types": "./dist/vitest/setup.d.mts",
+      "import": "./dist/vitest/setup.mjs"
     }
   },
   "main": "./dist/index.mjs",
@@ -44,8 +54,23 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "typecheck:test": "tsc --noEmit -p tsconfig.test.json"
   },
+  "peerDependencies": {
+    "vitest": ">=4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vitest": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@weapp-core/api": "workspace:*"
+  },
+  "tsd": {
+    "compilerOptions": {
+      "module": "NodeNext",
+      "moduleResolution": "NodeNext",
+      "paths": {}
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages-runtime/weapi/src/vitest.ts
+++ b/packages-runtime/weapi/src/vitest.ts
@@ -1,0 +1,1 @@
+export * from '@weapp-core/api/vitest'

--- a/packages-runtime/weapi/src/vitestSetup.ts
+++ b/packages-runtime/weapi/src/vitestSetup.ts
@@ -1,0 +1,3 @@
+import { setupApiMock } from '@weapp-core/api/vitest'
+
+setupApiMock(['@weapp-core/api', '@wevu/api'])

--- a/packages-runtime/weapi/test-d/vitest.test-d.ts
+++ b/packages-runtime/weapi/test-d/vitest.test-d.ts
@@ -1,0 +1,11 @@
+import type { ApiMock, createApiMock } from '@wevu/api/vitest'
+import {
+  apiMock,
+  createWpiMock,
+  wpiMock,
+} from '@wevu/api/vitest'
+import { expectType } from 'tsd'
+
+expectType<ApiMock>(apiMock)
+expectType<ApiMock>(wpiMock)
+expectType<typeof createApiMock>(createWpiMock)

--- a/packages-runtime/weapi/tsconfig.json
+++ b/packages-runtime/weapi/tsconfig.json
@@ -7,6 +7,9 @@
       ],
       "@weapp-core/api": [
         "../../@weapp-core/api/src/index.ts"
+      ],
+      "@weapp-core/api/vitest": [
+        "../../@weapp-core/api/src/vitest/index.ts"
       ]
     },
     "types": [

--- a/packages-runtime/weapi/tsdown.config.ts
+++ b/packages-runtime/weapi/tsdown.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['./src/index.ts'],
+  entry: {
+    'index': './src/index.ts',
+    'vitest': './src/vitest.ts',
+    'vitest/setup': './src/vitestSetup.ts',
+  },
   format: ['esm'],
   dts: true,
   clean: true,

--- a/packages-runtime/wevu/package.json
+++ b/packages-runtime/wevu/package.json
@@ -25,7 +25,10 @@
     "pinia",
     "state-management"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/api/vitest/setup.mjs",
+    "./dist/dev/api/vitest/setup.mjs"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",
@@ -89,6 +92,22 @@
         "types": "./dist/api.d.mts",
         "development": "./dist/dev/api.mjs",
         "default": "./dist/api.mjs"
+      }
+    },
+    "./api/vitest": {
+      "types": "./dist/api/vitest.d.mts",
+      "import": {
+        "types": "./dist/api/vitest.d.mts",
+        "development": "./dist/dev/api/vitest.mjs",
+        "default": "./dist/api/vitest.mjs"
+      }
+    },
+    "./api/vitest/setup": {
+      "types": "./dist/api/vitest/setup.d.mts",
+      "import": {
+        "types": "./dist/api/vitest/setup.d.mts",
+        "development": "./dist/dev/api/vitest/setup.mjs",
+        "default": "./dist/api/vitest/setup.mjs"
       }
     },
     "./fetch": {
@@ -179,6 +198,20 @@
         "default": "./dist/dev/api.mjs"
       }
     },
+    "./dev/api/vitest": {
+      "types": "./dist/api/vitest.d.mts",
+      "import": {
+        "types": "./dist/api/vitest.d.mts",
+        "default": "./dist/dev/api/vitest.mjs"
+      }
+    },
+    "./dev/api/vitest/setup": {
+      "types": "./dist/api/vitest/setup.d.mts",
+      "import": {
+        "types": "./dist/api/vitest/setup.d.mts",
+        "default": "./dist/dev/api/vitest/setup.mjs"
+      }
+    },
     "./dev/fetch": {
       "types": "./dist/fetch.d.mts",
       "import": {
@@ -234,7 +267,20 @@
     "lint:fix": "eslint . --fix"
   },
   "peerDependencies": {
-    "miniprogram-api-typings": "^5.0.0"
+    "miniprogram-api-typings": "^5.0.0",
+    "vitest": ">=4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vitest": {
+      "optional": true
+    }
+  },
+  "tsd": {
+    "compilerOptions": {
+      "module": "NodeNext",
+      "moduleResolution": "NodeNext",
+      "paths": {}
+    }
   },
   "dependencies": {
     "@weapp-core/constants": "workspace:*",

--- a/packages-runtime/wevu/src/apiVitest.ts
+++ b/packages-runtime/wevu/src/apiVitest.ts
@@ -1,0 +1,1 @@
+export * from '@wevu/api/vitest'

--- a/packages-runtime/wevu/src/apiVitestSetup.ts
+++ b/packages-runtime/wevu/src/apiVitestSetup.ts
@@ -1,0 +1,3 @@
+import { setupApiMock } from '@wevu/api/vitest'
+
+setupApiMock(['@weapp-core/api', '@wevu/api', 'wevu/api'])

--- a/packages-runtime/wevu/test-d/api-vitest.test-d.ts
+++ b/packages-runtime/wevu/test-d/api-vitest.test-d.ts
@@ -1,0 +1,11 @@
+import type { ApiMock, createApiMock } from 'wevu/api/vitest'
+import { expectType } from 'tsd'
+import {
+  apiMock,
+  createWpiMock,
+  wpiMock,
+} from 'wevu/api/vitest'
+
+expectType<ApiMock>(apiMock)
+expectType<ApiMock>(wpiMock)
+expectType<typeof createApiMock>(createWpiMock)

--- a/packages-runtime/wevu/tsconfig.json
+++ b/packages-runtime/wevu/tsconfig.json
@@ -4,6 +4,12 @@
     "paths": {
       "@/*": [
         "./src/*"
+      ],
+      "@weapp-core/api/vitest": [
+        "../../@weapp-core/api/src/vitest/index.ts"
+      ],
+      "@wevu/api/vitest": [
+        "../weapi/src/vitest.ts"
       ]
     },
     "types": [

--- a/packages-runtime/wevu/tsdown.config.ts
+++ b/packages-runtime/wevu/tsdown.config.ts
@@ -9,6 +9,8 @@ const entry = {
   'jsx-runtime': './src/jsx-runtime',
   'store': './src/store',
   'api': './src/api',
+  'api/vitest': './src/apiVitest',
+  'api/vitest/setup': './src/apiVitestSetup',
   'fetch': './src/fetch',
   'router': './src/router',
   'web-apis': './src/web-apis',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -612,6 +612,9 @@ importers:
       miniprogram-api-typings:
         specifier: 'catalog:'
         version: 5.2.3
+      vitest:
+        specifier: '>=4.0.0'
+        version: 4.1.11(@types/node@26.4.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.12(bufferutil@4.1.0))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.9.0(supports-color@10.2.2))(sass-embedded@1.103.1)(sass@1.103.1)(terser@5.34.1)(tsx@4.23.12)(yaml@2.9.0))
 
   '@weapp-core/constants': {}
 
@@ -2353,6 +2356,9 @@ importers:
       '@weapp-core/api':
         specifier: workspace:*
         version: link:../../@weapp-core/api
+      vitest:
+        specifier: '>=4.0.0'
+        version: 4.1.11(@types/node@26.4.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.12(bufferutil@4.1.0))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.9.0(supports-color@10.2.2))(sass-embedded@1.103.1)(sass@1.103.1)(terser@5.34.1)(tsx@4.23.12)(yaml@2.9.0))
 
   packages-runtime/web:
     dependencies:
@@ -2438,6 +2444,9 @@ importers:
       miniprogram-api-typings:
         specifier: ^5.0.0
         version: 5.2.3
+      vitest:
+        specifier: '>=4.0.0'
+        version: 4.1.11(@types/node@26.4.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.12(bufferutil@4.1.0))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.9.0(supports-color@10.2.2))(sass-embedded@1.103.1)(sass@1.103.1)(terser@5.34.1)(tsx@4.23.12)(yaml@2.9.0))
       vue:
         specifier: 'catalog:'
         version: 3.5.42(typescript@6.0.3)

--- a/test/fixture-projects/wpi-vitest-mock-consumer/package.json
+++ b/test/fixture-projects/wpi-vitest-mock-consumer/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "wpi-vitest-mock-consumer-fixture",
+  "type": "module",
+  "private": true
+}

--- a/test/fixture-projects/wpi-vitest-mock-consumer/src/compat.test.ts
+++ b/test/fixture-projects/wpi-vitest-mock-consumer/src/compat.test.ts
@@ -1,0 +1,13 @@
+import { api as coreApi } from '@weapp-core/api'
+import { api, createApi, wpi } from '@wevu/api'
+import { apiMock, wpiMock } from '@wevu/api/vitest'
+import { describe, expect, it } from 'vitest'
+
+describe('@wevu/api Vitest setup', () => {
+  it('shares one singleton across core and compatibility imports', () => {
+    expect(coreApi).toBe(apiMock)
+    expect(api).toBe(apiMock)
+    expect(wpi).toBe(wpiMock)
+    expect(typeof createApi).toBe('function')
+  })
+})

--- a/test/fixture-projects/wpi-vitest-mock-consumer/src/core.test.ts
+++ b/test/fixture-projects/wpi-vitest-mock-consumer/src/core.test.ts
@@ -1,0 +1,22 @@
+import { api, createApi, wpi } from '@weapp-core/api'
+import { apiMock, wpiMock } from '@weapp-core/api/vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+const unrelatedMock = vi.fn()
+unrelatedMock()
+
+describe('@weapp-core/api Vitest setup', () => {
+  it('replaces only the API singletons before static imports run', () => {
+    expect(api).toBe(apiMock)
+    expect(wpi).toBe(wpiMock)
+    expect(typeof createApi).toBe('function')
+
+    wpiMock.showToast({ title: 'core' })
+    expect(wpiMock.showToast).toHaveBeenCalledOnce()
+  })
+
+  it('resets its own mocks without clearing unrelated Vitest mocks', () => {
+    expect(wpiMock.showToast).not.toHaveBeenCalled()
+    expect(unrelatedMock).toHaveBeenCalledOnce()
+  })
+})

--- a/test/fixture-projects/wpi-vitest-mock-consumer/src/wevu.test.ts
+++ b/test/fixture-projects/wpi-vitest-mock-consumer/src/wevu.test.ts
@@ -1,0 +1,15 @@
+import { api as coreApi } from '@weapp-core/api'
+import { api as compatApi } from '@wevu/api'
+import { describe, expect, it } from 'vitest'
+import { api, createApi, wpi } from 'wevu/api'
+import { apiMock, wpiMock } from 'wevu/api/vitest'
+
+describe('wevu/api Vitest setup', () => {
+  it('shares one singleton across all API import layers', () => {
+    expect(coreApi).toBe(apiMock)
+    expect(compatApi).toBe(apiMock)
+    expect(api).toBe(apiMock)
+    expect(wpi).toBe(wpiMock)
+    expect(typeof createApi).toBe('function')
+  })
+})

--- a/test/fixture-projects/wpi-vitest-mock-consumer/tsconfig.json
+++ b/test/fixture-projects/wpi-vitest-mock-consumer/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": [
+      "vitest/globals"
+    ],
+    "strict": true
+  },
+  "include": [
+    "src",
+    "vitest.*.config.ts"
+  ]
+}

--- a/test/fixture-projects/wpi-vitest-mock-consumer/vitest.compat.config.ts
+++ b/test/fixture-projects/wpi-vitest-mock-consumer/vitest.compat.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  root: import.meta.dirname,
+  test: {
+    include: ['src/compat.test.ts'],
+    setupFiles: ['@wevu/api/vitest/setup'],
+  },
+})

--- a/test/fixture-projects/wpi-vitest-mock-consumer/vitest.core.config.ts
+++ b/test/fixture-projects/wpi-vitest-mock-consumer/vitest.core.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  root: import.meta.dirname,
+  test: {
+    include: ['src/core.test.ts'],
+    setupFiles: ['@weapp-core/api/vitest/setup'],
+  },
+})

--- a/test/fixture-projects/wpi-vitest-mock-consumer/vitest.wevu.config.ts
+++ b/test/fixture-projects/wpi-vitest-mock-consumer/vitest.wevu.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  root: import.meta.dirname,
+  test: {
+    include: ['src/wevu.test.ts'],
+    setupFiles: ['wevu/api/vitest/setup'],
+  },
+})

--- a/website/packages/weapi/overview.md
+++ b/website/packages/weapi/overview.md
@@ -71,6 +71,33 @@ const api = createWeapi({
 })
 ```
 
+## 在 Vitest 中 mock `wpi`
+
+在 Wevu 项目中，把 setup 子路径加入 Vitest 配置即可一次完成注册：
+
+```ts
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    setupFiles: ['wevu/api/vitest/setup'],
+  },
+})
+```
+
+```ts
+import { wpiMock } from 'wevu/api/vitest'
+
+wpiMock.request.mockResolvedValue(responseFixture)
+wpiMock.getSystemInfoSync.mockReturnValue(systemInfoFixture)
+```
+
+setup 会在业务模块静态导入前替换 `api` / `wpi`，并在每个测试前只重置自身创建的方法。`wevu/api`、`@wevu/api` 与 `@weapp-core/api` 在同一测试中混用时仍共享一个 mock 单例，不会清空用户创建的其他 Vitest mocks。
+
+只安装核心包或兼容包时，setup 路径分别使用 `@weapp-core/api/vitest/setup` 与 `@wevu/api/vitest/setup`。不希望使用全局 setup 时，可以从对应的 `/vitest` 子路径调用 `createApiMock()` / `createWpiMock()`，并通过 `resetApiMock()` 手动重置。
+
+这套工具只隔离 API 调用，不模拟小程序页面、组件、WXML、交互或宿主 runtime。需要这些能力时使用 [`@mpcore/test`](/packages/mpcore-test)。
+
 ## 行为说明
 
 - 仅在未传回调时返回 Promise

--- a/website/wevu/api-package.md
+++ b/website/wevu/api-package.md
@@ -306,6 +306,46 @@ await api.showToast({ title: '支付宝环境', icon: 'none' })
 - 一套能力探测接口：`resolveTarget` / `supports`
 - 一组运行时 adapter 控制接口：`platform / raw / getAdapter / setAdapter`
 
+## 在 Vitest 中隔离 API 调用
+
+在 Vitest 配置里注册 `wevu/api` 的 setup 子路径：
+
+```ts
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    setupFiles: ['wevu/api/vitest/setup'],
+  },
+})
+```
+
+业务代码仍然正常静态导入 `wpi`，测试通过同层 mock 入口配置行为：
+
+```ts
+import { wpiMock } from 'wevu/api/vitest'
+
+wpiMock.request.mockResolvedValue(responseFixture)
+wpiMock.onMemoryWarning.mockImplementation((callback) => {
+  callback({ level: 10 })
+})
+```
+
+`wpiMock` 保留 Promise、callback、同步 API 与事件 API 的参数和结果类型。setup 会让 `wevu/api`、`@wevu/api`、`@weapp-core/api` 三层入口共享同一 mock，并在每个测试前局部 reset；它不会调用 `vi.resetAllMocks()`。
+
+需要临时实例或手动控制生命周期时：
+
+```ts
+import { createWpiMock, resetApiMock } from 'wevu/api/vitest'
+
+const localWpi = createWpiMock()
+localWpi.showToast.mockResolvedValue(showToastResult)
+
+resetApiMock(localWpi)
+```
+
+没有配置实现的方法默认返回 `undefined`，不会伪造宿主结果。这套 mock 用于测试业务代码如何调用 API；页面/组件 render、WXML 查询、交互和宿主 runtime 行为应使用 [`@mpcore/test`](/packages/mpcore-test)。
+
 ## 业务里最常见的写法
 
 如果你只是日常写业务，通常只会用这两种：


### PR DESCRIPTION
## 背景

当前 `wpi` 是动态 Proxy，方法同时包含 Promise 与回调签名。直接使用 `vi.mock`、`vi.hoisted` 或 `vi.mocked` 时，容易重复编写模板并丢失 overload 类型。

Closes #889

相关讨论：https://github.com/weapp-vite/weapp-vite/discussions/338#discussioncomment-18182199

## 变更

- 在 `@weapp-core/api/vitest` 新增 `createApiMock`、`createWpiMock`、`apiMock`、`wpiMock` 与局部 reset。
- 新增 `@weapp-core/api/vitest/setup`，在 Vitest setup 阶段保留真实导出，仅替换 `api` / `wpi`。
- 为 `@wevu/api/vitest`、`@wevu/api/vitest/setup`、`wevu/api/vitest`、`wevu/api/vitest/setup` 提供兼容重导出，并共享同一单例。
- 使用生成式 API catalog 惰性创建方法 mock，保留 Promise、callback、同步、事件、内部辅助方法与自定义 adapter 类型。
- setup 仅重置自身已创建的 mock，不调用全局 `vi.resetAllMocks()`；未配置方法默认返回 `undefined`。
- Vitest 保持可选 peer dependency，生产入口不引用测试子路径。
- 同步核心/兼容包 README、website 文档、消费者 fixture 与中文 changeset。

## 验证

- `pnpm -C @weapp-core/api run typecheck`
- `pnpm -C @weapp-core/api run test`
- `pnpm -C @weapp-core/api exec tsd`
- `pnpm -C @weapp-core/api run build`
- `pnpm -C @weapp-core/api run lint`
- `pnpm -C packages-runtime/weapi run typecheck`
- `pnpm -C packages-runtime/weapi run test`
- `pnpm -C packages-runtime/weapi exec tsd`
- `pnpm -C packages-runtime/weapi run build`
- `pnpm -C packages-runtime/weapi run lint`
- `pnpm -C packages-runtime/wevu run typecheck`
- `pnpm -C packages-runtime/wevu run test`
- `pnpm -C packages-runtime/wevu exec tsd`
- `pnpm -C packages-runtime/wevu run build`
- `pnpm -C packages-runtime/wevu run lint`（仅既有 warning）
- 三种 setup 子路径的独立 Vitest 消费者 fixture
- 三个发布包的 `npm pack --dry-run`
- `pnpm -C website run build`
- changeset frontmatter、catalog、publishable workspace 与 create-weapp-vite 联动检查