### PR TITLE
fix(weapp-vite): 完善 Sass 资产占位符处理

### DIFF
--- a/.changeset/fix-dev-sass-asset-owner.md
+++ b/.changeset/fix-dev-sass-asset-owner.md
@@ -1,0 +1,6 @@
+---
+"create-weapp-vite": patch
+"weapp-vite": patch
+---
+
+修复 Sass/Less 等预处理样式资产在 Vite 占位符阶段再次处理时的 URL 解析问题，并补充 dev、HMR 与 production 回归覆盖。

--- a/e2e-apps/github-issues/src/styles/issue-892-app.scss
+++ b/e2e-apps/github-issues/src/styles/issue-892-app.scss
@@ -1,0 +1,11 @@
+$issue-892-color: #2468ac;
+$issue-892-image: '../assets/images/home/goods-1.png';
+
+.issue-892-unquoted {
+  color: $issue-892-color;
+  background-image: url("../assets/images/home/goods-1.png");
+}
+
+.issue-892-quoted {
+  background-image: url($issue-892-image);
+}

--- a/e2e/ci/githubIssuesBuild/cases/issue892.case.ts
+++ b/e2e/ci/githubIssuesBuild/cases/issue892.case.ts
@@ -1,0 +1,36 @@
+import type { GithubIssuesBuildCaseContext } from './types'
+import { fs } from '@weapp-core/shared/node'
+import path from 'pathe'
+import { expect, it } from 'vitest'
+import { runWeappViteBuildWithLogCapture } from '../../../utils/buildLog'
+
+export function registerGithubIssuesBuildCase(context: GithubIssuesBuildCaseContext) {
+  it('issue #892: preserves Sass asset URLs in production output', async () => {
+    const issueDistRoot = path.join(context.appRoot, 'dist-issue-892')
+    const configFile = path.join(import.meta.dirname, 'issue892.config.ts')
+
+    await fs.remove(issueDistRoot)
+    await runWeappViteBuildWithLogCapture({
+      cliPath: context.cliPath,
+      configFile,
+      projectRoot: context.appRoot,
+      platform: 'weapp',
+      cwd: context.appRoot,
+      label: 'ci:github-issues:issue892',
+      outDir: 'dist-issue-892',
+      skipNpm: true,
+    })
+
+    const style = await fs.readFile(
+      path.join(issueDistRoot, 'styles/issue-892-app.wxss'),
+      'utf8',
+    )
+
+    expect(style).toContain('.issue-892-unquoted')
+    expect(style).toContain('.issue-892-quoted')
+    expect(style).toContain('color: #2468ac;')
+    expect(style).toContain('goods-1.png')
+    expect(style).not.toContain('__VITE_ASSET__')
+    expect(style).not.toContain('__VITE_PUBLIC_ASSET__')
+  })
+}

--- a/e2e/ci/githubIssuesBuild/cases/issue892.config.ts
+++ b/e2e/ci/githubIssuesBuild/cases/issue892.config.ts
@@ -1,0 +1,16 @@
+import { mergeConfig } from 'vite'
+import { defineConfig } from 'weapp-vite'
+import baseConfig from '../../../../e2e-apps/github-issues/weapp-vite.config'
+
+export default defineConfig(mergeConfig(baseConfig, {
+  build: {
+    minify: false,
+    outDir: 'dist-issue-892',
+  },
+  weapp: {
+    styles: {
+      source: 'styles/issue-892-app.scss',
+      include: 'app.vue',
+    },
+  },
+}))

