### PR TITLE
fix(weapp-vite): 修复 stateful HMR 初始构建失败

### DIFF
--- a/.changeset/fix-stateful-hmr-initial-build.md
+++ b/.changeset/fix-stateful-hmr-initial-build.md
@@ -1,0 +1,6 @@
+---
+"create-weapp-vite": patch
+"weapp-vite": patch
+---
+
+修复 stateful-experimental HMR 初始构建与 Vite Rolldown 版本不一致、样式 sidecar 虚拟路径无法加载以及构建失败后命令持续挂起的问题。

--- a/e2e/ci/issue-896-stateful-initial.test.ts
+++ b/e2e/ci/issue-896-stateful-initial.test.ts
@@ -1,0 +1,87 @@
+import { mkdtemp } from 'node:fs/promises'
+import path from 'node:path'
+import { fs } from '@weapp-core/shared/node'
+import { afterEach, describe, expect, it } from 'vitest'
+import { startDevProcess } from '../utils/dev-process'
+import { cleanupResidualDevProcesses } from '../utils/dev-process-cleanup'
+import { createDevProcessEnv } from '../utils/dev-process-env'
+import { waitForFileContains } from '../utils/hmr-helpers'
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../..')
+const CLI_PATH = path.resolve(REPO_ROOT, 'packages/weapp-vite/bin/weapp-vite.js')
+const SOURCE_APP_ROOT = path.resolve(REPO_ROOT, 'e2e-apps/stateful-hmr')
+const TMP_ROOT = path.resolve(REPO_ROOT, '.tmp')
+const STYLE_MARKER = 'issue-896-style-marker'
+
+async function createIssue896Fixture() {
+  await fs.ensureDir(TMP_ROOT)
+  const fixtureRoot = await mkdtemp(path.join(TMP_ROOT, 'issue-896-stateful-'))
+  await fs.copy(SOURCE_APP_ROOT, fixtureRoot, {
+    filter: (source) => {
+      const relativePath = path.relative(SOURCE_APP_ROOT, source)
+      return relativePath !== 'dist' && !relativePath.startsWith(`dist${path.sep}`)
+    },
+  })
+
+  const configPath = path.join(fixtureRoot, 'weapp-vite.config.ts')
+  const config = await fs.readFile(configPath, 'utf8')
+  await fs.writeFile(
+    configPath,
+    config.replace(
+      'hmr: {\n      logLevel: \'verbose\',\n    },',
+      'hmr: {\n      runtime: \'stateful-experimental\',\n      logLevel: \'verbose\',\n    },',
+    ),
+    'utf8',
+  )
+
+  const pagePath = path.join(fixtureRoot, 'src/pages/wevu/index.vue')
+  const page = await fs.readFile(pagePath, 'utf8')
+  await fs.writeFile(
+    pagePath,
+    page.replace(/<style>[\s\S]*?<\/style>/, '<style src="./index.scss" lang="scss"></style>'),
+    'utf8',
+  )
+  await fs.writeFile(
+    path.join(fixtureRoot, 'src/pages/wevu/index.scss'),
+    `.${STYLE_MARKER} { color: #893a6d; }\n`,
+    'utf8',
+  )
+  return fixtureRoot
+}
+
+afterEach(async () => {
+  await cleanupResidualDevProcesses()
+})
+
+describe.sequential('issue #896 stateful initial build', () => {
+  it('compiles TypeScript SFC and style sidecars and reaches a ready output', async () => {
+    const fixtureRoot = await createIssue896Fixture()
+    const outputPath = path.join(fixtureRoot, 'dist/pages/wevu/index.wxss')
+    const dev = startDevProcess(process.execPath, [
+      CLI_PATH,
+      'dev',
+      fixtureRoot,
+      '--platform',
+      'weapp',
+      '--skipNpm',
+    ], {
+      all: true,
+      cwd: fixtureRoot,
+      env: createDevProcessEnv(),
+      reject: false,
+    })
+
+    try {
+      const style = await dev.waitFor(
+        waitForFileContains(outputPath, STYLE_MARKER, 60_000),
+        'issue #896 stateful initial style output',
+      )
+      expect(style).toContain('#893a6d')
+      expect(await fs.pathExists(path.join(fixtureRoot, 'dist/app.js'))).toBe(true)
+    }
+    finally {
+      await dev.stop(5_000)
+      await fs.remove(fixtureRoot)
+    }
+  }, 120_000)
+})

