### PR TITLE
fix(weapp-vite): 修复本地组件名称大小写解析

### DIFF
--- a/.changeset/fuzzy-local-components.md
+++ b/.changeset/fuzzy-local-components.md
@@ -1,0 +1,6 @@
+---
+"weapp-vite": patch
+"create-weapp-vite": patch
+---
+
+修复本地自动导入组件的文件名与模板标签分别使用 kebab-case 和 PascalCase 时无法解析的问题，统一按组件名的 kebab-case 语义匹配，同时保留原有注册名和生成路径。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -754,6 +754,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-900/index",
+          "pathName": "pages/issue-900/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/issue-829/index",
           "pathName": "pages/issue-829/index",
           "query": "",

--- a/e2e-apps/github-issues/src/components/issue-900/VPascalKebabTagProbe.vue
+++ b/e2e-apps/github-issues/src/components/issue-900/VPascalKebabTagProbe.vue
@@ -1,0 +1,3 @@
+<template>
+  <view>pascal-file-kebab-tag</view>
+</template>

--- a/e2e-apps/github-issues/src/components/issue-900/VPascalPascalTagProbe.vue
+++ b/e2e-apps/github-issues/src/components/issue-900/VPascalPascalTagProbe.vue
@@ -1,0 +1,3 @@
+<template>
+  <view>pascal-file-pascal-tag</view>
+</template>

--- a/e2e-apps/github-issues/src/components/issue-900/v-kebab-kebab-tag-probe.vue
+++ b/e2e-apps/github-issues/src/components/issue-900/v-kebab-kebab-tag-probe.vue
@@ -1,0 +1,3 @@
+<template>
+  <view>kebab-file-kebab-tag</view>
+</template>

--- a/e2e-apps/github-issues/src/components/issue-900/v-kebab-pascal-tag-probe.vue
+++ b/e2e-apps/github-issues/src/components/issue-900/v-kebab-pascal-tag-probe.vue
@@ -1,0 +1,3 @@
+<template>
+  <view>kebab-file-pascal-tag</view>
+</template>

--- a/e2e-apps/github-issues/src/pages/issue-900/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-900/index.vue
@@ -1,0 +1,8 @@
+<template>
+  <view>
+    <v-kebab-kebab-tag-probe />
+    <VKebabPascalTagProbe />
+    <VPascalPascalTagProbe />
+    <v-pascal-kebab-tag-probe />
+  </view>
+</template>

--- a/e2e/ci/githubIssuesBuild/cases/issue900LocalComponentCase.case.ts
+++ b/e2e/ci/githubIssuesBuild/cases/issue900LocalComponentCase.case.ts
@@ -1,0 +1,37 @@
+import type { GithubIssuesBuildCaseContext } from './types'
+import { fs } from '@weapp-core/shared/node'
+import path from 'pathe'
+import { expect, it } from 'vitest'
+
+export function registerGithubIssuesBuildCase(context: GithubIssuesBuildCaseContext) {
+  it('issue #900 regression: matches local component filenames across tag casing styles', async () => {
+    await context.runStandardBuild()
+
+    const pageBase = path.join(context.distRoot, 'pages/issue-900/index')
+    const pageWxml = await fs.readFile(`${pageBase}.wxml`, 'utf8')
+    const pageJson = await fs.readJSON(`${pageBase}.json`) as {
+      usingComponents?: Record<string, string>
+    }
+    const expectedComponents = {
+      'v-kebab-kebab-tag-probe': '/components/issue-900/v-kebab-kebab-tag-probe',
+      'v-kebab-pascal-tag-probe': '/components/issue-900/v-kebab-pascal-tag-probe',
+      'v-pascal-pascal-tag-probe': '/components/issue-900/VPascalPascalTagProbe',
+      'v-pascal-kebab-tag-probe': '/components/issue-900/VPascalKebabTagProbe',
+    }
+
+    expect(pageJson.usingComponents).toMatchObject(expectedComponents)
+    for (const componentName of Object.keys(expectedComponents)) {
+      expect(pageWxml).toContain(`<${componentName}`)
+    }
+
+    const emittedMarkers = {
+      'components/issue-900/v-kebab-kebab-tag-probe.wxml': 'kebab-file-kebab-tag',
+      'components/issue-900/v-kebab-pascal-tag-probe.wxml': 'kebab-file-pascal-tag',
+      'components/issue-900/VPascalPascalTagProbe.wxml': 'pascal-file-pascal-tag',
+      'components/issue-900/VPascalKebabTagProbe.wxml': 'pascal-file-kebab-tag',
+    }
+    for (const [relativePath, marker] of Object.entries(emittedMarkers)) {
+      expect(await fs.readFile(path.join(context.distRoot, relativePath), 'utf8')).toContain(marker)
+    }
+  })
+}