--- a/e2e/ci/issue-892-sass-assets.test.ts
+++ b/e2e/ci/issue-892-sass-assets.test.ts
@@ -1,0 +1,87 @@
+import { fs } from '@weapp-core/shared/node'
+import path from 'pathe'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { startDevProcess } from '../utils/dev-process'
+import { cleanupResidualDevProcesses } from '../utils/dev-process-cleanup'
+import { createDevProcessEnv } from '../utils/dev-process-env'
+import { replaceFileByRename } from '../utils/hmr-helpers'
+
+const CLI_PATH = path.resolve(import.meta.dirname, '../../packages/weapp-vite/src/cli.ts')
+const APP_ROOT = path.resolve(import.meta.dirname, '../../e2e-apps/github-issues')
+const CONFIG_FILE = path.resolve(import.meta.dirname, 'githubIssuesBuild/cases/issue892.config.ts')
+const STYLE_SOURCE_PATH = path.join(APP_ROOT, 'src/styles/issue-892-app.scss')
+const STYLE_OUTPUT_PATH = path.join(APP_ROOT, 'dist/styles/issue-892-app.wxss')
+
+async function waitForStyleOutput(markers: string[], timeoutMs = 60_000) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await fs.pathExists(STYLE_OUTPUT_PATH)) {
+      const source = await fs.readFile(STYLE_OUTPUT_PATH, 'utf8')
+      if (markers.every(marker => source.includes(marker))) {
+        return source
+      }
+    }
+    await new Promise(resolve => setTimeout(resolve, 250))
+  }
+  throw new Error(`Timed out waiting for ${STYLE_OUTPUT_PATH} to contain ${markers.join(', ')}`)
+}
+
+describe.sequential('issue #892 Sass asset placeholders', () => {
+  beforeEach(async () => {
+    await cleanupResidualDevProcesses()
+  })
+
+  afterEach(async () => {
+    await cleanupResidualDevProcesses()
+  })
+
+  it('keeps unquoted and quoted asset URLs valid across initial dev output and HMR', async () => {
+    const originalSource = await fs.readFile(STYLE_SOURCE_PATH, 'utf8')
+    await fs.remove(path.join(APP_ROOT, 'dist'))
+    const devProcess = startDevProcess(
+      'node',
+      [
+        '--import',
+        'tsx',
+        CLI_PATH,
+        'dev',
+        APP_ROOT,
+        '--platform',
+        'weapp',
+        '--config',
+        CONFIG_FILE,
+        '--skipNpm',
+      ],
+      {
+        env: createDevProcessEnv(),
+        stdio: 'inherit',
+      },
+    )
+
+    try {
+      const initialStyle = await waitForStyleOutput([
+        '.issue-892-unquoted',
+        '.issue-892-quoted',
+        'goods-1.png',
+      ])
+      expect(initialStyle).not.toContain('__VITE_ASSET__')
+      expect(initialStyle).not.toContain('__VITE_PUBLIC_ASSET__')
+
+      const updatedSource = originalSource.replace('#2468ac', '#ac6824')
+      expect(updatedSource).not.toBe(originalSource)
+      await replaceFileByRename(STYLE_SOURCE_PATH, updatedSource)
+
+      const updatedStyle = await waitForStyleOutput(['color: #ac6824;'])
+      expect(updatedStyle).toContain('url(../assets/images/home/goods-1.png)')
+      expect(updatedStyle).toContain('url("../assets/images/home/goods-1.png")')
+      expect(updatedStyle).not.toContain('__VITE_ASSET__')
+      expect(updatedStyle).not.toContain('__VITE_PUBLIC_ASSET__')
+      expect(devProcess.getOutput()).not.toContain('Undefined variable')
+      expect(devProcess.getOutput()).not.toContain('Build failed')
+    }
+    finally {
+      await devProcess.stop(2_000)
+      await fs.writeFile(STYLE_SOURCE_PATH, originalSource, 'utf8')
+    }
+  })
+})

--- a/packages/weapp-vite/src/plugins/css.test.ts
+++ b/packages/weapp-vite/src/plugins/css.test.ts
@@ -315,16 +315,21 @@ describe('css plugin shared style injection', () => {
     expect(emitted).toEqual([])
   })
 
