### PR TITLE
ci: 扩大 Ubuntu 覆盖率任务超时预算

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         include:
           - os: ubuntu-latest
             node-version: 22
-            timeout_minutes: 25
+            timeout_minutes: 40
             build_pkgs_script: build:pkgs:ci
             build_script: build:ci
             lint_script: lint


### PR DESCRIPTION
## 变更
- 将 PR build workflow 中 Ubuntu Node 22 覆盖率任务的超时从 25 分钟调整为 40 分钟。
- 其他平台、发布任务和完整构建的超时保持不变。

## 验证
- Workflow YAML 解析通过
- Ubuntu Node 22 build-pr timeout 为 40 分钟
- Release 与 full job timeout 仍为 25 分钟