### PR TITLE
fix(wevu): 确保 effectScope 异常后完成实例卸载

### DIFF
--- a/.changeset/steady-scopes-finish.md
+++ b/.changeset/steady-scopes-finish.md
@@ -1,0 +1,6 @@
+---
+'create-weapp-vite': patch
+'wevu': patch
+---
+
+修复 Wevu effectScope 与运行时实例的卸载可靠性：单个 effect、cleanup、子 scope 或 runtime unmount 抛错时继续完成其余资源释放和内部实例字段清理，并在结束后保留首个错误供调用方处理。

--- a/packages-runtime/wevu/src/reactivity/core.ts
+++ b/packages-runtime/wevu/src/reactivity/core.ts
@@ -118,21 +118,48 @@ class EffectScopeImpl implements EffectScope {
     }
     this.active = false
 
-    for (const effect of this.effects) {
-      stop(effect)
-    }
-    this.effects.length = 0
-
-    for (const cleanup of this.cleanups) {
-      cleanup()
-    }
-    this.cleanups.length = 0
-
-    if (this.scopes) {
-      for (const scope of this.scopes) {
-        scope.stop()
+    let firstError: unknown
+    let hasError = false
+    const recordError = (error: unknown) => {
+      if (hasError) {
+        return
       }
-      this.scopes.length = 0
+      firstError = error
+      hasError = true
+    }
+
+    const effects = this.effects.splice(0)
+    for (const effect of effects) {
+      try {
+        stop(effect)
+      }
+      catch (error) {
+        recordError(error)
+      }
+    }
+
+    const cleanups = this.cleanups.splice(0)
+    for (const cleanup of cleanups) {
+      try {
+        cleanup()
+      }
+      catch (error) {
+        recordError(error)
+      }
+    }
+
+    const scopes = this.scopes
+    this.scopes = undefined
+    if (scopes) {
+      for (const scope of scopes) {
+        try {
+          scope.stop()
+        }
+        catch (error) {
+          recordError(error)
+        }
+      }
+      scopes.length = 0
     }
 
     if (this.parent?.scopes) {
@@ -142,6 +169,10 @@ class EffectScopeImpl implements EffectScope {
       }
     }
     this.parent = undefined
+
+    if (hasError) {
+      throw firstError
+    }
   }
 }
 

--- a/packages-runtime/wevu/src/runtime/register/runtimeInstance.ts
+++ b/packages-runtime/wevu/src/runtime/register/runtimeInstance.ts
@@ -680,14 +680,41 @@ export function teardownRuntimeInstance(target: InternalRuntimeState, options?: 
     }
   }
   target[WEVU_WATCH_STOPS_KEY] = undefined
-  target[WEVU_EFFECT_SCOPE_KEY]?.stop()
+  let firstError: unknown
+  let hasError = false
+  const recordError = (error: unknown) => {
+    if (hasError) {
+      return
+    }
+    firstError = error
+    hasError = true
+  }
+
+  const effectScope = target[WEVU_EFFECT_SCOPE_KEY]
+  if (effectScope) {
+    try {
+      effectScope.stop()
+    }
+    catch (error) {
+      recordError(error)
+    }
+  }
   target[WEVU_EFFECT_SCOPE_KEY] = undefined
   if (runtime) {
-    runtime.unmount()
+    try {
+      runtime.unmount()
+    }
+    catch (error) {
+      recordError(error)
+    }
   }
   delete target.__wevu
   if (WEVU_PUBLIC_RUNTIME_KEY in target) {
     delete (target as any)[WEVU_PUBLIC_RUNTIME_KEY]
+  }
+
+  if (hasError) {
+    throw firstError
   }
 }
 

--- a/packages-runtime/wevu/test/reactivity-scope-batch.test.ts
+++ b/packages-runtime/wevu/test/reactivity-scope-batch.test.ts
@@ -1,5 +1,6 @@
+import type { EffectScope } from '@/reactivity'
 import { describe, expect, it } from 'vitest'
