### PR TITLE
fix(automator): 兼容 DevTools 自动化接口的不透明令牌响应

### DIFF
--- a/.changeset/fix-954-automator-token.md
+++ b/.changeset/fix-954-automator-token.md
@@ -1,0 +1,5 @@
+---
+'@weapp-vite/miniprogram-automator': patch
+---
+
+修复新版微信开发者工具 `/auto` 返回不透明 token 时被误判为失败的问题：成功响应使用请求的自动化端口建立连接，保留旧版响应兼容，并避免错误信息泄露响应 token。

--- a/e2e/utils/automator.cli-bridge.test.ts
+++ b/e2e/utils/automator.cli-bridge.test.ts
@@ -6,6 +6,8 @@ import { PassThrough } from 'node:stream'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { enableAutomatorViaHttp, extendProjectConfig, resolveBootstrapCliArgs, resolveCliSpawnOptions, waitForSocketReady } from './automator.cli-bridge'
 
+const opaqueToken = 'a'.repeat(32)
+
 function createMockChild(spawnfile = '/Applications/wechatwebdevtools.app/Contents/MacOS/cli') {
   const stdout = new PassThrough()
   const stderr = new PassThrough()
@@ -254,7 +256,7 @@ describe('enableAutomatorViaHttp', () => {
     })).resolves.toBe(45678)
   })
 
-  it('rejects an unknown successful response shape', async () => {
+  it('uses the requested port for a DevTools opaque token response', async () => {
     const server = net.createServer((socket) => {
       socket.once('data', () => {
         socket.end([
@@ -262,7 +264,7 @@ describe('enableAutomatorViaHttp', () => {
           'Content-Type: application/json',
           'Connection: close',
           '',
-          JSON.stringify({ status: 'ok' }),
+          JSON.stringify(opaqueToken),
         ].join('\r\n'))
       })
     })
@@ -279,7 +281,60 @@ describe('enableAutomatorViaHttp', () => {
       autoPort: 45678,
       projectPath: '/repo/demo app',
       servicePort,
-    })).rejects.toThrow('unsupported response')
+    })).resolves.toBe(45678)
+  })
+
+  it.each([
+    {
+      body: opaqueToken,
+      expectedMessage: 'WeChat DevTools HTTP automator fallback failed with status 500',
+      status: '500 Internal Server Error',
+    },
+    {
+      body: opaqueToken,
+      expectedMessage: 'WeChat DevTools HTTP automator fallback returned invalid JSON',
+      status: '200 OK',
+    },
+    {
+      body: JSON.stringify({ autoPort: opaqueToken }),
+      expectedMessage: 'WeChat DevTools HTTP automator fallback returned invalid autoPort',
+      status: '200 OK',
+    },
+    {
+      body: JSON.stringify({ token: opaqueToken }),
+      expectedMessage: 'WeChat DevTools HTTP automator fallback returned unsupported response',
+      status: '200 OK',
+    },
+  ])('preserves response errors without disclosing their bodies', async ({ body, expectedMessage, status }) => {
+    const server = net.createServer((socket) => {
+      socket.once('data', () => {
+        socket.end([
+          `HTTP/1.1 ${status}`,
+          'Content-Type: application/json',
+          'Connection: close',
+          '',
+          body,
+        ].join('\r\n'))
+      })
+    })
+    servers.push(server)
+    const servicePort = await new Promise<number>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', () => {
+        const address = server.address()
+        resolve(typeof address === 'object' && address ? address.port : 0)
+      })
+    })
+
+    const error = await enableAutomatorViaHttp({
+      autoPort: 45678,
+      projectPath: '/repo/demo app',
+      servicePort,
+    }).catch(error => error) as Error & { cause?: unknown }
+
+    expect(error.message).toBe(expectedMessage)
+    expect(String(error)).not.toContain(opaqueToken)
+    expect(error.cause).toBeUndefined()
   })
 })
 

