### PR TITLE
fix(wevu): 完善首屏路由守卫生命周期门控

### DIFF
--- a/.changeset/issue-911-page-runtime-gate.md
+++ b/.changeset/issue-911-page-runtime-gate.md
@@ -1,0 +1,6 @@
+---
+'wevu': patch
+'create-weapp-vite': patch
+---
+
+完善首屏异步路由守卫门控，确保页面 setup、created、beforeMount、ready 和 mounted 生命周期均在 app-level 守卫完成后执行，并覆盖页面生命周期重入与守卫拒绝场景。

--- a/packages-runtime/wevu/src/runtime/register/component/lifecycle.ts
+++ b/packages-runtime/wevu/src/runtime/register/component/lifecycle.ts
@@ -1,3 +1,4 @@
+import type { LocationQueryRaw } from '../../../router/types'
 import type { MiniProgramPageLike } from '../../../routerInternal/shared'
 import type { ComponentPropsOptions, ComputedDefinitions, DefineComponentOptions, InternalRuntimeState, MethodDefinitions, RuntimeApp } from '../../types'
 import type { WatchMap } from '../watch'
@@ -16,9 +17,51 @@ import { attachOptionalPageLifecycleHooks } from './lifecycle/optionalHooks'
 import { bindCurrentPageInstance, ensureMiniProgramGlobalPatched, ensurePageShareMenus, releaseCurrentPageInstance, resolvePageOptions } from './lifecycle/platform'
 
 const INITIAL_NAVIGATION_PROMISE_KEY = Symbol('wevu.initialNavigationPromise')
+const INITIAL_NAVIGATION_START_KEY = Symbol('wevu.startInitialNavigation')
 
 export function getInitialNavigationPromise(instance: InternalRuntimeState) {
   return (instance as any)[INITIAL_NAVIGATION_PROMISE_KEY] as Promise<boolean> | undefined
+}
+
+export function ensureInitialNavigation(
+  instance: InternalRuntimeState,
+  query?: LocationQueryRaw,
+  options: { start?: boolean } = {},
+) {
+  const existing = getInitialNavigationPromise(instance)
+  if (existing) {
+    if (options.start !== false) {
+      ;(instance as any)[INITIAL_NAVIGATION_START_KEY]?.(query)
+    }
+    return existing
+  }
+  const initialNavigationRunner = getInitialNavigationRunner()
+  if (!initialNavigationRunner) {
+    return undefined
+  }
+  let resolveInitialNavigation!: (shouldMount: boolean) => void
+  let rejectInitialNavigation!: (error: unknown) => void
+  const initialNavigationPromise = new Promise<boolean>((resolve, reject) => {
+    resolveInitialNavigation = resolve
+    rejectInitialNavigation = reject
+  })
+  ;(instance as any)[INITIAL_NAVIGATION_PROMISE_KEY] = initialNavigationPromise
+  let started = false
+  ;(instance as any)[INITIAL_NAVIGATION_START_KEY] = (startQuery?: LocationQueryRaw) => {
+    if (started) {
+      return
+    }
+    started = true
+    void initialNavigationRunner(instance as MiniProgramPageLike, startQuery ?? query)
+      .then((result) => {
+        const shouldMount = !isNavigationFailure(result)
+        resolveInitialNavigation(shouldMount)
+      }, rejectInitialNavigation)
+  }
+  if (options.start !== false) {
+    ;(instance as any)[INITIAL_NAVIGATION_START_KEY](query)
+  }
+  return initialNavigationPromise
 }
 
 export function createPageLifecycleHooks<D extends object, C extends ComputedDefinitions, M extends MethodDefinitions>(options: {
@@ -119,24 +162,15 @@ export function createPageLifecycleHooks<D extends object, C extends ComputedDef
         }
       }
 
