### PR TITLE
feat(website): 重塑 AI 小程序研发基线品牌表达

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@
   <a href="https://atomgit.com/sonofmagic/weapp-vite"><img src="https://atomgit.com/sonofmagic/weapp-vite/star/badge.svg" alt="GitCode Star"></a>
 </p>
 
-<p align="center"><strong>给小程序现代化的开发体验</strong></p>
+<p align="center"><strong>AI 时代，原生小程序研发的默认基线</strong></p>
 <p align="center"><a href="https://vite.weapp.dev">中文文档</a> · <a href="./README.en-US.md">English README</a></p>
 
-`weapp-vite` 面向正在维护小程序的团队：既保留原生小程序的目录、语法和平台能力，又把 TypeScript、Vite/Rolldown、Vue SFC、自动化调试和 AI 协作带进日常研发。你可以从一个新模板开始，也可以把已有项目渐进接入进来。
+`weapp-vite` 面向正在维护原生小程序的团队：保留 Page、Component、WXML、WXSS 和平台 API，同时把现代工程化、多端构建和可验证的 AI 工作流带进日常研发。它既适合从模板开始的新项目，也适合存量项目渐进接入。
 
 ## 目录
 
-- [为什么选择 weapp-vite](#为什么选择-weapp-vite)
+- [为什么选择默认基线](#为什么选择默认基线)
+- [AI 可执行闭环](#ai-可执行闭环)
 - [特性亮点](#特性亮点)
 - [快速开始](#快速开始)
 - [仓库结构](#仓库结构)
@@ -32,14 +33,27 @@
 - [Star History](#star-history)
 - [许可证](#许可证)
 
-## 为什么选择 weapp-vite
+## 为什么选择默认基线
 
-- **不必推翻现有小程序**：可以继续写原生 `Page` / `Component`、WXML、WXSS 和 JSON 配置；存量项目也能按目录迁移、配置补齐、依赖安装的方式渐进接入。
-- **把日常开发效率补齐**：TypeScript、ESM、Sass/Less、PostCSS、Tailwind CSS、JSONC、路径别名和 Vite 插件生态可以直接进入小程序工程，不再靠零散脚本拼维护体验。
-- **减少小程序工程的重复劳动**：自动构建 `miniprogram_npm`、分包依赖分析、自动导入组件、自动路由、布局、生成页面/组件等能力，适合页面多、分包多、组件多的项目。
-- **保留原生能力，同时可逐步升级写法**：团队可以先用 `weapp-vite + 原生` 稳定构建链路，再在新页面或局部模块中引入 Vue SFC 与 Wevu，而不是一次性重写业务。
-- **更适合真实小程序调试和验收**：`wv dev --open`、DevTools 配置预热、日志桥接、截图、截图对比、`preview/upload` 透传和 `analyze` 能覆盖从开发到上传前检查的常见链路。
-- **让 AI 协作落到真实运行时**：脚手架会生成 `AGENTS.md`，并可接入 MCP、DevTools 日志、运行时截图和截图对比，让 AI 不只改代码，还能按小程序环境做验证。
+- **不必推翻现有小程序**：继续写原生 `Page` / `Component`、WXML、WXSS 和 JSON 配置，按目录和模块渐进接入。
+- **现代工程能力成为默认行为**：TypeScript、ESM、Sass/Less、PostCSS、Tailwind CSS、JSONC、路径别名和 Vite 插件生态直接进入小程序工程。
+- **一次维护，多端构建**：用单目标构建覆盖微信、支付宝、抖音、百度、京东、小红书与 Web，同时保留平台边界。
+- **复杂项目有人托管**：自动构建 `miniprogram_npm`、分包依赖分析、自动导入组件、自动路由、布局和产物分析，减少重复维护。
+- **真实运行时可观察、可验收**：从 `wv dev --open` 到 DevTools 日志、截图对比、`preview/upload` 和 `analyze`，开发结果有证据可追踪。
+
+## AI 可执行闭环
+
+weapp-vite 不把 AI 当成一个聊天入口，而是把它接到真实项目的研发链路：
+
+```text
+项目上下文（AGENTS + 本地文档）
+        ↓
+MCP 工具（构建 / 日志 / 截图 / 对比）
+        ↓
+运行时证据（页面状态、控制台、视觉 diff）
+```
+
+AI 可以基于项目约定完成修改，再通过小程序运行时检查结果。查看[AI 工作流文档](https://vite.weapp.dev/guide/ai-workflows)和[统一 AI 入口](https://vite.weapp.dev/ai)。
 
 ## 特性亮点
 
@@ -47,9 +61,9 @@
 - 存量项目：通过手动集成或 `wv init` 接入现有小程序，保留原有页面结构和平台能力。
 - Vue SFC：在小程序里使用 `.vue`、`<script setup>`、JSON 宏、class/style 绑定和 Wevu 响应式运行时。
 - uni-app 组件库：通过 `WotUiResolver()` 或 `UviewPlusResolver()` 在微信小程序与 Web 中使用经过全组件矩阵验证的 Wot UI、uview-plus Vue SFC。
-- 工程体验：支持构建、开发监听、HMR、组件自动导入、自动路由、分包策略、npm 构建和产物分析。
+- 工程化：支持构建、开发监听、HMR、组件自动导入、自动路由、分包策略、npm 构建和产物分析。
 - IDE 与验收：集成 WeChat DevTools 打开、日志、截图、截图对比、预览和上传等工作流。
-- AI 友好：提供 MCP、packaged docs、skills 指引和面向真实小程序运行时的检查入口。
+- AI 可执行验证：提供 MCP、packaged docs、skills 指引和面向真实小程序运行时的检查入口。
 
 ## 快速开始
 

--- a/website/.vitepress/components/HomePage.vue
+++ b/website/.vitepress/components/HomePage.vue
@@ -1,547 +1,953 @@
 <script setup lang="ts">
 import { useData } from 'vitepress'
 import { computed } from 'vue'
-import TechBackground from './TechBackground.vue'
 
 const { isDark } = useData()
-const glowClass = computed(() => (isDark.value ? 'from-emerald-500/25 to-lime-400/20' : 'from-emerald-400/25 to-emerald-300/15'))
-const heroKeywordTextClass = computed(() => (isDark.value ? 'text-zinc-100' : 'text-zinc-800'))
-const heroKeywordChipToneClass = computed(() => (
-  isDark.value
-    ? 'border-emerald-300/45 bg-slate-900/75 text-emerald-50 shadow-[0_10px_20px_rgba(2,6,23,0.28)]'
-    : 'border-emerald-500/20 bg-white/90 text-zinc-800 shadow-[0_6px_14px_rgba(16,185,129,0.1)]'
-))
+const surfaceClass = computed(() => (isDark.value ? 'is-dark' : 'is-light'))
 
-interface HomeFeatureCard {
-  href: string
+interface Capability {
   icon: string
   title: string
-  packageName: string
   description: string
+  detail: string
+  href: string
 }
 
-const packageFeatureCards: HomeFeatureCard[] = [
+interface AdoptionPath {
+  icon: string
+  label: string
+  title: string
+  description: string
+  action: string
+  href: string
+}
+
+const capabilities: Capability[] = [
   {
-    href: '/packages/create-weapp-vite',
-    icon: '🚀',
-    title: '官方脚手架',
-    packageName: 'create-weapp-vite',
-    description: '内置 default / Wevu / tailwindcss / tdesign 等模板，快速创建并对齐依赖组合。',
+    icon: 'i-mdi-shield-check-outline',
+    title: '保留原生能力',
+    description: '继续使用 Page、Component、WXML、WXSS 与平台 API，按目录渐进接入。',
+    detail: '原生增强',
+    href: '/guide/manual-integration',
   },
   {
-    href: '/wevu/',
-    icon: '⚡',
-    title: '轻量运行时',
-    packageName: 'Wevu',
-    description: '提供 Vue 3 风格响应式与 Store，采用快照 diff 策略，尽量减少 setData 更新。',
+    icon: 'i-mdi-lightning-bolt-outline',
+    title: '现代工程默认开启',
+    description: 'TypeScript、Vite/Rolldown、HMR、自动导入与 npm 构建组成稳定的日常工作流。',
+    detail: '工程化',
+    href: '/guide/',
   },
   {
-    href: '/packages/wevu-compiler',
-    icon: '🧩',
-    title: '编译能力底座',
-    packageName: '@wevu/compiler',
-    description: '独立复用 SFC script/template/style/config 编译链，支持页面特性分析与注入。',
+    icon: 'i-mdi-layers-triple-outline',
+    title: '一次维护，多端构建',
+    description: '以单目标构建覆盖微信、支付宝、抖音与 Web，保留各平台的真实边界。',
+    detail: '多端构建',
+    href: '/guide/multi-platform',
   },
   {
-    href: '/packages/rolldown-require/index.zh',
-    icon: '🧠',
-    title: '配置加载引擎',
-    packageName: 'rolldown-require',
-    description: '基于 Rolldown 的 bundle + require，支持 ts/mjs/cjs 配置加载，适配 CLI 与 Node 脚本。',
+    icon: 'i-mdi-robot-outline',
+    title: 'AI 可以执行和验证',
+    description: 'MCP、AGENTS、本地文档、日志与截图对比，让 AI 进入真实研发闭环。',
+    detail: 'AI 可执行验证',
+    href: '/guide/ai-workflows',
+  },
+]
+
+const adoptionPaths: AdoptionPath[] = [
+  {
+    icon: 'i-mdi-rocket-launch-outline',
+    label: '01 / 新项目',
+    title: '从模板开始，第一天就有完整基线',
+    description: '选择原生、Vue SFC、Wevu 或多平台模板，直接获得可维护的项目结构。',
+    action: '创建项目',
+    href: '/guide/',
   },
   {
-    href: '/packages/weapp-ide-cli',
-    icon: '🤖',
-    title: '开发者工具自动化',
-    packageName: 'weapp-ide-cli',
-    description: '增强 open / preview / upload 命令，补齐路径与非交互参数，便于本地脚本和 CI。',
+    icon: 'i-mdi-source-branch-sync',
+    label: '02 / 存量项目',
+    title: '不推翻已有代码，逐步接入现代工具链',
+    description: '保留页面、组件和平台配置，把重复的构建、依赖和调试工作交给框架。',
+    action: '查看迁移路径',
+    href: '/migration/',
   },
   {
-    href: '/packages/',
-    icon: '📦',
-    title: '工具链能力矩阵',
-    packageName: 'rolldown-require / vite-plugin-performance / volar / web / mcp',
-    description: '覆盖配置加载、插件性能分析、编辑器智能提示与实验运行时，按场景自由组合。',
+    icon: 'i-mdi-message-processing-outline',
+    label: '03 / AI 协作团队',
+    title: '让 AI 从解释代码走到完成验收',
+    description: '给 AI 项目上下文、可调用工具和运行时证据，减少猜测式修改。',
+    action: '进入 AI 工作流',
+    href: '/ai',
   },
+]
+
+const workflowSteps = [
+  { name: 'build', caption: '构建', icon: 'i-mdi-hammer-wrench' },
+  { name: 'inspect', caption: '检查', icon: 'i-mdi-magnify' },
+  { name: 'verify', caption: '验收', icon: 'i-mdi-check-decagram-outline' },
 ]
 </script>
 
 <template>
-  <section class="relative overflow-hidden isolate home-hero">
-    <!-- Animated background -->
-    <TechBackground class="absolute inset-0" :speed="0.35" :density="0.9" />
+  <main class="home-page" :class="surfaceClass">
+    <section class="home-hero">
+      <div class="home-hero-inner">
+        <div class="hero-copy">
+          <p class="eyebrow"><span class="eyebrow-mark" /> AI 时代的小程序研发基线</p>
+          <h1>让 AI 真正参与<br><span>小程序开发</span></h1>
+          <p class="hero-description">
+            weapp-vite 把原生能力、现代工程化、多端构建和可验证的 AI 工作流，合成一套可以长期维护的开发基线。
+          </p>
+          <div class="hero-actions">
+            <a class="button button-primary" href="/guide/"><span class="i-mdi-rocket-launch-outline" /> 从模板开始</a>
+            <a class="button button-secondary" href="/ai"><span class="i-mdi-robot-outline" /> 看 AI 工作流</a>
+            <a class="button button-quiet" href="https://github.com/weapp-vite/weapp-vite" target="_blank" rel="noreferrer"><span class="i-mdi-github" /> GitHub</a>
+          </div>
+          <div class="hero-proof" aria-label="weapp-vite 核心能力">
+            <span>原生渐进接入</span><span>Vue SFC / Wevu</span><span>微信 · 支付宝 · 抖音 · Web</span>
+          </div>
+        </div>
 
-    <!-- Hero -->
-    <div class="relative z-10 mx-auto max-w-7xl px-6 py-20 sm:py-24 lg:py-28">
-      <div class="mx-auto max-w-3xl text-center hero-reveal">
-        <div
-          class="hero-chip inline-flex items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-500/5 px-3 py-1 text-xs font-semibold tracking-wide text-emerald-600 dark:text-emerald-300 shadow-[0_0_0_1px_rgba(16,185,129,0.15)_inset,0_8px_24px_rgba(16,185,129,0.15)]"
-        >
-          <span class="i-mdi-lightning-bolt text-emerald-500" />
-          现代小程序工程化
-        </div>
-        <h1
-          class="mt-6 bg-linear-to-br from-emerald-700 via-emerald-600 to-emerald-800 dark:from-emerald-400 dark:via-lime-300 dark:to-emerald-600 bg-clip-text text-5xl font-extrabold tracking-tight text-transparent sm:text-6xl"
-        >
-          Weapp‑vite
-        </h1>
-        <div class="hero-logo-formula" aria-label="Vue + Vite + Rolldown = weapp-vite">
-          <span class="hero-logo-badge">
-            <span class="i-vscode-icons-file-type-vue h-4.5 w-4.5" aria-hidden="true" />
-            <span>Vue</span>
-          </span>
-          <span class="hero-logo-sign">+</span>
-          <span class="hero-logo-badge">
-            <span class="i-vscode-icons-file-type-vite h-4.5 w-4.5 shrink-0 dark:brightness-110 dark:saturate-125" aria-hidden="true" />
-            <span>Vite</span>
-          </span>
-          <span class="hero-logo-sign">+</span>
-          <span class="hero-logo-badge">
-            <span class="i-vscode-icons-file-type-rolldown h-4.5 w-4.5 shrink-0 dark:brightness-115 dark:saturate-120" aria-hidden="true" />
-            <span>Rolldown</span>
-          </span>
-          <span class="hero-logo-sign">=</span>
-          <span class="hero-logo-badge hero-logo-badge-target">
-            <img src="/logo.svg" alt="weapp-vite logo" class="h-4.5 w-4.5 object-contain">
-            <span>Weapp‑vite</span>
-          </span>
-        </div>
-        <p class="mt-5 text-balance text-base/7 text-zinc-700 dark:text-zinc-300 sm:text-lg/8">
-          把现代化的开发模式带入小程序开发：极速热更、类型安全、插件生态、原子化样式与工程化能力，一站式串联。
-        </p>
-        <div class="mt-8 flex items-center justify-center gap-3">
-          <a
-            class="group relative inline-flex items-center gap-2 rounded-xl border border-emerald-500/50 bg-linear-to-b from-emerald-500/20 to-emerald-600/20 px-5 py-3 text-sm font-semibold text-emerald-900 dark:text-emerald-50 shadow-[0_1px_0_0_rgba(255,255,255,0.2)_inset,0_8px_24px_rgba(16,185,129,0.25)] hover:shadow-[0_0_0_1px_rgba(16,185,129,0.5)_inset,0_16px_40px_rgba(16,185,129,0.35)] transition interactive-cta"
-            href="/guide/"
-          >
-            <span class="i-mdi-rocket-launch-outline text-lg text-emerald-600 dark:text-emerald-300" />
-            快速开始
-            <span
-              class="absolute -inset-px -z-10 rounded-xl bg-linear-to-r from-emerald-400/20 via-lime-300/20 to-emerald-500/20 blur-xl opacity-0 group-hover:opacity-100 transition"
-            />
-          </a>
-          <a
-            class="inline-flex items-center gap-2 rounded-xl border border-emerald-500/50 bg-white/80 px-5 py-3 text-sm font-semibold text-emerald-900 shadow-[0_1px_0_0_rgba(255,255,255,0.2)_inset,0_8px_24px_rgba(16,185,129,0.15)] hover:shadow-[0_0_0_1px_rgba(16,185,129,0.5)_inset,0_14px_36px_rgba(16,185,129,0.25)] transition interactive-cta dark:border-emerald-300/40 dark:bg-white/10 dark:text-emerald-50"
-            href="/ai"
-          >
-            <span class="i-bi-openai text-lg" />
-            AI 学习入口
-          </a>
-          <a class="inline-flex items-center gap-2 rounded-xl border border-zinc-400/40 px-5 py-3 text-sm font-semibold text-zinc-800 dark:text-zinc-100 hover:bg-zinc-900/5 dark:hover:bg-white/5 transition interactive-cta" href="https://github.com/weapp-vite/weapp-vite" target="_blank" rel="noreferrer">
-            <span class="i-mdi-github text-lg" /> GitHub
-          </a>
-        </div>
-        <div class="hero-keywords mt-6 flex flex-wrap items-center justify-center gap-2 text-xs" :class="heroKeywordTextClass">
-          <span class="hero-keyword-chip" :class="heroKeywordChipToneClass">
-            TypeScript/ESM
-          </span>
-          <span class="hero-keyword-chip" :class="heroKeywordChipToneClass">
-            Vite / Rolldown 插件
-          </span>
-          <span class="hero-keyword-chip" :class="heroKeywordChipToneClass">
-            自动构建 npm
-          </span>
-          <span class="hero-keyword-chip" :class="heroKeywordChipToneClass">
-            自动引入组件
-          </span>
-        </div>
-      </div>
-    </div>
-
-    <!-- gradient glows -->
-    <div class="pointer-events-none absolute inset-x-0 top-0 z-0 overflow-hidden blur-2xl floating-glow">
-      <div class="mx-auto h-64 w-160 rounded-full bg-linear-to-tr" :class="glowClass" />
-    </div>
-  </section>
-
-  <!-- Features -->
-  <section class="relative feature-section">
-    <div class="pointer-events-none absolute inset-0 -z-10 opacity-70 mask-[radial-gradient(70%_60%_at_50%_0%,black,transparent)]">
-      <div class="absolute inset-0 -z-10 bg-[linear-gradient(90deg,rgba(16,185,129,0.08)_1px,transparent_1px),linear-gradient(rgba(16,185,129,0.08)_1px,transparent_1px)] bg-size-[24px_24px]" />
-    </div>
-    <div class="mx-auto max-w-7xl px-6 py-8 sm:py-12">
-      <div class="feature-grid grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        <a
-          v-for="(feature, featureIndex) in packageFeatureCards"
-          :key="feature.title"
-          :href="feature.href"
-          class="feature-card group relative overflow-hidden rounded-2xl border border-emerald-500/30 bg-white/60 p-6 shadow-[0_0_0_1px_rgba(16,185,129,0.15)_inset,0_10px_30px_rgba(16,185,129,0.12)] dark:border-emerald-300/20 dark:bg-white/5"
-          :style="{ '--card-index': featureIndex }"
-        >
-          <div class="flex items-center gap-3">
-            <div class="rounded-lg bg-emerald-500/10 p-2 text-emerald-600 dark:text-emerald-300">
-              {{ feature.icon }}
+        <div class="workbench" aria-label="AI 小程序研发工作台">
+          <div class="workbench-bar">
+            <div class="window-dots"><i /><i /><i /></div>
+            <span class="workbench-title">weapp-vite / workspace</span>
+            <span class="workbench-state"><span class="state-dot" /> ready</span>
+          </div>
+          <div class="workbench-grid">
+            <div class="code-pane">
+              <div class="pane-label"><span class="i-mdi-file-code-outline" /> pages/index/index.ts</div>
+              <pre><code><span class="code-muted">01</span> <span class="code-keyword">import</span> { ref } <span class="code-keyword">from</span> <span class="code-string">'vue'</span>
+<span class="code-muted">02</span>
+<span class="code-muted">03</span> <span class="code-keyword">export default</span> {
+<span class="code-muted">04</span>   <span class="code-key">setup</span>() {
+<span class="code-muted">05</span>     <span class="code-keyword">const</span> ready = ref(<span class="code-number">false</span>)
+<span class="code-muted">06</span>     <span class="code-key">onReady</span>(() =&gt; ready.value = <span class="code-number">true</span>)
+<span class="code-muted">07</span>     <span class="code-keyword">return</span> { ready }
+<span class="code-muted">08</span>   },
+<span class="code-muted">09</span> }</code></pre>
             </div>
-            <div>
-              <h3 class="text-lg font-semibold">{{ feature.title }}</h3>
-              <p class="text-[11px] font-semibold tracking-wide text-emerald-700/90 dark:text-emerald-200/90">
-                {{ feature.packageName }}
-              </p>
+
+            <div class="flow-pane">
+              <div class="pane-label"><span class="i-mdi-transit-connection-variant" /> pipeline</div>
+              <div class="workflow-list">
+                <template v-for="(step, index) in workflowSteps" :key="step.name">
+                  <div class="workflow-step">
+                    <span class="workflow-icon" :class="step.icon" />
+                    <div><strong>{{ step.name }}</strong><small>{{ step.caption }}</small></div>
+                    <span class="workflow-check i-mdi-check" />
+                  </div>
+                  <span v-if="index < workflowSteps.length - 1" class="workflow-line" />
+                </template>
+              </div>
+            </div>
+
+            <div class="evidence-pane">
+              <div class="pane-label"><span class="i-mdi-robot-outline" /> ai / evidence</div>
+              <div class="evidence-log">
+                <p><span class="log-time">09:41:08</span> MCP <b>inspect_page</b></p>
+                <p><span class="log-time">09:41:09</span> DevTools <b>console clean</b></p>
+                <p><span class="log-time">09:41:11</span> screenshot <b class="log-pass">diff 0.2%</b></p>
+              </div>
+              <div class="evidence-result"><span class="i-mdi-check-circle" /> verified <strong>3/3</strong></div>
             </div>
           </div>
-          <p class="mt-3 text-sm text-zinc-700 dark:text-zinc-300">{{ feature.description }}</p>
-          <div class="pointer-events-none absolute inset-0 -z-10 opacity-0 blur-2xl transition group-hover:opacity-100 bg-linear-to-br from-emerald-400/10 via-lime-300/10 to-emerald-600/10" />
+          <div class="workbench-footer"><span>native + web</span><span>mcp connected</span><span>last run 12s ago</span></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="capabilities" class="home-section capability-section">
+      <div class="section-heading"><p class="section-kicker">THE BASELINE</p><h2>一套基线，四个确定性</h2><p>把容易失控的工程细节变成团队可以依赖的默认行为。</p></div>
+      <div class="capability-grid">
+        <a v-for="item in capabilities" :key="item.title" class="capability-item" :href="item.href">
+          <div class="capability-icon"><span :class="item.icon" /></div>
+          <div><p class="capability-detail">{{ item.detail }}</p><h3>{{ item.title }}</h3><p class="capability-description">{{ item.description }}</p></div>
+          <span class="capability-arrow i-mdi-arrow-top-right" />
         </a>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <!-- Code demo + CTA -->
-  <section class="relative">
-    <!-- subtle background grid to reduce empty feel -->
-    <div class="pointer-events-none absolute inset-0 -z-10 opacity-60 mask-[radial-gradient(60%_50%_at_50%_0%,black,transparent)]">
-      <div class="absolute inset-0 -z-10 bg-[linear-gradient(90deg,rgba(16,185,129,0.06)_1px,transparent_1px),linear-gradient(rgba(16,185,129,0.06)_1px,transparent_1px)] bg-size-[24px_24px]" />
-    </div>
-    <div class="mx-auto max-w-7xl px-6 py-12 lg:py-16">
-      <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
-        <!-- Terminal: mimic docs code-group style and content -->
-        <div class="lg:col-span-2">
-          <div class="vp-doc">
-            <div class="vp-code-group">
-              <div class="tabs">
-                <input id="home-tab-pnpm" type="radio" name="home-code-group" checked>
-                <label data-title="pnpm" for="home-tab-pnpm">pnpm</label>
-                <input id="home-tab-yarn" type="radio" name="home-code-group">
-                <label data-title="yarn" for="home-tab-yarn">yarn</label>
-                <input id="home-tab-npm" type="radio" name="home-code-group">
-                <label data-title="npm" for="home-tab-npm">npm</label>
-                <input id="home-tab-bun" type="radio" name="home-code-group">
-                <label data-title="bun" for="home-tab-bun">bun</label>
-              </div>
-              <div class="blocks">
-                <div class="language-sh active">
-                  <span class="lang">sh</span>
-                  <pre><code>pnpm create weapp-vite@latest</code></pre>
-                </div>
-                <div class="language-sh">
-                  <span class="lang">sh</span>
-                  <pre><code>yarn create weapp-vite@latest</code></pre>
-                </div>
-                <div class="language-sh">
-                  <span class="lang">sh</span>
-                  <pre><code>npm create weapp-vite@latest</code></pre>
-                </div>
-                <div class="language-sh">
-                  <span class="lang">sh</span>
-                  <pre><code>bun create weapp-vite@latest</code></pre>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- CTA card -->
-        <div class="cta-card relative rounded-2xl border border-emerald-500/30 bg-white/60 p-6 sm:p-8 text-center shadow-[0_0_0_1px_rgba(16,185,129,0.15)_inset,0_10px_30px_rgba(16,185,129,0.12)] dark:bg-white/5">
-          <h2 class="text-xl font-bold tracking-tight">
-            准备好上手了么？
-          </h2>
-          <p class="mt-2 text-sm text-zinc-700 dark:text-zinc-300">
-            阅读指南以了解最佳实践，或直接从模板开始。
-          </p>
-          <div class="mt-5 flex items-center justify-center gap-3">
-            <a
-              class="inline-flex items-center gap-2 rounded-xl border border-emerald-500/50 bg-linear-to-b from-emerald-500/20 to-emerald-600/20 px-5 py-3 text-sm font-semibold text-emerald-900 dark:text-emerald-50 shadow-[0_1px_0_0_rgba(255,255,255,0.2)_inset,0_8px_24px_rgba(16,185,129,0.25)]"
-              href="/guide/"
-            >
-              <span class="i-mdi-book-open-page-variant-outline" />
-              阅读指南
-            </a>
-            <a
-              class="inline-flex items-center gap-2 rounded-xl border border-zinc-400/40 px-5 py-3 text-sm font-semibold text-zinc-800 dark:text-zinc-100 hover:bg-zinc-900/5 dark:hover:bg-white/5 transition"
-              href="https://github.com/weapp-vite/weapp-vite"
-              target="_blank"
-              rel="noreferrer"
-            >
-              <span class="i-mdi-star-outline" />
-              GitHub Star
-            </a>
-          </div>
-          <!-- soft glow to make it less empty while staying subtle -->
-          <div class="pointer-events-none absolute -inset-px -z-10 rounded-2xl bg-linear-to-b from-emerald-400/10 to-emerald-600/10 blur-xl" />
-        </div>
+    <section id="adoption" class="home-section adoption-section">
+      <div class="section-heading section-heading-inline"><div><p class="section-kicker">ADOPT WITHOUT REWRITE</p><h2>从你的现实出发</h2></div><p>新项目、存量项目和 AI 协作，都从同一条工程基线开始。</p></div>
+      <div class="adoption-list">
+        <a v-for="path in adoptionPaths" :key="path.label" class="adoption-item" :href="path.href">
+          <span class="adoption-icon" :class="path.icon" />
+          <span class="adoption-label">{{ path.label }}</span>
+          <span class="adoption-content"><strong>{{ path.title }}</strong><small>{{ path.description }}</small></span>
+          <span class="adoption-action">{{ path.action }} <span class="i-mdi-arrow-right" /></span>
+        </a>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <!-- End code demo + CTA -->
+    <section id="start" class="home-section start-section">
+      <div class="start-panel">
+        <div><p class="section-kicker">START WITH ONE COMMAND</p><h2>把下一次小程序迭代，交给一套更可靠的基线。</h2><p>从脚手架开始，沿着文档、AI 工作流和运行时验收一路走到上线。</p></div>
+        <div class="start-command"><span class="command-prompt">$</span><code>pnpm create weapp-vite@latest</code><a href="/guide/" aria-label="打开快速开始" class="i-mdi-arrow-top-right" /></div>
+      </div>
+    </section>
+  </main>
 </template>
 
-<style scoped lang="scss">
+<style scoped>
+.home-page {
+  --home-ink: #101418;
+  --home-muted: #59635e;
+  --home-line: #d8e0da;
+  --home-paper: #f5f7f3;
+  --home-panel: #fff;
+  --home-green: #2ba245;
+  --home-lime: #b6f36a;
+
+  color: var(--home-ink);
+  background: var(--home-paper);
+}
+
+.home-page.is-dark {
+  --home-ink: #f1f5f1;
+  --home-muted: #a7b3aa;
+  --home-line: #2d3932;
+  --home-paper: #101418;
+  --home-panel: #151c18;
+}
+
 .home-hero {
-  position: relative;
+  border-bottom: 1px solid var(--home-line);
 }
 
-.hero-reveal > * {
-  opacity: 0;
-  transform: translateY(12px);
-  animation: fade-rise 0.9s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+.home-hero-inner {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(500px, 1.2fr);
+  gap: clamp(32px, 6vw, 88px);
+  align-items: center;
+  max-width: 1240px;
+  padding: 92px 32px 84px;
+  margin: 0 auto;
 }
 
-.hero-reveal > *:nth-child(1) {
-  animation-delay: 0.05s;
+.hero-copy {
+  max-width: 540px;
 }
 
-.hero-reveal > *:nth-child(2) {
-  animation-delay: 0.12s;
+.eyebrow,
+.section-kicker,
+.pane-label,
+.workbench-footer,
+.hero-proof,
+.workbench-state,
+.adoption-label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
-.hero-reveal > *:nth-child(3) {
-  animation-delay: 0.18s;
-}
-
-.hero-reveal > *:nth-child(4) {
-  animation-delay: 0.26s;
-}
-
-.hero-reveal > *:nth-child(5) {
-  animation-delay: 0.34s;
-}
-
-.hero-chip {
-  animation: gentle-pulse 9s ease-in-out infinite;
-}
-
-.hero-logo-formula {
+.eyebrow {
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  gap: 9px;
   align-items: center;
-  justify-content: center;
-  margin-top: 14px;
-}
-
-.hero-logo-badge {
-  display: inline-flex;
-  gap: 6px;
-  align-items: center;
-  justify-content: center;
-  padding: 6px 10px;
+  margin: 0;
   font-size: 12px;
   font-weight: 700;
-  color: rgb(6 95 70);
-  letter-spacing: 0.01em;
-  background: rgb(255 255 255 / 78%);
-  border: 1px solid rgb(16 185 129 / 22%);
-  border-radius: 999px;
-  box-shadow: 0 6px 18px rgb(16 185 129 / 12%);
+  color: var(--home-green);
 }
 
-.hero-logo-sign {
-  font-size: 12px;
+.eyebrow-mark {
+  width: 8px;
+  height: 8px;
+  background: var(--home-lime);
+  border: 2px solid var(--home-green);
+  border-radius: 50%;
+}
+
+h1 {
+  margin: 24px 0 20px;
+  font-size: clamp(42px, 5.2vw, 72px);
   font-weight: 800;
-  color: rgb(5 150 105);
+  line-height: 1.03;
+  letter-spacing: -0.04em;
 }
 
-.hero-logo-badge-target {
-  color: rgb(6 78 59);
-  background: linear-gradient(180deg, rgb(209 250 229 / 92%), rgb(187 247 208 / 72%));
-  border-color: rgb(16 185 129 / 35%);
+h1 span {
+  color: var(--home-green);
 }
 
-:global(html.dark) .hero-logo-badge {
-  color: rgb(209 250 229 / 96%);
-  background: rgb(6 46 35 / 72%);
-  border-color: rgb(16 185 129 / 38%);
-  box-shadow: 0 10px 24px rgb(3 10 8 / 30%);
+.hero-description {
+  max-width: 490px;
+  margin: 0;
+  font-size: 18px;
+  line-height: 1.7;
+  color: var(--home-muted);
 }
 
-:global(html.dark) .hero-logo-sign {
-  color: rgb(110 231 183 / 92%);
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 30px;
 }
 
-:global(html.dark) .hero-logo-badge-target {
-  color: rgb(236 253 245);
-  background: linear-gradient(180deg, rgb(6 95 70 / 62%), rgb(4 47 46 / 68%));
-  border-color: rgb(110 231 183 / 52%);
-}
-
-.hero-keyword-chip {
-  padding: 4px 10px;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  border-radius: 999px;
-}
-
-.interactive-cta {
+.button {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  min-height: 42px;
+  padding: 0 15px;
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: none;
+  border: 1px solid var(--home-line);
+  border-radius: 6px;
   transition:
-    transform 220ms cubic-bezier(0.22, 1, 0.36, 1),
-    box-shadow 220ms ease,
-    filter 220ms ease;
+    transform 0.2s ease,
+    border-color 0.2s ease,
+    background 0.2s ease;
 }
 
-.interactive-cta:hover {
-  box-shadow: 0 10px 28px rgb(16 185 129 / 20%);
-  filter: drop-shadow(0 10px 25px rgb(16 185 129 / 15%));
-  transform: translateY(-1px) scale(1.01);
+.button:hover {
+  border-color: var(--home-green);
+  transform: translateY(-2px);
 }
 
-.floating-glow > div {
-  animation: slow-pulse 14s ease-in-out infinite;
+.button-primary {
+  color: #102015;
+  background: var(--home-lime);
+  border-color: var(--home-lime);
 }
 
-.feature-section {
-  .feature-grid {
-    --card-stagger: 90ms;
-  }
-
-  .feature-card {
-    position: relative;
-    overflow: hidden;
-    isolation: isolate;
-    opacity: 0;
-    transform: translateY(12px) scale(0.995);
-    transition:
-      transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
-      box-shadow 260ms ease,
-      border-color 260ms ease,
-      background-color 260ms ease;
-    animation: fade-rise 0.85s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-    animation-delay: calc(var(--card-index, 0) * var(--card-stagger) + 0.18s);
-  }
-
-  .feature-card::after {
-    position: absolute;
-    inset: -30% auto auto -30%;
-    z-index: -1;
-    width: 60%;
-    height: 60%;
-    pointer-events: none;
-    content: '';
-    background: radial-gradient(circle, rgb(16 185 129 / 20%), transparent 60%);
-    opacity: 0;
-    filter: blur(32px);
-    transform: t ranslate3d(0, 0, 0);
-    transition: opacity 240ms ease;
-    animation: orbit 18s linear infinite;
-  }
-
-  .feature-card:hover {
-    border-color: rgb(16 185 129 / 50%);
-    box-shadow:
-      0 14px 36px rgb(16 185 129 / 16%),
-      0 18px 40px rgb(0 0 0 / 8%);
-    transform: translateY(-6px) scale(1.01);
-  }
-
-  .feature-card:hover::after {
-    opacity: 1;
-  }
-
-  .feature-card :deep(div.rounded-lg) {
-    transition:
-      transform 220ms ease,
-      filter 220ms ease;
-  }
-
-  .feature-card:hover :deep(div.rounded-lg) {
-    filter: drop-shadow(0 10px 20px rgb(16 185 129 / 30%));
-    transform: translateY(-2px) scale(1.05);
-  }
+.button-secondary {
+  color: var(--home-green);
+  background: transparent;
+  border-color: color-mix(in srgb, var(--home-green) 50%, var(--home-line));
 }
 
-.cta-card {
+.button-quiet {
+  color: var(--home-muted);
+  background: transparent;
+}
+
+.hero-proof {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px 20px;
+  margin-top: 26px;
+  font-size: 10px;
+  color: var(--home-muted);
+}
+
+.hero-proof span::before {
+  margin-right: 6px;
+  font-size: 8px;
+  color: var(--home-green);
+  content: '●';
+}
+
+.workbench {
   overflow: hidden;
-  transition:
-    transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
-    box-shadow 260ms ease;
+  color: #dbe7dd;
+  background: #17221b;
+  border: 1px solid #34463a;
+  border-radius: 7px;
+  box-shadow: 0 20px 50px rgb(16 20 18 / 16%);
 }
 
-.cta-card::after {
+.workbench-bar,
+.workbench-footer {
+  display: flex;
+  align-items: center;
+  min-height: 38px;
+  padding: 0 14px;
+  border-bottom: 1px solid #34463a;
+}
+
+.window-dots {
+  display: flex;
+  gap: 5px;
+  margin-right: 13px;
+}
+
+.window-dots i {
+  width: 7px;
+  height: 7px;
+  background: #617367;
+  border-radius: 50%;
+}
+
+.window-dots i:first-child {
+  background: #ef8f55;
+}
+
+.window-dots i:nth-child(2) {
+  background: #d4bb5f;
+}
+
+.window-dots i:last-child {
+  background: #72be72;
+}
+
+.workbench-title {
+  font:
+    11px ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  color: #a9b8ad;
+}
+
+.workbench-state {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-left: auto;
+  font-size: 9px;
+  color: #9bdc91;
+}
+
+.state-dot {
+  width: 6px;
+  height: 6px;
+  background: #72d66d;
+  border-radius: 50%;
+}
+
+.workbench-grid {
+  display: grid;
+  grid-template-columns: 1.25fr 0.8fr 0.9fr;
+  min-height: 285px;
+}
+
+.code-pane,
+.flow-pane,
+.evidence-pane {
+  padding: 18px;
+}
+
+.code-pane,
+.flow-pane {
+  border-right: 1px solid #34463a;
+}
+
+.pane-label {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  font-size: 9px;
+  color: #8ea894;
+}
+
+.code-pane pre {
+  margin: 18px 0 0;
+  overflow: auto;
+  font:
+    12px/1.9 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+}
+
+.code-muted {
+  color: #607664;
+}
+
+.code-keyword {
+  color: #b6f36a;
+}
+
+.code-string {
+  color: #e7c77d;
+}
+
+.code-key,
+.code-number {
+  color: #7cd6c0;
+}
+
+.workflow-list {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  margin-top: 27px;
+}
+
+.workflow-step {
+  display: flex;
+  gap: 9px;
+  align-items: center;
+}
+
+.workflow-icon {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  color: #b6f36a;
+  background: #273a2b;
+  border: 1px solid #52745a;
+  border-radius: 5px;
+}
+
+.workflow-step strong {
+  display: block;
+  font:
+    700 11px ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+}
+
+.workflow-step small {
+  display: block;
+  margin-top: 3px;
+  font-size: 10px;
+  color: #8ea894;
+}
+
+.workflow-check {
+  margin-left: auto;
+  font-size: 14px;
+  color: #80d889;
+}
+
+.workflow-line {
+  width: 1px;
+  height: 20px;
+  margin: 3px 0 3px 13px;
+  background: #52745a;
+}
+
+.evidence-log {
+  padding: 11px;
+  margin-top: 25px;
+  font:
+    10px/1.8 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  background: #111913;
+  border: 1px solid #2f4435;
+  border-radius: 4px;
+}
+
+.evidence-log p {
+  margin: 0;
+}
+
+.log-time {
+  color: #657c6b;
+}
+
+.evidence-log b {
+  font-weight: 500;
+  color: #dbe7dd;
+}
+
+.evidence-log .log-pass {
+  color: #a4e28f;
+}
+
+.evidence-result {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  margin-top: 18px;
+  font:
+    10px ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  color: #8ea894;
+}
+
+.evidence-result span {
+  color: #80d889;
+}
+
+.evidence-result strong {
+  margin-left: auto;
+  font-size: 16px;
+  color: #b6f36a;
+}
+
+.workbench-footer {
+  justify-content: space-between;
+  min-height: 32px;
+  font-size: 8px;
+  color: #76927d;
+  border-top: 1px solid #34463a;
+  border-bottom: 0;
+}
+
+.home-section {
+  max-width: 1240px;
+  padding: 100px 32px;
+  margin: 0 auto;
+}
+
+.section-heading {
+  max-width: 570px;
+  margin-bottom: 38px;
+}
+
+.section-kicker {
+  margin: 0 0 12px;
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--home-green);
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: clamp(30px, 4vw, 46px);
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+}
+
+.section-heading > p:last-child {
+  margin: 16px 0 0;
+  line-height: 1.7;
+  color: var(--home-muted);
+}
+
+.capability-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-top: 1px solid var(--home-line);
+  border-left: 1px solid var(--home-line);
+}
+
+.capability-item {
+  position: relative;
+  display: block;
+  min-height: 270px;
+  padding: 24px;
+  color: inherit;
+  text-decoration: none;
+  border-right: 1px solid var(--home-line);
+  border-bottom: 1px solid var(--home-line);
+  transition: background 0.2s ease;
+}
+
+.capability-item:hover {
+  background: color-mix(in srgb, var(--home-green) 7%, transparent);
+}
+
+.capability-icon {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  color: var(--home-green);
+  background: color-mix(in srgb, var(--home-green) 12%, transparent);
+  border-radius: 5px;
+}
+
+.capability-detail {
+  margin: 24px 0 7px;
+  font:
+    10px ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  color: var(--home-green);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.capability-item h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.capability-description {
+  margin: 12px 0 0;
+  font-size: 13px;
+  line-height: 1.65;
+  color: var(--home-muted);
+}
+
+.capability-arrow {
   position: absolute;
-  inset: 12%;
-  z-index: -1;
-  pointer-events: none;
-  content: '';
-  background: conic-gradient(from 120deg, rgb(16 185 129 / 16%), rgb(190 242 100 / 12%), rgb(16 185 129 / 16%));
-  border-radius: 28px;
-  opacity: 0.75;
-  filter: blur(26px);
-  animation: slow-pan 16s ease-in-out infinite;
+  right: 22px;
+  bottom: 22px;
+  color: var(--home-muted);
+  transition:
+    color 0.2s ease,
+    transform 0.2s ease;
 }
 
-.cta-card:hover {
-  box-shadow:
-    0 16px 36px rgb(16 185 129 / 18%),
-    0 16px 40px rgb(0 0 0 / 8%);
-  transform: translateY(-4px);
+.capability-item:hover .capability-arrow {
+  color: var(--home-green);
+  transform: translate(3px, -3px);
 }
 
-@keyframes fade-rise {
-  from {
-    opacity: 0;
-    transform: translateY(14px) scale(0.99);
+.adoption-section {
+  border-top: 1px solid var(--home-line);
+}
+
+.section-heading-inline {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  max-width: none;
+}
+
+.section-heading-inline > p {
+  max-width: 330px;
+  margin: 0 0 4px;
+  line-height: 1.6;
+  color: var(--home-muted);
+}
+
+.adoption-list {
+  border-top: 1px solid var(--home-line);
+}
+
+.adoption-item {
+  display: grid;
+  grid-template-columns: 34px 120px minmax(0, 1fr) auto;
+  gap: 18px;
+  align-items: center;
+  padding: 23px 0;
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid var(--home-line);
+}
+
+.adoption-item:hover .adoption-action {
+  color: var(--home-green);
+}
+
+.adoption-icon {
+  font-size: 21px;
+  color: var(--home-green);
+}
+
+.adoption-label {
+  font-size: 10px;
+  color: var(--home-muted);
+}
+
+.adoption-content strong,
+.adoption-content small {
+  display: block;
+}
+
+.adoption-content strong {
+  font-size: 17px;
+}
+
+.adoption-content small {
+  margin-top: 7px;
+  font-size: 13px;
+  color: var(--home-muted);
+}
+
+.adoption-action {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 12px;
+  color: var(--home-muted);
+  transition: color 0.2s ease;
+}
+
+.start-section {
+  padding-top: 20px;
+  padding-bottom: 110px;
+}
+
+.start-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.8fr);
+  gap: 36px;
+  align-items: end;
+  padding: 38px;
+  background: var(--home-panel);
+  border: 1px solid var(--home-line);
+  border-radius: 7px;
+}
+
+.start-panel h2 {
+  max-width: 610px;
+  margin: 0;
+  font-size: clamp(26px, 3vw, 38px);
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+}
+
+.start-panel p:last-child {
+  margin: 14px 0 0;
+  line-height: 1.6;
+  color: var(--home-muted);
+}
+
+.start-command {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  min-height: 54px;
+  padding: 0 15px;
+  font:
+    12px ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  color: #dbe7dd;
+  background: #17221b;
+  border: 1px solid #34463a;
+  border-radius: 5px;
+}
+
+.command-prompt {
+  color: var(--home-lime);
+}
+
+.start-command code {
+  overflow: auto;
+  white-space: nowrap;
+}
+
+.start-command a {
+  flex: 0 0 auto;
+  margin-left: auto;
+  color: var(--home-lime);
+}
+
+@media (max-width: 1020px) {
+  .home-hero-inner {
+    grid-template-columns: 1fr;
   }
 
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
+  .hero-copy {
+    max-width: 680px;
+  }
+
+  .workbench-grid {
+    grid-template-columns: 1.2fr 0.8fr;
+  }
+
+  .evidence-pane {
+    grid-column: 1 / -1;
+    border-top: 1px solid #34463a;
+  }
+
+  .capability-grid {
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
-@keyframes gentle-pulse {
-  0%,
-  100% {
-    box-shadow:
-      0 0 0 1px rgb(16 185 129 / 15%) inset,
-      0 8px 24px rgb(16 185 129 / 15%);
+@media (max-width: 680px) {
+  .home-hero-inner,
+  .home-section {
+    padding-right: 20px;
+    padding-left: 20px;
   }
 
-  50% {
-    box-shadow:
-      0 0 0 1px rgb(16 185 129 / 30%) inset,
-      0 14px 36px rgb(16 185 129 / 22%);
-  }
-}
-
-@keyframes slow-pulse {
-  0%,
-  100% {
-    filter: blur(32px);
-    transform: translate3d(0, -6px, 0) scale(1);
+  .home-hero-inner {
+    padding-top: 62px;
+    padding-bottom: 58px;
   }
 
-  50% {
-    filter: blur(42px);
-    transform: translate3d(0, 8px, 0) scale(1.05);
-  }
-}
-
-@keyframes orbit {
-  from {
-    transform: translate3d(0, 0, 0) rotate(0deg);
+  .hero-description {
+    font-size: 16px;
   }
 
-  to {
-    transform: translate3d(0, 0, 0) rotate(360deg);
-  }
-}
-
-@keyframes slow-pan {
-  0%,
-  100% {
-    transform: rotate(0deg) scale(1);
+  .hero-actions .button-quiet {
+    display: none;
   }
 
-  50% {
-    transform: rotate(5deg) scale(1.03);
+  .workbench-grid {
+    display: block;
+  }
+
+  .code-pane,
+  .flow-pane {
+    border-right: 0;
+    border-bottom: 1px solid #34463a;
+  }
+
+  .code-pane {
+    min-height: 240px;
+  }
+
+  .flow-pane {
+    padding-bottom: 23px;
+  }
+
+  .evidence-pane {
+    border-top: 0;
+  }
+
+  .workbench-footer {
+    gap: 10px;
+    overflow: auto;
+    white-space: nowrap;
+  }
+
+  .home-section {
+    padding-top: 70px;
+    padding-bottom: 70px;
+  }
+
+  .section-heading-inline {
+    display: block;
+  }
+
+  .section-heading-inline > p {
+    margin-top: 16px;
+  }
+
+  .capability-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .capability-item {
+    min-height: 220px;
+  }
+
+  .adoption-item {
+    grid-template-columns: 28px 1fr auto;
+    gap: 12px;
+  }
+
+  .adoption-label {
+    grid-row: 1;
+    grid-column: 2;
+  }
+
+  .adoption-content {
+    grid-row: 2;
+    grid-column: 2 / -1;
+  }
+
+  .adoption-action {
+    grid-row: 1;
+    grid-column: 3;
+    font-size: 0;
+  }
+
+  .adoption-action span {
+    font-size: 17px;
+  }
+
+  .start-panel {
+    display: block;
+    padding: 25px 20px;
+  }
+
+  .start-command {
+    margin-top: 28px;
+  }
+
+  .start-command code {
+    font-size: 10px;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .hero-reveal > *,
-  .feature-card,
-  .floating-glow > div,
-  .hero-chip,
-  .cta-card::after {
-    opacity: 1 !important;
-    transform: none !important;
-    animation: none !important;
-  }
-
-  .interactive-cta,
-  .feature-card,
-  .cta-card {
-    transition: none !important;
+  .button,
+  .capability-item,
+  .capability-arrow,
+  .adoption-action {
+    transition: none;
   }
 }
 </style>

--- a/website/index.md
+++ b/website/index.md
@@ -1,16 +1,17 @@
 ---
 layout: page
-title: Weapp-vite
-titleTemplate: 小程序工程化、Vue SFC 与 Wevu 运行时的一体化工具链
-description: Weapp-vite 是面向小程序的现代工程化工具链，覆盖开发、构建、自动化、Vue SFC、Wevu 运行时、MCP 与多平台能力。
+title: Weapp-vite：AI 时代的小程序研发基线
+titleTemplate: 原生小程序工程化、多端构建与可验证 AI 工作流
+description: Weapp-vite 是面向原生小程序团队的现代研发基线，覆盖渐进接入、TypeScript、Vite/Rolldown、多端构建、Vue SFC、Wevu、MCP 与 DevTools 验收。
 keywords:
   - Weapp-vite
-  - 小程序工程化
+  - AI 小程序开发
+  - 原生小程序工程化
+  - 多端构建
   - Vue SFC
   - Wevu
   - MCP
-  - 多平台
-  - 自动化
+  - DevTools 验收
 ---
 
 <HomePage />


### PR DESCRIPTION
## 摘要

将 weapp-vite 的公开品牌表达统一为“AI 时代，原生小程序研发的默认基线”，首阶段覆盖官网首页、README 与首页 SEO 元数据。

## 主要改动

- 重写官网首页 Hero 与信息架构，新增 build / inspect / verify 研发工作台视觉。
- 突出原生渐进接入、现代工程化、多端构建、AI 可执行验证四项能力。
- 增加新项目、存量项目、AI 协作团队三条采用路径。
- 更新 README 的默认基线叙事与 AI 可执行闭环说明。
- 更新首页 SEO 标题、描述和关键词。

## 验证

- pnpm --dir website test
- pnpm --dir website build
- pnpm exec eslint website/.vitepress/components/HomePage.vue
- Playwright 验证桌面端、移动端、深色模式、键盘焦点和横向溢出

不涉及构建器、运行时或公开 API 变更。