-  it('preprocesses dev Sass assets from raw source instead of Vite placeholders', async () => {
+  it.each([
+    { isDev: true, mode: 'dev', placeholderToken: '__VITE_ASSET__$shop_bottom__' },
+    { isDev: true, mode: 'dev', placeholderToken: '__VITE_PUBLIC_ASSET__$shop_bottom__' },
+    { isDev: false, mode: 'production', placeholderToken: '__VITE_ASSET__$shop_bottom__' },
+    { isDev: false, mode: 'production', placeholderToken: '__VITE_PUBLIC_ASSET__$shop_bottom__' },
+  ])('preprocesses $mode Sass assets from raw source instead of $placeholderToken', async ({ isDev, placeholderToken }) => {
     const appScssPath = resolve(absoluteSrcRoot, 'app.scss')
     const rawScss = '.page{background:url(../../static/images/shop-bottom.png)}'
-    const vitePlaceholder = '.page{background:url(__VITE_ASSET__$shop_bottom__)}'
+    const vitePlaceholder = `.page{background:url(${placeholderToken})}`
     readFileMock.mockResolvedValueOnce(rawScss)
     const plugin = css({
       ...ctx,
       configService: {
         ...configService,
-        isDev: true,
+        isDev,
       },
     } as unknown as CompilerContext)[0]
     const bundle: Record<string, any> = {
@@ -341,6 +346,33 @@ describe('css plugin shared style injection', () => {
 
     expect(preprocessCSSMock).toHaveBeenCalledWith(rawScss, appScssPath, resolvedConfig)
     expect(preprocessCSSMock).not.toHaveBeenCalledWith(vitePlaceholder, appScssPath, resolvedConfig)
+  })
+
+  it.each(['scss', 'sass', 'less', 'styl'])('preprocesses source-style .%s assets from raw source when Vite leaves an asset placeholder', async (extension) => {
+    const stylePath = resolve(absoluteSrcRoot, `styles/asset.${extension}`)
+    const rawScss = '.asset{background:url(../assets/image.png)}'
+    const vitePlaceholder = '.asset{background:url(__VITE_ASSET__$image__)}'
+    readFileMock.mockResolvedValueOnce(rawScss)
+    const plugin = css(ctx)[0]
+    const bundle: Record<string, any> = {
+      [`styles/asset.${extension}`]: {
+        type: 'asset',
+        fileName: `styles/asset.${extension}`,
+        originalFileNames: [stylePath],
+        source: vitePlaceholder,
+      },
+    }
+
+    await invokeHook(plugin.configResolved, pluginContext, resolvedConfig)
+    await invokeHook(plugin.generateBundle, pluginContext, {} as any, bundle, true)
+
+    expect(preprocessCSSMock).toHaveBeenCalledWith(rawScss, stylePath, resolvedConfig)
+    expect(preprocessCSSMock).not.toHaveBeenCalledWith(vitePlaceholder, stylePath, resolvedConfig)
+    expect(bundle[`styles/asset.${extension}`]).toBeUndefined()
+    expect(emitted).toContainEqual(expect.objectContaining({
+      fileName: 'styles/asset.wxss',
+      source: rawScss,
+    }))
   })
 
   it('emits wxss asset with shared style imports for modules without local styles', async () => {

--- a/packages/weapp-vite/src/plugins/css.ts
+++ b/packages/weapp-vite/src/plugins/css.ts
@@ -147,6 +147,10 @@ function shouldPreprocessWithVite(fileName: string) {
   return VITE_PREPROCESS_STYLE_RE.test(fileName)
 }
 
+function hasViteStyleAssetPlaceholder(source: string) {
+  return source.includes('__VITE_ASSET__') || source.includes('__VITE_PUBLIC_ASSET__')
+}
+
 async function preprocessStyleSource(
   code: string,
   fileName: string,
@@ -446,11 +450,14 @@ async function handleBundleEntry(
     let cached = preparedStyleAssets.get(cacheKey)
     if (!cached) {
       cached = (async () => {
-        const { css, dependencies } = await preprocessStyleSource(rawCss, preprocessId, resolvedConfig, {
+        const graphSource = await readStyleGraphSource(preprocessId, rawCss)
+        const preprocessInput = shouldPreprocess && hasViteStyleAssetPlaceholder(rawCss)
+          ? graphSource
+          : rawCss
+        const { css, dependencies } = await preprocessStyleSource(preprocessInput, preprocessId, resolvedConfig, {
           enabled: shouldPreprocess,
         })
-        const graphCss = await readStyleGraphSource(preprocessId, rawCss)
-        syncCssImportDependencies(ctx, preprocessId, graphCss, dependencies)
+        syncCssImportDependencies(ctx, preprocessId, graphSource, dependencies)
         if (typeof this.addWatchFile === 'function') {
           for (const dependency of dependencies) {
             this.addWatchFile(normalizeWatchPath(dependency))
@@ -528,7 +535,7 @@ async function handleBundleEntry(
       const graphSource = await readStyleGraphSource(preprocessId, canonicalSource)
       const preprocessInput = freshHmrStyleSourcePath
         ? await resolveMemoryStyleSource(ctx, freshHmrStyleSourcePath) ?? graphSource
-        : shouldPreprocess && (canonicalSource.includes('__VITE_ASSET__') || canonicalSource.includes('__VITE_PUBLIC_ASSET__'))
+        : shouldPreprocess && hasViteStyleAssetPlaceholder(canonicalSource)
           ? graphSource
           : canonicalSource
       const { css, dependencies } = await preprocessStyleSource(preprocessInput, preprocessId, resolvedConfig, {


### PR DESCRIPTION
## 变更

- 将 Vite 资产占位符回读原始源码的规则下沉到所有 owner 样式资产预处理路径，覆盖最终 wxss 与中间 scss/sass/less/styl 资产。
- 新增 `github-issues` production 构建回归，校验无引号/带引号 URL、Sass 变量、占位符清理。
- 新增 dev/HMR 回归，校验初始输出和样式修改后的输出均不触发 `Undefined variable`。
- 增加 `__VITE_ASSET__` 与 `__VITE_PUBLIC_ASSET__`、dev/production、四种预处理器扩展名的单元覆盖。

## 验证

- `pnpm vitest run packages/weapp-vite/src/plugins/css.test.ts --configLoader bundle`
- `pnpm vitest run --pool forks -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/github-issues.build.test.ts -t "issue #892"`
- `pnpm vitest run --pool forks -c ./e2e/vitest.e2e.ci.config.ts e2e/ci/issue-892-sass-assets.test.ts`
- `pnpm --filter weapp-vite typecheck`
- 定向 ESLint

Closes #892