### PR TITLE
fix(wevu): 修复可选、可空及联合类型属性的原生转换

### DIFF
--- a/.changeset/fix-955-native-props.md
+++ b/.changeset/fix-955-native-props.md
@@ -1,0 +1,6 @@
+---
+'wevu': patch
+'create-weapp-vite': patch
+---
+
+修复 Vue 类型优先的可选、可空和联合类型 props 在微信原生属性层提前被转换的问题。启用空值传输兼容时使用无主类型约束的原生描述符，保留默认值和显式原生属性覆盖，并正确尊重 `allowNullPropInput: false`。

--- a/.changeset/fix-955-native-props.md
+++ b/.changeset/fix-955-native-props.md
@@ -1,6 +1,9 @@
 ---
 'wevu': patch
+'@weapp-vite/web': patch
 'create-weapp-vite': patch
 ---
 
 修复 Vue 类型优先的可选、可空和联合类型 props 在微信原生属性层提前被转换的问题。启用空值传输兼容时使用无主类型约束的原生描述符，保留默认值和显式原生属性覆盖，并正确尊重 `allowNullPropInput: false`。
+
+Web 注册入口不再应用小程序宿主的空值传输降级，保留 DOM 布尔、数字、对象和数组属性的解码类型，避免组件交互和视觉表现回归。

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -642,6 +642,13 @@
           "launchMode": "default"
         },
         {
+          "name": "pages/issue-955/index",
+          "pathName": "pages/issue-955/index",
+          "query": "",
+          "scene": null,
+          "launchMode": "default"
+        },
+        {
           "name": "pages/slot-fallback-compiler-off/index",
           "pathName": "pages/slot-fallback-compiler-off/index",
           "query": "",

--- a/e2e-apps/github-issues/src/app.vue
+++ b/e2e-apps/github-issues/src/app.vue
@@ -71,6 +71,9 @@ const tabBarList = issue793BuildScopeEnabled
 defineAppJson({
   pages: routes.pages,
   subPackages: appSubPackages,
+  ...(routes.pages.includes('pages/issue-955/index')
+    ? { style: 'v2', componentFramework: 'glass-easel' }
+    : {}),
   subpackages: appSubPackages,
   ...(issue793BuildScopeEnabled
     ? {

--- a/e2e-apps/github-issues/src/components/issue-955/NativePropsProbe/index.vue
+++ b/e2e-apps/github-issues/src/components/issue-955/NativePropsProbe/index.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { computed } from 'wevu'
+
+const props = withDefaults(
+  defineProps<{
+    content?: number | string
+    src?: string
+    nullable: string | null
+  }>(),
+  {
+    src: '',
+  },
+)
+
+function describeValue(value: unknown) {
+  if (value === undefined) {
+    return 'undefined'
+  }
+  if (value === null) {
+    return 'null'
+  }
+  return `${typeof value}:${String(value)}`
+}
+
+const currentSummary = computed(() => `${describeValue(props.content)}|${describeValue(props.src)}`)
+
+const initialSummary = currentSummary.value
+
+function snapshot() {
+  return {
+    content: describeValue(props.content),
+    src: describeValue(props.src),
+    nullable: describeValue(props.nullable),
+    initialSummary,
+  }
+}
+
+defineExpose({
+  snapshot,
+})
+</script>
+
+<template>
+  <view class="issue955-probe" :data-summary="currentSummary">
+    <text class="issue955-probe__content">
+      {{ props.content }}
+    </text>
+    <text class="issue955-probe__src">
+      {{ props.src }}
+    </text>
+    <text class="issue955-probe__nullable">
+      {{ props.nullable }}
+    </text>
+  </view>
+</template>
+
+<style scoped>
+.issue955-probe {
+  padding: 20rpx;
+  background: #fff;
+  border-radius: 12rpx;
+}
+
+.issue955-probe__content,
+.issue955-probe__src {
+  display: block;
+  color: #0f172a;
+}
+</style>

--- a/e2e-apps/github-issues/src/pages/issue-955/index.vue
+++ b/e2e-apps/github-issues/src/pages/issue-955/index.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import { nextTick, shallowRef, useTemplateRef } from 'wevu'
+import NativePropsProbe from '../../components/issue-955/NativePropsProbe/index.vue'
+
+type Transition = 'null' | 'number' | 'string' | 'undefined'
+
+interface NativePropsProbeSnapshot {
+  content: string
+  src: string
+  nullable: string
+  initialSummary: string
+}
+
+interface NativePropsProbeExposed {
+  snapshot: () => NativePropsProbeSnapshot
+}
+
+const content = shallowRef<number | string>('SALE')
+const src = shallowRef<string>()
+const nullable = shallowRef<string | null>(null)
+const probe = useTemplateRef<NativePropsProbeExposed>('probe')
+
+definePageJson({
+  navigationBarTitleText: 'issue-955',
+})
+
+function describeValue(value: unknown) {
+  if (value === undefined) {
+    return 'undefined'
+  }
+  if (value === null) {
+    return 'null'
+  }
+  return `${typeof value}:${String(value)}`
+}
+
+function applyTransition(transition: Transition) {
+  if (transition === 'number') {
+    content.value = 42
+    src.value = 'number.png'
+    nullable.value = 'number-label'
+  }
+  else if (transition === 'string') {
+    content.value = 'PROMO'
+    src.value = 'string.png'
+    nullable.value = 'string-label'
+  }
+  else if (transition === 'null') {
+    // 回归探针刻意越过静态类型，模拟模板桥把空值交给宿主 properties 的过程。
+    content.value = null as unknown as number | string
+    src.value = null as unknown as string
+    nullable.value = null
+  }
+  else {
+    content.value = undefined as unknown as number | string
+    src.value = undefined
+    nullable.value = null
+  }
+}
+
+async function _runE2E(transition?: Transition) {
+  if (transition) {
+    applyTransition(transition)
+    await nextTick()
+  }
+  return {
+    ready: typeof probe.value?.snapshot === 'function',
+    parent: {
+      content: describeValue(content.value),
+      src: describeValue(src.value),
+    },
+    child: probe.value?.snapshot() ?? null,
+  }
+}
+
+defineExpose({
+  _runE2E,
+})
+</script>
+
+<template>
+  <view id="issue955-page" class="issue955-page">
+    <text class="issue955-page__title">
+      issue-955 native nullable and union props
+    </text>
+    <NativePropsProbe
+      ref="probe"
+      :content="content"
+      :src="src"
+      :nullable="nullable"
+    />
+  </view>
+</template>
+
+<style scoped>
+.issue955-page {
+  box-sizing: border-box;
+  min-height: 100vh;
+  padding: 24rpx;
+  background: #f8fafc;
+}
+
+.issue955-page__title {
+  display: block;
+  margin-bottom: 16rpx;
+  font-weight: 700;
+  color: #0f172a;
+}
+</style>

--- a/e2e-apps/github-issues/weapp-vite.config.ts
+++ b/e2e-apps/github-issues/weapp-vite.config.ts
@@ -198,9 +198,11 @@ const githubIssuesRouteGroups: Record<string, string[]> = {
     'pages/issue-613/**',
     'pages/issue-599/**',
     'pages/issue-600/**',
+    'pages/issue-955/**',
     'components/issue-597/**',
     'components/issue-613/**',
     'components/issue-599/**',
+    'components/issue-955/**',
   ],
   'github-issues.runtime.subpackage-item.test.ts': [
     'subpackages/item/**',

--- a/e2e/ide/github-issues.runtime.props.test.ts
+++ b/e2e/ide/github-issues.runtime.props.test.ts
@@ -15,6 +15,8 @@ import {
 import { attachRuntimeErrorCollector } from './runtimeErrors'
 
 const ISSUE_600_ROUTE = '/pages/issue-600/index'
+const ISSUE_955_ROUTE = '/pages/issue-955/index'
+const ISSUE_955_TYPE_WARNING_RE = /type-uncompatible|property ["'](?:content|src)["'][^\n]*(?:expected|got|get) /i
 
 function createIssue600Readiness(expectedSummary: string) {
   return async (_page: any, miniProgram: any) => Boolean(await miniProgram.evaluate((summary: string) => {
@@ -163,6 +165,108 @@ describe('e2e app: github-issues / props', { concurrent: false }, () => {
       })
     }
     finally {
+      await releaseSharedMiniProgram(miniProgram)
+    }
+  })
+
+  it('issue #955: preserves union values and nullable defaults without native prop coercion', async (ctx) => {
+    const pageWxmlPath = path.join(DIST_ROOT, 'pages/issue-955/index.wxml')
+    const pageJsPath = path.join(DIST_ROOT, 'pages/issue-955/index.js')
+    const pageJsonPath = path.join(DIST_ROOT, 'pages/issue-955/index.json')
+    const probeJsPath = path.join(DIST_ROOT, 'components/issue-955/NativePropsProbe/index.js')
+    expect(await fs.readFile(pageWxmlPath, 'utf-8')).toContain('issue-955 native nullable and union props')
+    expect(await fs.readFile(pageJsPath, 'utf-8')).toContain('_runE2E')
+    expect(await fs.readFile(pageJsonPath, 'utf-8')).toContain('native-props-probe')
+    expect(await fs.readFile(probeJsPath, 'utf-8')).toContain('snapshot')
+
+    const miniProgram = await getSharedMiniProgram(ctx)
+    const runtimeErrors = attachRuntimeErrorCollector(miniProgram)
+    try {
+      const marker = runtimeErrors.mark()
+      const issuePage = await relaunchPage(miniProgram, ISSUE_955_ROUTE, undefined, 45_000, { readiness: 'route' })
+      if (!issuePage) {
+        throw new Error('Failed to launch issue-955 page')
+      }
+      await issuePage.waitForRendered({
+        dataset: {
+          summary: 'string:SALE|string:',
+        },
+        selector: '.issue955-probe',
+        timeout: 15_000,
+      })
+
+      const activeMiniProgram = await getSharedMiniProgram(ctx)
+      const initial = await callRoutePageMethod(activeMiniProgram, ISSUE_955_ROUTE, '_runE2E')
+      expect(initial).toEqual({
+        ready: true,
+        parent: {
+          content: 'string:SALE',
+          src: 'undefined',
+        },
+        child: {
+          content: 'string:SALE',
+          src: 'string:',
+          nullable: 'null',
+          initialSummary: 'string:SALE|string:',
+        },
+      })
+
+      const numberValue = await callRoutePageMethod(activeMiniProgram, ISSUE_955_ROUTE, '_runE2E', 'number')
+      expect(numberValue).toMatchObject({
+        parent: {
+          content: 'number:42',
+          src: 'string:number.png',
+        },
+        child: {
+          content: 'number:42',
+          src: 'string:number.png',
+          nullable: 'string:number-label',
+        },
+      })
+
+      const nullValue = await callRoutePageMethod(activeMiniProgram, ISSUE_955_ROUTE, '_runE2E', 'null')
+      expect(nullValue).toMatchObject({
+        parent: {
+          content: 'null',
+          src: 'null',
+        },
+        child: {
+          content: 'number:0',
+          src: 'string:',
+          nullable: 'null',
+        },
+      })
+
+      const undefinedValue = await callRoutePageMethod(activeMiniProgram, ISSUE_955_ROUTE, '_runE2E', 'undefined')
+      expect(undefinedValue).toMatchObject({
+        parent: {
+          content: 'undefined',
+          src: 'undefined',
+        },
+        child: {
+          content: 'number:0',
+          src: 'string:',
+          nullable: 'null',
+        },
+      })
+
+      const stringValue = await callRoutePageMethod(activeMiniProgram, ISSUE_955_ROUTE, '_runE2E', 'string')
+      expect(stringValue).toMatchObject({
+        parent: {
+          content: 'string:PROMO',
+          src: 'string:string.png',
+        },
+        child: {
+          content: 'string:PROMO',
+          src: 'string:string.png',
+          nullable: 'string:string-label',
+        },
+      })
+      expect(stringValue.child.initialSummary).toBe('string:SALE|string:')
+      expect(runtimeErrors.getLogsSince(marker).filter(log => ISSUE_955_TYPE_WARNING_RE.test(log))).toEqual([])
+    }
+    finally {
+      runtimeErrors.dispose()
       await releaseSharedMiniProgram(miniProgram)
     }
   })

--- a/packages-runtime/web/src/runtime/wevu.ts
+++ b/packages-runtime/web/src/runtime/wevu.ts
@@ -63,11 +63,12 @@ export function registerWebWevuApp(options: Record<string, any>, meta: WevuRegis
  * 将 Wevu 页面或组件注册过程接入 Web 自定义元素。
  */
 export function registerWebWevuComponent(options: Record<string, any>, meta: WevuRegisterMeta): void {
+  // Web 依赖 prop 构造器解码 DOM 属性，不使用小程序宿主的 nullable transport 降级。
   withRuntimeConstructor('Component', (definition) => {
     return meta.kind === 'page'
       ? registerPage(definition, meta)
       : registerComponent(definition, meta)
-  }, () => createWevuComponent(options))
+  }, () => createWevuComponent({ ...options, allowNullPropInput: false }))
 }
 
 /**

--- a/packages-runtime/web/test/wevu-props.test.ts
+++ b/packages-runtime/web/test/wevu-props.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+
+import type { ComponentPublicInstance } from '../src/runtime/component/types'
+import { afterEach, expect, it, vi } from 'vitest'
+import { registerWebWevuComponent } from '../src/runtime/wevu'
+import { slugify } from '../src/shared/slugify'
+
+afterEach(() => {
+  document.body.replaceChildren()
+  vi.unstubAllGlobals()
+})
+
+it.each(['component', 'page'] as const)('decodes Web %s attributes without native nullable transport erasing prop types', async (kind) => {
+  const id = `wevu-attribute-transport-${kind}`
+  const previousConstructor = vi.fn()
+  vi.stubGlobal('Component', previousConstructor)
+  registerWebWevuComponent({
+    allowNullPropInput: true,
+    props: {
+      enabled: Boolean,
+      count: Number,
+      payload: Object,
+      items: Array,
+    },
+  }, { kind, id })
+  expect((globalThis as Record<string, unknown>).Component).toBe(previousConstructor)
+
+  const element = document.createElement(slugify(id, kind === 'page' ? 'wv-page' : 'wv-component')) as ComponentPublicInstance & {
+    updateComplete: Promise<boolean>
+  }
+  element.setAttribute('enabled', '')
+  element.setAttribute('count', '7')
+  element.setAttribute('payload', '{"label":"initial"}')
+  element.setAttribute('items', '[1,2]')
+  document.body.append(element)
+  await element.updateComplete
+
+  expect(element.properties).toMatchObject({
+    enabled: true,
+    count: 7,
+    payload: { label: 'initial' },
+    items: [1, 2],
+  })
+
+  element.setAttribute('enabled', 'false')
+  element.setAttribute('count', '12')
+  element.setAttribute('payload', 'null')
+  element.setAttribute('items', '[3]')
+  await element.updateComplete
+
+  expect(element.properties).toMatchObject({
+    enabled: false,
+    count: 12,
+    payload: null,
+    items: [3],
+  })
+})

--- a/packages-runtime/web/test/wevu.test.ts
+++ b/packages-runtime/web/test/wevu.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   installWebModuleRegistration,
   registerWebWevuApp,
-  registerWebWevuComponent,
 } from '../src/runtime/wevu'
 
 const createAppMock = vi.hoisted(() => vi.fn((options: Record<string, any>) => {
@@ -61,21 +60,6 @@ describe('wevu web registration bridge', () => {
     expect(createAppMock).toHaveBeenCalledTimes(1)
     expect(registerAppMock).toHaveBeenCalledWith({ pending: true }, meta)
     expect((globalThis as any).App).toBe(previousApp)
-  })
-
-  it('routes Wevu pages and components through their matching registries', () => {
-    registerWebWevuComponent({ data: { page: true } }, { kind: 'page', id: 'pages/home' } as any)
-    expect(registerPageMock).toHaveBeenCalledWith(
-      { data: { page: true } },
-      { kind: 'page', id: 'pages/home' },
-    )
-
-    registerWebWevuComponent({ data: { component: true } }, { kind: 'component', id: 'card' } as any)
-    expect(registerComponentMock).toHaveBeenCalledWith(
-      { data: { component: true } },
-      { kind: 'component', id: 'card' },
-    )
-    expect((globalThis as any).Component).toBeUndefined()
   })
 
   it('installs app, page and component constructors and restores owned values', () => {

--- a/packages-runtime/wevu/src/runtime/define.ts
+++ b/packages-runtime/wevu/src/runtime/define.ts
@@ -293,7 +293,7 @@ function createComponentDefinition(
       .filter(path => !path.includes('.')),
   )
 
-  const normalizedMpOptions = normalizeProps(mpOptions, props)
+  const normalizedMpOptions = normalizeProps(mpOptions, props, mpOptions.properties)
   const initialDataContext = resolveInitialDataContext(normalizedMpOptions.properties, methods)
   const resolvedData = typeof data === 'function'
     ? () => data.call(initialDataContext)
@@ -420,23 +420,12 @@ export function createWevuComponent<
 >(
   options: DefineComponentOptions<P, D, C, M> & { properties?: MiniProgramComponentPropertyOption },
 ): void {
-  ensureScopedSlotComponentGlobal()
-  const {
-    properties,
-    props,
-    ...restOptions
-  } = options
-
-  const baseOptions = {
-    ...restOptions,
-    allowNullPropInput: (restOptions as any).allowNullPropInput ?? true,
-    __wevu_allowNullPropInput: true,
-  }
-
-  // 将 properties 合并到 mpOptions，保持小程序属性定义
-  const finalOptions = normalizeProps(baseOptions, props, properties)
-
-  defineComponent(finalOptions)
+  const allowNullPropInput = options.allowNullPropInput ?? true
+  defineComponent({
+    ...options,
+    allowNullPropInput,
+    __wevu_allowNullPropInput: allowNullPropInput,
+  })
 }
 
 /**

--- a/packages-runtime/wevu/src/runtime/define/props.ts
+++ b/packages-runtime/wevu/src/runtime/define/props.ts
@@ -37,32 +37,36 @@ function toNativePropertyType(candidate: unknown) {
   return NATIVE_PROPERTY_TYPE_MAP.get(candidate)
 }
 
+function collectNativePropertyTypeCandidates(
+  raw: unknown,
+  normalized: NormalizedNativePropertyType[] = [],
+) {
+  if (Array.isArray(raw)) {
+    for (const item of raw) {
+      collectNativePropertyTypeCandidates(item, normalized)
+    }
+    return normalized
+  }
+  const mapped = toNativePropertyType(raw)
+  if (mapped !== undefined && !normalized.includes(mapped)) {
+    normalized.push(mapped)
+  }
+  return normalized
+}
+
 function normalizeTypeCandidates(raw: unknown) {
   if (raw === undefined) {
     return []
   }
-  const source = Array.isArray(raw) ? raw : [raw]
-  const normalized: NormalizedNativePropertyType[] = []
-  source.forEach((item) => {
-    const mapped = toNativePropertyType(item)
-    if (mapped === undefined) {
-      return
-    }
-    if (!normalized.includes(mapped)) {
-      normalized.push(mapped)
-    }
-  })
+  const normalized = collectNativePropertyTypeCandidates(raw)
   const requiredNativeTypes = normalized.filter((item): item is Exclude<NormalizedNativePropertyType, null> => item !== null)
   if (requiredNativeTypes.length > 0) {
     return requiredNativeTypes
   }
-  if (normalized.includes(null)) {
-    return [null]
-  }
   return [null]
 }
 
-function applyTypeOptions(target: Record<string, any>, rawType: unknown) {
+function applyTypeOptions(target: Record<string, unknown>, rawType: unknown) {
   const candidates = normalizeTypeCandidates(rawType)
   if (candidates.length === 0) {
     return
@@ -70,7 +74,7 @@ function applyTypeOptions(target: Record<string, any>, rawType: unknown) {
 
   target.type = candidates[0]
   if (candidates.length > 1) {
-    const optionalTypes: any[] = []
+    const optionalTypes: NormalizedNativePropertyType[] = []
     for (const candidate of candidates.slice(1)) {
       if (!optionalTypes.includes(candidate)) {
         optionalTypes.push(candidate)
@@ -82,104 +86,55 @@ function applyTypeOptions(target: Record<string, any>, rawType: unknown) {
   }
 }
 
-function appendOptionalType(target: Record<string, any>, candidate: unknown) {
-  if (candidate === undefined || target.type === candidate) {
+function preserveImplicitNativeDefault(target: Record<string, unknown>) {
+  if (hasOwn(target, 'value')) {
     return
   }
-  const optionalTypes = Array.isArray(target.optionalTypes)
-    ? [...target.optionalTypes]
-    : []
-  if (optionalTypes.includes(candidate)) {
-    return
+  if (target.type === String) {
+    target.value = ''
   }
-  optionalTypes.push(candidate)
-  target.optionalTypes = optionalTypes
+  else if (target.type === Number) {
+    target.value = 0
+  }
+  else if (target.type === Boolean) {
+    target.value = false
+  }
+  else if (target.type === Array) {
+    target.value = []
+  }
 }
 
-function normalizeOptionalTypeCandidates(raw: unknown) {
-  if (!Array.isArray(raw)) {
-    return []
-  }
-  const normalized: Array<Exclude<NormalizedNativePropertyType, null>> = []
-  raw.forEach((item) => {
-    const mapped = toNativePropertyType(item)
-    if (mapped === undefined || mapped === null || normalized.includes(mapped)) {
-      return
-    }
-    normalized.push(mapped)
-  })
-  return normalized
-}
-
-function normalizeExplicitPropertyDefinition(
+function applyNullableTransportOptions(
+  target: Record<string, unknown>,
   definition: unknown,
   allowNullPropInput: boolean,
 ) {
-  if (definition === undefined) {
-    return undefined
+  if (!allowNullPropInput || target.type === null) {
+    return
   }
-  if (definition === null) {
-    return { type: null }
-  }
-  if (Array.isArray(definition) || typeof definition === 'function') {
-    const propOptions: Record<string, any> = {}
-    applyTypeOptions(propOptions, definition)
-    if (allowNullPropInput && propOptions.type !== null) {
-      appendOptionalType(propOptions, null)
-    }
-    if (!hasOwn(propOptions, 'type')) {
-      propOptions.type = null
-    }
-    return propOptions
-  }
-  if (typeof definition !== 'object') {
-    return definition
-  }
-
-  const propOptions: Record<string, any> = {
-    ...(definition as Record<string, any>),
+  const definitionRecord = definition && typeof definition === 'object' && !Array.isArray(definition)
+    ? (definition as Record<string, unknown>)
+    : undefined
+  const candidates = collectNativePropertyTypeCandidates(
+    definitionRecord
+      ? [definitionRecord.type, definitionRecord.optionalTypes]
+      : definition,
+  )
+  const explicitlyNullable = candidates.includes(null)
+  const nativeTypes = candidates.filter(candidate => candidate !== null)
+  const acceptsMultipleNativeTypes = nativeTypes.length > 1
+  const acceptsMissingInput = definitionRecord?.required !== true
+  // glass-easel 会先按主 type 校验并转换，optionalTypes 无法保护合法的联合值与空值传输。
+  if (!explicitlyNullable && !acceptsMultipleNativeTypes && !acceptsMissingInput) {
+    return
   }
 
-  if ('type' in propOptions) {
-    const normalizedTypes = normalizeTypeCandidates(propOptions.type)
-    propOptions.type = normalizedTypes[0] ?? null
-    const existingOptionalTypes = normalizeOptionalTypeCandidates(propOptions.optionalTypes)
-    for (const candidate of normalizedTypes.slice(1)) {
-      if (candidate !== null && !existingOptionalTypes.includes(candidate)) {
-        existingOptionalTypes.push(candidate)
-      }
-    }
-    if (existingOptionalTypes.length > 0) {
-      propOptions.optionalTypes = existingOptionalTypes
-    }
-    else {
-      delete propOptions.optionalTypes
-    }
+  // 显式声明的 null 必须保持可观察；其余降级场景则保留原主类型的宿主隐式默认值。
+  if (!explicitlyNullable) {
+    preserveImplicitNativeDefault(target)
   }
-
-  if (!hasOwn(propOptions, 'type')) {
-    propOptions.type = null
-  }
-
-  if (allowNullPropInput && propOptions.type !== null) {
-    appendOptionalType(propOptions, null)
-  }
-
-  return propOptions
-}
-
-function normalizeExplicitProperties(
-  properties: MiniProgramComponentPropertyOption,
-  allowNullPropInput: boolean,
-) {
-  const normalizedProperties: Record<string, any> = {}
-  Object.entries(properties).forEach(([key, definition]) => {
-    const normalizedDefinition = normalizeExplicitPropertyDefinition(definition, allowNullPropInput)
-    if (normalizedDefinition !== undefined) {
-      normalizedProperties[key] = normalizedDefinition
-    }
-  })
-  return normalizedProperties
+  target.type = null
+  delete target.optionalTypes
 }
 
 function normalizeVueProps(
@@ -200,14 +155,12 @@ function normalizeVueProps(
       return
     }
     if (Array.isArray(definition) || typeof definition === 'function') {
-      const propOptions: Record<string, any> = {}
+      const propOptions: Record<string, unknown> = {}
       applyTypeOptions(propOptions, definition)
-      if (allowNullPropInput && propOptions.type !== null) {
-        appendOptionalType(propOptions, null)
-      }
       if (!hasOwn(propOptions, 'type')) {
         propOptions.type = null
       }
+      applyNullableTransportOptions(propOptions, definition, allowNullPropInput)
       properties[key] = propOptions
       return
     }
@@ -217,7 +170,7 @@ function normalizeVueProps(
         properties[key] = { type: Object, value: {} }
         return
       }
-      const propOptions: Record<string, any> = {}
+      const propOptions: Record<string, unknown> = {}
       if ('type' in definition && definition.type !== undefined) {
         applyTypeOptions(propOptions, (definition as any).type)
       }
@@ -225,7 +178,7 @@ function normalizeVueProps(
         const optionalTypes = (definition as any).optionalTypes.map((item: unknown) => toNativePropertyType(item)).filter((item: unknown): item is Exclude<NormalizedNativePropertyType, null> => item !== undefined && item !== null)
         if (optionalTypes.length > 0) {
           const existingOptionalTypes = Array.isArray(propOptions.optionalTypes)
-            ? propOptions.optionalTypes as any[]
+            ? propOptions.optionalTypes as NormalizedNativePropertyType[]
             : []
           for (const optionalType of optionalTypes) {
             if (optionalType === propOptions.type) {
@@ -247,12 +200,10 @@ function normalizeVueProps(
       if (defaultValue !== undefined) {
         propOptions.value = typeof defaultValue === 'function' ? (defaultValue as any)() : defaultValue
       }
-      if (allowNullPropInput && propOptions.type !== null) {
-        appendOptionalType(propOptions, null)
-      }
       if (!hasOwn(propOptions, 'type')) {
         propOptions.type = null
       }
+      applyNullableTransportOptions(propOptions, definition, allowNullPropInput)
       properties[key] = propOptions
     }
   })
@@ -304,10 +255,6 @@ export function normalizeProps(
       ...rest
     } = normalizedBaseOptions
     const normalizedExplicitProperties = resolvedExplicit
-      ? allowNullPropInput
-        ? normalizeExplicitProperties(resolvedExplicit as any, allowNullPropInput)
-        : (resolvedExplicit as any)
-      : undefined
     const normalizedVueProps = normalizeVueProps(props, allowNullPropInput)
     return {
       ...rest,

--- a/packages-runtime/wevu/src/runtime/types/options.ts
+++ b/packages-runtime/wevu/src/runtime/types/options.ts
@@ -29,9 +29,9 @@ export interface DefineComponentOptions<
    */
   props?: P
   /**
-   * 允许将运行时传入的 `undefined` props 兼容为 `null` 输入，避免小程序对已声明类型 props 报告 `null` 类型告警。
+   * 兼容 Vue props 的 `undefined -> null` 传输，对可选、可空或联合类型使用无主类型约束的原生属性，避免提前转换。
    *
-   * 适合迁移 Vue 组件或需要兼容 `undefined -> null` 传参链路的场景；默认关闭，避免影响原生 `properties` 的严格类型语义。
+   * 默认关闭；显式原生 `properties` 始终原样传递，必填且不可空的单一类型仍保持原生类型约束。
    */
   allowNullPropInput?: boolean
   /**

--- a/packages-runtime/wevu/test/runtime-define-helpers.test.ts
+++ b/packages-runtime/wevu/test/runtime-define-helpers.test.ts
@@ -66,61 +66,87 @@ describe('runtime: define helpers', () => {
     expect(result.properties.__wvSlotScope).toBeTruthy()
   })
 
-  it('allows null as an optional native input for compiled vue props', () => {
+  it('keeps inferred nullable transport values out of native type coercion without losing defaults or observers', () => {
+    const unionObserver = vi.fn()
+    const nullableObserver = vi.fn()
     const result = normalizeProps({
       data: () => ({}),
       __wevu_allowNullPropInput: true,
     }, {
-      name: String,
-      count: { type: Number, default: 2 },
-      mode: [String, Number],
-      anyValue: null,
+      optionalShorthand: String,
+      optionalWithoutRequired: { type: String },
+      shorthandUnion: [String, Number],
+      requiredName: { type: String, required: true },
+      optionalName: { type: String, required: false },
+      optionalCount: { type: Number, required: false },
+      optionalEnabled: { type: Boolean, required: false },
+      optionalItems: { type: Array, required: false },
+      content: { type: [Number, String], required: false, observer: unionObserver },
+      optionalTypesUnion: { type: Number, optionalTypes: [String], required: true },
+      src: { type: String, required: false, default: '' },
+      nullableLabel: { type: [String, null], required: true, observer: nullableObserver },
+      unionWithDefault: { type: [String, Number], required: true, default: 'ready' },
     })
 
-    expect(result.properties.name.type).toBe(String)
-    expect(result.properties.name.optionalTypes).toEqual([null])
-    expect(result.properties.count.type).toBe(Number)
-    expect(result.properties.count.optionalTypes).toEqual([null])
-    expect(result.properties.mode.type).toBe(String)
-    expect(result.properties.mode.optionalTypes).toEqual([Number, null])
-    expect(result.properties.anyValue.type).toBeNull()
-    expect(result.properties.anyValue.optionalTypes).toBeUndefined()
+    expect(result.properties.requiredName).toEqual({ type: String })
+    expect(result.properties.optionalShorthand).toEqual({ type: null, value: '' })
+    expect(result.properties.optionalWithoutRequired).toEqual({ type: null, value: '' })
+    expect(result.properties.shorthandUnion).toEqual({ type: null, value: '' })
+    expect(result.properties.optionalName).toEqual({ type: null, value: '' })
+    expect(result.properties.optionalCount).toEqual({ type: null, value: 0 })
+    expect(result.properties.optionalEnabled).toEqual({ type: null, value: false })
+    expect(result.properties.optionalItems).toEqual({ type: null, value: [] })
+    expect(result.properties.content).toEqual({
+      type: null,
+      value: 0,
+      observer: unionObserver,
+    })
+    expect(result.properties.optionalTypesUnion).toEqual({ type: null, value: 0 })
+    expect(result.properties.src).toEqual({ type: null, value: '' })
+    expect(result.properties.nullableLabel).toEqual({
+      type: null,
+      observer: nullableObserver,
+    })
+    expect(result.properties.unionWithDefault).toEqual({ type: null, value: 'ready' })
   })
 
-  it('allows null as an optional native input for explicit properties', () => {
-    const result = normalizeProps({
-      data: () => ({}),
-      allowNullPropInput: true,
-    }, undefined, {
+  it('preserves explicit native property definitions when nullable transport is enabled', () => {
+    const observer = vi.fn()
+    const explicitProperties = {
       name: String,
       count: { type: Number, value: 2 },
+      mode: { type: Number, optionalTypes: [String], observer },
       anyValue: null,
-    })
+    }
+    const result = normalizeProps({
+      data: () => ({}),
+      allowNullPropInput: true,
+    }, undefined, explicitProperties)
 
-    expect(result.properties.name.type).toBe(String)
-    expect(result.properties.name.optionalTypes).toEqual([null])
-    expect(result.properties.count.type).toBe(Number)
-    expect(result.properties.count.value).toBe(2)
-    expect(result.properties.count.optionalTypes).toEqual([null])
-    expect(result.properties.anyValue.type).toBeNull()
-    expect(result.properties.anyValue.optionalTypes).toBeUndefined()
+    expect(result.properties).toMatchObject(explicitProperties)
+    expect(result.properties.name).toBe(String)
+    expect(result.properties.count).toBe(explicitProperties.count)
+    expect(result.properties.mode).toBe(explicitProperties.mode)
   })
 
-  it('merges explicit internal properties with compiled Vue props', () => {
+  it('keeps explicit overrides and internal properties while widening inferred props', () => {
+    const titleObserver = vi.fn()
     const ownerObserver = vi.fn()
+    const explicitTitle = { type: String, value: 'native-title', observer: titleObserver }
     const result = normalizeProps({
       data: () => ({}),
       allowNullPropInput: true,
     }, {
-      title: { type: String, required: true },
+      title: { type: [Number, String], required: false },
       items: { type: null, default: () => [] },
     }, {
+      title: explicitTitle,
       __wvSlotOwnerId: { type: String, value: '', observer: ownerObserver },
       __wvSlotScope: { type: null, value: null },
     })
 
-    expect(result.properties.title.type).toBe(String)
-    expect(result.properties.title.optionalTypes).toEqual([null])
+    expect(result.properties.title).toBe(explicitTitle)
+    expect(result.properties.title.observer).toBe(titleObserver)
     expect(result.properties.items.type).toBeNull()
     expect(result.properties.items.value).toEqual([])
     expect(result.properties.__wvSlotOwnerId.observer).toBe(ownerObserver)
@@ -149,8 +175,11 @@ describe('runtime: define helpers', () => {
     expect(second.properties).toEqual({})
   })
 
-  it('normalizes Vue inferred union arrays to native type and optionalTypes', () => {
-    const result = normalizeProps({ data: () => ({}) }, {
+  it('keeps native union descriptors when nullable transport compatibility is disabled', () => {
+    const result = normalizeProps({
+      data: () => ({}),
+      allowNullPropInput: false,
+    }, {
       mixed: { type: [Number, String] },
       literalUnion: { type: [String, Number] },
       multiNative: { type: [String, Number, Boolean, Object, Array] },

--- a/packages-runtime/wevu/test/runtime-more.test.ts
+++ b/packages-runtime/wevu/test/runtime-more.test.ts
@@ -1,11 +1,12 @@
 import { WEVU_PUBLIC_RUNTIME_KEY } from '@weapp-core/constants'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp, createWevuComponent, defineComponent } from '@/index'
+import { createApp, createWevuComponent, defineComponent, resetWevuDefaults, setWevuDefaults } from '@/index'
 
 const registeredComponents: Record<string, any>[] = []
 const registeredApps: Record<string, any>[] = []
 
 beforeEach(() => {
+  resetWevuDefaults()
   registeredComponents.length = 0
   registeredApps.length = 0
   ;(globalThis as any).Component = vi.fn((options: Record<string, any>) => {
@@ -17,6 +18,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  resetWevuDefaults()
   delete (globalThis as any).Component
   delete (globalThis as any).App
 })
@@ -89,27 +91,113 @@ describe('runtime (component as page lifetimes mapping)', () => {
     expect(opts.data).toEqual({ value1: '111' })
   })
 
-  it('preserves first-paint seeds and nullable prop bridge for compiled SFC components', () => {
+  it('registers nullable and union SFC props without native primary-type coercion', () => {
+    const propObserver = vi.fn()
+    const nativeOverride = { type: String, value: 'native', observer: vi.fn() }
     createWevuComponent({
       data: () => ({
         value1: '111',
       }),
+      properties: {
+        nativeMode: nativeOverride,
+      },
       props: {
-        value: {
+        shorthand: String,
+        withoutRequired: { type: String },
+        content: {
+          type: [Number, String],
+          required: false,
+        },
+        observedContent: {
+          type: [String, Number],
+          required: true,
+          default: 'observed',
+          observer: propObserver,
+        },
+        nativeMode: {
+          type: [Number, String],
+          required: false,
+        },
+        src: {
           type: String,
-          default: '0.00',
+          required: false,
+          default: '',
+        },
+        strictCount: {
+          type: Number,
+          required: true,
         },
       },
       setup() {
         return {}
       },
-    } as any)
+    })
 
     const opts = registeredComponents[0]
     expect(opts.data).toEqual({ value1: '111' })
-    expect(opts.properties.value.type).toBe(String)
-    expect(opts.properties.value.value).toBe('0.00')
-    expect(opts.properties.value.optionalTypes).toEqual([null])
+    expect(opts.properties.content).toEqual({ type: null, value: 0 })
+    expect(opts.properties.observedContent).toEqual({
+      type: null,
+      value: 'observed',
+      observer: propObserver,
+    })
+    expect(opts.properties.nativeMode).toBe(nativeOverride)
+    expect(opts.properties.shorthand).toEqual({ type: null, value: '' })
+    expect(opts.properties.withoutRequired).toEqual({ type: null, value: '' })
+    expect(opts.properties.src).toEqual({ type: null, value: '' })
+    expect(opts.properties.strictCount).toEqual({ type: Number })
+    expect(opts.properties.__wvSlotOwnerId.type).toBe(String)
+    expect(opts.properties.__wvSlotScope.type).toBeNull()
+  })
+
+  it('honors the compiled SFC nullable transport opt-out', () => {
+    createWevuComponent({
+      allowNullPropInput: false,
+      props: {
+        shorthand: String,
+        withoutRequired: { type: String },
+        content: {
+          type: [Number, String],
+          required: false,
+        },
+        src: {
+          type: String,
+          required: false,
+          default: '',
+        },
+      },
+    })
+
+    const opts = registeredComponents[0]
+    expect(opts.properties.content).toEqual({
+      type: Number,
+      optionalTypes: [String],
+    })
+    expect(opts.properties.src).toEqual({ type: String, value: '' })
+    expect(opts.properties.shorthand).toEqual({ type: String })
+    expect(opts.properties.withoutRequired).toEqual({ type: String })
+  })
+
+  it.each([true, false])('preserves local nullable transport %s over global defaults for inherited props', (allowNullPropInput) => {
+    setWevuDefaults({
+      component: { allowNullPropInput: !allowNullPropInput },
+    })
+    createWevuComponent({
+      allowNullPropInput,
+      props: { local: String },
+      extends: { props: { fromExtends: String } },
+      mixins: [{ props: { fromMixin: String, nativeOverride: [String, Number] } }],
+      properties: { nativeOverride: String },
+    })
+
+    const properties = registeredComponents[0].properties
+    const expected = allowNullPropInput ? { type: null, value: '' } : { type: String }
+    expect(properties).toMatchObject({
+      local: expected,
+      fromExtends: expected,
+      fromMixin: expected,
+    })
+    expect(properties.nativeOverride).toBe(String)
   })
 })
 

--- a/website/config/wevu.md
+++ b/website/config/wevu.md
@@ -89,9 +89,11 @@ export default defineConfig({
 })
 ```
 
-它的作用是兼容小程序运行时把传入的 `undefined` 视为 `null` 的行为，减少 `String`、`Number` 等已声明类型 props 在微信开发者工具里反复出现的 `null` 类型告警。
+它兼容小程序运行时把传入的 `undefined` 视为 `null` 的行为。对 Vue `props` 推导出的可选属性（未设置 `required: true`，包含 `String` 等构造器简写）、显式可空类型和多种原生类型的联合类型，启用后会使用 `type: null`，避免微信开发者工具先按主类型校验而将合法字符串转换为 `0`，或对临时 `null` 输出类型告警。已有默认值和 observer 会保留；非显式可空属性还会保留原生类型的隐式默认值。
 
-如果你的项目明确希望保持“`null` 一律视为非法输入”的旧行为，也可以显式关闭：
+必填、不可空的单一类型属性仍保留原生类型约束。显式声明的原生 `properties` 原样传递，并优先于同名 Vue `props`，不受此开关影响。
+
+如果你的项目明确希望保持推导属性原有的主类型和 `optionalTypes` 校验行为，可以显式关闭；Vue SFC 也会尊重此设置：
 
 ```ts
 export default defineConfig({


### PR DESCRIPTION
## Problem / Goal

修复 #955：类型优先 SFC 的 `content?: number | string` 接收 `SALE` 时，glass-easel 可能先按原生主类型 `Number` 将它转换成 `0`；可选 `src?: string` 在 `undefined → null` 传输时也可能提前触发原生类型告警。

本 PR 先保持 **Draft**：源码与 headless 回归已通过，但安装版 DevTools 尚未提供成功的原生端到端证据。

## Reproduction / Baseline

原报告环境为 Wevu 7.0.4、DevTools 2.01.2510290、基础库 3.17.2、glass-easel。父组件初始传入 `content = 'SALE'`、`src = undefined`，子组件对 `src` 使用空字符串默认值。旧描述符保留 `Number`/`String` 主类型；`optionalTypes` 不能阻止宿主提前转换。

回归还复现了构造器简写遗漏可选性，以及局部 `allowNullPropInput` 在 `mixins/extends` 二次归一化时被相反的全局默认值覆盖。

## Root cause / Design

在 Wevu 原生属性注册边界修复，而非修改模板输入或屏蔽告警。启用 nullable transport 时，可选（包含省略 `required` 和构造器简写）、显式可空或多原生类型联合的推导 props 使用 `type: null`。保留显式默认值、原有隐式默认值和 observer；必填、不可空的单一类型仍保持严格约束。

SFC 入口将原始选项与一致的开关传递给统一注册流程，在全局默认值及 `mixins/extends` 解析后只归一化一次。显式原生 `properties` 保持优先且原样传递，包括用于 slot-only 组件的空声明。

## Bug class / Variant sweep

不变量：Vue/TypeScript 允许的值必须在未被原生主类型破坏的情况下进入框架默认值处理。排查覆盖 9 个边界：

| 边界 | 处理 |
| --- | --- |
| 对象形式推导 props、`optionalTypes` | 在共同归一化 owner 修复 |
| 构造器及构造器数组简写 | 同一修复，省略 `required` 视为可选 |
| SFC 公有/私有开关及继承优先级 | 单次归一化，并覆盖 true/false 两个方向 |
| 显式原生属性、同名覆盖、内部 slot 属性 | 保持原生定义与空声明语义 |
| 编译器默认值注入 | 通过运行时 owner 修复，无编译器改动 |
| Web adapter | 已消费无主类型描述符，无重复 producer 需修改 |
| mpcore simulator | 已支持 `type: null`；用于 headless 对等验证 |
| AST/自动导入静态元数据 | 不注册或转换运行时值，排除 |
| weapp-vite 兼容转发入口 | 仅转发原生属性，无该推导归一化逻辑，排除 |

编译器原先已经放宽为 `type: null` 的 Array/Object 保持原状；不承诺为这些既有描述符新增 `[]` 默认值。

## Change

- 修改 `packages-runtime/wevu/src/runtime/define/props.ts` 和 `runtime/define.ts` 的注册边界。
- 增加默认值、nullable、简写、严格 opt-out、显式覆盖、继承优先级回归；保留既有 slot 元数据测试。
- 新增类型优先父子 SFC 探针，覆盖初始 `SALE`、number/null/undefined/string 更新，以及必填 `string | null` 属性。
- 更新 `allowNullPropInput` 文档及 JSDoc；添加 `wevu`、`create-weapp-vite` patch changeset。

## Non-goals

不新增 props API，不重写编译器或 simulator，不放宽显式原生 `properties`，不修改真实 DevTools 就绪检查或增加重试兜底。

## Verification

环境：macOS ARM64、Node 24.14.0、pnpm 11.25.0。

| Acceptance / Surface | 命令或证据 | 结果 |
| --- | --- | --- |
| 完整 wevu 包回归 | `pnpm --filter wevu exec vitest run --coverage.enabled=false` | 79 个文件、916 个测试通过，0 失败 |
| 类型及构建 | `pnpm --filter wevu typecheck`、`pnpm --filter wevu test:types`、`pnpm --filter wevu build` | 通过 |
| 最新编译产物上的 #955 headless 场景 | 下方命令 | 1 个目标测试通过；7 个非目标用例跳过 |
| staged 检查 | 仓库正常 pre-commit 与 commit-msg hooks | 通过；hooks 未改变已审查内容 |
| 发布元数据 | `node scripts/check-changeset-frontmatter.mjs` | 通过 |

```sh
WEAPP_VITE_E2E_TARGET_FILE=ide/github-issues.runtime.props.test.ts \
WEAPP_VITE_E2E_RUNTIME_PROVIDER=headless \
pnpm exec vitest run -c e2e/vitest.e2e.headless.config.ts -t 'issue #955'
```

Headless 实际断言初始及后续值/类型、显式 nullable 的 null/string 转换、默认值、不可变初始快照，以及无匹配的类型转换告警。

**原生验证阻塞：** 安装版 DevTools 通过构建与登录 preflight，随后 direct automator 启动在 90 秒超时；8 个测试全部跳过，零原生 #955 断言执行。该尝试早于最终简写/继承修正，不能作为最终源码的原生通过证据。曾在临时验证配置中复用 #954 的已构建驱动，但两个修复分支没有互相依赖；临时配置已移除。

未宣称完整 props E2E 文件通过：原有 #600 alias 路由失败已在未修改的 `origin/main` 上复现，属于目标外问题。早期遇到的 3 个 Rolldown 测试失败也曾在基线复现；最终 916 测试全量运行没有这些失败。

## Risks

- Compatibility：推导属性在兼容开关启用时有意降低原生主类型约束；显式原生属性、必填不可空单类型和 `false` opt-out 保持严格。
- Security/privacy：不增加日志或上传业务数据；发布说明不包含本机路径、凭据或内部报告链接。
- Performance/resources：移除 SFC 入口的重复归一化，不增加运行时重试或订阅。
- Platform/runtime：真实 glass-easel 行为仍需 DevTools 就绪恢复后确认。包含 issue955 路由的构建会在 app 级启用 glass-easel/v2（含完整 fixture 构建）；不含该路由的 scoped 构建不受影响。

## Rollback

Revert 本 PR 即可恢复原注册行为；无数据迁移。

## Related

Closes #955
