### PR TITLE
test(wevu): 补齐 issue 911 runtime 回归覆盖

### DIFF
--- a/e2e-apps/github-issues/src/shared/issue911.ts
+++ b/e2e-apps/github-issues/src/shared/issue911.ts
@@ -1,8 +1,29 @@
 import { useRouter } from 'wevu/router'
 
 const ISSUE_911_ROUTE = 'pages/issue-911/index'
+const ISSUE_911_TRACE_STORAGE_KEY = '__weapp_vite_issue_911_trace__'
 const trace: string[] = []
 let guardInstalled = false
+let traceMode: string | undefined
+
+type Issue911Mode = 'default' | 'redirect' | 'redirect-target' | 'abort'
+
+function resolveIssue911Mode(to: { query?: Record<string, unknown> }): Issue911Mode {
+  const mode = String(to.query?.mode ?? 'default')
+  return mode === 'redirect' || mode === 'redirect-target' || mode === 'abort'
+    ? mode
+    : 'default'
+}
+
+function recordIssue911Trace(mode: Issue911Mode, entry: string) {
+  trace.push(entry)
+  if (typeof wx !== 'undefined' && typeof wx.setStorageSync === 'function') {
+    wx.setStorageSync(ISSUE_911_TRACE_STORAGE_KEY, {
+      mode,
+      trace: [...trace],
+    })
+  }
+}
 
 export function ensureIssue911Guard() {
   if (guardInstalled) {
@@ -15,14 +36,32 @@ export function ensureIssue911Guard() {
       return
     }
 
-    trace.push('beforeEach:start')
+    const mode = resolveIssue911Mode(to)
+    if (traceMode !== mode && !(traceMode === 'redirect' && mode === 'redirect-target')) {
+      trace.length = 0
+    }
+    traceMode = mode
+    recordIssue911Trace(mode, 'beforeEach:start')
     await new Promise<void>(resolve => setTimeout(resolve, 100))
-    trace.push('beforeEach:done')
+    recordIssue911Trace(mode, 'beforeEach:done')
+    if (mode === 'abort') {
+      return false
+    }
+    if (mode === 'redirect') {
+      recordIssue911Trace(mode, 'redirect')
+      return `${ISSUE_911_ROUTE}?mode=redirect-target`
+    }
   })
 }
 
 export function recordIssue911Mounted() {
   trace.push('mounted')
+  if (typeof wx !== 'undefined' && typeof wx.setStorageSync === 'function') {
+    wx.setStorageSync(ISSUE_911_TRACE_STORAGE_KEY, {
+      mode: traceMode ?? 'default',
+      trace: [...trace],
+    })
+  }
 }
 
 export function readIssue911Trace() {

--- a/e2e/ide/github-issues.runtime.issue911.test.ts
+++ b/e2e/ide/github-issues.runtime.issue911.test.ts
@@ -5,9 +5,26 @@ import {
   PREPARE_GITHUB_ISSUES_BUILD_TIMEOUT,
   prepareGithubIssuesBuild,
   relaunchPage,
+  waitForCurrentPagePath,
 } from './github-issues.runtime.shared'
 
 const ISSUE_911_ROUTE = '/pages/issue-911/index'
+const ISSUE_911_REDIRECT_ROUTE = `${ISSUE_911_ROUTE}?mode=redirect`
+const ISSUE_911_ABORT_ROUTE = `${ISSUE_911_ROUTE}?mode=abort`
+const ISSUE_550_ROUTE = '/pages/issue-550/index'
+const ISSUE_911_TRACE_STORAGE_KEY = '__weapp_vite_issue_911_trace__'
+
+async function clearIssue911Trace(miniProgram: any) {
+  await miniProgram.callWxMethodWithOptions('removeStorageSync', {
+    timeout: 2_500,
+  }, ISSUE_911_TRACE_STORAGE_KEY).catch(() => {})
+}
+
+async function readIssue911Trace(miniProgram: any) {
+  return await miniProgram.callWxMethodWithOptions('getStorageSync', {
+    timeout: 2_500,
+  }, ISSUE_911_TRACE_STORAGE_KEY).catch(() => undefined)
+}
 
 describe.sequential('e2e app: github-issues / issue #911', () => {
   beforeAll(async () => {
@@ -32,5 +49,54 @@ describe.sequential('e2e app: github-issues / issue #911', () => {
       async () => await page?.callMethodWithOptions('_runE2E', { protocolTimeoutMs: 8_000 }),
       { timeout: 10_000 },
     ).toEqual(['beforeEach:start', 'beforeEach:done', 'mounted'])
+  })
+
+  it('waits for an async guard before resolving a redirect and mounting the initial page', async (ctx) => {
+    const miniProgram = await getSharedMiniProgram(ctx)
+    await clearIssue911Trace(miniProgram)
+    await miniProgram.reLaunch(ISSUE_911_REDIRECT_ROUTE).catch(() => {})
+    const page = await waitForCurrentPagePath(miniProgram, ISSUE_911_ROUTE, 10_000)
+    expect(page).toBeTruthy()
+    await expect.poll(
+      async () => (await readIssue911Trace(miniProgram))?.trace,
+      { timeout: 10_000 },
+    ).toEqual([
+      'beforeEach:start',
+      'beforeEach:done',
+      'redirect',
+      'beforeEach:start',
+      'beforeEach:done',
+      'mounted',
+    ])
+    expect((await readIssue911Trace(miniProgram))?.mode).toBe('redirect-target')
+  })
+
+  it('aborts after an async guard without mounting the target page', async (ctx) => {
+    const miniProgram = await getSharedMiniProgram(ctx)
+    await clearIssue911Trace(miniProgram)
+    await miniProgram.reLaunch(ISSUE_911_ABORT_ROUTE).catch(() => {})
+
+    await expect.poll(
+      async () => (await readIssue911Trace(miniProgram))?.trace,
+      { timeout: 10_000 },
+    ).toEqual(['beforeEach:start', 'beforeEach:done'])
+    expect((await readIssue911Trace(miniProgram))?.mode).toBe('abort')
+  })
+
+  it('does not run the issue guard for a subsequent non-target navigation', async (ctx) => {
+    const miniProgram = await getSharedMiniProgram(ctx)
+    const page = await relaunchPage(miniProgram, ISSUE_911_ROUTE, undefined, 45_000, {
+      readiness: async (targetPage) => {
+        await targetPage.waitForRendered({ selector: '#issue-911-page', timeout: 5_000 })
+        return true
+      },
+    })
+    expect(page).toBeTruthy()
+
+    await clearIssue911Trace(miniProgram)
+    const nextPage = await relaunchPage(miniProgram, ISSUE_550_ROUTE, undefined, 45_000)
+    expect(nextPage).toBeTruthy()
+    expect(await waitForCurrentPagePath(miniProgram, ISSUE_550_ROUTE, 8_000)).toBeTruthy()
+    expect(['', undefined]).toContain(await readIssue911Trace(miniProgram))
   })
 })


### PR DESCRIPTION
## 摘要

补齐 GitHub issue #911 的 runtime 回归场景，并确认 #910/#911 现有根因修复在构建、headless runtime 和真实微信 DevTools 中均可观察。

## 变更

- 为 issue 911 fixture 增加 `default`、`redirect`、`abort` 和非目标路由场景。
- 使用稳定的 `wx` storage trace 验证 guard 完成顺序和 `mounted` 结果。
- 在同一 suite 中复用 automator，通过 `reLaunch` 串联场景。
- abort 断言聚焦跨 provider 一致的“guard 完成但未 mounted”语义，不依赖宿主 page-stack 差异。

## 验证

- `pnpm build:pkgs`：33/33 成功
- `wevu` 类型检查、`test:types`：通过
- `wevu` 生命周期/路由单测：110/110
- `weapp-vite` `requireAnalysis` 单测：34/34
- #910 构建回归：1/1
- #911 headless runtime：4/4
- #911 真实微信 DevTools runtime：4/4，`warn=0 error=0 exception=0`
- `node --import tsx scripts/check-e2e-ide-shared-launch.ts`：通过

本 PR 仅增加回归 fixture 和测试，不改变发布包行为，因此不新增 changeset。

Refs #910
Refs #911