--- a/packages/weapp-vite/src/runtime/statefulHmr/sidecarPlugin.test.ts
+++ b/packages/weapp-vite/src/runtime/statefulHmr/sidecarPlugin.test.ts
@@ -43,4 +43,26 @@ describe('stateful HMR sidecar plugin', () => {
       await rm(root, { force: true, recursive: true })
     }
   })
+
+  it('loads style sidecars from their decoded source id', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'weapp-vite-stateful-style-sidecar-'))
+    const sourceId = path.join(root, 'index.scss')
+    const ownerId = path.join(root, 'index.vue')
+    const addWatchFile = vi.fn()
+    try {
+      await writeFile(sourceId, '.page { color: red; }')
+      const plugin = createStatefulHmrSidecarPlugin()
+      const load = plugin.load as (...args: any[]) => any
+      const result = await load.call(
+        { addWatchFile },
+        `${sourceId}?weapp-vite-sidecar-owner=${encodeURIComponent(ownerId)}&weapp-vite-sidecar=style&lang.css`,
+      )
+
+      expect(result).toBe('.page { color: red; }')
+      expect(addWatchFile).toHaveBeenCalledWith(normalizePath(await realpath(sourceId)))
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
 })

--- a/packages/weapp-vite/src/runtime/statefulHmr/sidecarPlugin.ts
+++ b/packages/weapp-vite/src/runtime/statefulHmr/sidecarPlugin.ts
@@ -18,11 +18,14 @@ export function createStatefulHmrSidecarPlugin(): Plugin {
     enforce: 'pre',
     async load(id) {
       const request = parseSidecarSourceRequest(id)
-      if (!request || request.kind === 'style') {
+      if (!request) {
         return
       }
       this.addWatchFile(request.sourceId)
       const source = await readFile(request.sourceId, 'utf8')
+      if (request.kind === 'style') {
+        return source
+      }
       const code = createStatefulHmrSidecarModuleCode(id, source)
       return code ? { code, moduleSideEffects: 'no-treeshake' } : undefined
     },

--- a/packages/weapp-vite/src/runtime/statefulHmr/viteAdapter.test.ts
+++ b/packages/weapp-vite/src/runtime/statefulHmr/viteAdapter.test.ts
@@ -250,4 +250,39 @@ describe('stateful HMR Vite adapter', () => {
       '__weapp_vite_hmr/update.js',
     ])
   })
+
+  it('fails a hung initial build instead of keeping the dev command alive', async () => {
+    const adapter = new StatefulHmrViteAdapter(
+      { build: { rolldownOptions: {} }, root: '/project' } as any,
+      {
+        environments: {
+          client: {
+            bundledDev: {
+              getRolldownOptions: async () => ({}),
+              listen: async () => {},
+              storeOutputFiles: () => {},
+            },
+          },
+        },
+      } as any,
+      {
+        onError: () => {},
+        onOutput: () => {},
+        onPatch: () => true,
+        waitForInitialBundle: async () => {},
+      },
+      {},
+      (async () => ({
+        ensureCurrentBuildFinish: () => new Promise<void>(() => {}),
+        getBundleState: async () => ({ lastBuildErrored: false }),
+        registerClient: async () => {},
+        run: async () => {},
+      })) as any,
+      5,
+    )
+
+    adapter.install()
+    const bundledDev = (adapter as any).bundledDev
+    await expect(bundledDev.listen()).rejects.toThrow('初始构建超时')
+  })
 })

