### PR TITLE
fix(weapp-vite): 合并同一 owner 的多个 style src 资产

### DIFF
--- a/.changeset/fix-tailwind-style-src-app-wxss.md
+++ b/.changeset/fix-tailwind-style-src-app-wxss.md
@@ -1,0 +1,6 @@
+---
+"create-weapp-vite": patch
+"weapp-vite": patch
+---
+
+修复同一入口由多个 `<style src>` 产生多个 CSS asset 时分别写入同名 wxss、导致后写样式覆盖前写样式的问题；现在按最终 owner 样式文件稳定归组并合并片段，再统一注入共享样式和写出 `app.wxss`。

--- a/packages/weapp-vite/src/plugins/css.test.ts
+++ b/packages/weapp-vite/src/plugins/css.test.ts
@@ -655,6 +655,50 @@ describe('css plugin shared style injection', () => {
     expect(cssAsset?.source).toContain('.root{color:red}')
   })
 
+  it('merges multiple app style src assets into one app wxss output', async () => {
+    const appEntry = resolve(absoluteSrcRoot, 'app.vue')
+    const plugin = css(ctx)[0]
+    const bundle: Record<string, any> = {
+      'app.js': {
+        type: 'chunk',
+        fileName: 'app.js',
+        facadeModuleId: createLogicalEntryId(appEntry, 'app'),
+        code: '',
+        map: null,
+        imports: [],
+        exports: [],
+        modules: {},
+        dynamicImports: [],
+        implicitlyLoadedBefore: [],
+        referencedFiles: [],
+        viteMetadata: {
+          importedAssets: new Set(),
+          importedCss: new Set(['app-base.css', 'app-tailwind.css']),
+          importedScripts: new Set(),
+          importedUrls: new Set(),
+        },
+      },
+      'app-base.css': {
+        type: 'asset',
+        fileName: 'app-base.css',
+        source: '.app-base{display:block}',
+      },
+      'app-tailwind.css': {
+        type: 'asset',
+        fileName: 'app-tailwind.css',
+        source: '.text-red-500{color:red}',
+      },
+    }
+
+    await invokeHook(plugin.configResolved, pluginContext, resolvedConfig)
+    await invokeHook(plugin.generateBundle, pluginContext, {} as any, bundle, false)
+
+    const appStyles = emitted.filter(asset => asset.fileName === 'app.wxss')
+    expect(appStyles).toHaveLength(1)
+    expect(appStyles[0]?.source).toContain('.app-base{display:block}')
+    expect(appStyles[0]?.source).toContain('.text-red-500{color:red}')
+  })
+
   it('reuses processed css asset source for multiple chunk owners', async () => {
     preprocessCSSMock.mockResolvedValue({
       code: '.shared{color:red}',

--- a/packages/weapp-vite/src/plugins/css.ts
+++ b/packages/weapp-vite/src/plugins/css.ts
@@ -36,6 +36,12 @@ type OutputChunkWithViteMetadata = OutputChunk & {
 interface PreparedStyleAsset {
   processedCss: string
 }
+interface PreparedOwnedStyleAsset {
+  fileName: string
+  modulePath: string
+  normalizedFileName: string
+  processedCss: string
+}
 
 interface SharedStyleEmissionTask {
   entry: StyleEntry
@@ -460,27 +466,41 @@ async function handleBundleEntry(
     return cached
   }
 
-  const emitStyleAssetForOwner = async (owner: string, preprocessId: string, shouldPreprocess: boolean) => {
+  const prepareOwnedStyleAsset = async (
+    owner: string,
+    preprocessId: string,
+    shouldPreprocess: boolean,
+  ): Promise<PreparedOwnedStyleAsset | undefined> => {
     const fileName = resolveOutputStyleFileName(configService, owner)
     if (!fileName) {
       return undefined
     }
-    const normalizedFileName = toPosixPath(fileName)
     const rawCss = asset.source.toString()
     const { processedCss } = await prepareStyleAssetForOwner(rawCss, preprocessId, shouldPreprocess)
-
-    const cssWithImports = injectSharedStyleImportsCached(
-      processedCss,
-      owner,
+    return {
       fileName,
+      modulePath: owner,
+      normalizedFileName: toPosixPath(fileName),
+      processedCss,
+    }
+  }
+
+  const emitStyleAssetForOwner = async (owner: string, preprocessId: string, shouldPreprocess: boolean) => {
+    const prepared = await prepareOwnedStyleAsset(owner, preprocessId, shouldPreprocess)
+    if (!prepared) {
+      return undefined
+    }
+    const cssWithImports = injectSharedStyleImportsCached(
+      prepared.processedCss,
+      prepared.modulePath,
+      prepared.fileName,
       sharedStyles,
       configService,
       sharedStyleImportCache,
     )
-
-    emitCssAssetIfChanged(ctx, this, bundle, fileName, cssWithImports)
-    emitted.add(normalizedFileName)
-    return normalizedFileName
+    emitCssAssetIfChanged(ctx, this, bundle, prepared.fileName, cssWithImports)
+    emitted.add(prepared.normalizedFileName)
+    return prepared.normalizedFileName
   }
 
   const isCssAsset = bundleKey.endsWith('.css')
@@ -562,15 +582,14 @@ async function handleBundleEntry(
     return
   }
 
-  const emittedOwners = await Promise.all(Array.from(owners).map(async (owner) => {
-    const modulePath = owner
-    return await emitStyleAssetForOwner(modulePath, resolveOriginalStylePath(), !isCssAsset)
-  }))
-
+  const preparedOwners = (await Promise.all(Array.from(owners).map(async (owner) => {
+    return await prepareOwnedStyleAsset(owner, resolveOriginalStylePath(), !isCssAsset)
+  }))).filter((prepared): prepared is PreparedOwnedStyleAsset => prepared !== undefined)
   const normalizedBundleKey = toPosixPath(bundleKey)
-  if (!isCssAsset || !emittedOwners.includes(normalizedBundleKey)) {
+  if (!isCssAsset || !preparedOwners.some(prepared => prepared.normalizedFileName === normalizedBundleKey)) {
     delete bundle[bundleKey]
   }
+  return preparedOwners
 }
 
 async function emitSharedStyleEntries(
@@ -781,7 +800,38 @@ async function generateBundleSharedCss(
     return handleBundleEntry.call(this, ctx, bundle, bundleKey, asset, configService, sharedStyles, ownersByCssAsset, emitted, sharedStyleImportCache, resolvedConfig)
   })
 
-  await Promise.all(tasks)
+  const preparedOwnerStyles = (await Promise.all(tasks))
+    .flatMap(result => result ?? [])
+  const ownerStyleGroups = new Map<string, {
+    fileName: string
+    fragments: string[]
+    modulePath: string
+  }>()
+  for (const prepared of preparedOwnerStyles) {
+    let group = ownerStyleGroups.get(prepared.normalizedFileName)
+    if (!group) {
+      group = {
+        fileName: prepared.fileName,
+        fragments: [],
+        modulePath: prepared.modulePath,
+      }
+      ownerStyleGroups.set(prepared.normalizedFileName, group)
+    }
+    group.fragments.push(prepared.processedCss)
+  }
+  for (const [normalizedFileName, group] of ownerStyleGroups) {
+    const mergedCss = group.fragments.join('\n')
+    const cssWithImports = injectSharedStyleImportsCached(
+      mergedCss,
+      group.modulePath,
+      group.fileName,
+      sharedStyles,
+      configService,
+      sharedStyleImportCache,
+    )
+    emitCssAssetIfChanged(ctx, this, bundle, group.fileName, cssWithImports)
+    emitted.add(normalizedFileName)
+  }
   await emitSharedStyleEntries.call(this, ctx, sharedStyles, emitted, configService, bundle, resolvedConfig)
   await emitSharedStyleImportsForChunks.call(this, ctx, sharedStyles, emitted, configService, bundle, facadeChunks, sharedStyleImportCache)
 }


### PR DESCRIPTION
## 问题

同一入口通过多个 `<style src>` 产生多个 CSS asset 时，现有逻辑会并发地把每个 asset 分别写到同一个 `app.wxss`。最终只保留其中一个片段，Tailwind transform 虽然成功执行，但生成的 utility 可能被后续同名写出覆盖。

## 修复

- CSS asset 仍并行完成预处理和 PostCSS/Tailwind 转换。
- 将处理结果按最终 owner 样式文件归组，并保持 bundle 中的原始 asset 顺序。
- 同一 owner 的片段合并后只注入一次共享样式，再统一写出 `app.wxss`。
- 保留输出文件名与 bundle key 相同的既有就地更新行为。
- 增加多 app style asset 回归测试，断言基础样式与 Tailwind utility 同时存在且只写出一个 `app.wxss`。

## 验证

- `pnpm vitest run packages/weapp-vite/src/plugins/css.test.ts`：35 tests passed
- `pnpm --filter weapp-vite build`：通过
- changeset guards：通过

Closes #893