### PR TITLE
修复内置 Tailwind CSS 集成的源码扫描与后置样式产物

### DIFF
--- a/.changeset/tidy-tailwindcss-bundle.md
+++ b/.changeset/tidy-tailwindcss-bundle.md
@@ -1,0 +1,5 @@
+---
+"weapp-vite": patch
+---
+
+修复内置 Tailwind CSS 集成对嵌套运行时配置、源码扫描规则和后置样式产物的处理，确保业务 utility 在最终 WXSS 中生成。

--- a/.changeset/tidy-tailwindcss-bundle.md
+++ b/.changeset/tidy-tailwindcss-bundle.md
@@ -1,5 +1,6 @@
 ---
 "weapp-vite": patch
+"create-weapp-vite": patch
 ---
 
 修复内置 Tailwind CSS 集成对嵌套运行时配置、源码扫描规则和后置样式产物的处理，确保业务 utility 在最终 WXSS 中生成。

--- a/packages/weapp-vite/src/plugins/tailwindcss.test.ts
+++ b/packages/weapp-vite/src/plugins/tailwindcss.test.ts
@@ -223,6 +223,15 @@ describe('managed Tailwind integration', () => {
 
     const plugins = getPlugins({
       cssEntries: [entry],
+      tailwindcss: {
+        v4: {
+          sources: [{
+            base: root,
+            pattern: 'src/**/*.{vue,ts}',
+            negated: false,
+          }],
+        },
+      },
       compiler: {
         maxRoots: 32,
         onRootEvicted,
@@ -262,6 +271,11 @@ describe('managed Tailwind integration', () => {
     } as unknown as OutputBundle
 
     await getHookHandler(plugin.generateBundle)?.call({ addWatchFile } as any, {} as any, bundle, false)
+    bundle['late.wxss'] = {
+      type: 'asset',
+      fileName: 'late.wxss',
+      source: marker,
+    } as any
     await getHookHandler(outputPlugin.generateBundle)?.call({ addWatchFile } as any, {} as any, bundle, false)
     await outputPlugin.closeBundle?.call({} as any)
 
@@ -269,6 +283,7 @@ describe('managed Tailwind integration', () => {
     expect((bundle['app.wxss'] as any).source).toContain('.author{color:red}')
     expect((bundle['app.wxss'] as any).source).not.toMatch(/@(plugin|source|theme)\b/)
     expect((bundle['app.wxss'] as any).source).not.toContain('managed-tailwindcss-entry')
+    expect((bundle['late.wxss'] as any).source).toContain('.gap-4_d25{gap:17rpx}')
     expect((bundle['pages/index/index.wxml'] as any).source).toContain('gap-4_d25')
     expect((bundle['app.js'] as any).code).toContain('gap-4_d25')
     expect(transformedCssSources[0]).toMatch(/@plugin "@iconify\/tailwind4"/)
@@ -286,6 +301,15 @@ describe('managed Tailwind integration', () => {
         onRootEvicted,
       },
     }))
+    expect(compiler.generate).toHaveBeenCalledWith(expect.objectContaining({
+      sourceOptions: expect.objectContaining({
+        sources: [{
+          base: root,
+          pattern: 'src/**/*.{vue,ts}',
+          negated: false,
+        }],
+      }),
+    }))
     expect(calls).toEqual([
       'start',
       'load',
@@ -295,6 +319,7 @@ describe('managed Tailwind integration', () => {
       'end',
       'start',
       'merge',
+      'wxss',
       'wxml',
       'js',
       'end',

--- a/packages/weapp-vite/src/plugins/tailwindcss.ts
+++ b/packages/weapp-vite/src/plugins/tailwindcss.ts
@@ -33,7 +33,18 @@ const VIRTUAL_ENTRY_PREFIX = '\0weapp-vite:managed-tailwindcss-entry:'
 const TAILWIND_IMPORT_RE = /@import\s+(?:url\(\s*)?['"]tailwindcss['"]\s*\)?(?:\s|;|$)/
 const TAILWIND_SOURCE_DIRECTIVE_RE = /@(?:config|custom-variant|layer|plugin|reference|source|tailwind|theme|utility|variant)\b/
 
-type TailwindV4SourceOptions = Extract<CompilerGenerateRequest, { sourceOptions: unknown }>['sourceOptions']
+interface TailwindV4SourcePattern {
+  base: string
+  pattern: string
+  negated: boolean
+}
+type TailwindV4SourceOptions = Extract<CompilerGenerateRequest, { sourceOptions: unknown }>['sourceOptions'] & {
+  sources?: TailwindV4SourcePattern[]
+}
+type TailwindcssRuntimeConfig = NonNullable<UserDefinedOptions['tailwindcss']>
+type TailwindcssConfigWithNestedRuntime = TailwindcssRuntimeConfig & {
+  tailwindcss?: TailwindcssRuntimeConfig
+}
 type ManagedTailwindcssOptions = UserDefinedOptions & Pick<CreateCompilerOptions, 'compiler'>
 
 interface ResolvedManagedTailwindcssOptions {
@@ -53,9 +64,12 @@ function resolveCssEntries(
   options: ManagedTailwindcssOptions,
   basedir: string,
 ) {
+  const tailwindcss = options.tailwindcss as TailwindcssConfigWithNestedRuntime | undefined
+  const nestedTailwindcss = tailwindcss?.tailwindcss
   const entries = unique([
     ...(options.cssEntries ?? []),
     ...(options.tailwindcss?.v4?.cssEntries ?? []),
+    ...(nestedTailwindcss?.v4?.cssEntries ?? []),
     ...(options.tailwindcssRuntimeOptions?.tailwindcss?.v4?.cssEntries ?? []),
   ]).map(entry => path.isAbsolute(entry) ? path.normalize(entry) : path.resolve(basedir, entry))
 
@@ -171,14 +185,17 @@ function createTailwindV4SourceOptions(
   resolved: ResolvedManagedTailwindcssOptions,
   entry: string,
 ): TailwindV4SourceOptions {
-  const tailwindcss = resolved.options.tailwindcss
+  const configuredTailwindcss = resolved.options.tailwindcss as TailwindcssConfigWithNestedRuntime | undefined
+  const tailwindcss = configuredTailwindcss?.tailwindcss ?? configuredTailwindcss
   const v4 = tailwindcss?.v4
+  const runtimeV4 = resolved.options.tailwindcssRuntimeOptions?.tailwindcss?.v4
   return {
     projectRoot: resolved.basedir,
     cwd: tailwindcss?.cwd,
     base: v4?.base,
     cssSources: v4?.cssSources,
     cssEntries: [entry],
+    sources: v4?.sources ?? runtimeV4?.sources,
     packageName: tailwindcss?.packageName ?? 'tailwindcss',
   }
 }
@@ -223,6 +240,7 @@ export function createTailwindcssPlugin(ctx: CompilerContext): Plugin[] {
   const compilerRootIds = new Map<number, string>()
   const compilerSourceOptions = new Map<number, TailwindV4SourceOptions>()
   const compilerSnapshots = new Map<number, CompilerSnapshot>()
+  const processedStyleOutputs = new WeakSet<object>()
   let generatedEntriesPromise: Promise<CompilerGenerateResult[]> | undefined
   let coreModulePromise: Promise<typeof import('weapp-tailwindcss/core')> | undefined
   let compilerPromise: Promise<Compiler> | undefined
@@ -349,6 +367,10 @@ export function createTailwindcssPlugin(ctx: CompilerContext): Plugin[] {
       if (output.type !== 'asset') {
         continue
       }
+      if (processedStyleOutputs.has(output)) {
+        generatedOutputEntries.get(output.fileName)?.forEach(index => seenEntries.add(index))
+        continue
+      }
       let source = outputAssetSource(output)
       let hasManagedEntry = false
       let isMainChunk = output.fileName === `app.${styleExtension}`
@@ -410,6 +432,7 @@ export function createTailwindcssPlugin(ctx: CompilerContext): Plugin[] {
       output.source = stripManagedTailwindcssOutputMarkers(
         await stripResidualTailwindSourceDirectives(transformed.css),
       )
+      processedStyleOutputs.add(output)
     }
 
     if (transformStyles && !ctx.configService.isDev && resolved.options.generator !== false) {
@@ -561,7 +584,7 @@ export function createTailwindcssPlugin(ctx: CompilerContext): Plugin[] {
       async handler(_options, bundle) {
         resolved.options.onStart?.()
         try {
-          await transformBundle.call(this, bundle as unknown as OutputBundle, { styles: false })
+          await transformBundle.call(this, bundle as unknown as OutputBundle)
         }
         finally {
           resolved.options.onEnd?.()


### PR DESCRIPTION
问题

weapp-vite@6.25.0 的内置 Tailwind CSS 适配没有完整传递 tailwindcss.v4.sources，且后置阶段不处理构建图后续生成的 WXSS 资产，导致真实项目只生成 theme 变量和残留 @tailwind utilities，业务 utility 丢失。

改动

- 兼容直接与嵌套的 Tailwind 运行时配置，传递 sources 与 CSS 入口。
- 让 output 阶段处理尚未在 pre 阶段出现的样式资产。
- 使用 bundle 对象级去重，避免 pre/post 阶段重复注入。
- 增加源码扫描配置和后置样式资产回归测试。

验证

- pnpm exec vitest run src/plugins/tailwindcss.test.ts（28/28）
- pnpm --filter weapp-vite typecheck
- pnpm --filter weapp-vite lint:src（0 errors）
- Varo 真实项目生产构建：51 页面、组件路径、WXML、主题和 Tailwind WXSS 校验全部通过，构建约 5.4 秒。

Related to #1127