### PR TITLE
fix(runtime): 收敛全仓运行时兼容与回归边界

### DIFF
--- a/.changeset/calm-runtimes-agree.md
+++ b/.changeset/calm-runtimes-agree.md
@@ -1,0 +1,9 @@
+---
+'@mpcore/simulator': patch
+'@weapp-vite/react': patch
+'create-weapp-vite': patch
+'wevu': patch
+'weapp-vite': patch
+---
+
+收敛小程序运行时兼容边界：React static bindings 不再依赖 `Object.fromEntries`，simulator 补齐 `toolInfo()`、隔离 headless evaluator 的 Node/浏览器宿主全局，并对齐微信开发者工具的 `switchTab` 成功回调与页面栈提交顺序，Wevu 页面路由状态可通过 setup instance bridge 正确识别当前原生页面；同时隔离 stateful HMR snapshot 的产物缓存，确保重复文件事件下样式更新仍由最新 snapshot 正确提交。

--- a/apps/vite-native/app.scss
+++ b/apps/vite-native/app.scss
@@ -1,9 +1,3 @@
 @import 'tailwindcss';
 /* stylelint-disable-next-line scss/at-rule-no-unknown */
 @wv-keep-import 'miniprogram_npm/tdesign-miniprogram/common/style/theme/_index.wxss';
-
-// @wv-keep-import '@vant/weapp/common/index.wxss';
-
-// @import '@vant/weapp/common/index.wxss';
-
-// @import './node_modules/@vant/weapp/dist/common/index.wxss';

