### PR TITLE
fix(weapp-vite): 修复 dev Sass 资产占位符二次预处理

### DIFF
--- a/.changeset/fix-dev-sass-asset-placeholder.md
+++ b/.changeset/fix-dev-sass-asset-placeholder.md
@@ -1,0 +1,6 @@
+---
+"create-weapp-vite": patch
+"weapp-vite": patch
+---
+
+修复 dev 样式资产已经包含 Vite URL 占位符时再次进入 Sass 预处理导致无引号 `url(...)` 报未定义变量的问题；仅对占位符中间产物回读原始预处理源码，保持普通 CSS、production 和既有 HMR 输出路径不变。

--- a/packages/weapp-vite/src/plugins/css.test.ts
+++ b/packages/weapp-vite/src/plugins/css.test.ts
@@ -315,6 +315,34 @@ describe('css plugin shared style injection', () => {
     expect(emitted).toEqual([])
   })
 
+  it('preprocesses dev Sass assets from raw source instead of Vite placeholders', async () => {
+    const appScssPath = resolve(absoluteSrcRoot, 'app.scss')
+    const rawScss = '.page{background:url(../../static/images/shop-bottom.png)}'
+    const vitePlaceholder = '.page{background:url(__VITE_ASSET__$shop_bottom__)}'
+    readFileMock.mockResolvedValueOnce(rawScss)
+    const plugin = css({
+      ...ctx,
+      configService: {
+        ...configService,
+        isDev: true,
+      },
+    } as unknown as CompilerContext)[0]
+    const bundle: Record<string, any> = {
+      'app.wxss': {
+        type: 'asset',
+        fileName: 'app.wxss',
+        originalFileNames: [appScssPath],
+        source: vitePlaceholder,
+      },
+    }
+
+    await invokeHook(plugin.configResolved, pluginContext, resolvedConfig)
+    await invokeHook(plugin.generateBundle, pluginContext, {} as any, bundle, true)
+
+    expect(preprocessCSSMock).toHaveBeenCalledWith(rawScss, appScssPath, resolvedConfig)
+    expect(preprocessCSSMock).not.toHaveBeenCalledWith(vitePlaceholder, appScssPath, resolvedConfig)
+  })
+
   it('emits wxss asset with shared style imports for modules without local styles', async () => {
     const plugin = css(ctx)[0]
     const bundle: Record<string, any> = {

--- a/packages/weapp-vite/src/plugins/css.ts
+++ b/packages/weapp-vite/src/plugins/css.ts
@@ -504,15 +504,17 @@ async function handleBundleEntry(
       const normalizedFileName = toPosixPath(fileName)
       const freshHmrStyleSourcePath = resolveFreshHmrStyleSourcePath(ctx, normalizedFileName)
       const preprocessId = freshHmrStyleSourcePath ?? absOriginal
+      const shouldPreprocess = shouldPreprocessWithVite(preprocessId)
+      const graphSource = await readStyleGraphSource(preprocessId, canonicalSource)
       const preprocessInput = freshHmrStyleSourcePath
-        ? await resolveMemoryStyleSource(ctx, freshHmrStyleSourcePath) ?? await readStyleGraphSource(freshHmrStyleSourcePath, canonicalSource)
-        : canonicalSource
+        ? await resolveMemoryStyleSource(ctx, freshHmrStyleSourcePath) ?? graphSource
+        : shouldPreprocess && (canonicalSource.includes('__VITE_ASSET__') || canonicalSource.includes('__VITE_PUBLIC_ASSET__'))
+          ? graphSource
+          : canonicalSource
       const { css, dependencies } = await preprocessStyleSource(preprocessInput, preprocessId, resolvedConfig, {
-        enabled: shouldPreprocessWithVite(preprocessId),
+        enabled: shouldPreprocess,
       })
-      const graphCss = freshHmrStyleSourcePath
-        ? preprocessInput
-        : await readStyleGraphSource(absOriginal, canonicalSource)
+      const graphCss = freshHmrStyleSourcePath ? preprocessInput : graphSource
       syncCssImportDependencies(ctx, preprocessId, graphCss, dependencies)
       if (typeof this.addWatchFile === 'function') {
         for (const dependency of dependencies) {


### PR DESCRIPTION
## 问题

Dev 最终样式资产已经包含 Vite 的 `__VITE_ASSET__...` 中间占位符，但代码仍按原始 `.scss` 文件名再次调用 Sass 预处理。无引号 `url(...)` 中的 `$` 因此被 Sass 当成变量并报错。

## 修复

- 当最终样式资产包含 Vite asset/public asset 占位符且源文件需要预处理时，从原始文件或 HMR memory source 回读源码后再执行 Sass/Less 预处理。
- 普通 CSS、已经完成预处理且不含占位符的资产继续使用当前 Vite 输出，避免改变既有 production/HMR 路径。
- 增加 generateBundle 回归测试，锁定无引号 URL 对应的原始 Sass 输入。

## 验证

- `pnpm vitest run packages/weapp-vite/src/plugins/css.test.ts`：35 tests passed
- `pnpm --filter weapp-vite build`：通过
- changeset guards：通过

Closes #892