--- a/e2e/utils/automator.cli-bridge.ts
+++ b/e2e/utils/automator.cli-bridge.ts
@@ -170,31 +170,28 @@ export async function enableAutomatorViaHttp(options: EnableAutomatorViaHttpOpti
   })
   const body = await response.text()
   if (!response.ok) {
-    const details = summarizeTextOutput(body)
-    throw new Error(`WeChat DevTools HTTP automator fallback failed with status ${response.status}${details ? `: ${details}` : ''}`)
+    throw new Error(`WeChat DevTools HTTP automator fallback failed with status ${response.status}`)
   }
   let result: unknown
   try {
     result = JSON.parse(body) as unknown
   }
-  catch (error) {
-    throw new Error('WeChat DevTools HTTP automator fallback returned invalid JSON', {
-      cause: error as Error,
-    })
+  catch {
+    throw new Error('WeChat DevTools HTTP automator fallback returned invalid JSON')
   }
   if (result && typeof result === 'object' && 'autoPort' in result) {
     const autoPort = Number(result.autoPort)
     if (!Number.isInteger(autoPort) || autoPort <= 0 || autoPort > 65535) {
-      throw new Error(`WeChat DevTools HTTP automator fallback returned invalid autoPort: ${String(result.autoPort)}`)
+      throw new Error('WeChat DevTools HTTP automator fallback returned invalid autoPort')
     }
     return autoPort
   }
 
-  if (typeof result === 'string' && /^s\d+$/.test(result)) {
+  if (typeof result === 'string' && (/^s\d+$/.test(result) || /^[0-9a-f]{32}$/i.test(result))) {
     return options.autoPort
   }
 
-  throw new Error(`WeChat DevTools HTTP automator fallback returned unsupported response: ${summarizeTextOutput(body)}`)
+  throw new Error('WeChat DevTools HTTP automator fallback returned unsupported response')
 }
 
 const AUTOMATOR_VALUE_OPTIONS = new Set([

--- a/packages/miniprogram-automator/src/launcher.test.ts
+++ b/packages/miniprogram-automator/src/launcher.test.ts
@@ -6,6 +6,8 @@ import { PassThrough } from 'node:stream'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { resolveWechatDevtoolsBootstrapArgs } from './launcher/wechatCliFallback'
 
+const opaqueToken = 'a'.repeat(32)
+
 const spawnMock = vi.hoisted(() => vi.fn())
 const accessMock = vi.hoisted(() => vi.fn(async () => undefined))
 const readFileMock = vi.hoisted(() => vi.fn(async () => '{}'))
@@ -462,7 +464,10 @@ describe('Launcher', () => {
     expect(result).toEqual(secondCandidate)
   })
 
-  it('enables automator through the DevTools HTTP service after a successful cli exit', async () => {
+  it.each([
+    { response: { autoPort: 9527 }, expectedPort: 9527, format: 'legacy assigned-port' },
+    { response: opaqueToken, expectedPort: 9420, format: 'opaque-token requested-port' },
+  ])('connects using the $format HTTP fallback response', async ({ response, expectedPort }) => {
     const { default: Launcher } = await loadLauncherModule()
     const child = new EventEmitter() as EventEmitter & {
       stderr: PassThrough
@@ -473,7 +478,7 @@ describe('Launcher', () => {
     child.stdout = new PassThrough()
     child.unref = vi.fn()
     spawnMock.mockReturnValue(child)
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ autoPort: 9527 }))))
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(response))))
 
     const launcher = new Launcher()
     const candidate = {
@@ -509,16 +514,65 @@ describe('Launcher', () => {
     })
     expect(connectToolSpy).toHaveBeenNthCalledWith(2, {
       timeout: 3_000,
-      wsEndpoint: 'ws://127.0.0.1:9527',
+      wsEndpoint: `ws://127.0.0.1:${expectedPort}`,
     })
     expect(result).toEqual({
       ...candidate,
       __WEAPP_VITE_SESSION_METADATA: {
-        port: 9527,
+        port: expectedPort,
         projectPath: '/tmp/project',
-        wsEndpoint: 'ws://127.0.0.1:9527',
+        wsEndpoint: `ws://127.0.0.1:${expectedPort}`,
       },
     })
+  })
+
+  it('preserves a fallback protocol error without disclosing its response body', async () => {
+    const { default: Launcher } = await loadLauncherModule()
+    const child = new EventEmitter() as EventEmitter & {
+      stderr: PassThrough
+      stdout: PassThrough
+      unref: () => void
+    }
+    child.stderr = new PassThrough()
+    child.stdout = new PassThrough()
+    child.unref = vi.fn()
+    spawnMock.mockReturnValue(child)
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ token: opaqueToken }))))
+    const consoleSpies = [
+      vi.spyOn(console, 'error').mockImplementation(() => {}),
+      vi.spyOn(console, 'log').mockImplementation(() => {}),
+      vi.spyOn(console, 'warn').mockImplementation(() => {}),
+    ]
+
+    const launcher = new Launcher()
+    vi.spyOn(launcher as unknown as { connectTool: () => Promise<unknown> }, 'connectTool').mockImplementationOnce(async () => {
+      child.stdout.write('IDE server started successfully, listening on http://127.0.0.1:9420\n')
+      child.emit('exit', 0, null)
+      throw new Error('Failed connecting to ws://127.0.0.1:9420, check if target project window is opened with automation enabled')
+    })
+
+    try {
+      const error = await launcher.launch({
+        cliPath: '/Applications/wechatwebdevtools.app/Contents/MacOS/cli',
+        port: 9420,
+        projectPath: '/tmp/project',
+      }).catch(error => error) as Error & { cause?: unknown }
+
+      const loggedOutput = consoleSpies
+        .flatMap(spy => spy.mock.calls)
+        .flat()
+        .map(value => value instanceof Error ? `${value.message}\n${value.stack ?? ''}` : String(value))
+        .join('\n')
+      expect(error.message).toBe('WeChat DevTools HTTP automator fallback returned unsupported response')
+      expect(String(error)).not.toContain(opaqueToken)
+      expect(error.cause).toBeUndefined()
+      expect(loggedOutput).not.toContain(opaqueToken)
+    }
+    finally {
+      for (const spy of consoleSpies) {
+        spy.mockRestore()
+      }
+    }
   })
 
   it('retries automatic launch when cli exits before the automator socket is ready', async () => {

--- a/packages/miniprogram-automator/src/launcher/wechatCliFallback.test.ts
+++ b/packages/miniprogram-automator/src/launcher/wechatCliFallback.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { enableAutomatorViaHttp } from './wechatCliFallback'
+
+const opaqueToken = 'a'.repeat(32)
 
 describe('enableAutomatorViaHttp', () => {
   const options = {
@@ -7,6 +9,10 @@ describe('enableAutomatorViaHttp', () => {
     projectPath: '/repo/demo app',
     servicePort: 20023,
   }
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
 
   it('supports the legacy autoPort response and sends both port query names', async () => {
     const fetchMock = vi.fn(async (_input: string | URL) => new Response(JSON.stringify({ autoPort: 45679 })))
@@ -28,15 +34,59 @@ describe('enableAutomatorViaHttp', () => {
     await expect(enableAutomatorViaHttp(options)).resolves.toBe(45678)
   })
 
-  it('rejects an unknown successful response shape', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ status: 'ok' }))))
+  it('uses the requested port for a DevTools opaque token response', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(opaqueToken))))
+
+    await expect(enableAutomatorViaHttp(options)).resolves.toBe(45678)
+  })
+
+  it.each([
+    'a'.repeat(31),
+    'a'.repeat(33),
+    'g'.repeat(32),
+  ])('rejects a string outside the opaque token protocol shape', async (body) => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(body))))
 
     await expect(enableAutomatorViaHttp(options)).rejects.toThrow('unsupported response')
   })
 
