### PR TITLE
fix(compiler): 修正 CRLF 源码的 binding 位置偏移

### DIFF
--- a/.changeset/bright-bindings-own.md
+++ b/.changeset/bright-bindings-own.md
@@ -7,3 +7,5 @@
 ---
 
 让 `@wevu/compiler` 在同一次模板编译中生成并消费版本化 Binding Manifest，移除 `weapp-vite` 对生成模板和脚本的 binding 二次解析；完整编译 IR 现在包含逐 dependency 更新策略和显式作用域关系，覆盖 CSS 变量样式状态、自定义指令、组件 `v-model` 修饰符及内建 template 属性等编译器生成的 mustache，且不完整清单不会启用自动 `setData.pick`。组件脚本仅注入运行时所需的精简 manifest，开发态再附加源码位置；跨文件 JSX binding 也会保留各自的源码归属和正确重映射位置。同时让 Wevu 的 `setData` 诊断按 binding id、输出路径和源码位置归因，并继续保留现有 snapshot/diff 正确性 fallback。`ScopedSlotComponentAsset` 现在直接提供必需的 `script` 与 `bindingManifest`，并移除旧的 `classStyleBindings`、`inlineExpressions`、`templateRefs` 侧通道；编译器消费者应直接 emit 新的完整资源。
+
+开发态 binding 源码位置保留原文件的 CRLF 源码偏移，不再使用编译中间态规范化后的换行重新计算所属源文件位置。

--- a/packages-runtime/wevu-compiler/src/plugins/vue/compiler/bindingManifest.test.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/compiler/bindingManifest.test.ts
@@ -440,7 +440,7 @@ const themeColor = 'red'
     expect(result.script).not.toContain('setData')
   })
 
-  it('maps SFC JSX binding locations back to the original component', async () => {
+  it.each(['\n', '\r\n'])('maps SFC JSX binding locations back to the original component with %j line endings', async (lineEnding) => {
     const source = `<script lang="tsx">
 const title = 'ready'
 export default {
@@ -448,7 +448,7 @@ export default {
     return <view>{title}</view>
   },
 }
-</script>`
+</script>`.replaceAll('\n', lineEnding)
     const result = await compileVueFile(
       source,
       '/src/components/RenderCard.vue',

--- a/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/bindingManifestLocations.ts
+++ b/packages-runtime/wevu-compiler/src/plugins/vue/transform/compileVueFile/bindingManifestLocations.ts
@@ -103,10 +103,11 @@ export function remapJsxBindingManifestLocations(
     if (!mapped.hasMappedContent && !sourceFilesMatch(ownedSourceFile, manifest.sourceFile)) {
       return undefined
     }
-    let lineStarts = lineStartsCache.get(mapped.content)
+    const content = sourceFilesMatch(ownedSourceFile, manifest.sourceFile) ? source : mapped.content
+    let lineStarts = lineStartsCache.get(content)
     if (!lineStarts) {
-      lineStarts = createSourceLineStarts(mapped.content)
-      lineStartsCache.set(mapped.content, lineStarts)
+      lineStarts = createSourceLineStarts(content)
+      lineStartsCache.set(content, lineStarts)
     }
     return {
       position: {


### PR DESCRIPTION
## 问题与目标

补齐 #949 合并后的 CRLF 边界：JSX binding 的源码位置重映射使用了编译中间态中已规范化换行的 `sourcesContent`，导致偏移量与调用方传入的原始 SFC 不一致。

## 复现与根因

对包含 CRLF 的 SFC 执行 `compileVueFile`，源码中的目标表达式起始 offset 为 **94**；修复前返回 **90**，修复后返回 **94**，行列仍为第 5 行、第 19 列。

根因位于 `bindingManifestLocations.ts`：属于当前源文件的 binding 应使用调用方原始源码计算 offset，不能使用已规范化换行的中间态内容。

## 修改

- 当前源文件使用原始 `source` 计算位置；其他映射源文件继续使用其自身 `sourcesContent`。
- 现有真实编译回归用例同时覆盖 LF 与 CRLF，断言原始源码推导出的 offset 及行列。
- 更新现有 changeset，说明 CRLF 源码偏移修复。

## 同类边界检查

- 本次修复：内联 JSX SFC 所有者，以及复用相同重映射边界的外部 script 源码所有者。
- 保持不变：其他映射源文件的源码归属，以及缺失或无效 source map 的处理。
- 独立源码复查无未解决发现。

## 非目标

不改变 Binding Manifest 格式、binding 更新策略、模板渲染逻辑或运行时 API；不引入额外的源码规范化副本。

## 本地验证

| 验收项 | 命令或观察 | 结果 |
| --- | --- | --- |
| LF / CRLF 编译回归 | `pnpm vitest run packages-runtime/wevu-compiler/src/plugins/vue/compiler/bindingManifest.test.ts` | 29 项通过 |
| 编译器类型检查 | `pnpm --filter @wevu/compiler typecheck` | 通过 |
| 构建与公开类型契约 | `pnpm --filter @wevu/compiler test:types` | 通过 |
| 构建后真实编译调用 | 原始 offset 94，返回 start offset 94、end offset 99 | 通过 |
| 修改范围 ESLint 与提交钩子 | 两个 TypeScript 文件及 changeset | 通过 |

本轮未重跑真实微信 IDE；上述证据覆盖编译期源码位置契约。创建 PR 后不等待 CI，不将尚未观察到的远端检查标为通过。

## 风险与回滚

- 兼容性：仅修正当前源文件的源码位置偏移；其他文件的映射内容与既有异常路径不变。
- 性能与隐私：不增加逐 binding 源码扫描，不包含机器路径或敏感信息。
- 回滚：撤销本 PR 即可，无数据迁移。

## 关联

后续修复 #949；关联 #930。

修复提交：`97bf8c6d308b0b0a7663a7635b3ab36320bd11e1`。