--- a/e2e-apps/github-issues/src/pages/issue-705/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-705/index.vue
@@ -114,7 +114,10 @@ async function _runE2E(action?: 'push' | 'switchTab') {
       wx.switchTab({
         url: '/pages/issue-705-tab/index',
         success() {
-          wx.setStorageSync(SWITCH_TAB_RESULT_STORAGE_KEY, createSnapshot())
+          wx.setStorageSync(SWITCH_TAB_RESULT_STORAGE_KEY, {
+            ...createSnapshot(),
+            pageStack: getCurrentPages().map(page => page.route),
+          })
           resolve()
         },
         fail: reject,

--- a/e2e/ci/react-interop.build.test.ts
+++ b/e2e/ci/react-interop.build.test.ts
@@ -7,6 +7,16 @@ import { describe, expect, it } from 'vitest'
 const CLI_PATH = path.resolve(import.meta.dirname, '../../packages/weapp-vite/bin/weapp-vite.js')
 const APP_ROOT = path.resolve(import.meta.dirname, '../../e2e-apps/react-runtime-spike')
 const TEMPLATE_ROOT = path.resolve(import.meta.dirname, '../../templates/weapp-vite-react-template')
+const RESTRICTED_RUNTIME_BUILTINS = [
+  ['Object.fromEntries', /\bObject\.fromEntries\s*\(/],
+  ['Object.hasOwn', /\bObject\.hasOwn\s*\(/],
+  ['Promise.any', /\bPromise\.any\s*\(/],
+  ['Promise.allSettled', /\bPromise\.allSettled\s*\(/],
+  ['Array.prototype.at', /\.at\s*\(/],
+  ['Array.prototype.flat', /\.flat\s*\(/],
+  ['Array.prototype.flatMap', /\.flatMap\s*\(/],
+  ['String.prototype.replaceAll', /\.replaceAll\s*\(/],
+] as const
 
 async function runBuild(root: string, mode?: string) {
   const args = [CLI_PATH, 'build', root, '--platform', 'weapp', '--skipNpm']
@@ -19,6 +29,17 @@ async function runBuild(root: string, mode?: string) {
 
 async function readText(root: string, file: string) {
   return await fs.readFile(path.join(root, 'dist', file), 'utf8')
+}
+
+async function assertNoRestrictedRuntimeBuiltins(root: string) {
+  const distRoot = path.join(root, 'dist')
+  const files = await fs.readdir(distRoot, { recursive: true }) as string[]
+  for (const file of files.filter(file => /\.(?:c|m)?js$/.test(file))) {
+    const code = await fs.readFile(path.join(distRoot, file), 'utf8')
+    for (const [api, pattern] of RESTRICTED_RUNTIME_BUILTINS) {
+      expect(code, `${file} must not depend on ${api} in AppService`).not.toMatch(pattern)
+    }
+  }
 }
 
 async function assertInteropAppOutput() {
@@ -62,6 +83,7 @@ async function assertInteropAppOutput() {
   expect(reactLeafWxml).toContain('<slot />')
   expect(reactLeafJs).toContain('../../renderer.js')
   expect(wevuLeafJs).toContain('../../weapp-vendors/wevu-runtime.js')
+  await assertNoRestrictedRuntimeBuiltins(APP_ROOT)
 }
 
 describe.sequential('React, Wevu and native component interoperability (build)', () => {
@@ -87,5 +109,6 @@ describe.sequential('React, Wevu and native component interoperability (build)',
     expect(pageWxml).toContain('<wevu-leaf')
     expect(pageWxml).toContain('bind:change="__weapp_vite_react_event"')
     expect(await readText(TEMPLATE_ROOT, 'components/wevu-leaf/index.wxml')).toContain('<slot />')
+    await assertNoRestrictedRuntimeBuiltins(TEMPLATE_ROOT)
   })
 })

--- a/e2e/ci/wevu-runtime-demo.request-globals.build.test.ts
+++ b/e2e/ci/wevu-runtime-demo.request-globals.build.test.ts
@@ -1,5 +1,6 @@
 import type { TestJsFormat } from '../utils/jsFormat'
 import {
+  REQUEST_GLOBAL_BUNDLE_MARKER,
   REQUEST_GLOBAL_LOCAL_BINDINGS_MARKER,
 } from '@weapp-core/constants'
 import { fs } from '@weapp-core/shared/node'
@@ -14,16 +15,13 @@ const APP_ROOT = path.resolve(import.meta.dirname, '../../apps/wevu-runtime-demo
 const DIST_ROOT = path.join(APP_ROOT, 'dist')
 const JS_FORMATS: TestJsFormat[] = ['cjs', 'esm']
 
-function escapeRegex(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+function exposesRequestGlobalsInstaller(code: string) {
+  return /Object\.defineProperty\(exports,\s*(['"])installWebRuntimeGlobals\1/.test(code)
+    || /export\s*\{[^}]*\binstallWebRuntimeGlobals\b[^}]*\}/.test(code)
 }
 
-function expectOneModuleReference(code: string, specifiers: string[]) {
-  expect(specifiers.some((specifier) => {
-    const escapedSpecifier = escapeRegex(specifier)
-    const escapedGlobalModuleKey = escapeRegex(specifier.replace(/^(?:\.\.\/)+/, ''))
-    return new RegExp(`(?:require\\((['"\`])${escapedSpecifier}\\1\\)|from\\s+(['"\`])${escapedSpecifier}\\2|globalThis\\[(['"\`])__weappViteRequestGlobalsModule:${escapedGlobalModuleKey}\\3\\])`).test(code)
-  })).toBe(true)
+function invokesRequestGlobalsInstaller(code: string) {
+  return /installWebRuntimeGlobals["'\]]*\s*\(\{\s*targets\s*:/.test(code)
 }
 
 async function runBuild(jsFormat: TestJsFormat) {
@@ -87,27 +85,23 @@ describe.sequential('e2e app: wevu-runtime-demo request globals (build)', () => 
         DIST_ROOT,
         code =>
           code.includes('installWebRuntimeGlobals')
-          && code.includes('__weappViteRequestGlobalsModule:weapp-vendors/request-globals-web-apis-shared.js'),
+          && code.includes(REQUEST_GLOBAL_BUNDLE_MARKER)
+          && exposesRequestGlobalsInstaller(code)
+          && invokesRequestGlobalsInstaller(code),
         'request globals runtime',
       )
 
       for (const target of FULL_REQUEST_GLOBAL_TARGETS) {
         expect(appJs).toContain(JSON.stringify(target))
       }
-      expect(requestGlobalsRuntimeJs).toMatch(/Object\.defineProperty\(exports,|export\s+\{/)
+      expect(exposesRequestGlobalsInstaller(requestGlobalsRuntimeJs)).toBe(true)
+      expect(invokesRequestGlobalsInstaller(requestGlobalsRuntimeJs)).toBe(true)
 
       for (const testCase of PAGE_CASES) {
         const pageJs = await fs.readFile(path.join(DIST_ROOT, testCase.fileName), 'utf8')
 
         expect(pageJs).toContain(REQUEST_GLOBAL_LOCAL_BINDINGS_MARKER)
-        expectOneModuleReference(pageJs, [
-          '../../request-globals-web-apis-shared.js',
-          '../../request-globals-wevu-web-apis-shared.js',
-          '../../weapp-vendors/request-globals-web-apis-shared.js',
-          '../../weapp-vendors/request-globals-wevu-web-apis-shared.js',
-          '../../weapp-vendors/request-globals-runtime.js',
-          '../../weapp-vendors/web-apis-shared.js',
-        ])
+        expect(invokesRequestGlobalsInstaller(pageJs)).toBe(true)
         for (const target of FULL_REQUEST_GLOBAL_TARGETS) {
           expect(pageJs).toContain(JSON.stringify(target))
         }

--- a/e2e/ci/wevu-runtime.template-compat.integration.test.ts
+++ b/e2e/ci/wevu-runtime.template-compat.integration.test.ts
@@ -24,6 +24,7 @@ describe.sequential('wevu runtime template compat integration', () => {
     expect(wxml).toContain(`wx:for-item="value" wx:for-index="key"`)
 
     expect(wxml).not.toContain(`.  = `)
-    expect(script).toMatch(/Object\.fromEntries/)
+    expect(script).toContain('summaryMap')
+    expect(script).not.toContain('Object.fromEntries')
   })
 })

--- a/e2e/ci/wevu-vue-demo.template-compat.build.test.ts
+++ b/e2e/ci/wevu-vue-demo.template-compat.build.test.ts
@@ -65,7 +65,7 @@ describe.sequential('e2e app: wevu-vue-demo (template compat)', () => {
     expect(pageJs).toContain('entries')
     expect(pageJs).toContain('entryObjects')
     expect(pageJs).toContain('summaryMap')
-    expect(pageJs).toContain('Object.fromEntries')
+    expect(pageJs).not.toContain('Object.fromEntries')
     expect(pageJs).toContain('dynamic-')
     expect(pageJs).toContain('onNativeEventWithArgs')
     expect(pageJs).toMatch(/['"`]touchcancel['"`],\s*['"`]zone['"`],/)

--- a/e2e/ide/github-issues.runtime.issue705.test.ts
+++ b/e2e/ide/github-issues.runtime.issue705.test.ts
@@ -201,7 +201,15 @@ describe.sequential('e2e app: github-issues / issue #705', () => {
 
       await callIssue705PageMethod(miniProgram, ISSUE_PAGE_PATH, 'switchTab', 12_000).catch(() => undefined)
       const switchTabResult = await waitForStorage(miniProgram, SWITCH_TAB_RESULT_STORAGE_KEY)
-      expect(switchTabResult.route.path).toBe('pages/issue-705-tab/index')
+      expect({
+        pageStack: switchTabResult.pageStack,
+        route: switchTabResult.route.path,
+        routerRoute: switchTabResult.routerRoute.path,
+      }).toEqual({
+        pageStack: ['pages/issue-705-tab/index'],
+        route: 'pages/issue-705-tab/index',
+        routerRoute: 'pages/issue-705-tab/index',
+      })
 
       const tabPage = await waitForCurrentPagePath(miniProgram, '/pages/issue-705-tab/index', 8_000)
       if (!tabPage) {

--- a/e2e/utils/webDevServer.test.ts
+++ b/e2e/utils/webDevServer.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { createWebDevServerEnv, resolveWebDevServerUrl } from './webDevServer'
+
+describe('web dev server URL', () => {
+  it('keeps CLI startup logging enabled outside the Vitest child environment', () => {
+    expect(createWebDevServerEnv({
+      CUSTOM_VALUE: 'kept',
+      NODE_ENV: 'test',
+      TEST: 'true',
+      VITEST: 'true',
+      VITEST_MODE: 'RUN',
+      VITEST_POOL_ID: '1',
+      VITEST_WORKER_ID: '2',
+    })).toEqual({
+      BROWSER: 'none',
+      CUSTOM_VALUE: 'kept',
+      NODE_ENV: 'development',
+    })
+  })
+
+  it('reads the resolved Web URL after Vite falls back from an occupied port', () => {
+    const logs = [
+      'Port 5173 is in use, trying another one...',
+      'MCP: http://127.0.0.1:20040/mcp',
+      '\u001B[32mWeb\u001B[39m\uFF1Ahttp://127.0.0.1:5174/',
+    ].join('\n')
+
+    expect(resolveWebDevServerUrl(logs)).toBe('http://127.0.0.1:5174/')
+  })
+
+  it('does not treat unrelated service URLs as the Web application URL', () => {
+    expect(resolveWebDevServerUrl('MCP: http://127.0.0.1:20040/mcp')).toBeUndefined()
+  })
+})

--- a/e2e/utils/webDevServer.ts
+++ b/e2e/utils/webDevServer.ts
@@ -1,0 +1,36 @@
+import { stripVTControlCharacters } from 'node:util'
+
+const WEB_URL_RE = /Web[\uFF1A:]\s*(https?:\/\/\S+)/i
+const TEST_ENV_KEYS = [
+  'TEST',
+  'VITEST',
+  'VITEST_MODE',
+  'VITEST_POOL_ID',
+  'VITEST_WORKER_ID',
+] as const
+
+export function createWebDevServerEnv(source: NodeJS.ProcessEnv) {
+  const env = {
+    ...source,
+    BROWSER: 'none',
+    NODE_ENV: 'development',
+  }
+  for (const key of TEST_ENV_KEYS) {
+    delete env[key]
+  }
+  return env
+}
+
+export function resolveWebDevServerUrl(logs: string) {
+  const plainLogs = stripVTControlCharacters(logs)
+  for (const line of plainLogs.split(/\r?\n/).reverse()) {
+    const matchedUrl = line.match(WEB_URL_RE)?.[1]
+    if (!matchedUrl) {
+      continue
+    }
+    try {
+      return new URL(matchedUrl).toString()
+    }
+    catch {}
+  }
+}

--- a/e2e/vitest.e2e.web.config.ts
+++ b/e2e/vitest.e2e.web.config.ts
@@ -8,7 +8,10 @@ export default defineConfig({
     tsconfig: false,
   },
   test: {
-    include: [path.resolve(import.meta.dirname, './web-runtime/*.test.ts')],
+    include: [
+      path.resolve(import.meta.dirname, './utils/webDevServer.test.ts'),
+      path.resolve(import.meta.dirname, './web-runtime/*.test.ts'),
+    ],
     exclude: [path.resolve(import.meta.dirname, './web-runtime/web-browser-smoke.test.ts')],
     testTimeout: 180_000,
     hookTimeout: 180_000,

--- a/e2e/web-runtime/web-projects.test.ts
+++ b/e2e/web-runtime/web-projects.test.ts
@@ -1,9 +1,10 @@
 /* eslint-disable e18e/ban-dependencies -- Web 项目矩阵需要 execa 管理逐项目 dev server。 */
 import type { Subprocess } from 'execa'
+import type { Server } from 'node:http'
 import type { Browser, Page } from 'playwright'
 import { existsSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
-import { get } from 'node:http'
+import { createServer, get } from 'node:http'
 import path from 'node:path'
 import process from 'node:process'
 import { setTimeout as sleep } from 'node:timers/promises'
@@ -12,12 +13,11 @@ import { execa } from 'execa'
 import { chromium } from 'playwright'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { discoverWebProjects } from '../../scripts/web-project-matrix'
+import { createWebDevServerEnv, resolveWebDevServerUrl } from '../utils/webDevServer'
 
 const ROOT = fileURLToPath(new URL('../..', import.meta.url))
 const CLI_PATH = fileURLToPath(new URL('../../packages/weapp-vite/dist/cli.mjs', import.meta.url))
 const WEB_HOST = '127.0.0.1'
-const WEB_PORT = Number(process.env.WEAPP_VITE_WEB_PROJECT_E2E_PORT ?? 5173)
-const WEB_URL = `http://${WEB_HOST}:${WEB_PORT}`
 const STARTUP_TIMEOUT = Number(process.env.WEAPP_VITE_WEB_PROJECT_STARTUP_TIMEOUT ?? 90_000)
 const RUNTIME_TIMEOUT = Number(process.env.WEAPP_VITE_WEB_PROJECT_RUNTIME_TIMEOUT ?? 45_000)
 const RUNTIME_STATE_ATTEMPTS = 3
@@ -70,29 +70,63 @@ async function stopServer(server: Subprocess | undefined, gracePeriod = 250) {
   }
 }
 
+async function occupyDefaultWebPort() {
+  const blocker = createServer((_request, response) => {
+    response.writeHead(204)
+    response.end()
+  })
+  try {
+    await new Promise<void>((resolve, reject) => {
+      blocker.once('error', reject)
+      blocker.listen(5173, WEB_HOST, resolve)
+    })
+    return blocker
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EADDRINUSE') {
+      return undefined
+    }
+    throw error
+  }
+}
+
+async function closeHttpServer(server: Server | undefined) {
+  if (!server) {
+    return
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close(error => error ? reject(error) : resolve())
+  })
+}
+
 async function waitForServer(server: Subprocess, logs: { value: string }) {
   const startedAt = Date.now()
   while (Date.now() - startedAt < STARTUP_TIMEOUT) {
     if (server.nodeChildProcess.exitCode !== null) {
       throw new Error(`Web dev server exited with ${server.nodeChildProcess.exitCode}.\n${logs.value}`)
     }
+    const webUrl = resolveWebDevServerUrl(logs.value)
+    if (!webUrl) {
+      await sleep(200)
+      continue
+    }
     try {
       const statusCode = await new Promise<number | undefined>((resolve, reject) => {
-        const request = get(WEB_URL, (response) => {
+        const request = get(webUrl, (response) => {
           response.resume()
           response.once('end', () => resolve(response.statusCode))
         })
         request.once('error', reject)
-        request.setTimeout(5_000, () => request.destroy(new Error(`Timed out requesting ${WEB_URL}.`)))
+        request.setTimeout(5_000, () => request.destroy(new Error(`Timed out requesting ${webUrl}.`)))
       })
       if (statusCode && statusCode >= 200 && statusCode < 400) {
-        return
+        return webUrl
       }
     }
     catch {}
     await sleep(200)
   }
-  throw new Error(`Timed out waiting for ${WEB_URL}.\n${logs.value}`)
+  throw new Error(`Timed out waiting for the resolved Web dev server URL.\n${logs.value}`)
 }
 
 async function readRuntimeState(page: Page) {
@@ -181,6 +215,28 @@ describeWeb.sequential('workspace Web project matrix', async () => {
     await browser?.close()
   })
 
+  it('uses the resolved URL when Vite falls back from occupied port 5173', async () => {
+    const blocker = await occupyDefaultWebPort()
+    const projectRoot = path.join(ROOT, 'e2e-apps/base')
+    const command = execa(process.execPath, [CLI_PATH, projectRoot, '--platform', 'web', '--host', WEB_HOST], {
+      cwd: ROOT,
+      env: createWebDevServerEnv(process.env),
+      extendEnv: false,
+    })
+    const logs = createServerLogger(command)
+    server = command
+
+    try {
+      const webUrl = await waitForServer(command, logs)
+      expect(new URL(webUrl).port).not.toBe('5173')
+    }
+    finally {
+      await stopServer(command)
+      server = undefined
+      await closeHttpServer(blocker)
+    }
+  })
+
   for (const project of projects) {
     it(project.relativeRoot, async () => {
       const mutableSnapshots = await Promise.all(
@@ -191,23 +247,21 @@ describeWeb.sequential('workspace Web project matrix', async () => {
       )
       const command = execa(process.execPath, [CLI_PATH, project.root, '--platform', 'web', '--host', WEB_HOST], {
         cwd: ROOT,
-        env: {
-          ...process.env,
-          BROWSER: 'none',
-        },
+        env: createWebDevServerEnv(process.env),
+        extendEnv: false,
       })
+      const logs = createServerLogger(command)
       const completion = command.then(
         result => result,
         error => error,
       )
       server = command
-      const logs = createServerLogger(command)
 
       try {
         if (project.expectation === 'startup-error') {
           const startup = await Promise.race([
             completion.then(result => ({ kind: 'exit' as const, result })),
-            waitForServer(command, logs).then(() => ({ kind: 'server' as const })),
+            waitForServer(command, logs).then(webUrl => ({ kind: 'server' as const, webUrl })),
           ])
           if (startup.kind === 'exit') {
             expect(`${String(startup.result)}\n${logs.value}`).toMatch(/withDefaults|defineProps|编译|compile/i)
@@ -219,7 +273,7 @@ describeWeb.sequential('workspace Web project matrix', async () => {
           const pageErrors: string[] = []
           page.on('pageerror', error => pageErrors.push(error.stack ?? error.message))
           try {
-            await page.goto(WEB_URL, { waitUntil: 'domcontentloaded' })
+            await page.goto(startup.webUrl, { waitUntil: 'domcontentloaded' })
             await expect.poll(
               () => `${logs.value}\n${pageErrors.join('\n')}`,
               { timeout: 15_000 },
@@ -231,13 +285,13 @@ describeWeb.sequential('workspace Web project matrix', async () => {
           return
         }
 
-        await waitForServer(command, logs)
+        const webUrl = await waitForServer(command, logs)
         const context = await browser!.newContext()
         const page = await context.newPage()
         const pageErrors: string[] = []
         page.on('pageerror', error => pageErrors.push(error.stack ?? error.message))
         try {
-          await page.goto(WEB_URL, { waitUntil: 'domcontentloaded' })
+          await page.goto(webUrl, { waitUntil: 'domcontentloaded' })
           let runtime: Awaited<ReturnType<typeof readRuntimeState>>
           try {
             runtime = await waitForExpectedRuntimeState(page, project.expectation)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -88,6 +88,7 @@ export default await defineEslintConfig({
     }, {
       ...createMiniProgramRuntimeConfig({
         files: [
+          'packages-runtime/react/src/**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,vue}',
           'packages-runtime/wevu/src/**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,vue}',
           'packages-runtime/web-apis/src/**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,vue}',
           '@weapp-core/shared/src/**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,vue}',
@@ -97,6 +98,7 @@ export default await defineEslintConfig({
       }),
     }, {
       files: [
+        'packages-runtime/react/src/**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,vue}',
         'packages-runtime/wevu/src/**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,vue}',
         '@weapp-core/shared/src/**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,vue}',
       ],

--- a/mpcore/demos/web/src/fixtures/route-maze/package-flow/queue/index.js
+++ b/mpcore/demos/web/src/fixtures/route-maze/package-flow/queue/index.js
@@ -42,6 +42,10 @@ Page({
   bounceSettings() {
     wx.switchTab({
       url: '/pages/settings/index',
+      success() {
+        const pages = getCurrentPages()
+        wx.setStorageSync('route-maze-switch-tab-success-route', pages[pages.length - 1]?.route)
+      },
     })
   },
 })

--- a/mpcore/packages/simulator/README.md
+++ b/mpcore/packages/simulator/README.md
@@ -11,6 +11,7 @@
 - 支持本地 `pluginRoot` 的 `requirePlugin`、`plugin://` 公开组件与插件页面导航
 - 提供测试节点句柄上的 `tap()`、`trigger()`、`input()`、`change()`、`blur()` 交互辅助方法
 - 提供测试页面/会话句柄上的 `waitForSelector()`、`waitForText()`、`waitForTextGone()`、`waitForData()`、`waitForCurrentPage()` 等轮询等待方法
+- 测试会话句柄提供与 `miniprogram-automator` 对齐的 `toolInfo()`，headless provider 返回稳定的 simulator 标识
 - 通过共享 `RuntimeKernel` 管理 artifact、独立执行 realm、timer、diagnostics 与平台适配边界
 - `close()` 会清理页面栈、组件 scope、observer、timer、事件和模块缓存，并使旧页面/节点 handle 失效
 

--- a/mpcore/packages/simulator/e2e/browser.e2e.test.ts
+++ b/mpcore/packages/simulator/e2e/browser.e2e.test.ts
@@ -1574,7 +1574,9 @@ describe.sequential('simulator browser e2e', () => {
     )
 
     const pageData = parseJsonString<Record<string, any>>(state.pageData)
+    const storageData = parseJsonString<Record<string, any>>(state.storageData)
     expect(state.pageStack).toEqual(['pages/settings/index'])
+    expect(storageData['route-maze-switch-tab-success-route']).toBe('pages/settings/index')
     expect(pageData.title).toBe('Settings Tab')
     expect(pageData.logs).toContain('settings-tab:onShow')
     expect(pageData.logs).not.toContain(expect.stringContaining('settings-tab:onTabItemTap:'))

--- a/mpcore/packages/simulator/src/browser/session.ts
+++ b/mpcore/packages/simulator/src/browser/session.ts
@@ -16,6 +16,7 @@ import type {
 import type { BrowserVirtualFiles } from './virtualFiles'
 import { join, posix } from 'pathe'
 import { createHostRegistries } from '../host'
+import { invokePreparedNavigationApi } from '../host/wx/navigation'
 import { RuntimeKernel } from '../kernel'
 import { cloneBackgroundSnapshot, cloneNavigationBarSnapshot, resolveBackgroundSnapshot, resolveNavigationBarSnapshot } from '../project/pageConfig'
 import { resolvePluginRequest } from '../project/plugins'
@@ -346,7 +347,10 @@ export class BrowserHeadlessSession {
         showToast: option => this.wxState.showToast(option),
         startPullDownRefresh: () => this.startPullDownRefresh(),
         stopPullDownRefresh: () => this.stopPullDownRefresh(),
-        switchTab: option => this.switchTab(option.url),
+        switchTab: option => invokePreparedNavigationApi(
+          () => this.prepareSwitchTab(option.url),
+          option,
+        ),
         uploadFile: option => this.wxState.uploadFile(option),
         removeTabBarBadge: option => this.removeTabBarBadge(option.index),
         setTabBarBadge: option => this.setTabBarBadge(option.index, option.text),
@@ -1149,20 +1153,30 @@ export class BrowserHeadlessSession {
   }
 
   switchTab(url: string) {
+    const finalize = this.prepareSwitchTab(url)()
+    finalize()
+    return this.currentPageInstance
+  }
+
+  private prepareSwitchTab(url: string) {
     const target = this.resolveNavigationTarget(url)
-    this.bootstrap(createAppLaunchOptions(target.normalizedRoute, target.query))
     if (Object.keys(target.query).length > 0) {
       throw new Error(`wx.switchTab() url cannot contain query in browser simulator runtime: ${url}`)
     }
     if (!this.isTabBarRoute(target.routeRecord.route)) {
       throw new Error(`wx.switchTab() can only open a tabBar page in browser simulator runtime: ${url}`)
     }
+    this.bootstrap(createAppLaunchOptions(target.normalizedRoute, target.query))
 
+    return () => this.commitSwitchTab(target)
+  }
+
+  private commitSwitchTab(target: ResolvedNavigationTarget) {
     const current = this.currentPageInstance
     const cachedTarget = this.tabPages.get(target.routeRecord.route) ?? null
 
     if (current === cachedTarget && current) {
-      return current
+      return () => {}
     }
 
     if (current && current !== cachedTarget) {
@@ -1170,12 +1184,11 @@ export class BrowserHeadlessSession {
       this.runPageComponentLifetime(current.route, 'hide')
     }
 
-    for (const page of [...this.pages].reverse()) {
-      if (this.isTabBarRoute(stripLeadingSlash(page.route))) {
-        continue
-      }
+    const pagesToUnload = [...this.pages]
+      .reverse()
+      .filter(page => !this.isTabBarRoute(stripLeadingSlash(page.route)))
+    for (const page of pagesToUnload) {
       this.removePageInstance(page)
-      this.unloadPage(page)
     }
 
     let nextPage = cachedTarget
@@ -1197,7 +1210,11 @@ export class BrowserHeadlessSession {
       this.runPageComponentLifetime(nextPage.route, 'show')
     }
 
-    return nextPage
+    return () => {
+      for (const page of pagesToUnload) {
+        this.unloadPage(page)
+      }
+    }
   }
 
   pageScrollTo(option: {

--- a/mpcore/packages/simulator/src/host/wx/index.ts
+++ b/mpcore/packages/simulator/src/host/wx/index.ts
@@ -310,9 +310,7 @@ export function createHeadlessWx(driver: HeadlessWxDriver): HeadlessWx {
     showToast: option => invokeWxApi(() => driver.showToast(option), option),
     startPullDownRefresh: option => invokeWxApi(() => driver.startPullDownRefresh(), option),
     stopPullDownRefresh: () => driver.stopPullDownRefresh(),
-    switchTab: option => invokeWxApi(() => {
-      driver.switchTab(option)
-    }, option),
+    switchTab: option => driver.switchTab(option),
     uploadFile: option => driver.uploadFile(option),
     removeTabBarBadge: option => invokeWxApi(() => driver.removeTabBarBadge(option), option),
     setTabBarBadge: option => invokeWxApi(() => driver.setTabBarBadge(option), option),

--- a/mpcore/packages/simulator/src/host/wx/navigation.ts
+++ b/mpcore/packages/simulator/src/host/wx/navigation.ts
@@ -1,0 +1,24 @@
+import type { HeadlessWxCallbackOption } from './core'
+
+export function invokePreparedNavigationApi(
+  prepare: () => () => unknown,
+  option?: HeadlessWxCallbackOption,
+) {
+  try {
+    const commit = prepare()
+    const finalize = commit()
+    try {
+      option?.success?.()
+    }
+    finally {
+      if (typeof finalize === 'function') {
+        finalize()
+      }
+    }
+    option?.complete?.()
+  }
+  catch (error) {
+    option?.fail?.(error as Error)
+    option?.complete?.()
+  }
+}

--- a/mpcore/packages/simulator/src/runtime/session.ts
+++ b/mpcore/packages/simulator/src/runtime/session.ts
@@ -15,6 +15,7 @@ import type {
 } from './wxState'
 import path from 'node:path'
 import { createHostRegistries } from '../host'
+import { invokePreparedNavigationApi } from '../host/wx/navigation'
 import { RuntimeKernel } from '../kernel'
 import { loadProject } from '../project'
 import { cloneBackgroundSnapshot, cloneNavigationBarSnapshot, resolveBackgroundSnapshot, resolveNavigationBarSnapshot } from '../project/pageConfig'
@@ -337,7 +338,10 @@ export class HeadlessSession {
         showToast: option => this.wxState.showToast(option),
         startPullDownRefresh: () => this.startPullDownRefresh(),
         stopPullDownRefresh: () => this.stopPullDownRefresh(),
-        switchTab: option => this.switchTab(option.url),
+        switchTab: option => invokePreparedNavigationApi(
+          () => this.prepareSwitchTab(option.url),
+          option,
+        ),
         uploadFile: option => this.wxState.uploadFile(option),
         removeTabBarBadge: option => this.removeTabBarBadge(option.index),
         setTabBarBadge: option => this.setTabBarBadge(option.index, option.text),
@@ -1075,20 +1079,30 @@ export class HeadlessSession {
   }
 
   switchTab(url: string) {
+    const finalize = this.prepareSwitchTab(url)()
+    finalize()
+    return this.currentPageInstance
+  }
+
+  private prepareSwitchTab(url: string) {
     const target = this.resolveNavigationTarget(url)
-    this.bootstrap(createAppLaunchOptions(target.normalizedRoute, target.query))
     if (Object.keys(target.query).length > 0) {
       throw new Error(`wx.switchTab() url cannot contain query in headless runtime: ${url}`)
     }
     if (!this.isTabBarRoute(target.routeRecord.route)) {
       throw new Error(`wx.switchTab() can only open a tabBar page in headless runtime: ${url}`)
     }
+    this.bootstrap(createAppLaunchOptions(target.normalizedRoute, target.query))
 
+    return () => this.commitSwitchTab(target)
+  }
+
+  private commitSwitchTab(target: ResolvedNavigationTarget) {
     const current = this.currentPageInstance
     const cachedTarget = this.tabPages.get(target.routeRecord.route) ?? null
 
     if (current === cachedTarget && current) {
-      return current
+      return () => {}
     }
 
     if (current && current !== cachedTarget) {
@@ -1096,12 +1110,11 @@ export class HeadlessSession {
       this.runPageComponentLifetime(current.route, 'hide')
     }
 
-    for (const page of [...this.pages].reverse()) {
-      if (this.isTabBarRoute(stripLeadingSlash(page.route))) {
-        continue
-      }
+    const pagesToUnload = [...this.pages]
+      .reverse()
+      .filter(page => !this.isTabBarRoute(stripLeadingSlash(page.route)))
+    for (const page of pagesToUnload) {
       this.removePageInstance(page)
-      this.unloadPage(page)
     }
 
     let nextPage = cachedTarget
@@ -1123,7 +1136,11 @@ export class HeadlessSession {
       this.runPageComponentLifetime(nextPage.route, 'show')
     }
 
-    return nextPage
+    return () => {
+      for (const page of pagesToUnload) {
+        this.unloadPage(page)
+      }
+    }
   }
 
   pageScrollTo(option: {

--- a/mpcore/packages/simulator/src/testing/sessionHandle.ts
+++ b/mpcore/packages/simulator/src/testing/sessionHandle.ts
@@ -1,2 +1,3 @@
 export { HeadlessTestingSessionHandle } from './sessionHandle/index'
+export type { HeadlessTestingToolInfo } from './sessionHandle/index'
 export { HeadlessTestingScopeHandle } from './sessionHandle/scope'

--- a/mpcore/packages/simulator/src/testing/sessionHandle/index.ts
+++ b/mpcore/packages/simulator/src/testing/sessionHandle/index.ts
@@ -2,6 +2,7 @@ import type { HeadlessProjectDescriptor } from '../../project'
 import type { HeadlessSession } from '../../runtime'
 import type { HeadlessTestingWaitOptions } from '../pageWait'
 import vm from 'node:vm'
+import { createMiniProgramRuntimeGlobals } from '../../runtime/runtimeGlobals'
 import { HeadlessTestingPageHandle } from '../pageHandle'
 import { HeadlessTestingScopeHandle } from './scope'
 import { normalizeNonEmptyInput, normalizeRoute, pollUntil, runWithTimeout } from './shared'
@@ -14,6 +15,10 @@ export interface HeadlessTestingProtocolOptions {
 
 export type HeadlessTestingEvaluator<T = unknown> = ((...args: any[]) => T | PromiseLike<T>) | string
 
+export interface HeadlessTestingToolInfo {
+  version: 'mpcore-simulator'
+}
+
 export class HeadlessTestingSessionHandle {
   constructor(
     private readonly project: HeadlessProjectDescriptor,
@@ -22,6 +27,12 @@ export class HeadlessTestingSessionHandle {
 
   async close() {
     this.session.close()
+  }
+
+  async toolInfo(): Promise<HeadlessTestingToolInfo> {
+    return {
+      version: 'mpcore-simulator',
+    }
   }
 
   on(eventName: string, handler: (...args: any[]) => void) {
@@ -223,42 +234,26 @@ export class HeadlessTestingSessionHandle {
   }
 
   private async evaluateInRuntime<T>(evaluator: HeadlessTestingEvaluator<T>, args: any[]) {
-    const runtimeGlobals: Record<string, unknown> = {
+    const runtimeGlobals = createMiniProgramRuntimeGlobals({
+      clearInterval: globalThis.clearInterval,
+      clearTimeout: globalThis.clearTimeout,
       getApp: () => this.session.getApp(),
       getCurrentPages: () => this.session.getCurrentPages(),
+      setInterval: globalThis.setInterval,
+      setTimeout: globalThis.setTimeout,
+      TextDecoder: globalThis.TextDecoder,
+      TextEncoder: globalThis.TextEncoder,
+      URL: globalThis.URL,
       wx: this.session.getWx(),
+    }, {})
+    runtimeGlobals.globalThis = runtimeGlobals
+    const source = typeof evaluator === 'string'
+      ? evaluator
+      : Function.prototype.toString.call(evaluator)
+    const fn = new vm.Script(`(${source})`).runInNewContext(runtimeGlobals) as (...values: any[]) => T
+    if (typeof fn !== 'function') {
+      throw new TypeError('Headless evaluator must be a function or function source string.')
     }
-    const host = globalThis as Record<string, unknown>
-    const previous = new Map<string, PropertyDescriptor | undefined>()
-
-    for (const [name, value] of Object.entries(runtimeGlobals)) {
-      previous.set(name, Object.getOwnPropertyDescriptor(host, name))
-      Object.defineProperty(host, name, {
-        configurable: true,
-        enumerable: false,
-        value,
-        writable: true,
-      })
-    }
-
-    try {
-      const fn = typeof evaluator === 'string'
-        ? new vm.Script(`(${evaluator})`).runInThisContext() as (...values: any[]) => T
-        : evaluator
-      if (typeof fn !== 'function') {
-        throw new TypeError('Headless evaluator must be a function or function source string.')
-      }
-      return await fn(...args)
-    }
-    finally {
-      for (const [name, descriptor] of previous) {
-        if (descriptor) {
-          Object.defineProperty(host, name, descriptor)
-        }
-        else {
-          delete host[name]
-        }
-      }
-    }
+    return await fn(...args)
   }
 }

--- a/mpcore/packages/simulator/test-d/public-api.sessions-and-saved-files.test-d.ts
+++ b/mpcore/packages/simulator/test-d/public-api.sessions-and-saved-files.test-d.ts
@@ -2,6 +2,7 @@ import type {
   HeadlessPluginDescriptor,
   HeadlessTestingRenderedNodeSnapshot,
   HeadlessTestingSessionHandle,
+  HeadlessTestingToolInfo,
   HeadlessWxDeviceInfoResult,
   HeadlessWxDownloadFileMockDefinition,
   HeadlessWxGetLocationResult,
@@ -805,6 +806,8 @@ launchResult.then((session) => {
   expectType<HeadlessTestingSessionHandle>(session.on('console', () => {}))
   expectType<HeadlessTestingSessionHandle>(session.removeListener('console', () => {}))
   expectType<HeadlessTestingSessionHandle>(session.off('console', () => {}))
+  expectType<Promise<HeadlessTestingToolInfo>>(session.toolInfo())
+  session.toolInfo().then(info => expectType<'mpcore-simulator'>(info.version))
   session.reLaunch('/pages/index/index').then((page) => {
     expectType<string>(page.path)
     expectType<Record<string, string>>(page.query)

--- a/mpcore/packages/simulator/test/browserSession.test.ts
+++ b/mpcore/packages/simulator/test/browserSession.test.ts
@@ -5,6 +5,56 @@ import {
 } from '../src/browser'
 
 describe('BrowserHeadlessSession', () => {
+  it('commits the tab stack before running switchTab success', () => {
+    const files = createBrowserVirtualFiles([
+      ['app.json', JSON.stringify({
+        pages: ['pages/home/index', 'pages/profile/index'],
+        tabBar: {
+          list: [
+            { pagePath: 'pages/profile/index', text: 'Profile' },
+          ],
+        },
+      })],
+      ['app.js', 'App({})'],
+      ['pages/home/index.js', `
+Page({
+  data: { callbackRoute: '', completed: false, unloaded: false, unloadedBeforeSuccess: false },
+  openProfile() {
+    wx.switchTab({
+      url: '/pages/profile/index',
+      success: () => {
+        const pages = getCurrentPages()
+        this.setData({
+          callbackRoute: pages[pages.length - 1].route,
+          unloadedBeforeSuccess: this.data.unloaded,
+        })
+      },
+      complete: () => this.setData({ completed: true }),
+    })
+  },
+  onUnload() {
+    this.setData({ unloaded: true })
+  },
+})
+`],
+      ['pages/home/index.wxml', '<view>home</view>'],
+      ['pages/profile/index.js', 'Page({ data: { title: "Profile" } })'],
+      ['pages/profile/index.wxml', '<view>profile</view>'],
+    ])
+    const session = createBrowserHeadlessSession({ files })
+    const homePage = session.reLaunch('/pages/home/index')
+
+    homePage.openProfile()
+
+    expect(homePage.data).toMatchObject({
+      callbackRoute: 'pages/profile/index',
+      completed: true,
+      unloaded: true,
+      unloadedBeforeSuccess: false,
+    })
+    expect(session.getCurrentPages().map(page => page.route)).toEqual(['pages/profile/index'])
+  })
+
   it('does not leak browser globals and allows explicit runtime overrides', () => {
     const files = createBrowserVirtualFiles([
       ['app.json', JSON.stringify({ pages: ['pages/index/index'] })],

--- a/mpcore/packages/simulator/test/helpers.ts
+++ b/mpcore/packages/simulator/test/helpers.ts
@@ -228,6 +228,16 @@ Page({
       url: '/pages/profile/index',
     })
   },
+  goProfileWithCallbacks() {
+    wx.switchTab({
+      url: '/pages/profile/index',
+      success: () => {
+        const pages = getCurrentPages()
+        this.push('home:switchTab:success:' + pages[pages.length - 1].route)
+      },
+      complete: () => this.push('home:switchTab:complete'),
+    })
+  },
   goProfileWithQueryCallbacks() {
     wx.switchTab({
       url: '/pages/profile/index?from=home',

--- a/mpcore/packages/simulator/test/session.test.ts
+++ b/mpcore/packages/simulator/test/session.test.ts
@@ -611,9 +611,9 @@ Page({
       'settings:onShow',
       'settings:onReady',
       'settings:onHide',
-      'settings:onUnload',
       'home:onShow',
     ])
+    expect(settingsPage?.data.logs.at(-1)).toBe('settings:onUnload')
 
     session.reLaunch('/pages/profile/index?mode=relaunch')
 
@@ -632,8 +632,8 @@ Page({
       'settings:onShow',
       'settings:onReady',
       'settings:onHide',
-      'settings:onUnload',
       'home:onShow',
+      'settings:onUnload',
       'home:onUnload',
       'profile:onLoad:{"mode":"relaunch"}',
       'profile:onShow',
@@ -674,6 +674,24 @@ Page({
     ])
     expect(homePage.options).toEqual({})
     expect(profilePage?.options).toEqual({})
+  })
+
+  it('commits the tab stack before running switchTab success', () => {
+    const projectPath = createNavigationFixture()
+    tempDirs.push(projectPath)
+    const session = createHeadlessSession({ projectPath })
+
+    const homePage = session.reLaunch('/pages/home/index')
+    homePage.goDetail()
+    const detailPage = session.getCurrentPages().at(-1)
+    homePage.goProfileWithCallbacks()
+
+    expect(session.getCurrentPages().map(page => page.route)).toEqual(['pages/profile/index'])
+    const successIndex = homePage.data.logs.indexOf('home:switchTab:success:pages/profile/index')
+    const unloadIndex = detailPage?.data.logs.indexOf('detail:onUnload') ?? -1
+    expect(successIndex).toBeGreaterThan(-1)
+    expect(unloadIndex).toBeGreaterThan(successIndex)
+    expect(homePage.data.logs.at(-1)).toBe('home:switchTab:complete')
   })
 
   it('rejects switchTab urls that contain query parameters', () => {

--- a/mpcore/packages/simulator/test/testingBridge.test.ts
+++ b/mpcore/packages/simulator/test/testingBridge.test.ts
@@ -37,6 +37,31 @@ describe('headless testing bridge', () => {
     const miniProgram = await launch({ projectPath })
     const currentPage = await miniProgram.currentPage()
 
+    await expect(miniProgram.toolInfo()).resolves.toEqual({
+      version: 'mpcore-simulator',
+    })
+    await expect(miniProgram.evaluate(() => ({
+      // eslint-disable-next-line node/prefer-global/buffer -- 此处验证小程序执行上下文不会泄漏 Node Buffer。
+      Buffer: typeof globalThis['Buffer'],
+      fetch: typeof fetch,
+      process: typeof process,
+      queueMicrotask: typeof queueMicrotask,
+      setTimeout: typeof setTimeout,
+      structuredClone: typeof structuredClone,
+      URLSearchParams: typeof URLSearchParams,
+      wx: typeof wx,
+      wxFromGlobalThis: typeof globalThis.wx,
+    }))).resolves.toEqual({
+      Buffer: 'undefined',
+      fetch: 'undefined',
+      process: 'undefined',
+      queueMicrotask: 'undefined',
+      setTimeout: 'function',
+      structuredClone: 'undefined',
+      URLSearchParams: 'undefined',
+      wx: 'object',
+      wxFromGlobalThis: 'object',
+    })
     expect(currentPage?.path).toBe('pages/index/index')
     expect(await currentPage?.data('__e2eResult.status')).toBe('ready')
 

--- a/packages-runtime/react/src/hostTree/staticBindings.ts
+++ b/packages-runtime/react/src/hostTree/staticBindings.ts
@@ -102,9 +102,11 @@ export class StaticBindingState {
       if (fields.length === 0) {
         continue
       }
-      slots[element.sid] = Object.fromEntries(
-        fields.map(field => [field, readBindingValue(element, field)]),
-      )
+      const slot: Record<string, unknown> = {}
+      for (const field of fields) {
+        slot[field] = readBindingValue(element, field)
+      }
+      slots[element.sid] = slot
     }
     return slots
   }

--- a/packages-runtime/wevu/src/router/routeSync.ts
+++ b/packages-runtime/wevu/src/router/routeSync.ts
@@ -1,5 +1,6 @@
 import type { MiniProgramPageLike } from '../routerInternal/shared'
 import type { RouteLocationNormalizedLoaded } from './types'
+import { getCurrentMiniProgramPages } from '../runtime/platform'
 
 export interface RouteStateSyncPayload {
   page?: MiniProgramPageLike
@@ -34,7 +35,11 @@ export function notifyRouteStateSync(payload?: RouteStateSyncPayload) {
   }
 }
 
-function createNativeRouteStateSyncPayload(methodName: NativeRouterMethodName, option: unknown): RouteStateSyncPayload | undefined {
+function createNativeRouteStateSyncPayload(
+  methodName: NativeRouterMethodName,
+  option: unknown,
+  sourcePage: MiniProgramPageLike | undefined,
+): RouteStateSyncPayload | undefined {
   if (methodName === 'navigateBack') {
     return {
       method: methodName,
@@ -46,6 +51,7 @@ function createNativeRouteStateSyncPayload(methodName: NativeRouterMethodName, o
     if (typeof url === 'string') {
       return {
         method: methodName,
+        page: sourcePage,
         source: 'native',
         url,
       }
@@ -53,6 +59,7 @@ function createNativeRouteStateSyncPayload(methodName: NativeRouterMethodName, o
   }
   return {
     method: methodName,
+    page: sourcePage,
     source: 'native',
   }
 }
@@ -74,13 +81,15 @@ export function installRouteStateSyncOnNativeRouter(nativeRouter: unknown) {
     }
 
     router[methodName] = function routeStateSyncNativeRouterMethod(this: unknown, option?: unknown, ...args: any[]) {
+      const pages = getCurrentMiniProgramPages() as MiniProgramPageLike[]
+      const sourcePage = pages[pages.length - 1]
       let synced = false
       const syncRouteState = () => {
         if (synced) {
           return
         }
         synced = true
-        notifyRouteStateSync(createNativeRouteStateSyncPayload(methodName, option))
+        notifyRouteStateSync(createNativeRouteStateSyncPayload(methodName, option, sourcePage))
       }
 
       const nextOption = option && typeof option === 'object'

--- a/packages-runtime/wevu/src/router/useRoute.ts
+++ b/packages-runtime/wevu/src/router/useRoute.ts
@@ -2,6 +2,7 @@ import type { MiniProgramPageLifetime } from '../runtime/types'
 import type { SetupContextRouter } from '../runtime/types/props'
 import type { RouteStateSyncPayload } from './routeSync'
 import type { LocationQueryRaw, RouteLocationNormalizedLoaded } from './types'
+import { WEVU_NATIVE_INSTANCE_KEY } from '@weapp-core/constants'
 import { reactive, readonly } from '../reactivity'
 import { cloneLocationQuery, cloneRouteLocationRedirectedFrom, cloneRouteMeta, cloneRouteParams, cloneRouteRecordMatchedList, resolveCurrentRoute, resolvePageRoute } from '../routerInternal/shared'
 import { getCurrentSetupContext, onLoad, onReady, onRouteDone, onShow, onUnload } from '../runtime/hooks'
@@ -33,6 +34,13 @@ function isPageLikeInstance(instance: Record<string, any>): boolean {
   return typeof instance.route === 'string' || typeof instance.__route__ === 'string'
 }
 
+function resolveRouteControllerInstance(instance: Record<string, any>): Record<string, any> {
+  const nativeInstance = instance[WEVU_NATIVE_INSTANCE_KEY]
+  return nativeInstance && typeof nativeInstance === 'object'
+    ? nativeInstance
+    : instance
+}
+
 function shouldSyncRouteStateForInstance(
   instance: Record<string, any>,
   isPageController: boolean,
@@ -48,12 +56,13 @@ function shouldSyncRouteStateForInstance(
     return true
   }
 
+  const routeControllerInstance = resolveRouteControllerInstance(instance)
   if (payload?.page) {
-    return payload.page === instance
+    return payload.page === routeControllerInstance
   }
 
   const pages = getCurrentMiniProgramPages()
-  return pages[pages.length - 1] === instance
+  return pages[pages.length - 1] === routeControllerInstance
 }
 
 function applyRouteState(
@@ -104,11 +113,12 @@ export function createRouteStateController(options: RouteStateControllerOptions 
   }
 
   const fallbackPage = setupContext.instance
+  const initialRouteControllerInstance = resolveRouteControllerInstance(fallbackPage)
   const resolveRoute = options.resolveRoute
     ?? ((route: RouteLocationNormalizedLoaded) => getActiveRouter()?.resolve(route) ?? route)
   const currentRoute = resolveRoute(resolveCurrentRoute(undefined, fallbackPage))
-  const isPageController = isPageLikeInstance(fallbackPage)
-    || getCurrentMiniProgramPages().includes(fallbackPage)
+  const isPageController = isPageLikeInstance(initialRouteControllerInstance)
+    || getCurrentMiniProgramPages().includes(initialRouteControllerInstance)
   const routeState = reactive<RouteLocationNormalizedLoaded>({
     path: currentRoute.path,
     fullPath: currentRoute.fullPath,
@@ -152,12 +162,12 @@ export function createRouteStateController(options: RouteStateControllerOptions 
       syncRoute(undefined, payload.route, payload)
       return
     }
-    if (payload?.page) {
-      syncRoute(undefined, resolvePageRoute(payload.page), payload)
-      return
-    }
     if (payload?.url) {
       syncRoute(undefined, resolveRouteLocation(payload.url, routeState.path), payload)
+      return
+    }
+    if (payload?.page) {
+      syncRoute(undefined, resolvePageRoute(payload.page), payload)
       return
     }
     syncRoute(undefined, undefined, payload)

--- a/packages-runtime/wevu/src/runtime/register/runtimeInstance/setupContext.ts
+++ b/packages-runtime/wevu/src/runtime/register/runtimeInstance/setupContext.ts
@@ -201,6 +201,25 @@ export function ensureSetupContextInstance(
   }
 
   const setupInstanceBridge: Record<string, any> = Object.create(null)
+  try {
+    Object.defineProperty(setupInstanceBridge, WEVU_NATIVE_INSTANCE_KEY, {
+      configurable: true,
+      enumerable: false,
+      get() {
+        const runtimeState = runtime?.state
+        const rawRuntimeState = runtimeState && typeof runtimeState === 'object'
+          ? toRaw(runtimeState as any)
+          : undefined
+        const nativeInstance = rawRuntimeState?.[WEVU_NATIVE_INSTANCE_KEY]
+        return nativeInstance && typeof nativeInstance === 'object'
+          ? nativeInstance
+          : target
+      },
+    })
+  }
+  catch {
+    setupInstanceBridge[WEVU_NATIVE_INSTANCE_KEY] = target
+  }
   const resolvePublicValue = (key: PropertyKey) => {
     const runtimeProxy = runtime?.proxy as Record<PropertyKey, any> | undefined
     if (runtimeProxy && Reflect.has(runtimeProxy, key)) {

--- a/packages-runtime/wevu/test/router-api.test.ts
+++ b/packages-runtime/wevu/test/router-api.test.ts
@@ -1,11 +1,12 @@
-import { WEVU_HOOKS_KEY } from '@weapp-core/constants'
+import { WEVU_HOOKS_KEY, WEVU_NATIVE_INSTANCE_KEY } from '@weapp-core/constants'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createRouter, parseQuery, resolveRouteLocation, stringifyQuery, useRoute, useRouter } from '@/router'
 import { clearActiveRouter } from '@/router/instance'
-import { notifyRouteStateSync } from '@/router/routeSync'
+import { installRouteStateSyncOnNativeRouter, notifyRouteStateSync } from '@/router/routeSync'
 import { createRouteStateController } from '@/router/useRoute'
 import { callHookList, setCurrentInstance, setCurrentSetupContext } from '@/runtime/hooks'
 import { bindCurrentPageInstance } from '@/runtime/register/component/lifecycle/platform'
+import { ensureSetupContextInstance } from '@/runtime/register/runtimeInstance/setupContext'
 
 describe('router api', () => {
   afterEach(() => {
@@ -287,6 +288,130 @@ describe('router api', () => {
     expect(syncCalls).toEqual(['page2'])
     callHookList(page1, 'onUnload', [])
     callHookList(page2, 'onUnload', [])
+  })
+
+  it('matches setup instance bridges to their activated native page', () => {
+    const page1 = {
+      route: 'pages/home/index',
+      options: {},
+      __wevu: {},
+      [WEVU_HOOKS_KEY]: {},
+    } as any
+    const page2 = {
+      route: 'pages/detail/index',
+      options: {},
+      __wevu: {},
+      [WEVU_HOOKS_KEY]: {},
+    } as any
+    const runtimeState1 = { [WEVU_NATIVE_INSTANCE_KEY]: page1 }
+    const runtimeState2 = { [WEVU_NATIVE_INSTANCE_KEY]: page2 }
+    const bridge1 = ensureSetupContextInstance(page1, {
+      state: runtimeState1,
+      proxy: Object.create(null),
+    } as any)
+    const bridge2 = ensureSetupContextInstance(page2, {
+      state: runtimeState2,
+      proxy: Object.create(null),
+    } as any)
+    let pages = [page1, page2]
+    ;(globalThis as any).getCurrentPages = vi.fn(() => pages)
+
+    const syncCalls: string[] = []
+    setCurrentInstance(page1)
+    setCurrentSetupContext({ instance: bridge1, emit: vi.fn(), attrs: {}, slots: {} })
+    createRouteStateController({
+      beforeRouteStateSync: () => syncCalls.push('page1'),
+    })
+
+    setCurrentInstance(page2)
+    setCurrentSetupContext({ instance: bridge2, emit: vi.fn(), attrs: {}, slots: {} })
+    const { route } = createRouteStateController({
+      beforeRouteStateSync: () => syncCalls.push('page2'),
+    })
+
+    const nativePage1 = { route: page1.route, options: {} } as any
+    const nativePage2 = { route: page2.route, options: {} } as any
+    runtimeState1[WEVU_NATIVE_INSTANCE_KEY] = nativePage1
+    runtimeState2[WEVU_NATIVE_INSTANCE_KEY] = nativePage2
+    pages = [nativePage1, nativePage2]
+
+    notifyRouteStateSync({
+      source: 'native',
+      method: 'switchTab',
+      url: '/pages/issue-705-tab/index',
+    })
+
+    expect(syncCalls).toEqual(['page2'])
+    expect(route.path).toBe('pages/issue-705-tab/index')
+    callHookList(page1, 'onUnload', [])
+    callHookList(page2, 'onUnload', [])
+  })
+
+  it('syncs the source page controller after native navigation commits the target stack', () => {
+    const sourcePage = {
+      route: 'pages/home/index',
+      options: {},
+      __wevu: {},
+      [WEVU_HOOKS_KEY]: {},
+    } as any
+    const targetPage = {
+      route: 'pages/profile/index',
+      options: {},
+    } as any
+    let pages = [sourcePage]
+    ;(globalThis as any).getCurrentPages = vi.fn(() => pages)
+    const nativeRouter = {
+      switchTab: vi.fn((option: any) => {
+        pages = [targetPage]
+        option.success?.({})
+      }),
+    }
+
+    setCurrentInstance(sourcePage)
+    setCurrentSetupContext({ instance: sourcePage, emit: vi.fn(), attrs: {}, slots: {} })
+    const { route } = createRouteStateController()
+    installRouteStateSyncOnNativeRouter(nativeRouter)
+
+    nativeRouter.switchTab({ url: '/pages/profile/index' })
+
+    expect(route.path).toBe('pages/profile/index')
+    callHookList(sourcePage, 'onUnload', [])
+  })
+
+  it('restores the activated page controller after native back commits the target stack', () => {
+    const targetPage = {
+      route: 'pages/home/index',
+      options: {},
+      __wevu: {},
+      [WEVU_HOOKS_KEY]: {},
+    } as any
+    const sourcePage = {
+      route: 'pages/detail/index',
+      options: {},
+    } as any
+    let pages = [targetPage]
+    ;(globalThis as any).getCurrentPages = vi.fn(() => pages)
+    const nativeRouter = {
+      navigateBack: vi.fn((option: any) => {
+        pages = [targetPage]
+        option.success?.({})
+      }),
+    }
+
+    setCurrentInstance(targetPage)
+    setCurrentSetupContext({ instance: targetPage, emit: vi.fn(), attrs: {}, slots: {} })
+    const { route } = createRouteStateController()
+    installRouteStateSyncOnNativeRouter(nativeRouter)
+    pages = [targetPage, sourcePage]
+    notifyRouteStateSync({
+      route: resolveRouteLocation('/pages/detail/index'),
+      source: 'router',
+    })
+
+    nativeRouter.navigateBack({})
+
+    expect(route.path).toBe('pages/home/index')
+    callHookList(targetPage, 'onUnload', [])
   })
 
   it('useRoute infers name from an existing named router instance', () => {

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.test.ts
@@ -517,7 +517,7 @@ describe('runtime buildPlugin service', () => {
       }),
     }))
 
-    const output = await snapshots.rebuild(['/project/src/pages/index.vue'])
+    const output = await snapshots.rebuild(['/project/src/pages/index.css'])
     const refreshOptions = buildMock.mock.calls[1]![0]
     expect(refreshOptions).toEqual(expect.objectContaining({
       build: expect.objectContaining({
@@ -526,6 +526,7 @@ describe('runtime buildPlugin service', () => {
         write: false,
       }),
     }))
+    expect(resetEmittedOutputCachesMock).toHaveBeenCalledTimes(2)
     expect(output).toEqual([{ fileName: 'app.wxss', source: '.updated{}', type: 'asset' }])
   })
 

--- a/packages/weapp-vite/src/runtime/buildPlugin/service.ts
+++ b/packages/weapp-vite/src/runtime/buildPlugin/service.ts
@@ -1385,6 +1385,7 @@ export function createBuildService(ctx: MutableCompilerContext): BuildService {
                 invalidateFileCache(file)
               }
               resetRuntimeStateForFreshBuild(ctx.runtimeState)
+              resetEmittedOutputCaches(ctx.runtimeState)
               await configService.load(configService.loadOptions)
               await scanService.loadAppEntry()
               scanService.loadSubPackages()


### PR DESCRIPTION
## 背景

这是 #926 合并后的 runtime follow-up，继续收敛 #911 暴露的小程序 AppService 宿主兼容边界，并补齐全面验收中发现的构建、Web E2E、simulator parity 与 React runtime 缺口。

关联 #911、#926，并同步修复验证中发现的 #705 DevTools/headless 导航语义差异。

## 主要改动

- 清理 vite-native 中会破坏 SCSS/Tailwind 构建的失效注释导入示例。
- 将 Wevu template compatibility 与 request-globals 断言改为稳定的公开 marker、导出和调用语义，不再依赖具体 chunk 路径。
- Web 项目矩阵从 CLI 日志读取实际 resolved URL，并增加真实占用 5173 后自动换端口的回归。
- React static bindings 改为 ES2018 循环构造，将 React runtime 纳入严格小程序 runtime ESLint scope，并审计全部最终 AppService JS。
- simulator 新增 toolInfo() 公共接口，隔离 headless evaluator 的 Node/浏览器宿主全局。
- headless/browser 共用 switchTab 分阶段提交模型，对齐真实 DevTools 中 success 回调的页面栈、route sync、缓存 tab 和失败行为。
- Wevu setup instance bridge 显式关联当前原生页面，保证原生导航成功回调内 route 与 routerRoute 同步。
- stateful HMR snapshot 每轮重建前隔离 emit cache，避免重复 watcher 事件使首轮未提交产物污染下一轮剪枝，确保 native style 最终由最新 snapshot 写出。
- 保持所有模板、app 和 fixture 不依赖 @weapp-vite/eslint，由上层 eslint config 后续集成。

## 验证

- 受影响 package build、test、typecheck、test:types 全部通过。
- simulator unit 248 项、browser E2E 23 项通过；本次收尾定向回归 208 项通过。
- React build/runtime、template compatibility、request-globals 和 runtime artifact audit 通过。
- e2e:web：6 个文件、74 项通过，包含真实端口冲突回归。
- e2e:ci:full：68 项通过。
- e2e:ide:headless:full：13 项通过。
- #911 headless 与 DevTools：各 7 项通过；#705 headless 与 DevTools：各 2 项通过。
- 完整 DevTools suite：18 项通过；capability suite 通过。
- build:all：138 个任务通过；全仓 test：891 个文件通过，7878 项通过；test:types：19 个任务通过；lint：40 个任务通过。
- Workspace HMR changed-project 审计通过：native template、script、style 均更新正确，影响面阈值无回归。
- shared automator、agents、skills、changeset 联动与 diff check 均通过。

## 发布

添加中文 patch changeset，覆盖 @weapp-vite/react、@mpcore/simulator、wevu、weapp-vite 与 create-weapp-vite。