-  it('surfaces DevTools HTTP errors', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ code: 31 }), { status: 400 })))
+  it('rejects an unknown successful response without disclosing its body', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ token: opaqueToken }))))
 
-    await expect(enableAutomatorViaHttp(options)).rejects.toThrow('status 400')
+    const error = await enableAutomatorViaHttp(options).catch(error => error) as Error & { cause?: unknown }
+
+    expect(error.message).toBe('WeChat DevTools HTTP automator fallback returned unsupported response')
+    expect(String(error)).not.toContain(opaqueToken)
+    expect(error.cause).toBeUndefined()
+  })
+
+  it('surfaces DevTools HTTP errors without disclosing their body', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(opaqueToken, { status: 400 })))
+
+    const error = await enableAutomatorViaHttp(options).catch(error => error) as Error & { cause?: unknown }
+
+    expect(error.message).toBe('WeChat DevTools HTTP automator fallback failed with status 400')
+    expect(String(error)).not.toContain(opaqueToken)
+    expect(error.cause).toBeUndefined()
+  })
+
+  it('rejects invalid JSON without retaining a body-bearing parse cause', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(opaqueToken)))
+
+    const error = await enableAutomatorViaHttp(options).catch(error => error) as Error & { cause?: unknown }
+
+    expect(error.message).toBe('WeChat DevTools HTTP automator fallback returned invalid JSON')
+    expect(String(error)).not.toContain(opaqueToken)
+    expect(error.cause).toBeUndefined()
+  })
+
+  it('rejects an invalid legacy port without disclosing its value', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ autoPort: opaqueToken }))))
+
+    const error = await enableAutomatorViaHttp(options).catch(error => error) as Error & { cause?: unknown }
+
+    expect(error.message).toBe('WeChat DevTools HTTP automator fallback returned invalid autoPort')
+    expect(String(error)).not.toContain(opaqueToken)
+    expect(error.cause).toBeUndefined()
   })
 })