--- a/packages/weapp-vite/src/runtime/statefulHmr/viteAdapter.ts
+++ b/packages/weapp-vite/src/runtime/statefulHmr/viteAdapter.ts
@@ -3,6 +3,7 @@
 import type { DevEngine, DevOptions } from 'rolldown/experimental'
 import type { ResolvedConfig, ViteDevServer } from 'vite'
 import type { StatefulHmrOutputFile } from './outputWriter'
+import { createRequire } from 'node:module'
 import path from 'node:path'
 import {
   WEAPP_VITE_STATEFUL_HMR_BRIDGE_KEY,
@@ -14,6 +15,42 @@ import { dev } from 'rolldown/experimental'
 import { assertStatefulHmrRuntimeOutput, createStatefulHmrRolldownRuntimeSource } from './commonRuntime'
 
 const clientId = 'weapp-vite-stateful-hmr'
+const initialBuildTimeoutMs = 60_000
+const require = createRequire(import.meta.url)
+
+function resolveViteDevEngine(): typeof dev {
+  try {
+    const vitePackagePath = require.resolve('vite/package.json')
+    const viteRequire = createRequire(vitePackagePath)
+    const viteRolldown = viteRequire('rolldown/experimental') as { dev?: typeof dev }
+    if (typeof viteRolldown.dev === 'function') {
+      return viteRolldown.dev
+    }
+  }
+  catch {
+    // Vite 未暴露 Rolldown 时回退到 weapp-vite 自身依赖。
+  }
+  return dev
+}
+
+async function withInitialBuildTimeout<T>(task: Promise<T>, timeoutMs = initialBuildTimeoutMs): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      task,
+      new Promise<T>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error(`stateful-experimental HMR 初始构建超时（>${timeoutMs}ms）。`))
+        }, timeoutMs)
+      }),
+    ])
+  }
+  finally {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+  }
+}
 
 export type StatefulHmrDevEngineUpdate
   = | { type: 'Noop' }
@@ -59,7 +96,8 @@ export class StatefulHmrViteAdapter {
       waitForInitialBundle: () => Promise<void>
     },
     private readonly watchOptions: StatefulHmrDevWatchOptions = {},
-    private readonly createDevEngine: typeof dev = dev,
+    private readonly createDevEngine: typeof dev = resolveViteDevEngine(),
+    private readonly initialBuildTimeout = initialBuildTimeoutMs,
   ) {}
 
   install(): void {
@@ -221,14 +259,14 @@ export class StatefulHmrViteAdapter {
         this.callbacks.onError(message)
       })
       await engine.registerClient(clientId)
-      await engine.ensureCurrentBuildFinish()
+      await withInitialBuildTimeout(engine.ensureCurrentBuildFinish(), this.initialBuildTimeout)
       if (this.initialOutputError) {
         throw this.initialOutputError
       }
       if ((await engine.getBundleState()).lastBuildErrored) {
         throw new Error('微信状态保持 HMR 初次构建失败。')
       }
-      await this.callbacks.waitForInitialBundle()
+      await withInitialBuildTimeout(this.callbacks.waitForInitialBundle(), this.initialBuildTimeout)
     }
   }
 


### PR DESCRIPTION
## 背景
修复 issue #896 中 stateful-experimental HMR 将 TypeScript/SFC 交给 JS parser、style sidecar 虚拟 ID 被当作磁盘路径，以及初始构建失败后命令持续挂起的问题。

## 改动
- 优先从 Vite 解析同版本的 Rolldown experimental dev engine。
- stateful sidecar 插件直接加载 style source，保留后续 Sass/CSS 管线。
- 为初始构建与 ready 等待增加超时并传播失败。
- 增加单测与 stateful 初始构建 E2E 回归。

## 验证
- pnpm --filter weapp-vite exec vitest run src/runtime/statefulHmr/sidecarPlugin.test.ts src/runtime/statefulHmr/viteAdapter.test.ts
- pnpm vitest run -c e2e/vitest.e2e.ci.config.ts e2e/ci/issue-896-stateful-initial.test.ts
- pnpm build:pkgs
- pnpm --filter weapp-vite typecheck（仓库基线 independent.ts Rolldown 类型字段错误，非本次改动引入）

Closes #896