--- a/e2e/ci/githubIssuesBuild/legacy.ts
+++ b/e2e/ci/githubIssuesBuild/legacy.ts
@@ -30,7 +30,7 @@ let standardBuildPromise: Promise<void> | null = null
 let distVariant: 'standard' | 'sourcemap' | null = null
 
 async function runBuild() {
-  if (distVariant !== 'standard') {
+  if (distVariant !== 'standard' || !await fs.pathExists(path.join(DIST_ROOT, 'app.json'))) {
     standardBuildPromise = null
   }
 

--- a/packages/weapp-vite/src/plugins/autoImport.test.ts
+++ b/packages/weapp-vite/src/plugins/autoImport.test.ts
@@ -1,3 +1,5 @@
+import type { ResolvedConfig } from 'vite'
+import type { CompilerContext } from '../context'
 import { fs } from '@weapp-core/shared/fs'
 import path from 'pathe'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -930,21 +932,31 @@ describe('autoImport plugin', () => {
     }
   })
 
-  it('refreshes importers after watchChange registers a newly created component', async () => {
+  it('refreshes importers across component filename and tag casing on create and delete', async () => {
     const tempRoot = path.resolve(import.meta.dirname, '../test/__temp__')
     await fs.ensureDir(tempRoot)
     const tempDir = await fs.mkdtemp(path.join(tempRoot, 'auto-import-watch-change-refresh-'))
     const srcRoot = path.join(tempDir, 'src')
     const pageVueFile = path.join(srcRoot, 'pages/index/index.vue')
-    const hotCardFile = path.join(srcRoot, 'components/HotCard/index.vue')
+    const componentFile = path.join(srcRoot, 'components/VPascalKebabTagProbe.vue')
+    const pageBaseName = pageVueFile.replace(/\.vue$/, '')
     await fs.ensureDir(path.dirname(pageVueFile))
-    await fs.ensureDir(path.dirname(hotCardFile))
-    await fs.writeFile(pageVueFile, '<template><HotCard /></template>', 'utf8')
-    await fs.writeFile(hotCardFile, '<template><view>hot</view></template>', 'utf8')
+    await fs.ensureDir(path.dirname(componentFile))
+    await fs.writeFile(pageVueFile, '<template><v-pascal-kebab-tag-probe /></template>', 'utf8')
+    await fs.writeFile(componentFile, '<template><view>probe</view></template>', 'utf8')
 
     const registerPotentialComponent = vi.fn().mockResolvedValue(undefined)
+    const removePotentialComponent = vi.fn()
+    const resolve = vi.fn(() => ({
+      value: {
+        name: 'VPascalKebabTagProbe',
+        from: '/components/VPascalKebabTagProbe',
+      },
+    }))
+    const touchSpy = vi.spyOn(fs, 'utimes').mockResolvedValue()
     chokidarWatchMock.mockReturnValue(createMockSidecarWatcher())
 
+    // 单元测试仅提供 watch 组件刷新路径需要的最小编译上下文。
     const ctx = {
       runtimeState: {
         autoImport: {
@@ -956,8 +968,8 @@ describe('autoImport plugin', () => {
       },
       wxmlService: {
         wxmlComponentsMap: new Map([
-          [pageVueFile.replace(/\.vue$/, ''), {
-            HotCard: [{ start: 0, end: 9 }],
+          [pageBaseName, {
+            'v-pascal-kebab-tag-probe': [{ start: 0, end: 26 }],
           }],
         ]),
       },
@@ -978,38 +990,38 @@ describe('autoImport plugin', () => {
         awaitManifestWrites: vi.fn().mockResolvedValue(undefined),
         filter: (target: string) => target.includes('components/'),
         registerPotentialComponent,
-        removePotentialComponent: vi.fn(),
-        resolve: vi.fn(() => ({
-          value: {
-            name: 'HotCard',
-            from: '/components/HotCard/index',
-          },
-        })),
+        removePotentialComponent,
+        resolve,
         getRegisteredLocalComponents: vi.fn(),
       },
-    } as any
+    } as unknown as CompilerContext
 
     try {
       const plugin = autoImport(ctx)[0]
-      plugin.configResolved?.({ build: { outDir: 'dist' } } as any)
+      const resolvedConfig = { build: { outDir: 'dist' } } as unknown as ResolvedConfig
+      plugin.configResolved?.(resolvedConfig)
       await plugin.buildStart?.()
 
       registerPotentialComponent.mockClear()
-      const initialPageStat = await fs.stat(pageVueFile)
-      await new Promise(resolve => setTimeout(resolve, 20))
+      await plugin.watchChange?.(componentFile, { event: 'create' })
 
-      await plugin.watchChange?.('components/HotCard/index.vue', { event: 'create' } as any)
+      expect(registerPotentialComponent).toHaveBeenCalledWith(componentFile)
+      expect(resolve).toHaveBeenCalledWith('v-pascal-kebab-tag-probe', pageBaseName)
+      expect(touchSpy).toHaveBeenCalledWith(pageVueFile, expect.any(Date), expect.any(Date))
+      expect(ctx.runtimeState.autoImport.pendingEntriesByImporter.get(pageBaseName)).toEqual(
+        new Set(['/components/VPascalKebabTagProbe']),
+      )
 
-      await vi.waitFor(async () => {
-        expect(registerPotentialComponent).toHaveBeenCalledWith(hotCardFile)
-        const nextPageStat = await fs.stat(pageVueFile)
-        expect(nextPageStat.mtimeMs).toBeGreaterThan(initialPageStat.mtimeMs)
-        expect(ctx.runtimeState.autoImport.pendingEntriesByImporter.get(pageVueFile.replace(/\.vue$/, ''))).toEqual(
-          new Set(['/components/HotCard/index']),
-        )
-      })
+      resolve.mockClear()
+      touchSpy.mockClear()
+      await plugin.watchChange?.(componentFile, { event: 'delete' })
+
+      expect(removePotentialComponent).toHaveBeenCalledWith(componentFile)
+      expect(resolve).toHaveBeenCalledWith('v-pascal-kebab-tag-probe', pageBaseName)
+      expect(touchSpy).toHaveBeenCalledWith(pageVueFile, expect.any(Date), expect.any(Date))
     }
     finally {
+      touchSpy.mockRestore()
       await fs.remove(tempDir)
       if (await fs.pathExists(tempRoot)) {
         const remaining = await fs.readdir(tempRoot)

--- a/packages/weapp-vite/src/plugins/autoImport.ts
+++ b/packages/weapp-vite/src/plugins/autoImport.ts
@@ -12,6 +12,7 @@ import { defaultExcluded } from '../defaults'
 import { getAutoImportConfig } from '../runtime/autoImport/config'
 import { createSidecarWatchOptions } from '../runtime/watch/options'
 import { findJsEntry, findVueEntry, toPosixPath, touch } from '../utils'
+import { toKebabCaseComponentName } from '../utils/json'
 
 interface AutoImportState {
   ctx: CompilerContext
@@ -275,6 +276,21 @@ async function runAutoImportBatch<T>(
   }
   return await task()
 }
+function findMatchingComponentName(components: ComponentsMap, componentName: string) {
+  if (hasOwn(components, componentName)) {
+    return componentName
+  }
+
+  const normalizedComponentName = toKebabCaseComponentName(componentName)
+  for (const candidateName in components) {
+    if (
+      hasOwn(components, candidateName)
+      && toKebabCaseComponentName(candidateName) === normalizedComponentName
+    ) {
+      return candidateName
+    }
+  }
+}
 
 async function refreshAutoImportImporters(ctx: AutoImportState['ctx'], filePath: string) {
   const { wxmlService, configService, autoImportService } = ctx
@@ -290,12 +306,13 @@ async function refreshAutoImportImporters(ctx: AutoImportState['ctx'], filePath:
   const touchedImporters = new Set<string>()
   const entries = Array.from(wxmlService.wxmlComponentsMap.entries()) as Array<[string, ComponentsMap]>
   for (const [baseName, components] of entries) {
-    if (!hasOwn(components, componentName)) {
+    const matchingComponentName = findMatchingComponentName(components, componentName)
+    if (!matchingComponentName) {
       continue
     }
 
     const pendingEntriesByImporter = ctx.runtimeState?.autoImport?.pendingEntriesByImporter
-    const resolvedComponent = autoImportService?.resolve(componentName, baseName)
+    const resolvedComponent = autoImportService?.resolve(matchingComponentName, baseName)
     const pendingEntry = resolvedComponent?.value.from
     if (pendingEntriesByImporter && pendingEntry) {
       const pendingEntries = pendingEntriesByImporter.get(baseName) ?? new Set<string>()

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/autoImport.test.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/autoImport.test.ts
@@ -276,12 +276,12 @@ describe('createAutoImportAugmenter', () => {
     )
   })
 
-  it('registers existing local SFC candidates for unresolved template tags before retrying', async () => {
+  it('registers existing kebab SFC candidates for unresolved Pascal template tags before retrying', async () => {
     const tempRoot = path.resolve(import.meta.dirname, '../../../test/__temp__')
     await fs.ensureDir(tempRoot)
     const tempDir = await fs.mkdtemp(path.join(tempRoot, 'auto-import-augmenter-'))
     const srcRoot = path.join(tempDir, 'src')
-    const hotCardPath = path.join(srcRoot, 'components/HotCard/index.vue')
+    const hotCardPath = path.join(srcRoot, 'components/hot-card.vue')
     await fs.ensureDir(path.dirname(hotCardPath))
     await fs.writeFile(hotCardPath, '<template><view>hot</view></template>', 'utf8')
 
@@ -290,8 +290,8 @@ describe('createAutoImportAugmenter', () => {
       if (registered && name === 'HotCard') {
         return {
           value: {
-            name: 'HotCard',
-            from: '/components/HotCard/index',
+            name: 'hot-card',
+            from: '/components/hot-card',
             resolvedId: hotCardPath,
           },
         }
@@ -332,10 +332,10 @@ describe('createAutoImportAugmenter', () => {
       expect(registerPotentialComponent).toHaveBeenCalledTimes(1)
       expect(resolve).toHaveBeenCalledWith('HotCard', path.join(srcRoot, 'pages/index/index'))
       expect(json.usingComponents).toEqual({
-        HotCard: '/components/HotCard/index',
+        'hot-card': '/components/hot-card',
       })
-      expect(injectedEntries).toEqual(['/components/HotCard/index'])
-      expect(componentEntryMap.get('components/HotCard/index')).toBe(hotCardPath)
+      expect(injectedEntries).toEqual(['/components/hot-card'])
+      expect(componentEntryMap.get('components/hot-card')).toBe(hotCardPath)
     }
     finally {
       await fs.remove(tempDir)

--- a/packages/weapp-vite/src/plugins/hooks/useLoadEntry/autoImport.ts
+++ b/packages/weapp-vite/src/plugins/hooks/useLoadEntry/autoImport.ts
@@ -3,6 +3,7 @@ import { get, isObject, set } from '@weapp-core/shared'
 import { fs } from '@weapp-core/shared/fs'
 import path from 'pathe'
 import { getAutoImportConfig } from '../../../runtime/autoImport/config/defaults'
+import { toKebabCaseComponentName } from '../../../utils/json'
 
 const GLOB_WILDCARD_RE = /[*?[{]/
 const AUTO_IMPORT_LOCAL_EXTENSIONS = ['vue', 'wxml', 'js', 'ts', 'json'] as const
@@ -44,7 +45,11 @@ function collectLocalCandidatePaths(
   globs: string[],
   absoluteSrcRoot: string,
 ) {
-  const names = new Set([componentName, toPascalTagName(componentName)])
+  const names = new Set([
+    componentName,
+    toPascalTagName(componentName),
+    toKebabCaseComponentName(componentName),
+  ])
   const candidates = new Set<string>()
   for (const glob of globs) {
     const extensions = collectAutoImportGlobExtensions(glob)

--- a/packages/weapp-vite/src/runtime/autoImport/service.test.ts
+++ b/packages/weapp-vite/src/runtime/autoImport/service.test.ts
@@ -38,4 +38,82 @@ describe('autoImport service resolver normalization', () => {
       },
     })
   })
+
+  it('resolves local components across PascalCase and kebab-case filename styles', () => {
+    const runtimeState = createRuntimeState()
+    const kebabFileComponent = {
+      kind: 'local' as const,
+      entry: {
+        path: '/project/src/components/v-button.vue',
+        json: { component: true },
+        jsonPath: '/project/src/components/v-button.vue',
+        type: 'component' as const,
+        templatePath: '/project/src/components/v-button.vue',
+      },
+      value: {
+        name: 'v-button',
+        from: '/components/v-button',
+        resolvedId: '/project/src/components/v-button.vue',
+      },
+    }
+    const pascalFileComponent = {
+      kind: 'local' as const,
+      entry: {
+        path: '/project/src/components/VInput.vue',
+        json: { component: true },
+        jsonPath: '/project/src/components/VInput.vue',
+        type: 'component' as const,
+        templatePath: '/project/src/components/VInput.vue',
+      },
+      value: {
+        name: 'VInput',
+        from: '/components/VInput',
+        resolvedId: '/project/src/components/VInput.vue',
+      },
+    }
+    runtimeState.autoImport.registry.set('v-button', kebabFileComponent)
+    runtimeState.autoImport.registry.set('VInput', pascalFileComponent)
+
+    // 单元测试仅提供组件解析路径需要的最小编译上下文。
+    const ctx = {
+      runtimeState,
+      configService: {
+        cwd: '/project',
+        currentSubPackageRoot: undefined,
+        weappViteConfig: {
+          autoImportComponents: {
+            output: false,
+            typedComponents: false,
+            htmlCustomData: false,
+            vueComponents: false,
+          },
+        },
+      },
+    } as unknown as Parameters<typeof createAutoImportService>[0]
+    const service = createAutoImportService(ctx)
+
+    expect(service.resolve('VButton')).toBe(kebabFileComponent)
+    expect(service.resolve('v-input')).toBe(pascalFileComponent)
+
+    const pascalCollisionComponent = {
+      ...kebabFileComponent,
+      entry: {
+        ...kebabFileComponent.entry,
+        path: '/project/src/components/VButton.vue',
+        jsonPath: '/project/src/components/VButton.vue',
+        templatePath: '/project/src/components/VButton.vue',
+      },
+      value: {
+        name: 'VButton',
+        from: '/components/VButton',
+        resolvedId: '/project/src/components/VButton.vue',
+      },
+    }
+    runtimeState.autoImport.registry.set('VButton', pascalCollisionComponent)
+    const collisionService = createAutoImportService(ctx)
+
+    expect(collisionService.resolve('v-button')).toBe(kebabFileComponent)
+    expect(collisionService.resolve('VButton')).toBe(pascalCollisionComponent)
+    expect(collisionService.resolve('vButton')).toBeUndefined()
+  })
 })

--- a/packages/weapp-vite/src/runtime/autoImport/service/actions.ts
+++ b/packages/weapp-vite/src/runtime/autoImport/service/actions.ts
@@ -5,9 +5,11 @@ import type { RegistryHelpers } from './registry'
 import type { ResolverHelpers } from './resolver'
 import type { AutoImportService, ResolverAutoImportMatch } from './types'
 import { removeExtensionDeep } from '@weapp-core/shared'
+import { toKebabCaseComponentName } from '../../../utils/json'
 
 interface AutoImportActionsOptions {
   registry: Map<string, LocalAutoImportMatch>
+  normalizedLocalComponents: Map<string, LocalAutoImportMatch>
   autoImportState: MutableCompilerContext['runtimeState']['autoImport']
   resolvedResolverComponents: Map<string, string>
   componentMetadataMap: Map<string, ComponentMetadata>
@@ -90,6 +92,7 @@ export function createAutoImportActions(
     reset() {
       bumpVersion()
       options.registry.clear()
+      options.normalizedLocalComponents.clear()
       options.autoImportState.matcher = undefined
       options.autoImportState.matcherKey = ''
       options.autoImportState.preparedGlobsKey = undefined
@@ -163,6 +166,7 @@ export function createAutoImportActions(
 
     resolve(componentName: string, importerBaseName?: string) {
       const local = options.registry.get(componentName)
+        ?? options.normalizedLocalComponents.get(toKebabCaseComponentName(componentName))
       if (local) {
         return local
       }

--- a/packages/weapp-vite/src/runtime/autoImport/service/index.test.ts
+++ b/packages/weapp-vite/src/runtime/autoImport/service/index.test.ts
@@ -9,6 +9,7 @@ const createResolverHelpersMock = vi.hoisted(() => vi.fn())
 const createMetadataHelpersMock = vi.hoisted(() => vi.fn())
 const createOutputsHelpersMock = vi.hoisted(() => vi.fn())
 const createRegistryHelpersMock = vi.hoisted(() => vi.fn())
+const rebuildNormalizedLocalComponentsMock = vi.hoisted(() => vi.fn())
 const loggerWarnMock = vi.hoisted(() => vi.fn())
 
 vi.mock('../config', () => ({
@@ -32,6 +33,7 @@ vi.mock('./outputs', () => ({
 
 vi.mock('./registry', () => ({
   createRegistryHelpers: createRegistryHelpersMock,
+  rebuildNormalizedLocalComponents: rebuildNormalizedLocalComponentsMock,
 }))
 
 vi.mock('../../../context/shared', () => ({
@@ -105,6 +107,10 @@ describe('autoImport service index', () => {
     ctx.runtimeState.autoImport.matcherKey = 'dirty'
     ctx.runtimeState.autoImport.preparedGlobsKey = 'components/**/*'
     const service = createAutoImportService(ctx)
+    expect(rebuildNormalizedLocalComponentsMock).toHaveBeenCalledWith(
+      ctx.runtimeState.autoImport.registry,
+      ctx.runtimeState.autoImport.normalizedLocalComponents,
+    )
 
     service.reset()
 

--- a/packages/weapp-vite/src/runtime/autoImport/service/index.ts
+++ b/packages/weapp-vite/src/runtime/autoImport/service/index.ts
@@ -8,7 +8,7 @@ import {
 import { createAutoImportActions } from './actions'
 import { createMetadataHelpers } from './metadata'
 import { createOutputsHelpers } from './outputs'
-import { createRegistryHelpers } from './registry'
+import { createRegistryHelpers, rebuildNormalizedLocalComponents } from './registry'
 import { createResolverHelpers } from './resolver'
 import { createAutoImportScheduling } from './scheduling'
 import { logWarnOnce } from './shared'
@@ -19,6 +19,8 @@ export type { AutoImportMatch, AutoImportService, ResolverAutoImportMatch } from
 export function createAutoImportService(ctx: MutableCompilerContext): AutoImportService {
   const autoImportState = ctx.runtimeState.autoImport
   const registry = autoImportState.registry
+  const normalizedLocalComponents = autoImportState.normalizedLocalComponents
+  rebuildNormalizedLocalComponents(registry, normalizedLocalComponents)
   const resolvedResolverComponents = autoImportState.resolvedResolverComponents
   const manifestFileName = DEFAULT_AUTO_IMPORT_MANIFEST_FILENAME
   const manifestCache = new Map<string, string>()
@@ -97,6 +99,7 @@ export function createAutoImportService(ctx: MutableCompilerContext): AutoImport
   const registryHelpers = createRegistryHelpers({
     ctx,
     registry,
+    normalizedLocalComponents,
     autoImportState,
     resolverComponentNames,
     componentMetadataMap,
@@ -112,6 +115,7 @@ export function createAutoImportService(ctx: MutableCompilerContext): AutoImport
 
   const actions = createAutoImportActions({
     registry,
+    normalizedLocalComponents,
     autoImportState,
     resolvedResolverComponents,
     componentMetadataMap,

--- a/packages/weapp-vite/src/runtime/autoImport/service/registry.test.ts
+++ b/packages/weapp-vite/src/runtime/autoImport/service/registry.test.ts
@@ -105,6 +105,7 @@ function createState() {
       jsonService,
     },
     registry: new Map<string, any>(),
+    normalizedLocalComponents: new Map(),
     autoImportState,
     resolverComponentNames: new Set<string>(),
     componentMetadataMap: new Map<string, any>(),
@@ -175,9 +176,14 @@ describe('autoImport registry helpers', () => {
 
   it('removes registered local component by template/js/json/baseName', () => {
     const state = createState()
-    state.registry.set('CompA', createLocalEntry('/project/src/components/a/index'))
-    state.registry.set('CompB', createLocalEntry('/project/src/components/b/index'))
+    const compA = createLocalEntry('/project/src/components/a/index')
+    const compB = createLocalEntry('/project/src/components/b/index')
+    const semanticDuplicate = createLocalEntry('/project/src/components/a-kebab/index')
+    state.registry.set('CompA', compA)
+    state.registry.set('comp-a', semanticDuplicate)
+    state.registry.set('CompB', compB)
     state.registry.set('ResolverOnly', { kind: 'resolver', value: { name: 'ResolverOnly', from: 'pkg/a' } })
+    state.normalizedLocalComponents.set('comp-b', compB)
 
     const helpers = createRegistryHelpers(state)
 
@@ -185,10 +191,17 @@ describe('autoImport registry helpers', () => {
       removed: true,
       removedNames: ['CompA'],
     })
+    expect(state.normalizedLocalComponents.get('comp-a')).toBe(semanticDuplicate)
     expect(helpers.removeRegisteredComponent({ jsEntry: '/project/src/components/b/index.js' })).toEqual({
       removed: true,
       removedNames: ['CompB'],
     })
+    expect(state.normalizedLocalComponents.has('comp-b')).toBe(false)
+    expect(helpers.removeRegisteredComponent({ jsEntry: '/project/src/components/a-kebab/index.js' })).toEqual({
+      removed: true,
+      removedNames: ['comp-a'],
+    })
+    expect(state.normalizedLocalComponents.has('comp-a')).toBe(false)
     expect(helpers.removeRegisteredComponent({ baseName: '/project/src/components/missing/index' })).toEqual({
       removed: false,
       removedNames: [],

--- a/packages/weapp-vite/src/runtime/autoImport/service/registry.ts
+++ b/packages/weapp-vite/src/runtime/autoImport/service/registry.ts
@@ -9,6 +9,7 @@ import { resolveAstEngine } from '../../../ast'
 import { isBuiltinComponent } from '../../../auto-import-components/builtin'
 import { logger, resolvedComponentName } from '../../../context/shared'
 import { extractConfigFromVue, findJsEntry, findJsonEntry, findTemplateEntry, findVueEntry } from '../../../utils'
+import { toKebabCaseComponentName } from '../../../utils/json'
 import { extractComponentProps } from '../../componentProps'
 import { requireConfigService } from '../../utils/requireConfigService'
 import { getAutoImportConfig, getHtmlCustomDataSettings, getTypedComponentsSettings, getVueComponentsSettings } from '../config'
@@ -32,6 +33,7 @@ interface RegistryState {
   ctx: MutableCompilerContext
   registry: Map<string, LocalAutoImportMatch>
   autoImportState: MutableCompilerContext['runtimeState']['autoImport']
+  normalizedLocalComponents: Map<string, LocalAutoImportMatch>
   resolverComponentNames: Set<string>
   componentMetadataMap: Map<string, ComponentMetadata>
   logWarnOnce: (message: string) => void
@@ -40,6 +42,51 @@ interface RegistryState {
   scheduleTypedComponentsWrite: (shouldWrite: boolean) => void
   scheduleHtmlCustomDataWrite: (shouldWrite: boolean) => void
   scheduleVueComponentsWrite: (shouldWrite: boolean) => void
+}
+
+export function rebuildNormalizedLocalComponents(
+  registry: Map<string, LocalAutoImportMatch>,
+  normalizedLocalComponents: Map<string, LocalAutoImportMatch>,
+) {
+  normalizedLocalComponents.clear()
+  const ambiguousNames = new Set<string>()
+  for (const [componentName, match] of registry) {
+    const normalizedName = toKebabCaseComponentName(componentName)
+    if (ambiguousNames.has(normalizedName)) {
+      continue
+    }
+    if (normalizedLocalComponents.has(normalizedName)) {
+      normalizedLocalComponents.delete(normalizedName)
+      ambiguousNames.add(normalizedName)
+      continue
+    }
+    normalizedLocalComponents.set(normalizedName, match)
+  }
+}
+
+function refreshNormalizedLocalComponent(
+  registry: Map<string, LocalAutoImportMatch>,
+  normalizedLocalComponents: Map<string, LocalAutoImportMatch>,
+  normalizedName: string,
+) {
+  let normalizedMatch: LocalAutoImportMatch | undefined
+  for (const [componentName, match] of registry) {
+    if (toKebabCaseComponentName(componentName) !== normalizedName) {
+      continue
+    }
+    if (normalizedMatch) {
+      normalizedLocalComponents.delete(normalizedName)
+      return
+    }
+    normalizedMatch = match
+  }
+
+  if (normalizedMatch) {
+    normalizedLocalComponents.set(normalizedName, normalizedMatch)
+  }
+  else {
+    normalizedLocalComponents.delete(normalizedName)
+  }
 }
 
 export function createRegistryHelpers(state: RegistryState): RegistryHelpers {
@@ -67,6 +114,7 @@ export function createRegistryHelpers(state: RegistryState): RegistryHelpers {
     const { baseName, templatePath, jsEntry, jsonPath } = paths
     let removed = false
     const removedNames: string[] = []
+    const removedNormalizedNames = new Set<string>()
     for (const [key, value] of state.registry) {
       if (value.kind !== 'local') {
         continue
@@ -85,8 +133,12 @@ export function createRegistryHelpers(state: RegistryState): RegistryHelpers {
         if (state.registry.delete(key)) {
           removed = true
           removedNames.push(key)
+          removedNormalizedNames.add(toKebabCaseComponentName(key))
         }
       }
+    }
+    for (const normalizedName of removedNormalizedNames) {
+      refreshNormalizedLocalComponent(state.registry, state.normalizedLocalComponents, normalizedName)
     }
 
     return { removed, removedNames }
@@ -191,7 +243,7 @@ export function createRegistryHelpers(state: RegistryState): RegistryHelpers {
       state.ctx.configService.relativeCwd(sourceWithoutExt),
     )}`
 
-    state.registry.set(componentName, {
+    const match: LocalAutoImportMatch = {
       kind: 'local',
       entry: {
         path: resolvedJsEntry,
@@ -205,7 +257,9 @@ export function createRegistryHelpers(state: RegistryState): RegistryHelpers {
         from,
         resolvedId: resolvedJsEntry,
       },
-    })
+    }
+    state.registry.set(componentName, match)
+    refreshNormalizedLocalComponent(state.registry, state.normalizedLocalComponents, toKebabCaseComponentName(componentName))
 
     state.scheduleManifestWrite(true)
 

--- a/packages/weapp-vite/src/runtime/resetRuntimeState.test.ts
+++ b/packages/weapp-vite/src/runtime/resetRuntimeState.test.ts
@@ -10,7 +10,23 @@ describe('runtime state fresh build reset', () => {
     const previousHmr = state.build.hmr
 
     state.autoImport.version = 4
-    state.autoImport.registry.set('Button', {} as any)
+    const component = {
+      kind: 'local' as const,
+      entry: {
+        path: '/project/src/components/Button.vue',
+        json: { component: true },
+        jsonPath: '/project/src/components/Button.vue',
+        type: 'component' as const,
+        templatePath: '/project/src/components/Button.vue',
+      },
+      value: {
+        name: 'Button',
+        from: '/components/Button',
+        resolvedId: '/project/src/components/Button.vue',
+      },
+    }
+    state.autoImport.registry.set('Button', component)
+    state.autoImport.normalizedLocalComponents.set('button', component)
     state.build.hmr.loadedEntrySet.add('/project/src/pages/index.ts')
     state.json.emittedSource.set('app.json', '{}')
     state.css.transformedSidecarSource.set('/project/src/pages/index/index.css', {
@@ -37,6 +53,7 @@ describe('runtime state fresh build reset', () => {
     expect(state.build.hmr.loadedEntrySet.size).toBe(0)
     expect(state.autoImport.version).toBe(5)
     expect(state.autoImport.registry.size).toBe(0)
+    expect(state.autoImport.normalizedLocalComponents.size).toBe(0)
     expect(state.json.emittedSource.size).toBe(0)
     expect(state.css.transformedSidecarSource.size).toBe(0)
     expect(state.css.emittedSource.size).toBe(0)

--- a/packages/weapp-vite/src/runtime/resetRuntimeState.ts
+++ b/packages/weapp-vite/src/runtime/resetRuntimeState.ts
@@ -24,6 +24,7 @@ export function resetRuntimeStateForFreshBuild(runtimeState: RuntimeState): void
 
   const autoImport = runtimeState.autoImport
   autoImport.registry.clear()
+  autoImport.normalizedLocalComponents.clear()
   autoImport.resolvedResolverComponents.clear()
   autoImport.matcher = undefined
   autoImport.matcherKey = fresh.autoImport.matcherKey

--- a/packages/weapp-vite/src/runtime/runtimeState.ts
+++ b/packages/weapp-vite/src/runtime/runtimeState.ts
@@ -107,6 +107,7 @@ export interface RuntimeState {
   }
   autoImport: {
     registry: Map<string, LocalAutoImportMatch>
+    normalizedLocalComponents: Map<string, LocalAutoImportMatch>
     resolvedResolverComponents: Map<string, string>
     matcher?: (input: string) => boolean
     matcherKey: string
@@ -347,6 +348,7 @@ export function createRuntimeState(): RuntimeState {
     },
     autoImport: {
       registry: new Map<string, LocalAutoImportMatch>(),
+      normalizedLocalComponents: new Map<string, LocalAutoImportMatch>(),
       resolvedResolverComponents: new Map<string, string>(),
       matcherKey: '',
       preparedGlobsKey: undefined,


### PR DESCRIPTION
## Problem / Goal

本地自动导入组件只按扫描得到的文件名精确查找。组件文件名与模板标签分别使用 kebab-case 和 PascalCase 时，构建会保留标签却漏掉 `usingComponents`；dev/watch 的新增、变更和删除也可能不刷新引用页。

## Reproduction / Baseline

在 issue #900 的四组合场景中，修复前运行：

```sh
pnpm vitest run -c ./e2e/vitest.e2e.ci.build-only.config.ts e2e/ci/github-issues.build.test.ts -t "issue #900 regression"
```

预期注册 4 个组件，实际只注册文件名与标签风格一致的 2 个；两个交叉风格组合缺失。补充的 watch 与 lazy retry 回归在修复前分别观察到引用解析调用为 0、候选组件注册次数为 0。

## Root cause / Design

扫描阶段以组件原始文件名注册，模板阶段及 #806 后的最终标签可能使用另一种大小写风格。registry、watch importer 刷新和 lazy candidate retry 三个调用路径没有共享 kebab-case 语义。

修复保留精确名称优先级，并维护本地组件的规范化索引。仅在精确查找失败时使用 kebab-case fallback；语义重名时禁用模糊 fallback，避免并发扫描顺序决定结果。watch 刷新使用模板中实际匹配到的 key，lazy retry 同时检查原名、PascalCase 和 kebab-case 候选。

## Change

- 为本地组件 registry 增加规范化索引，并覆盖构建初始化、注册、删除、service reset 与 fresh-build reset。
- 补齐 dev/watch 的跨大小写 create/change/delete importer 刷新。
- 补齐 PascalCase 标签发现 kebab-case 本地 SFC 的 lazy retry。
- 新增 issue #900 四组合构建场景、focused unit regressions 和 changeset。
- `packages/weapp-vite/src/plugins/autoImport.ts` 与 `service/registry.ts` 修改前已超过 300 行。本次逻辑分别属于 watcher 刷新和 registry 生命周期唯一 ownership；拆出单用途文件只会增加跳转且不能简化控制流，因此未拆分。

## Non-goals

- 不修改第三方 resolver 的解析契约。
- 不新增公开配置或兼容别名。
- 不改变精确组件名的优先级。

## Verification

|Acceptance|Surface|Evidence|Result|
|---|---|---|---|
|双向大小写解析、生命周期、watch 与 lazy retry|focused Vitest|5 files / 52 tests|Pass|
|owning package 类型契约|`pnpm --filter weapp-vite typecheck`|exit 0|Pass|
|最新 CLI 产物|`pnpm --filter weapp-vite build`|48 files emitted|Pass|
|四组合真实构建输出|issue #900 build-only E2E|1 passed / 91 skipped|Pass|
|changeset 约束|frontmatter + create-weapp-vite checks|exit 0|Pass|
|独立验证与最终 review|fresh verifier + reviewer|no unresolved findings|Pass|

## Risks

- Compatibility: 精确名称行为不变；仅语义重名的非精确 fallback 由扫描顺序相关改为确定性不解析。
- Security/privacy: 无新增输入边界、secret 或个人信息；commit 使用 GitHub noreply identity。
- Performance/resources: resolve 热路径仍为精确 Map 优先、规范化 Map fallback；仅 registry 变更时扫描本地名称以恢复/抑制歧义。
- Platform/runtime: 路径与匹配使用现有跨平台 helper；未新增平台分支。

## Rollback

可直接 revert 本 PR；无数据迁移、持久化格式或公开 API 回滚要求。

## Related

Closes #900