--- a/packages/miniprogram-automator/src/launcher/wechatCliFallback.ts
+++ b/packages/miniprogram-automator/src/launcher/wechatCliFallback.ts
@@ -30,31 +30,29 @@ export async function enableAutomatorViaHttp(options: {
   const response = await fetch(endpoint, { redirect: 'follow' })
   const body = await response.text()
   if (!response.ok) {
-    throw new Error(`WeChat DevTools HTTP automator fallback failed with status ${response.status}${body.trim() ? `: ${body.trim().slice(0, 400)}` : ''}`)
+    throw new Error(`WeChat DevTools HTTP automator fallback failed with status ${response.status}`)
   }
 
   let result: unknown
   try {
     result = JSON.parse(body) as unknown
   }
-  catch (error) {
-    throw new Error('WeChat DevTools HTTP automator fallback returned invalid JSON', {
-      cause: error as Error,
-    })
+  catch {
+    throw new Error('WeChat DevTools HTTP automator fallback returned invalid JSON')
   }
   if (result && typeof result === 'object' && 'autoPort' in result) {
     const autoPort = Number(result.autoPort)
     if (!Number.isInteger(autoPort) || autoPort <= 0 || autoPort > 65535) {
-      throw new Error(`WeChat DevTools HTTP automator fallback returned invalid autoPort: ${String(result.autoPort)}`)
+      throw new Error('WeChat DevTools HTTP automator fallback returned invalid autoPort')
     }
     return autoPort
   }
 
-  if (typeof result === 'string' && /^s\d+$/.test(result)) {
+  if (typeof result === 'string' && (/^s\d+$/.test(result) || /^[0-9a-f]{32}$/i.test(result))) {
     return options.autoPort
   }
 
-  throw new Error(`WeChat DevTools HTTP automator fallback returned unsupported response: ${body.trim().slice(0, 400)}`)
+  throw new Error('WeChat DevTools HTTP automator fallback returned unsupported response')
 }
 
 const AUTOMATOR_VALUE_OPTIONS = new Set([


### PR DESCRIPTION
## Problem / Goal

修复 #954：新版微信开发者工具 `/auto` 成功返回 JSON 编码的不透明 token，但 `Launcher.launch()` 只识别旧版响应，导致已开启的自动化会话被误报为失败，且错误可能回显响应 token。

本 PR 先保持 **Draft**：协议解析和连接阶段已验证，安装版 DevTools 的后续应用就绪检查仍超时。

## Reproduction / Baseline

原报告使用 `@weapp-vite/miniprogram-automator@1.2.16`、Weapp Vite 7.0.4、DevTools 2.01.2510290。HTTP `/auto` 返回成功和 32 位十六进制 JSON 字符串后，旧解析器抛出 unsupported response；请求的自动化端口实际上已经可连接。

## Root cause / Design

成功响应解析遗漏了当前版本的 opaque acknowledgement。对于精确匹配 `/^[0-9a-f]{32}$/i` 的 JSON 字符串，使用调用方请求的自动化端口；保留旧 `{ autoPort }` 的分配端口语义和 `sN` 的请求端口语义。

错误只保留固定诊断及必要的 HTTP 状态，不回显响应体、非法端口值或 JSON parse cause。未知成功响应仍拒绝，不将任意字符串视为成功。

## Bug class / Variant sweep

不变量：控制协议的已知成功确认应进入连接阶段；不可将不可信响应体带入异常及日志。

对 `/auto`、`autoPort`、`sN` 和 unsupported-response 分支的排查定位到 **2 个解析 owner**，均在本 PR 修复：

1. `packages/miniprogram-automator/src/launcher/wechatCliFallback.ts`：正式 Launcher HTTP fallback。
2. `e2e/utils/automator.cli-bridge.ts`：E2E HTTP bridge 中的同类实现。

同时检查 Launcher 调用方及 E2E 外层错误传播；现有调用方不再收到携带响应体的异常。`packages/weapp-ide-cli/src/cli/http.ts` 不实现 `/auto` 响应解析，排除。没有剩余的同机制解析副本需要修改。

## Change

- 两个解析器增加精确 token 成功分支并统一无响应体的错误信息。
- 回归覆盖 token 长度/字符边界、旧响应、HTTP/JSON/端口/未知响应失败及错误脱敏。
- Launcher 集成测试分别证明旧版分配端口与 token 请求端口进入 WebSocket 连接和会话元数据。
- 添加 `@weapp-vite/miniprogram-automator` patch changeset。

## Non-goals

不改变 Launcher API，不新增重试或 fallback，不放宽任意成功响应，不重构进程管理，不绕过 `waitForAppReady`。

## Verification

环境：macOS ARM64、Node 24.14.0、pnpm 11.25.0；真实 DevTools 2.01.2510290，基础库 3.17.2。

| Acceptance / Surface | 命令或证据 | 结果 |
| --- | --- | --- |
| 包及 Launcher 回归 | `pnpm --filter @weapp-vite/miniprogram-automator test` | 11 个文件、152/152 测试通过 |
| 真实 loopback HTTP bridge | `pnpm exec vitest run -c ./e2e/vitest.e2e.utils.config.ts e2e/utils/automator.cli-bridge.test.ts` | 1 个文件、20/20 测试通过；未启动 provider |
| 类型及产物 | `pnpm --filter @weapp-vite/miniprogram-automator typecheck`、`pnpm --filter @weapp-vite/miniprogram-automator build` | 通过 |
| staged 检查 | 仓库正常 pre-commit 与 commit-msg hooks | 通过；hooks 未改变已审查内容 |
| 发布元数据 | `node scripts/check-changeset-frontmatter.mjs` | 通过 |

两次安装版 DevTools smoke 均使用最新构建的包，下面摘录其中一次的阶段日志（未记录 token 值）：

```text
HTTP_AUTO {"status":200,"format":"opaque-hex-token","requestedPortMatches":true}
WEBSOCKET_CONNECTED {"requestedPortMatches":true}
LAUNCH_STAGE_OK checkVersion
LAUNCH_STAGE_FAILED waitForAppReady Error: DevTools did not respond to protocol method App.captureScreenshot within 1882ms
SMOKE_FAILED Error: Wait timed out after 60000 ms
```

**精确限制：** 后续未修改的 `waitForAppReady` 中，`App.captureScreenshot` 没有响应（两次分别为 1882 ms、2625 ms 的协议调用超时），最终触发 60 秒启动超时。因此已经验证 token 接受、请求端口 WebSocket 和版本检查，但没有观察到 `Launcher.launch()` 返回页面就绪的 MiniProgram，不能宣称原生全链路通过。临时 smoke 脚本和项目已清理；长期回归保留在包测试及 loopback 测试中。

## Risks

- Compatibility：旧 `autoPort`/`sN` 语义保留；新格式只接受精确 32 位十六进制 JSON 字符串。
- Security/privacy：异常不携带响应体或 parse cause；不记录真实 token。
- Performance/resources：增加一个有界格式检查，不增加请求、连接、重试或后台资源。
- Platform/runtime：DevTools 后续截图/应用就绪仍受环境阻塞；该阶段没有被绕过或修改。

## Rollback

Revert 本 PR 即可恢复旧解析行为；无配置或数据迁移。

## Related

Closes #954