-import { batch, effect, effectScope, reactive, watchEffect } from '@/reactivity'
+import { batch, effect, effectScope, onScopeDispose, reactive, watchEffect } from '@/reactivity'
 
 describe('reactivity (batch + effectScope)', () => {
   it('batch dedupes sync effects', () => {
@@ -46,5 +47,64 @@ describe('reactivity (batch + effectScope)', () => {
     state.n++
     await Promise.resolve()
     expect(runs).toBe(2)
+  })
+
+  it('stops every effect, cleanup, and nested scope before rethrowing the first failure', () => {
+    const parent = effectScope()
+    const calls: string[] = []
+    const firstFailure = new Error('effect stop failed')
+    const cleanupFailure = new Error('scope cleanup failed')
+    const childFailure = new Error('child scope cleanup failed')
+    let firstChild!: EffectScope
+    let secondChild!: EffectScope
+
+    parent.run(() => {
+      effect(() => 0, {
+        onStop() {
+          calls.push('effect:first')
+          throw firstFailure
+        },
+      })
+      effect(() => 0, {
+        onStop() {
+          calls.push('effect:second')
+        },
+      })
+      onScopeDispose(() => {
+        calls.push('parent:first')
+        throw cleanupFailure
+      })
+      onScopeDispose(() => {
+        calls.push('parent:second')
+      })
+
+      firstChild = effectScope()
+      firstChild.run(() => {
+        onScopeDispose(() => {
+          calls.push('child:first')
+          throw childFailure
+        })
+      })
+
+      secondChild = effectScope()
+      secondChild.run(() => {
+        onScopeDispose(() => {
+          calls.push('child:second')
+        })
+      })
+    })
+
+    expect(() => parent.stop()).toThrow(firstFailure)
+    expect(calls).toEqual([
+      'effect:first',
+      'effect:second',
+      'parent:first',
+      'parent:second',
+      'child:first',
+      'child:second',
+    ])
+    expect(parent.active).toBe(false)
+    expect(firstChild.active).toBe(false)
+    expect(secondChild.active).toBe(false)
   })
 })

--- a/packages-runtime/wevu/test/runtime-register-extra.test.ts
+++ b/packages-runtime/wevu/test/runtime-register-extra.test.ts
@@ -1,4 +1,4 @@
-import type { RuntimeApp } from '@/runtime/types'
+import type { InternalRuntimeState, RuntimeApp } from '@/runtime/types'
 import {
   WEVU_EXPOSED_KEY,
   WEVU_HOOKS_KEY,
@@ -258,6 +258,55 @@ describe('mountRuntimeInstance and teardown', () => {
 
     teardownRuntimeInstance(target)
     expect(runtime.unmount).toHaveBeenCalled()
+  })
+
+  it('finishes runtime teardown before rethrowing a scope cleanup failure', () => {
+    const app = createApp({})
+    const target: InternalRuntimeState = {
+      route: 'pages/scope-error/index',
+      setData: vi.fn(),
+    }
+    const cleanupAfterFailure = vi.fn()
+    const failure = new Error('scope cleanup failed')
+
+    mountRuntimeInstance(target, app, undefined, () => {
+      onScopeDispose(() => {
+        throw failure
+      })
+      onScopeDispose(cleanupAfterFailure)
+      return {}
+    })
+    const runtime = target.__wevu
+    if (!runtime) {
+      throw new Error('Expected runtime instance to be mounted')
+    }
+    const unmountFailure = new Error('runtime unmount failed')
+    const unmount = vi.spyOn(runtime, 'unmount').mockImplementation(() => {
+      throw unmountFailure
+    })
+
+    expect(() => teardownRuntimeInstance(target)).toThrow(failure)
+    expect(cleanupAfterFailure).toHaveBeenCalledTimes(1)
+    expect(unmount).toHaveBeenCalledTimes(1)
+    expect(target.__wevu).toBeUndefined()
+    expect(target[WEVU_PUBLIC_RUNTIME_KEY]).toBeUndefined()
+  })
+
+  it('clears runtime fields before rethrowing an unmount failure', () => {
+    const { app, runtime } = createRuntimeAppStub()
+    const target: InternalRuntimeState = {
+      setData: vi.fn(),
+    }
+    const failure = new Error('runtime unmount failed')
+    runtime.unmount.mockImplementation(() => {
+      throw failure
+    })
+
+    mountRuntimeInstance(target, app, undefined, undefined)
+
+    expect(() => teardownRuntimeInstance(target)).toThrow(failure)
+    expect(target.__wevu).toBeUndefined()
+    expect(target[WEVU_PUBLIC_RUNTIME_KEY]).toBeUndefined()
   })
 
   it('handles frozen runtime objects', () => {


### PR DESCRIPTION
## 问题

`EffectScopeImpl.stop()` 遇到 effect、cleanup 或子 scope 抛错时会提前中断，导致后续资源未释放；实例 teardown 也会因此跳过 `runtime.unmount()` 以及 `__wevu` / `$wevu` 字段清理。

Closes #938

## 根因

- scope 关闭流程直接执行每个 stop/cleanup，没有隔离并保留首个失败。
- 父 scope 直接遍历可被子 scope 原地修改的 `scopes` 数组，可能跳过相邻 sibling。
- `teardownRuntimeInstance()` 在 scope 或 runtime unmount 抛错后不会继续完成内部字段清理。

## 修改

- scope 关闭时依次尝试所有 effects、cleanups 和子 scopes，完成后重新抛出首个错误。
- 在停止子 scope 前先分离父 scope 的子列表，避免 sibling 被跳过。
- runtime teardown 独立尝试 scope stop 与 runtime unmount，并在抛出首个错误前清理内部实例字段。
- 增加多阶段错误、first-error-wins、子 scope、unmount 和字段清理回归测试。
- 增加 `wevu` 与 `create-weapp-vite` patch changeset。

## 验证

- `pnpm vitest run packages-runtime/wevu/test/reactivity-scope-batch.test.ts packages-runtime/wevu/test/runtime-register-extra.test.ts`：28/28 通过
- `pnpm --filter wevu test`：79 个文件、907 个测试通过
- `pnpm --filter wevu build`：通过
- `pnpm --filter wevu typecheck`：通过
- `pnpm --filter wevu test:types`：通过
- 相关文件 ESLint：通过
- changeset frontmatter 与 `create-weapp-vite` 联动检查：通过

## 兼容性与风险

- 不改变 `EffectScope` 与 teardown 的公开签名。
- 保持正常路径 effects → cleanups → 子 scopes 的既有顺序。
- 不引入 Effect 依赖，不修改状态更新热路径。
- 新增分配仅发生在卸载阶段，用于保证回调修改集合时仍能完整释放。