-      const initialNavigationRunner = isPage ? getInitialNavigationRunner() : undefined
-      if (initialNavigationRunner) {
-        let resolveInitialNavigation!: (shouldMount: boolean) => void
-        let rejectInitialNavigation!: (error: unknown) => void
-        const initialNavigationPromise = new Promise<boolean>((resolve, reject) => {
-          resolveInitialNavigation = resolve
-          rejectInitialNavigation = reject
-        })
-        ;(this as any)[INITIAL_NAVIGATION_PROMISE_KEY] = initialNavigationPromise
-        void initialNavigationRunner(this as MiniProgramPageLike, args[0])
-          .then((result) => {
-            if (isNavigationFailure(result)) {
-              resolveInitialNavigation(false)
-              return
-            }
+      const initialNavigationPromise = isPage
+        ? ensureInitialNavigation(this, args[0])
+        : undefined
+      if (initialNavigationPromise) {
+        void initialNavigationPromise.then((shouldMount) => {
+          if (shouldMount) {
             mountPage()
-            resolveInitialNavigation(true)
-          }, rejectInitialNavigation)
+          }
+        }, () => {})
         return initialNavigationPromise
       }
       return mountPage()

--- a/packages-runtime/wevu/src/runtime/register/component/registerDefinition.ts
+++ b/packages-runtime/wevu/src/runtime/register/component/registerDefinition.ts
@@ -30,7 +30,7 @@ import { getMiniProgramRuntimeGlobalObject } from '../../platform'
 import { getOwnerProxy } from '../../scopedSlots'
 import { clearTemplateRefs, scheduleTemplateRefUpdate } from '../../templateRefs'
 import { enableDeferredSetData, mountRuntimeInstance, refreshRuntimeInstance, setRuntimeSetDataVisibility, teardownRuntimeInstance } from '../runtimeInstance'
-import { getInitialNavigationPromise } from './lifecycle'
+import { ensureInitialNavigation, getInitialNavigationPromise } from './lifecycle'
 import { registerNativeComponentDefinition } from './registerNativeDefinition'
 
 function scheduleOwnerTemplateRefUpdate(target: InternalRuntimeState) {
@@ -150,6 +150,23 @@ export function registerComponentDefinition<D extends object, C extends Computed
     return undefined
   }
 
+  const deferPageUntilNavigation = (instance: InternalRuntimeState, task: () => void) => {
+    if (!isPage) {
+      task()
+      return
+    }
+    const initialNavigationPromise = ensureInitialNavigation(instance, undefined, { start: false })
+    if (!initialNavigationPromise) {
+      task()
+      return
+    }
+    void initialNavigationPromise.then((shouldMount) => {
+      if (shouldMount) {
+        task()
+      }
+    }, () => {})
+  }
+
   const ensureReadyRuntime = (instance: InternalRuntimeState) => {
     if (resolveRuntime(instance) || typeof vueLifecycles.mounted !== 'function') {
       return
@@ -212,7 +229,6 @@ export function registerComponentDefinition<D extends object, C extends Computed
     lifetimes: {
       ...userLifetimes,
       created: function created(this: InternalRuntimeState, ...args: any[]) {
-        callVueLifecycle(this, 'beforeCreate', args)
         applyExtraInstanceFields(this)
         if (Array.isArray(templateRefs) && templateRefs.length) {
           Object.defineProperty(this, WEVU_TEMPLATE_REFS_KEY, {
@@ -223,23 +239,27 @@ export function registerComponentDefinition<D extends object, C extends Computed
           })
         }
         attachWevuPropKeys(this)
-        if (setupLifecycle === 'created') {
-          try {
-            mountRuntimeInstance(this, runtimeApp, watch, setup, {
-              deferSetData: true,
-              snapshotOmitKeys: directPropsDerivedKeys,
-            })
+        const runCreated = () => {
+          callVueLifecycle(this, 'beforeCreate', args)
+          if (setupLifecycle === 'created') {
+            try {
+              mountRuntimeInstance(this, runtimeApp, watch, setup, {
+                deferSetData: true,
+                snapshotOmitKeys: directPropsDerivedKeys,
+              })
+            }
+            catch (error) {
+              const label = getRuntimeOwnerLabel(this)
+              throw new Error(`[wevu] mount runtime failed in created (${label}): ${error instanceof Error ? error.message : String(error)}`)
+            }
+            syncWevuPropsFromInstance(this)
+            attachPageLayoutSetter(this)
           }
-          catch (error) {
-            const label = getRuntimeOwnerLabel(this)
-            throw new Error(`[wevu] mount runtime failed in created (${label}): ${error instanceof Error ? error.message : String(error)}`)
+          if (typeof (userLifetimes as any).created === 'function') {
+            ;(userLifetimes as any).created.apply(this, args)
           }
-          syncWevuPropsFromInstance(this)
-          attachPageLayoutSetter(this)
         }
-        if (typeof (userLifetimes as any).created === 'function') {
-          ;(userLifetimes as any).created.apply(this, args)
-        }
+        deferPageUntilNavigation(this, runCreated)
       },
       moved: function moved(this: InternalRuntimeState, ...args: any[]) {
         callHookList(this, 'onMoved', args)
@@ -258,30 +278,44 @@ export function registerComponentDefinition<D extends object, C extends Computed
           })
         }
         attachWevuPropKeys(this)
-        if (setupLifecycle !== 'created' || !(this as any).__wevu) {
-          try {
-            mountRuntimeInstance(this, runtimeApp, watch, setup, {
-              deferSetData: true,
-              snapshotOmitKeys: directPropsDerivedKeys,
-            })
+        deferPageUntilNavigation(this, () => {
+          if (setupLifecycle !== 'created' || !(this as any).__wevu) {
+            try {
+              mountRuntimeInstance(this, runtimeApp, watch, setup, {
+                deferSetData: true,
+                snapshotOmitKeys: directPropsDerivedKeys,
+              })
+            }
+            catch (error) {
+              const label = getRuntimeOwnerLabel(this)
+              throw new Error(`[wevu] mount runtime failed in attached (${label}): ${error instanceof Error ? error.message : String(error)}`)
+            }
           }
-          catch (error) {
-            const label = getRuntimeOwnerLabel(this)
-            throw new Error(`[wevu] mount runtime failed in attached (${label}): ${error instanceof Error ? error.message : String(error)}`)
+          syncWevuPropsFromInstance(this)
+          callVueLifecycle(this, 'created', args)
+          callVueLifecycle(this, 'beforeMount', args)
+          attachPageLayoutSetter(this)
+          attachRuntimeLayoutHosts(this)
+          enableDeferredSetData(this)
+          callHookList(this, 'onAttached', args)
+          if (typeof (userLifetimes as any).attached === 'function') {
+            ;(userLifetimes as any).attached.apply(this, args)
           }
-        }
-        syncWevuPropsFromInstance(this)
-        callVueLifecycle(this, 'created', args)
-        callVueLifecycle(this, 'beforeMount', args)
-        attachPageLayoutSetter(this)
-        attachRuntimeLayoutHosts(this)
-        enableDeferredSetData(this)
-        callHookList(this, 'onAttached', args)
-        if (typeof (userLifetimes as any).attached === 'function') {
-          ;(userLifetimes as any).attached.apply(this, args)
-        }
+        })
       },
       ready: function ready(this: InternalRuntimeState, ...args: any[]) {
+        if (isPage && !(this as any)[WEVU_READY_CALLED_KEY]) {
+          const initialNavigationPromise = ensureInitialNavigation(this, undefined, { start: true })
+          if (initialNavigationPromise && !(this as any).__wevuInitialNavigationReady) {
+            void initialNavigationPromise.then((shouldMount) => {
+              if (shouldMount) {
+                ;(this as any).__wevuInitialNavigationReady = true
+                componentDefinition.lifetimes.ready.call(this, ...args)
+              }
+            }, () => {})
+            return
+          }
+        }
         ensureReadyRuntime(this)
         if (isPage && typeof (pageLifecycleHooks as any).onReady === 'function') {
           const wasReadyCalled = Boolean((this as any)[WEVU_READY_CALLED_KEY])

--- a/packages-runtime/wevu/test/runtime-component.test.ts
+++ b/packages-runtime/wevu/test/runtime-component.test.ts
@@ -15,6 +15,9 @@ import {
   resetWevuDefaults,
   setWevuDefaults,
 } from '@/index'
+import { createRouter } from '@/router'
+import { clearActiveRouter } from '@/router/instance'
+import { setCurrentInstance, setCurrentSetupContext } from '@/runtime/hooks'
 
 const registeredComponents: Record<string, any>[] = []
 
@@ -27,6 +30,10 @@ beforeEach(() => {
 })
 afterEach(() => {
   delete (globalThis as any).Component
+  delete (globalThis as any).getCurrentPages
+  clearActiveRouter()
+  setCurrentInstance(undefined)
+  setCurrentSetupContext(undefined)
   resetWevuDefaults()
 })
 
@@ -221,6 +228,180 @@ describe('runtime: component lifetimes/pageLifetimes mapping', () => {
     await Promise.resolve()
     expect(setData).toHaveBeenCalled()
     expect(setData.mock.calls[0]?.[0]).toMatchObject({ count: 1 })
+  })
+
+  it('does not run page setup before the initial async router guard', async () => {
+    const order: string[] = []
+    let resolveGuard!: () => void
+    ;(globalThis as any).getCurrentPages = vi.fn(() => [{
+      route: 'pages/home/index',
+      options: {},
+    }])
+    const routerInstance: any = {
+      __wevu: {},
+      router: {
+        switchTab: vi.fn(),
+        reLaunch: vi.fn(),
+        redirectTo: vi.fn(),
+        navigateTo: vi.fn(),
+        navigateBack: vi.fn(),
+      },
+    }
+    setCurrentInstance(routerInstance)
+    setCurrentSetupContext({ instance: routerInstance, emit: vi.fn(), attrs: {}, slots: {} })
+    const router = createRouter({
+      routes: [{ name: 'home', path: '/pages/home/index' }],
+    })
+    router.beforeEach(async () => {
+      order.push('guard-start')
+      await new Promise<void>((resolve) => {
+        resolveGuard = resolve
+      })
+      order.push('guard-done')
+    })
+
+    defineComponent({
+      __wevu_isPage: true,
+      setup() {
+        order.push('setup')
+        return {}
+      },
+    })
+
+    const opts = registeredComponents[0]
+    const instance: any = {
+      route: 'pages/home/index',
+      setData() {},
+    }
+    opts.lifetimes.attached.call(instance)
+    const pending = opts.onLoad.call(instance, {})
+    await Promise.resolve()
+    expect(order).toEqual(['guard-start'])
+
+    resolveGuard()
+    await pending
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(order).toEqual(['guard-start', 'guard-done', 'setup'])
+  })
+
+  it('gates created-lifecycle pages and rejects aborted initial navigation', async () => {
+    const order: string[] = []
+    ;(globalThis as any).getCurrentPages = vi.fn(() => [{
+      route: 'pages/home/index',
+      options: {},
+    }])
+    const routerInstance: any = {
+      __wevu: {},
+      router: {
+        switchTab: vi.fn(),
+        reLaunch: vi.fn(),
+        redirectTo: vi.fn(),
+        navigateTo: vi.fn(),
+        navigateBack: vi.fn(),
+      },
+    }
+    setCurrentInstance(routerInstance)
+    setCurrentSetupContext({ instance: routerInstance, emit: vi.fn(), attrs: {}, slots: {} })
+    const router = createRouter({
+      routes: [{ name: 'home', path: '/pages/home/index' }],
+    })
+    router.beforeEach(() => {
+      order.push('guard')
+      return false
+    })
+
+    defineComponent({
+      __wevu_isPage: true,
+      setupLifecycle: 'created',
+      beforeCreate() {
+        order.push('beforeCreate')
+      },
+      setup() {
+        order.push('setup')
+        return {}
+      },
+    })
+
+    const opts = registeredComponents[0]
+    const instance: any = {
+      route: 'pages/home/index',
+      setData() {},
+    }
+    opts.lifetimes.created.call(instance)
+    expect(order).toEqual([])
+    expect((instance as any).__wevu).toBeUndefined()
+
+    opts.lifetimes.attached.call(instance)
+    const pending = opts.onLoad.call(instance, {})
+    expect(order).toEqual(['guard'])
+    await expect(pending).resolves.toBe(false)
+    await Promise.resolve()
+    expect(order).toEqual(['guard'])
+    expect((instance as any).__wevu).toBeUndefined()
+  })
+
+  it('starts one initial guard when created, attached, onLoad, and ready overlap', async () => {
+    const order: string[] = []
+    let resolveGuard!: () => void
+    ;(globalThis as any).getCurrentPages = vi.fn(() => [{
+      route: 'pages/home/index',
+      options: {},
+    }])
+    const routerInstance: any = {
+      __wevu: {},
+      router: {
+        switchTab: vi.fn(),
+        reLaunch: vi.fn(),
+        redirectTo: vi.fn(),
+        navigateTo: vi.fn(),
+        navigateBack: vi.fn(),
+      },
+    }
+    setCurrentInstance(routerInstance)
+    setCurrentSetupContext({ instance: routerInstance, emit: vi.fn(), attrs: {}, slots: {} })
+    const router = createRouter({
+      routes: [{ name: 'home', path: '/pages/home/index' }],
+    })
+    const guard = vi.fn(async () => {
+      order.push('guard-start')
+      await new Promise<void>((resolve) => {
+        resolveGuard = resolve
+      })
+      order.push('guard-done')
+    })
+    router.beforeEach(guard)
+
+    defineComponent({
+      __wevu_isPage: true,
+      setup() {
+        order.push('setup')
+        return {}
+      },
+    })
+
+    const opts = registeredComponents[0]
+    const instance: any = {
+      route: 'pages/home/index',
+      setData() {},
+    }
+    opts.lifetimes.created.call(instance)
+    opts.lifetimes.attached.call(instance)
+    opts.lifetimes.ready.call(instance)
+    const pending = opts.onLoad.call(instance, {})
+    await Promise.resolve()
+    expect(guard).toHaveBeenCalledTimes(1)
+    expect(order).toEqual(['guard-start'])
+
+    resolveGuard()
+    await expect(pending).resolves.toBe(true)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(order).toContain('setup')
+    expect(order.indexOf('guard-done')).toBeLessThan(order.indexOf('setup'))
+    expect(guard).toHaveBeenCalledTimes(1)
   })
 
   it('runs setup in created when setupLifecycle is set and defers setData until attached', async () => {

--- a/packages-runtime/wevu/test/runtime-register-component-page-lifecycle.test.ts
+++ b/packages-runtime/wevu/test/runtime-register-component-page-lifecycle.test.ts
@@ -17,12 +17,14 @@ const mockState = vi.hoisted(() => {
     hooks,
     createPageLifecycleHooks: vi.fn(() => hooks),
     getInitialNavigationPromise: vi.fn(() => undefined),
+    ensureInitialNavigation: vi.fn(() => undefined),
   }
 })
 
 vi.mock('@/runtime/register/component/lifecycle', () => ({
   createPageLifecycleHooks: mockState.createPageLifecycleHooks,
   getInitialNavigationPromise: mockState.getInitialNavigationPromise,
+  ensureInitialNavigation: mockState.ensureInitialNavigation,
 }))
 
 const componentCalls: Record<string, any>[] = []


### PR DESCRIPTION
## 摘要

- 将首屏异步导航 gate 提升为页面实例级状态，created/attached/onLoad/ready 共用并保证只启动一次。
- 页面 `beforeCreate`、`setup`、`created`、`beforeMount`、`attached`、`ready`、`mounted` 均在 app-level `router.beforeEach` 完成后执行；守卫拒绝时不挂载页面 runtime。
- 补充默认 attached、显式 `setupLifecycle: "created"`、守卫拒绝和生命周期重入回归测试。

## 关联问题

- 修复并验证 #911。
- #910 的现有 native `require.async` 路径修复在本次 issue 构建矩阵中继续通过，未引入额外路径逻辑变更。

## 验证

- `pnpm --filter wevu typecheck`
- `pnpm --filter wevu test -- --runInBand`：891/891
- `pnpm --filter wevu build`
- issue 910 目标构建断言通过；同一 CI 文件的其他 4 项失败为既有 tdesign 依赖拷贝目录竞态（ENOENT），与本次改动无关。
- issue 911 headless E2E：1/1
- issue 911 WeChat DevTools E2E：1/1
- 变更文件 ESLint 与 `git diff --check` 通过。
