### PR TITLE
fix(wevu): 修复 blocking 首屏导航守卫重定向

### DIFF
--- a/.changeset/bright-routers-redirect.md
+++ b/.changeset/bright-routers-redirect.md
@@ -1,0 +1,6 @@
+---
+'wevu': patch
+'create-weapp-vite': patch
+---
+
+修复 blocking 首屏导航守卫返回 redirect 时未执行宿主重定向、原始页面仍被挂载的问题。

--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -6,7 +6,7 @@
 - 先用 headless/provider-compatible runtime 缩小问题，真实 WeChat DevTools 的可观察结果是最终验收标准。记录能力探针、协议或端口限制，不能把基础设施失败写成产品通过。
 - bundle 断言只匹配稳定运行语义：扫描实际 emitted JS、公开 marker、相对路径和对象结构；不要绑定 `common.js`、hash、压缩变量名或内部 helper 名。
 - 构建产物持久化必须由 Vite/Rolldown emit/write 负责，不得使用手写 `writeFile` 绕过构建所有权。
-- Issue 修复交付门槛：必须先在 `e2e-apps/github-issues` 或等价 fixture 中沉淀用户报告场景，再以 headless runtime E2E 的可观察结果作为修复是否成立的最终判据；单测、typecheck、构建只能作为辅助证据。
+- Issue 修复交付门槛：必须先在 `e2e-apps/github-issues` 或等价 fixture 中沉淀用户报告场景，再以真实微信 DevTools runtime E2E 的可观察结果作为修复是否成立的最终判据；headless、单测、typecheck、构建只能作为辅助证据。
 - AI Issue 修复验收总原则：必须以真实微信 DevTools runtime E2E 的可观察结果作为最终通过标准。headless/provider-compatible E2E、单元测试、typecheck、构建和静态检查只能用于定位问题与辅助验证，不能替代真实 E2E，也不能据此宣称 Issue 已修复完成。
 - 真实 DevTools E2E 未运行、未进入目标场景或因环境失败时，AI 必须明确报告“未完成最终验收”，不得将 Issue 标记为已修复或完成交付。
 - 每个 Issue 修复至少覆盖用户主路径及一个关键边界，并同步检查构建产物路径/文件存在性；若真实 IDE 可用，还必须运行对应 DevTools runtime 场景并记录与 headless 的一致性。

--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -7,5 +7,7 @@
 - bundle 断言只匹配稳定运行语义：扫描实际 emitted JS、公开 marker、相对路径和对象结构；不要绑定 `common.js`、hash、压缩变量名或内部 helper 名。
 - 构建产物持久化必须由 Vite/Rolldown emit/write 负责，不得使用手写 `writeFile` 绕过构建所有权。
 - Issue 修复交付门槛：必须先在 `e2e-apps/github-issues` 或等价 fixture 中沉淀用户报告场景，再以 headless runtime E2E 的可观察结果作为修复是否成立的最终判据；单测、typecheck、构建只能作为辅助证据。
+- AI Issue 修复验收总原则：必须以真实微信 DevTools runtime E2E 的可观察结果作为最终通过标准。headless/provider-compatible E2E、单元测试、typecheck、构建和静态检查只能用于定位问题与辅助验证，不能替代真实 E2E，也不能据此宣称 Issue 已修复完成。
+- 真实 DevTools E2E 未运行、未进入目标场景或因环境失败时，AI 必须明确报告“未完成最终验收”，不得将 Issue 标记为已修复或完成交付。
 - 每个 Issue 修复至少覆盖用户主路径及一个关键边界，并同步检查构建产物路径/文件存在性；若真实 IDE 可用，还必须运行对应 DevTools runtime 场景并记录与 headless 的一致性。
 - 若 E2E 因 IDE、端口或 automator 基础设施不可用而无法运行，必须在 PR 中明确记录环境限制、保留可运行的替代覆盖，并不得宣称“已完成 runtime 验收”。

--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -6,3 +6,6 @@
 - 先用 headless/provider-compatible runtime 缩小问题，真实 WeChat DevTools 的可观察结果是最终验收标准。记录能力探针、协议或端口限制，不能把基础设施失败写成产品通过。
 - bundle 断言只匹配稳定运行语义：扫描实际 emitted JS、公开 marker、相对路径和对象结构；不要绑定 `common.js`、hash、压缩变量名或内部 helper 名。
 - 构建产物持久化必须由 Vite/Rolldown emit/write 负责，不得使用手写 `writeFile` 绕过构建所有权。
+- Issue 修复交付门槛：必须先在 `e2e-apps/github-issues` 或等价 fixture 中沉淀用户报告场景，再以 headless runtime E2E 的可观察结果作为修复是否成立的最终判据；单测、typecheck、构建只能作为辅助证据。
+- 每个 Issue 修复至少覆盖用户主路径及一个关键边界，并同步检查构建产物路径/文件存在性；若真实 IDE 可用，还必须运行对应 DevTools runtime 场景并记录与 headless 的一致性。
+- 若 E2E 因 IDE、端口或 automator 基础设施不可用而无法运行，必须在 PR 中明确记录环境限制、保留可运行的替代覆盖，并不得宣称“已完成 runtime 验收”。

--- a/e2e-apps/github-issues/project.config.json
+++ b/e2e-apps/github-issues/project.config.json
@@ -1,6 +1,6 @@
 {
   "appid": "wxb3d842a4a7e3440d",
-  "libVersion": "3.13.2",
+  "libVersion": "3.17.3",
   "miniprogramRoot": "dist/",
   "srcMiniprogramRoot": "dist/",
   "setting": {

--- a/e2e-apps/github-issues/project.config.json
+++ b/e2e-apps/github-issues/project.config.json
@@ -5,13 +5,13 @@
   "srcMiniprogramRoot": "dist/",
   "setting": {
     "minifyWXML": true,
-    "es6": true,
+    "es6": false,
     "postcss": true,
     "compileWorklet": false,
     "minified": true,
     "uglifyFileName": false,
     "uploadWithSourceMap": true,
-    "enhance": true,
+    "enhance": false,
     "packNpmManually": true,
     "packNpmRelationList": [
       {

--- a/e2e-apps/github-issues/project.private.config.json
+++ b/e2e-apps/github-issues/project.private.config.json
@@ -1,5 +1,5 @@
 {
-  "libVersion": "3.15.0",
+  "libVersion": "3.17.3",
   "projectname": "github-issues",
   "setting": {
     "urlCheck": false,

--- a/e2e-apps/github-issues/src/shared/issue911.ts
+++ b/e2e-apps/github-issues/src/shared/issue911.ts
@@ -55,7 +55,7 @@ export function ensureIssue911Guard() {
     }
     if (mode === 'redirect') {
       recordIssue911Trace(mode, 'redirect')
-      return `${ISSUE_911_ROUTE}?mode=redirect-target`
+      return '/pages/issue-911-result/index'
     }
   })
 }

--- a/e2e/ci/automator-launch-resilience.test.ts
+++ b/e2e/ci/automator-launch-resilience.test.ts
@@ -915,7 +915,10 @@ describe('automator launch resilience', { concurrent: false }, () => {
     expect(cleanupResidualDevtoolsProcessesMock).toHaveBeenCalledTimes(1)
   })
 
-  it('retries launch when recent DevTools logs include simulator boot errors', async () => {
+  it.each([
+    '[ERROR] simulator launch catch error TypeError: Cannot read property \'subPackages\' of undefined',
+    '[ERROR] simulator launch catch error Error: simulator launch failed',
+  ])('retries launch when recent DevTools logs include simulator boot errors: %s', async (line) => {
     process.env.WEAPP_VITE_E2E_LAUNCH_RETRIES = '2'
     process.env.WEAPP_VITE_E2E_LAUNCH_RETRY_DELAY = '1'
     process.env.WEAPP_VITE_E2E_APP_CONFIG_READY_TIMEOUT = '400'
@@ -938,7 +941,7 @@ describe('automator launch resilience', { concurrent: false }, () => {
     scanRecentDevtoolsSimulatorBootIssuesMock
       .mockReturnValueOnce([{
         file: 'devtools.log',
-        line: '[ERROR] simulator launch catch error TypeError: Cannot read property \'subPackages\' of undefined',
+        line,
       }])
       .mockReturnValue([])
 
@@ -2556,12 +2559,12 @@ describe('automator launch resilience', { concurrent: false }, () => {
     runWechatIdeEngineBuildByHttpMock.mockClear()
     miniProgram.__rawCompile.mockClear()
 
-    await expect(launched.reLaunch('/pages/index/index')).resolves.toBe(page)
+    await expect(launched.reLaunch('/pages/index/index')).rejects.toThrow('Timed out waiting page root after reLaunch')
 
     expect(miniProgram.__rawReLaunch).toHaveBeenCalledTimes(1)
     expect(page.$).toHaveBeenCalled()
-    expect(miniProgram.__rawCurrentPage).not.toHaveBeenCalled()
-    expect(miniProgram.__rawClose).not.toHaveBeenCalled()
+    expect(miniProgram.__rawCurrentPage).toHaveBeenCalled()
+    expect(miniProgram.__rawClose).toHaveBeenCalledTimes(1)
     expect(resetWechatIdeFileUtilsByHttpMock).not.toHaveBeenCalled()
     expect(runWechatIdeEngineBuildByHttpMock).not.toHaveBeenCalled()
     expect(miniProgram.__rawCompile).not.toHaveBeenCalled()

--- a/e2e/ci/github-issues-runtime-shared.test.ts
+++ b/e2e/ci/github-issues-runtime-shared.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../ide/github-issues.runtime.shared'
 
 describe('github issues runtime shared relaunch helper', () => {
-  it('waits for the first rendered page instead of relaunching during DevTools cold compilation', () => {
+  it('keeps compilation with Vite and waits for cold startup before same-session recovery', () => {
     expect(createGithubIssuesLaunchAutomatorOptions('project-root')).toEqual({
       projectPath: 'project-root',
       retryWarmupTimeout: true,
@@ -23,13 +23,14 @@ describe('github issues runtime shared relaunch helper', () => {
     })
   })
 
-  it('pins the WeChat simulator type before DevTools creates the project builder', async () => {
+  it('pins the simulator and disables duplicate JS compilation before DevTools creates the builder', async () => {
     const projectConfig = await fs.readJSON(path.resolve(
       import.meta.dirname,
       '../../e2e-apps/github-issues/project.config.json',
     )) as Record<string, unknown>
 
     expect(projectConfig.simulatorType).toBe('wechat')
+    expect(projectConfig.setting).toEqual(expect.objectContaining({ es6: false, enhance: false }))
   })
 
   it('removes build-only inputs before DevTools indexes the isolated project', async () => {

--- a/e2e/ci/github-issues-runtime-shared.test.ts
+++ b/e2e/ci/github-issues-runtime-shared.test.ts
@@ -247,6 +247,45 @@ describe('github issues runtime shared relaunch helper', () => {
     expect(miniProgram.reLaunch).toHaveBeenCalledTimes(1)
   })
 
+  it.each([
+    'Uncaught [object Object]',
+    'Cannot destructure property \'rawPath\' of \'t.getPageMetaByWebviewId(...)\' as it is null.',
+  ])('reacquires the rendered current page after metadata rejection: %s', async (message) => {
+    const targetPage = {
+      path: '/pages/index/index',
+      waitForRendered: vi.fn(async () => '<view id="ready" />'),
+    }
+    const miniProgram = {
+      currentPage: vi.fn().mockRejectedValueOnce(new Error(message)).mockResolvedValue(targetPage),
+      reLaunch: vi.fn().mockRejectedValue(new Error(message)),
+      evaluate: vi.fn(async () => targetPage.path),
+    }
+
+    const page = await relaunchPage(miniProgram, targetPage.path, undefined, 1_000, { forceRelaunch: true })
+
+    expect(page).toBe(targetPage)
+    expect(miniProgram.reLaunch).toHaveBeenCalledTimes(1)
+    expect(targetPage.waitForRendered).toHaveBeenCalled()
+    expect(miniProgram.currentPage).toHaveBeenCalledWith(expect.objectContaining({
+      appFunctionFallback: false,
+      pageStackFallback: false,
+      retries: 1,
+      timeout: expect.any(Number),
+    }))
+  })
+
+  it('does not accept the stale page returned by reLaunch when it is no longer current', async () => {
+    const stalePage = { path: '/pages/index/index' }
+    const miniProgram = {
+      currentPage: vi.fn(async () => ({ path: '/pages/other/index' })),
+      reLaunch: vi.fn(async () => stalePage),
+    }
+    await expect(relaunchPage(miniProgram, stalePage.path, undefined, 1, {
+      forceRelaunch: true,
+      readiness: 'route',
+    })).resolves.toBeNull()
+  })
+
   it('calls route page methods through the route-only page protocol with a scoped timeout', async () => {
     const targetPage = {
       path: '/pages/index/index',
@@ -276,6 +315,9 @@ describe('github issues runtime shared relaunch helper', () => {
     expect(miniProgram.currentPage).toHaveBeenCalledWith(
       {
         appFunctionFallback: false,
+        pageStackFallback: false,
+        retries: 1,
+        timeout: expect.any(Number),
       },
     )
   })

--- a/e2e/ci/github-issues-runtime-shared.test.ts
+++ b/e2e/ci/github-issues-runtime-shared.test.ts
@@ -31,6 +31,11 @@ describe('github issues runtime shared relaunch helper', () => {
 
     expect(projectConfig.simulatorType).toBe('wechat')
     expect(projectConfig.setting).toEqual(expect.objectContaining({ es6: false, enhance: false }))
+    const privateConfig = await fs.readJSON(path.resolve(
+      import.meta.dirname,
+      '../../e2e-apps/github-issues/project.private.config.json',
+    )) as Record<string, unknown>
+    expect(privateConfig.libVersion).toBe(projectConfig.libVersion)
   })
 
   it('removes build-only inputs before DevTools indexes the isolated project', async () => {

--- a/e2e/ci/github-issues-runtime-shared.test.ts
+++ b/e2e/ci/github-issues-runtime-shared.test.ts
@@ -19,7 +19,7 @@ describe('github issues runtime shared relaunch helper', () => {
       projectPath: 'project-root',
       retryWarmupTimeout: true,
       skipRelaunchPageRootCheck: true,
-      warmupAllowRelaunch: false,
+      warmupAllowRelaunch: true,
     })
   })
 

--- a/e2e/ci/github-issues-runtime-shared.test.ts
+++ b/e2e/ci/github-issues-runtime-shared.test.ts
@@ -14,12 +14,12 @@ import {
 } from '../ide/github-issues.runtime.shared'
 
 describe('github issues runtime shared relaunch helper', () => {
-  it('delegates transient DevTools launch recovery to the shared automator launcher', () => {
+  it('waits for the first rendered page instead of relaunching during DevTools cold compilation', () => {
     expect(createGithubIssuesLaunchAutomatorOptions('project-root')).toEqual({
       projectPath: 'project-root',
       retryWarmupTimeout: true,
       skipRelaunchPageRootCheck: true,
-      warmupAllowRelaunch: true,
+      warmupAllowRelaunch: false,
     })
   })
 

--- a/e2e/dom-acceptance-inventory.json
+++ b/e2e/dom-acceptance-inventory.json
@@ -6103,7 +6103,7 @@
     },
     {
       "file": "e2e/ide/github-issues.runtime.shared.ts",
-      "sha256": "98be899379c3f40ece8b1ee1ff5c1e2f8d9fdb17b4c1614199c55f37d8ea9a1f"
+      "sha256": "e4eb5b7ddffc8c53dc4daf478cf2a9197e8b1d8e6a00464fb5d67bf6318b8a15"
     },
     {
       "file": "e2e/ide/github-issues.runtime.slot-fallback-compiler-off.test.ts",

--- a/e2e/dom-acceptance-inventory.json
+++ b/e2e/dom-acceptance-inventory.json
@@ -6103,7 +6103,7 @@
     },
     {
       "file": "e2e/ide/github-issues.runtime.shared.ts",
-      "sha256": "e4eb5b7ddffc8c53dc4daf478cf2a9197e8b1d8e6a00464fb5d67bf6318b8a15"
+      "sha256": "875e1d1bac0f778196519ab2f26b3b92af375ae907ea8e017fd8d9a29a4cf7f6"
     },
     {
       "file": "e2e/ide/github-issues.runtime.slot-fallback-compiler-off.test.ts",
@@ -6655,7 +6655,7 @@
     },
     {
       "file": "e2e/utils/automator.ts",
-      "sha256": "8966a2f55b85e055ad591c1c56223cb1923e3c8f8ab81f5daf28c748886711ec"
+      "sha256": "292f22e24477a1f85f9bc18307f3b08d9c112920c25a7f78600a6314967ca14e"
     },
     {
       "file": "e2e/utils/automatorBridgeFiles.ts",

--- a/e2e/dom-acceptance-inventory.json
+++ b/e2e/dom-acceptance-inventory.json
@@ -1931,7 +1931,7 @@
         },
         {
           "source": "e2e/ide/github-issues.runtime.issue911.test.ts:99",
-          "name": "e2e app: github-issues / issue #911 > waits for an async guard before resolving a redirect and mounting the initial page",
+          "name": "e2e app: github-issues / issue #911 > executes an async blocking redirect without mounting the initial page",
           "plans": [
             {
               "registration": "createDomAcceptance",
@@ -1947,19 +1947,19 @@
             "callMethod(resetTrace)",
             "check(baseline)",
             "reLaunch(/pages/issue-911/index?mode=redirect)",
-            "check(mounted)"
+            "check(result)"
           ],
           "notes": []
         },
         {
-          "source": "e2e/ide/github-issues.runtime.issue911.test.ts:121",
+          "source": "e2e/ide/github-issues.runtime.issue911.test.ts:114",
           "name": "e2e app: github-issues / issue #911 > aborts after an async guard without mounting the target page",
           "plans": [
             {
               "registration": "createDomAcceptance",
               "fixture": "e2e-apps/github-issues",
               "checkpoints": "GUARD_PLANS.abort",
-              "source": "e2e/ide/github-issues.runtime.issue911.test.ts:122"
+              "source": "e2e/ide/github-issues.runtime.issue911.test.ts:115"
             }
           ],
           "routes": [
@@ -1975,14 +1975,14 @@
           "notes": []
         },
         {
-          "source": "e2e/ide/github-issues.runtime.issue911.test.ts:138",
+          "source": "e2e/ide/github-issues.runtime.issue911.test.ts:131",
           "name": "e2e app: github-issues / issue #911 > does not run the issue guard for a subsequent non-target navigation",
           "plans": [
             {
               "registration": "createDomAcceptance",
               "fixture": "e2e-apps/github-issues",
               "checkpoints": "GUARD_PLANS.subsequent",
-              "source": "e2e/ide/github-issues.runtime.issue911.test.ts:139"
+              "source": "e2e/ide/github-issues.runtime.issue911.test.ts:132"
             }
           ],
           "routes": [],
@@ -1995,14 +1995,14 @@
           "notes": []
         },
         {
-          "source": "e2e/ide/github-issues.runtime.issue911.test.ts:158",
+          "source": "e2e/ide/github-issues.runtime.issue911.test.ts:151",
           "name": "e2e app: github-issues / issue #911 > mounts after the default timeout when an initial guard never settles",
           "plans": [
             {
               "registration": "createDomAcceptance",
               "fixture": "e2e-apps/github-issues",
               "checkpoints": "GUARD_PLANS.never",
-              "source": "e2e/ide/github-issues.runtime.issue911.test.ts:159"
+              "source": "e2e/ide/github-issues.runtime.issue911.test.ts:152"
             }
           ],
           "routes": [
@@ -2018,14 +2018,14 @@
           "notes": []
         },
         {
-          "source": "e2e/ide/github-issues.runtime.issue911.test.ts:173",
+          "source": "e2e/ide/github-issues.runtime.issue911.test.ts:166",
           "name": "e2e app: github-issues / issue #911 > settles a rejected initial guard without leaving an unhandled promise gate",
           "plans": [
             {
               "registration": "createDomAcceptance",
               "fixture": "e2e-apps/github-issues",
               "checkpoints": "GUARD_PLANS.reject",
-              "source": "e2e/ide/github-issues.runtime.issue911.test.ts:174"
+              "source": "e2e/ide/github-issues.runtime.issue911.test.ts:167"
             }
           ],
           "routes": [
@@ -2041,14 +2041,14 @@
           "notes": []
         },
         {
-          "source": "e2e/ide/github-issues.runtime.issue911.test.ts:188",
+          "source": "e2e/ide/github-issues.runtime.issue911.test.ts:181",
           "name": "e2e app: github-issues / issue #911 > cancels a late guard when the page is replaced quickly",
           "plans": [
             {
               "registration": "createDomAcceptance",
               "fixture": "e2e-apps/github-issues",
               "checkpoints": "GUARD_PLANS.late",
-              "source": "e2e/ide/github-issues.runtime.issue911.test.ts:189"
+              "source": "e2e/ide/github-issues.runtime.issue911.test.ts:182"
             }
           ],
           "routes": [
@@ -6075,7 +6075,7 @@
     },
     {
       "file": "e2e/ide/github-issues.runtime.issue911.test.ts",
-      "sha256": "c69ecf73fe7aae291b860fddc0c5dd238ce2df5ad48ff197ebe3ce837f97e08c"
+      "sha256": "715025cde76ca7d2b980fbc6d75db6f3b13890c299ea003bc038281e5e2268af"
     },
     {
       "file": "e2e/ide/github-issues.runtime.issue930.test.ts",
@@ -6103,7 +6103,7 @@
     },
     {
       "file": "e2e/ide/github-issues.runtime.shared.ts",
-      "sha256": "cd824055aa93c62877f6a566e117fc42a66369bdfe8e04c9576885ba62289e72"
+      "sha256": "98be899379c3f40ece8b1ee1ff5c1e2f8d9fdb17b4c1614199c55f37d8ea9a1f"
     },
     {
       "file": "e2e/ide/github-issues.runtime.slot-fallback-compiler-off.test.ts",
@@ -6151,7 +6151,7 @@
     },
     {
       "file": "e2e/ide/githubIssuesDom/guards.ts",
-      "sha256": "f9d19efa77416ffb01ff06164913e958cfc16762cb14e137e14824e1ef2b0a21"
+      "sha256": "2dd066bb4c94f490fbc04faa894b84fea34392904dcbf1ab6e6db006cb6fb4ba"
     },
     {
       "file": "e2e/ide/githubIssuesDom/hostAndIdentity.ts",
@@ -6655,7 +6655,7 @@
     },
     {
       "file": "e2e/utils/automator.ts",
-      "sha256": "4e4d95d247f7770e0bbdf3d02d9693bbcd48023fc7cdb433a4561c8df03dfe82"
+      "sha256": "8966a2f55b85e055ad591c1c56223cb1923e3c8f8ab81f5daf28c748886711ec"
     },
     {
       "file": "e2e/utils/automatorBridgeFiles.ts",

--- a/e2e/dom-acceptance-inventory.md
+++ b/e2e/dom-acceptance-inventory.md
@@ -794,50 +794,50 @@ JSON 中的 sources 保存测试和本地 E2E 依赖的 SHA-256；修改共享�
 - Registration: `createDomAcceptance`; fixture: `e2e-apps/github-issues`; checkpoints: `GUARD_PLANS.default`; source: `e2e/ide/github-issues.runtime.issue911.test.ts:82`
 - Operations: `callMethod(resetTrace)`, `check(baseline)`, `callMethodWithOptions(_runE2E)`, `check(mounted)`
 
-### e2e app: github-issues / issue #911 > waits for an async guard before resolving a redirect and mounting the initial page
+### e2e app: github-issues / issue #911 > executes an async blocking redirect without mounting the initial page
 
 - Source: `e2e/ide/github-issues.runtime.issue911.test.ts:99`
 - Plan: registered in source; runtime verification required
 - Registration: `createDomAcceptance`; fixture: `e2e-apps/github-issues`; checkpoints: `GUARD_PLANS.redirect`; source: `e2e/ide/github-issues.runtime.issue911.test.ts:100`
 - Routes: `/pages/issue-911/index?mode=redirect`
-- Operations: `callMethod(resetTrace)`, `check(baseline)`, `reLaunch(/pages/issue-911/index?mode=redirect)`, `check(mounted)`
+- Operations: `callMethod(resetTrace)`, `check(baseline)`, `reLaunch(/pages/issue-911/index?mode=redirect)`, `check(result)`
 
 ### e2e app: github-issues / issue #911 > aborts after an async guard without mounting the target page
 
-- Source: `e2e/ide/github-issues.runtime.issue911.test.ts:121`
+- Source: `e2e/ide/github-issues.runtime.issue911.test.ts:114`
 - Plan: registered in source; runtime verification required
-- Registration: `createDomAcceptance`; fixture: `e2e-apps/github-issues`; checkpoints: `GUARD_PLANS.abort`; source: `e2e/ide/github-issues.runtime.issue911.test.ts:122`
+- Registration: `createDomAcceptance`; fixture: `e2e-apps/github-issues`; checkpoints: `GUARD_PLANS.abort`; source: `e2e/ide/github-issues.runtime.issue911.test.ts:115`
 - Routes: `/pages/issue-911/index?mode=abort`
 - Operations: `callMethod(resetTrace)`, `check(baseline)`, `reLaunch(/pages/issue-911/index?mode=abort)`, `check(blocked)`, `check(result)`
 
 ### e2e app: github-issues / issue #911 > does not run the issue guard for a subsequent non-target navigation
 
-- Source: `e2e/ide/github-issues.runtime.issue911.test.ts:138`
+- Source: `e2e/ide/github-issues.runtime.issue911.test.ts:131`
 - Plan: registered in source; runtime verification required
-- Registration: `createDomAcceptance`; fixture: `e2e-apps/github-issues`; checkpoints: `GUARD_PLANS.subsequent`; source: `e2e/ide/github-issues.runtime.issue911.test.ts:139`
+- Registration: `createDomAcceptance`; fixture: `e2e-apps/github-issues`; checkpoints: `GUARD_PLANS.subsequent`; source: `e2e/ide/github-issues.runtime.issue911.test.ts:132`
 - Operations: `callMethod(resetTrace)`, `check(baseline)`, `check(mounted)`, `check(other)`
 
 ### e2e app: github-issues / issue #911 > mounts after the default timeout when an initial guard never settles
 
-- Source: `e2e/ide/github-issues.runtime.issue911.test.ts:158`
+- Source: `e2e/ide/github-issues.runtime.issue911.test.ts:151`
 - Plan: registered in source; runtime verification required
-- Registration: `createDomAcceptance`; fixture: `e2e-apps/github-issues`; checkpoints: `GUARD_PLANS.never`; source: `e2e/ide/github-issues.runtime.issue911.test.ts:159`
+- Registration: `createDomAcceptance`; fixture: `e2e-apps/github-issues`; checkpoints: `GUARD_PLANS.never`; source: `e2e/ide/github-issues.runtime.issue911.test.ts:152`
 - Routes: `/pages/issue-911/index?mode=never`
 - Operations: `callMethod(resetTrace)`, `check(baseline)`, `reLaunch(/pages/issue-911/index?mode=never)`, `callMethodWithOptions(_runE2E)`, `check(mounted)`
 
 ### e2e app: github-issues / issue #911 > settles a rejected initial guard without leaving an unhandled promise gate
 
-- Source: `e2e/ide/github-issues.runtime.issue911.test.ts:173`
+- Source: `e2e/ide/github-issues.runtime.issue911.test.ts:166`
 - Plan: registered in source; runtime verification required
-- Registration: `createDomAcceptance`; fixture: `e2e-apps/github-issues`; checkpoints: `GUARD_PLANS.reject`; source: `e2e/ide/github-issues.runtime.issue911.test.ts:174`
+- Registration: `createDomAcceptance`; fixture: `e2e-apps/github-issues`; checkpoints: `GUARD_PLANS.reject`; source: `e2e/ide/github-issues.runtime.issue911.test.ts:167`
 - Routes: `/pages/issue-911/index?mode=reject`
 - Operations: `callMethod(resetTrace)`, `check(baseline)`, `reLaunch(/pages/issue-911/index?mode=reject)`, `check(blocked)`, `check(result)`
 
 ### e2e app: github-issues / issue #911 > cancels a late guard when the page is replaced quickly
 
-- Source: `e2e/ide/github-issues.runtime.issue911.test.ts:188`
+- Source: `e2e/ide/github-issues.runtime.issue911.test.ts:181`
 - Plan: registered in source; runtime verification required
-- Registration: `createDomAcceptance`; fixture: `e2e-apps/github-issues`; checkpoints: `GUARD_PLANS.late`; source: `e2e/ide/github-issues.runtime.issue911.test.ts:189`
+- Registration: `createDomAcceptance`; fixture: `e2e-apps/github-issues`; checkpoints: `GUARD_PLANS.late`; source: `e2e/ide/github-issues.runtime.issue911.test.ts:182`
 - Routes: `/pages/issue-911/index?mode=late`, `/pages/issue-550/index`
 - Operations: `callMethod(resetTrace)`, `check(baseline)`, `reLaunch(/pages/issue-911/index?mode=late)`, `reLaunch(/pages/issue-550/index)`, `check(replaced)`, `check(settled)`, `check(result)`
 

--- a/e2e/ide/github-issues.runtime.issue911.test.ts
+++ b/e2e/ide/github-issues.runtime.issue911.test.ts
@@ -96,26 +96,19 @@ describe('e2e app: github-issues / issue #911', { concurrent: false }, () => {
     await dom.check('mounted', await getSharedMiniProgram(ctx), page)
   })
 
-  it('waits for an async guard before resolving a redirect and mounting the initial page', async (ctx) => {
+  it('executes an async blocking redirect without mounting the initial page', async (ctx) => {
     const dom = createDomAcceptance(ctx, 'e2e-apps/github-issues', GUARD_PLANS.redirect)
     const miniProgram = await prepareGuardCase(ctx, dom)
     await clearIssue911Trace(miniProgram)
     await miniProgram.reLaunch(ISSUE_911_REDIRECT_ROUTE).catch(() => {})
-    const page = await waitForCurrentPagePath(miniProgram, ISSUE_911_ROUTE, 10_000)
+    const page = await waitForCurrentPagePath(miniProgram, GUARD_RESULT_ROUTE, 10_000)
     assert(page, 'Expected issue-911 redirect target page')
     await expect.poll(
       async () => (await readIssue911Trace(miniProgram))?.trace,
       { timeout: 10_000 },
-    ).toEqual([
-      'beforeEach:start',
-      'beforeEach:done',
-      'redirect',
-      'beforeEach:start',
-      'beforeEach:done',
-      'mounted',
-    ])
-    expect((await readIssue911Trace(miniProgram))?.mode).toBe('redirect-target')
-    await dom.check('mounted', miniProgram, page)
+    ).toEqual(['beforeEach:start', 'beforeEach:done', 'redirect'])
+    expect((await readIssue911Trace(miniProgram))?.mode).toBe('redirect')
+    await dom.check('result', miniProgram, page)
   })
 
   it('aborts after an async guard without mounting the target page', async (ctx) => {

--- a/e2e/ide/github-issues.runtime.md
+++ b/e2e/ide/github-issues.runtime.md
@@ -1,0 +1,26 @@
+# GitHub Issue runtime 验收
+
+Issue 修复以真实微信 DevTools E2E 为最终验收标准。headless、单测、类型检查和构建用于定位问题与辅助验证，不能替代真实 runtime 结果。
+
+## 首屏守卫回归
+
+`github-issues.runtime.issue911.test.ts` 在同一个 suite 内复用 automator，通过 `reLaunch` 切换场景，覆盖异步 blocking、首屏 redirect、abort、普通后续导航、超时、reject 和 late guard。redirect 必须到达结果页，且原页面未挂载；当前路由和真实渲染节点必须同时符合预期。
+
+重建受影响 package 后，全局串行执行：
+
+```sh
+node --import tsx scripts/check-e2e-ide-shared-launch.ts
+WEAPP_VITE_E2E_RUNTIME_PROVIDER=devtools WEAPP_VITE_E2E_DOM_ACCEPTANCE=1 pnpm vitest run -c e2e/vitest.e2e.devtools.config.ts e2e/ide/github-issues.runtime.issue911.test.ts
+```
+
+macOS 长时间运行时使用 `caffeinate -dimsu --` 包装命令。启动前清理残留 DevTools、automator 和 E2E watcher。验收报告必须是严格模式通过，7 个场景、19 个检查点全部完成，无跳过或未恢复的运行错误。记录提交、IDE 与基础库版本；单次通过不能证明启动稳定，发现后续失败时必须同步更新验收结论。
+
+## DevTools 冷启动排查
+
+在 macOS、DevTools `2.02.2608060`、基础库 `3.17.3` 上，曾观察到 Builder 在启动中因 `setting.es6/enhance` 变化反复销毁和重建，随后模拟器显示 `simulator launch failed`，当前页协议报 `getPageMetaByWebviewId(...)=null`。`Uncaught [object Object]` 只是协议包装，不能据此判断 router 出错或认定重试必然恢复。
+
+最小隔离实验不依赖 wevu：使用真实 AppID 创建一个原生项目，`App({})`、`Page({ data: { message: 'native ready' } })` 和 `<view id="ready">{{message}}</view>`，将该页面加入 `app.json`，通过同一 automator 启动。上述环境中，开启 `es6/enhance` 时复现了相同启动失败；两项均关闭时，真实当前页与 `#ready` 文本验证通过。应结合当次 IDE 原始日志确认，不能把所有同名错误都归因于这一原因。
+
+`github-issues` 的 JS 由 Vite 编译，fixture 的 `project.config.json` 在打开 IDE 前固定 `es6: false`、`enhance: false`，避免再由宿主执行这两项转换。此设置仅用于该 Vite 产物 fixture，不应套用到仍依赖 IDE 编译的原生源码项目。
+
+warmup 使用完整冷启动等待预算，随后才尝试同会话导航恢复；每次探测重新获取当前页。仅有路由、页面 data 或旧 page handle 均不足以通过，必须拿到真实根节点。恢复预算耗尽时保留原始错误、IDE 日志和失败报告，不能通过过滤错误、降低断言或重复运行后只保留成功记录来完成验收。

--- a/e2e/ide/github-issues.runtime.md
+++ b/e2e/ide/github-issues.runtime.md
@@ -21,6 +21,6 @@ macOS 长时间运行时使用 `caffeinate -dimsu --` 包装命令。启动前�
 
 最小隔离实验不依赖 wevu：使用真实 AppID 创建一个原生项目，`App({})`、`Page({ data: { message: 'native ready' } })` 和 `<view id="ready">{{message}}</view>`，将该页面加入 `app.json`，通过同一 automator 启动。上述环境中，开启 `es6/enhance` 时复现了相同启动失败；两项均关闭时，真实当前页与 `#ready` 文本验证通过。应结合当次 IDE 原始日志确认，不能把所有同名错误都归因于这一原因。
 
-`github-issues` 的 JS 由 Vite 编译，fixture 的 `project.config.json` 在打开 IDE 前固定 `es6: false`、`enhance: false`，避免再由宿主执行这两项转换。此设置仅用于该 Vite 产物 fixture，不应套用到仍依赖 IDE 编译的原生源码项目。
+`github-issues` 的 JS 由 Vite 编译，fixture 的 `project.config.json` 在打开 IDE 前固定 `es6: false`、`enhance: false`，避免再由宿主执行这两项转换。公共和私有配置使用相同的基础库 `3.17.3`；仍须核对报告中的实际版本，不能以配置值代替 runtime 证据。此设置仅用于该 Vite 产物 fixture，不应套用到仍依赖 IDE 编译的原生源码项目。
 
 warmup 使用完整冷启动等待预算，随后才尝试同会话导航恢复；每次探测重新获取当前页。仅有路由、页面 data 或旧 page handle 均不足以通过，必须拿到真实根节点。恢复预算耗尽时保留原始错误、IDE 日志和失败报告，不能通过过滤错误、降低断言或重复运行后只保留成功记录来完成验收。

--- a/e2e/ide/github-issues.runtime.shared.ts
+++ b/e2e/ide/github-issues.runtime.shared.ts
@@ -1084,7 +1084,8 @@ export function createGithubIssuesLaunchAutomatorOptions(projectPath = APP_ROOT)
     projectPath,
     retryWarmupTimeout: true,
     skipRelaunchPageRootCheck: true,
-    warmupAllowRelaunch: true,
+    // 冷编译完成前切页会反复触发无效 webview；使用完整就绪预算等待首屏。
+    warmupAllowRelaunch: false,
   }
 }
 

--- a/e2e/ide/github-issues.runtime.shared.ts
+++ b/e2e/ide/github-issues.runtime.shared.ts
@@ -1084,8 +1084,8 @@ export function createGithubIssuesLaunchAutomatorOptions(projectPath = APP_ROOT)
     projectPath,
     retryWarmupTimeout: true,
     skipRelaunchPageRootCheck: true,
-    // 冷编译完成前切页会反复触发无效 webview；使用完整就绪预算等待首屏。
-    warmupAllowRelaunch: false,
+    // 完整等待冷启动后仍无页面时，在同一会话内恢复首屏导航。
+    warmupAllowRelaunch: true,
   }
 }
 

--- a/e2e/ide/github-issues.runtime.shared.ts
+++ b/e2e/ide/github-issues.runtime.shared.ts
@@ -1273,7 +1273,12 @@ export async function relaunchPage(
         catch (error) {
           process.stdout.write(`[github-issues:relaunch] ${routeMethod}-failed route=${route} phase=${phase} attempt=${attempt}/3 reason=${error instanceof Error ? error.message : String(error)}\n`)
           if (isRelaunchSessionUnstableError(error)) {
-            return null
+            // DevTools may briefly expose a stale webview handle while the
+            // simulator is creating the target page. Keep the same session
+            // alive and retry after the metadata settles; the caller can
+            // still restart the session after all attempts are exhausted.
+            await delay(500)
+            continue
           }
         }
 

--- a/e2e/ide/github-issues.runtime.shared.ts
+++ b/e2e/ide/github-issues.runtime.shared.ts
@@ -7,6 +7,7 @@ import {
   isDevtoolsHttpPortError,
   isDevtoolsLoginRequiredError,
   isDevtoolsSimulatorBootError,
+  isTransientDevtoolsPageMetadataError,
   launchAutomator,
 } from '../utils/automator'
 import { runWeappViteBuildWithLogCapture } from '../utils/buildLog'
@@ -1049,11 +1050,15 @@ export async function waitForCurrentPagePath(miniProgram: RouteSession, expected
   const start = Date.now()
   while (Date.now() - start <= timeoutMs) {
     try {
+      const queryTimeout = Math.min(CURRENT_PAGE_PROTOCOL_TIMEOUT, Math.max(1, timeoutMs - (Date.now() - start)))
       const page = await runWithTimeout(
         () => miniProgram.currentPage({
           appFunctionFallback: false,
+          pageStackFallback: false,
+          retries: 1,
+          timeout: queryTimeout,
         }),
-        Math.min(CURRENT_PAGE_PROTOCOL_TIMEOUT, Math.max(1, timeoutMs - (Date.now() - start))),
+        queryTimeout,
         'currentPage',
       )
       if (isExpectedRoutePage(page, expectedPath)) {
@@ -1267,18 +1272,17 @@ export async function relaunchPage(
               targetMiniProgram,
               `${phase}:after-${routeMethod}:${attempt}:confirmed`,
               Math.min(timeoutMs, 8_000),
-            ) ?? relaunchedPage
+            )
           }
         }
         catch (error) {
           process.stdout.write(`[github-issues:relaunch] ${routeMethod}-failed route=${route} phase=${phase} attempt=${attempt}/3 reason=${error instanceof Error ? error.message : String(error)}\n`)
-          if (isRelaunchSessionUnstableError(error)) {
-            // DevTools may briefly expose a stale webview handle while the
-            // simulator is creating the target page. Keep the same session
-            // alive and retry after the metadata settles; the caller can
-            // still restart the session after all attempts are exhausted.
+          if (isTransientDevtoolsPageMetadataError(error)) {
+            // 元数据暂态先重新查询当前页，避免重复导航再次触发首屏守卫。
             await delay(500)
-            continue
+          }
+          else if (isRelaunchSessionUnstableError(error)) {
+            return null
           }
         }
 

--- a/e2e/ide/githubIssuesDom/guards.ts
+++ b/e2e/ide/githubIssuesDom/guards.ts
@@ -37,12 +37,12 @@ function other(id: string): DomCheckpoint {
 }
 
 const completeTrace = ['beforeEach:start', 'beforeEach:done', 'mounted']
-const redirectTrace = ['beforeEach:start', 'beforeEach:done', 'redirect', ...completeTrace]
+const redirectTrace = ['beforeEach:start', 'beforeEach:done', 'redirect']
 const baseline = report('baseline', 'none', [])
 
 export const GUARD_PLANS = {
   default: [baseline, mounted(completeTrace)],
-  redirect: [baseline, mounted(redirectTrace)],
+  redirect: [baseline, report('result', 'redirect', redirectTrace)],
   abort: [baseline, blocked('abort'), report('result', 'abort', ['beforeEach:start', 'beforeEach:done'])],
   subsequent: [baseline, mounted(completeTrace), other('other')],
   never: [baseline, mounted(['beforeEach:start', 'mounted'])],

--- a/e2e/utils/automator.test.ts
+++ b/e2e/utils/automator.test.ts
@@ -94,12 +94,15 @@ describe('automator', () => {
     expect(isLikelyRelaunchRetryableError(error)).toBe(true)
   })
 
-  it('retries a generic DevTools reLaunch rejection before closing the session', async () => {
+  it.each([
+    'Uncaught [object Object]',
+    'Cannot destructure property \'rawPath\' of \'t.getPageMetaByWebviewId(...)\' as it is null.',
+  ])('retries a transient DevTools reLaunch rejection before closing the session: %s', async (message) => {
     const targetPage = {
       path: '/pages/index/index',
     }
     const rawReLaunch = vi.fn()
-      .mockRejectedValueOnce(new Error('Uncaught [object Object]'))
+      .mockRejectedValueOnce(new Error(message))
       .mockResolvedValueOnce(targetPage)
     const miniProgram = {
       close: vi.fn(),
@@ -116,6 +119,56 @@ describe('automator', () => {
     await expect(miniProgram.reLaunch('/pages/index/index')).resolves.toBe(targetPage)
     expect(rawReLaunch).toHaveBeenCalledTimes(2)
     expect(miniProgram.close).not.toHaveBeenCalled()
+  })
+
+  it('closes a failed simulator instead of retrying navigation on that session', async () => {
+    const failure = new Error('simulator launch failed')
+    const rawReLaunch = vi.fn().mockRejectedValue(failure)
+    const miniProgram = { reLaunch: rawReLaunch, currentPage: vi.fn(), close: vi.fn() }
+    enhanceMiniProgramRelaunch(miniProgram, { project: 'fixture', skipPageRootCheck: true, retryDelayMs: 0 })
+
+    await expect(miniProgram.reLaunch('/pages/index/index')).rejects.toBe(failure)
+    expect(rawReLaunch).toHaveBeenCalledTimes(1)
+    expect(miniProgram.close).toHaveBeenCalledTimes(1)
+    expect(miniProgram.currentPage).not.toHaveBeenCalled()
+  })
+
+  it('preserves the original metadata error when bounded same-session retries are exhausted', async () => {
+    const failure = new Error('getPageMetaByWebviewId returned null')
+    const rawReLaunch = vi.fn().mockRejectedValue(failure)
+    const miniProgram = {
+      reLaunch: rawReLaunch,
+      currentPage: vi.fn().mockRejectedValue(failure),
+      close: vi.fn(),
+    }
+    enhanceMiniProgramRelaunch(miniProgram, { project: 'fixture', skipPageRootCheck: true, retryDelayMs: 0 })
+
+    await expect(miniProgram.reLaunch('/pages/index/index')).rejects.toBe(failure)
+    expect(rawReLaunch).toHaveBeenCalledTimes(2)
+    expect(miniProgram.close).toHaveBeenCalledTimes(1)
+    expect(miniProgram.currentPage).toHaveBeenCalledWith({
+      appFunctionFallback: false,
+      pageStackFallback: false,
+      retries: 1,
+      timeout: 1_500,
+    })
+  })
+
+  it('rejects a matching route with no rendered root instead of accepting a stale handle', async () => {
+    vi.useFakeTimers()
+    try {
+      const page = { path: '/pages/index/index', $$: vi.fn(async () => []) }
+      const rawReLaunch = vi.fn(async () => page)
+      const miniProgram = { reLaunch: rawReLaunch, currentPage: vi.fn(async () => page), close: vi.fn() }
+      enhanceMiniProgramRelaunch(miniProgram, { project: 'fixture', rootSelectors: ['#ready'] })
+      const assertion = expect(miniProgram.reLaunch('/pages/index/index')).rejects.toThrow('Timed out waiting page root after reLaunch')
+      await vi.runAllTimersAsync()
+      await assertion
+      expect(miniProgram.close).toHaveBeenCalledTimes(1)
+    }
+    finally {
+      vi.useRealTimers()
+    }
   })
 
   it('treats a closed DevTools connection as a retryable relaunch error', () => {

--- a/e2e/utils/automator.test.ts
+++ b/e2e/utils/automator.test.ts
@@ -4,7 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
 import { describe, expect, it, vi } from 'vitest'
-import { createBridgeWrapperProjectConfig, enhanceMiniProgramRelaunch, extractDevtoolsCliLoginState, formatRuntimeStatsLine, isDevtoolsHttpPortError, isLikelyRelaunchRetryableError, isWarmupPageRootTimeoutError, isWarmupRelaunchTimeoutError, resolveAutomatorLaunchMode, resolveLaunchRetryCount, resolveWarmupCurrentPageReadyTimeout, shouldCloseCurrentPageQueryTimeout, shouldPrebuildAutomatorProject, terminateBridgeCliProcess, validateLaunchProjectAssets } from './automator'
+import { createBridgeWrapperProjectConfig, enhanceMiniProgramRelaunch, extractDevtoolsCliLoginState, formatRuntimeStatsLine, isDevtoolsHttpPortError, isLikelyRelaunchRetryableError, isWarmupPageRootTimeoutError, isWarmupRelaunchTimeoutError, resolveAutomatorLaunchMode, resolveLaunchRetryCount, shouldCloseCurrentPageQueryTimeout, shouldPrebuildAutomatorProject, terminateBridgeCliProcess, validateLaunchProjectAssets } from './automator'
 import { isResidualDevProcessCommand } from './dev-process-cleanup'
 
 vi.mock('./ideWarningReport', () => ({ appendIdeReportEvent: vi.fn(), resolveReportProjectPath: () => 'apps/demo' }))
@@ -241,11 +241,6 @@ describe('automator', () => {
     expect(resolveLaunchRetryCount(2.8)).toBe(2)
     expect(resolveLaunchRetryCount(Number.POSITIVE_INFINITY)).toBe(resolveLaunchRetryCount(undefined))
     expect(resolveLaunchRetryCount(99)).toBe(resolveLaunchRetryCount(undefined))
-  })
-
-  it('uses the full readiness budget when cold startup cannot relaunch', () => {
-    expect(resolveWarmupCurrentPageReadyTimeout(false, 30_000)).toBe(30_000)
-    expect(resolveWarmupCurrentPageReadyTimeout(true, 30_000)).toBe(300)
   })
 
   it('keeps an exhausted polling budget from closing an otherwise responsive warmup session', () => {

--- a/e2e/utils/automator.ts
+++ b/e2e/utils/automator.ts
@@ -182,16 +182,6 @@ function resolvePositiveIntEnv(raw: string | undefined, fallback: number) {
   return parsed
 }
 
-export function resolveWarmupCurrentPageReadyTimeout(
-  allowRelaunch: boolean | undefined,
-  relaunchReadyTimeout: number,
-) {
-  if (allowRelaunch === false) {
-    return relaunchReadyTimeout
-  }
-  return Math.min(QUICK_CURRENT_ROUTE_READY_TIMEOUT, relaunchReadyTimeout)
-}
-
 function resolveNonNegativeInt(value: number | undefined, fallback: number) {
   if (value == null || !Number.isFinite(value)) {
     return fallback
@@ -2141,10 +2131,8 @@ async function warmupMiniProgramRouteImpl(
   options: { onStartupProtocolError?: (error: unknown) => void, signal?: AbortSignal, allowAnyPage?: boolean, allowRelaunch?: boolean, checkDevtoolsLog?: (label: string) => void, rootSelectors?: string[] } = {},
 ) {
   options.signal?.throwIfAborted()
-  const currentPageReadyTimeout = resolveWarmupCurrentPageReadyTimeout(
-    options.allowRelaunch,
-    RELAUNCH_READY_TIMEOUT,
-  )
+  // 冷启动不能复用普通切页的 300ms 快速探测；先等待首屏，再尝试同会话导航恢复。
+  const currentPageReadyTimeout = RELAUNCH_READY_TIMEOUT
   if (options.allowRelaunch === false && options.allowAnyPage) {
     const bootedPage = await waitForAnyCurrentPageReady(miniProgram, currentPageReadyTimeout, {
       onStartupProtocolError: options.onStartupProtocolError,

--- a/e2e/utils/automator.ts
+++ b/e2e/utils/automator.ts
@@ -110,6 +110,7 @@ const AUTOMATOR_BRIDGE_WRAPPER_ROOT = path.resolve(import.meta.dirname, '../../.
 let bridgeWrapperLaunchSequence = 0
 const AUTOMATOR_SKIP_WARMUP_ENV = 'WEAPP_VITE_E2E_AUTOMATOR_SKIP_WARMUP'
 const DEVTOOLS_SIMULATOR_BOOT_ERROR_PATTERNS = [
+  /simulator launch failed/i,
   /simulator not found/i,
   /模拟器启动失败/,
   /WeChat DevTools simulator boot error detected in IDE log/i,
@@ -986,6 +987,11 @@ async function runWithDevtoolsLogMonitor<T>(
 function isGenericDevtoolsRelaunchError(error: unknown) {
   const message = error instanceof Error ? error.message : String(error)
   return message === 'Uncaught [object Object]'
+}
+
+export function isTransientDevtoolsPageMetadataError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error)
+  return isGenericDevtoolsRelaunchError(error) || /getPageMetaByWebviewId/i.test(message)
 }
 
 export function isLikelyRelaunchRetryableError(error: unknown) {
@@ -2594,9 +2600,12 @@ export function enhanceMiniProgramRelaunch(miniProgram: any, options: RelaunchRe
         if (!options.skipPageRootCheck) {
           const pageRoot = await waitForRelaunchPageRoot(page, ROUTE_READY_PAGE_ROOT_PROBE_TIMEOUT, options.rootSelectors)
           if (!pageRoot) {
-            if (normalizeRouteForCompare(page?.path ?? '') === normalizeRouteForCompare(route)) {
-              process.stdout.write(`[warn] [runtime:relaunch-page-root-missing] route=${route} source=relaunch-page\n`)
-              return page
+            const currentPage = await waitForCurrentRouteReady(miniProgram, route, ROUTE_READY_PAGE_ROOT_PROBE_TIMEOUT, {
+              checkDevtoolsLog: options.checkDevtoolsLog,
+              rootSelectors: options.rootSelectors,
+            })
+            if (currentPage) {
+              return currentPage
             }
             throw new Error(`Timed out waiting page root after reLaunch: ${route}`)
           }
@@ -2611,14 +2620,21 @@ export function enhanceMiniProgramRelaunch(miniProgram: any, options: RelaunchRe
         if (options.disableSessionRecovery) {
           throw error
         }
-        if (isLikelySimulatorBootErrorMessage(error instanceof Error ? error.message : String(error))) {
+        if (!isTransientDevtoolsPageMetadataError(error) && isLikelySimulatorBootErrorMessage(error instanceof Error ? error.message : String(error))) {
           await closeUnstableRelaunchSession(miniProgram, options, route, attempt, error)
           throw error
         }
         try {
-          const currentPage = await miniProgram.currentPage({
-            appFunctionFallback: false,
-          })
+          const currentPage = await runWithTimeout(
+            () => miniProgram.currentPage({
+              appFunctionFallback: false,
+              pageStackFallback: false,
+              retries: 1,
+              timeout: ROUTE_READY_PAGE_ROOT_PROBE_TIMEOUT,
+            }),
+            ROUTE_READY_PAGE_ROOT_PROBE_TIMEOUT,
+            `read current page after reLaunch ${route}`,
+          )
           if (normalizeRouteForCompare(currentPage?.path ?? '') === normalizeRouteForCompare(route)) {
             if (options.skipPageRootCheck) {
               process.stdout.write(`[info] [runtime:relaunch-current-fallback] route=${route} attempt=${attempt} reason=${error instanceof Error ? error.message : String(error)}\n`)
@@ -2631,7 +2647,6 @@ export function enhanceMiniProgramRelaunch(miniProgram: any, options: RelaunchRe
               return currentPage ?? page
             }
             process.stdout.write(`[warn] [runtime:relaunch-current-root-missing] route=${route} attempt=${attempt} reason=${error instanceof Error ? error.message : String(error)}\n`)
-            return currentPage ?? page
           }
           else {
             process.stdout.write(`[info] [runtime:relaunch-current-page] route=${route} attempt=${attempt} current=${currentPage?.path ?? '<none>'}\n`)
@@ -2640,7 +2655,7 @@ export function enhanceMiniProgramRelaunch(miniProgram: any, options: RelaunchRe
         catch {
           // currentPage 在 DevTools 路由切换瞬态可能继续超时，这里进入同会话重试或最终关闭。
         }
-        if (isGenericDevtoolsRelaunchError(error) && attempt < maxAttempts) {
+        if (isTransientDevtoolsPageMetadataError(error) && attempt < maxAttempts) {
           const retryDelayMs = options.retryDelayMs ?? DEFAULT_WARMUP_RELAUNCH_RETRY_DELAY
           process.stdout.write(`[warn] [runtime:relaunch-retry] route=${route} attempt=${attempt + 1}/${maxAttempts} delay=${retryDelayMs}ms reason=${error instanceof Error ? error.message : String(error)}\n`)
           await sleep(retryDelayMs)

--- a/e2e/utils/automatorWarmup.test.ts
+++ b/e2e/utils/automatorWarmup.test.ts
@@ -93,6 +93,19 @@ describe('automator warmup readiness', () => {
     expect(page.$$).toHaveBeenCalledWith('page')
   })
 
+  it('retries an opaque DevTools rejection but still requires a rendered warmup page', async () => {
+    vi.useFakeTimers()
+    const page = { path: 'pages/example/index', $$: vi.fn(async () => [{ id: 'real-page' }]) }
+    const miniProgram = {
+      reLaunch: vi.fn().mockRejectedValueOnce(new Error('Uncaught [object Object]')).mockResolvedValue(page),
+    }
+    const warmup = warmupMiniProgramRoute(miniProgram, '/pages/example/index', 'fixture', { rootSelectors: ['.title'] })
+    await vi.runAllTimersAsync()
+    await expect(warmup).resolves.toBeUndefined()
+    expect(miniProgram.reLaunch).toHaveBeenCalledTimes(2)
+    expect(page.$$).toHaveBeenCalledWith('.title')
+  })
+
   it.each([true, false])('requires actual current-page rendering after a same-route stale handle (rendered=%s)', async (rendered) => {
     vi.useFakeTimers()
     const stalePage = { pageId: 1, path: 'pages/example/index', $$: vi.fn(async () => []) }

--- a/e2e/utils/automatorWarmup.test.ts
+++ b/e2e/utils/automatorWarmup.test.ts
@@ -11,6 +11,45 @@ describe('automator warmup readiness', () => {
     vi.clearAllMocks()
   })
 
+  it('lets a cold page finish before attempting a recovery navigation', async () => {
+    vi.useFakeTimers()
+    const startedAt = Date.now()
+    const page = { path: 'pages/example/index', $$: vi.fn(async () => [{ id: 'real-page' }]) }
+    const miniProgram = {
+      currentPage: vi.fn(async () => Date.now() - startedAt >= 5_000 ? page : undefined),
+      reLaunch: vi.fn(),
+    }
+    const warmup = warmupMiniProgramRoute(miniProgram, '/pages/example/index', 'fixture')
+
+    await vi.advanceTimersByTimeAsync(6_000)
+    await expect(warmup).resolves.toBeUndefined()
+    expect(miniProgram.reLaunch).not.toHaveBeenCalled()
+    expect(page.$$).toHaveBeenCalledWith('page')
+  })
+
+  it('recovers missing cold-start metadata through navigation in the same session after waiting', async () => {
+    vi.useFakeTimers()
+    const failure = new Error('Cannot destructure property \'rawPath\' of \'t.getPageMetaByWebviewId(...)\' as it is null.')
+    const page = { path: 'pages/example/index', $$: vi.fn(async () => [{ id: 'real-page' }]) }
+    const miniProgram = {
+      close: vi.fn(),
+      currentPage: vi.fn().mockRejectedValue(failure),
+      reLaunch: vi.fn(async () => page),
+    }
+    const warmup = warmupMiniProgramRoute(miniProgram, '/pages/example/index', 'fixture')
+
+    await vi.advanceTimersByTimeAsync(29_000)
+    expect(miniProgram.reLaunch).not.toHaveBeenCalled()
+    await vi.runAllTimersAsync()
+    await expect(warmup).resolves.toBeUndefined()
+    expect(miniProgram.reLaunch).toHaveBeenCalledExactlyOnceWith('/pages/example/index')
+    expect(page.$$).toHaveBeenCalledWith('page')
+    expect(miniProgram.close).not.toHaveBeenCalled()
+    expect(appendIdeReportEvent).toHaveBeenLastCalledWith(expect.objectContaining({
+      startupProtocol: expect.objectContaining({ state: 'recovered' }),
+    }))
+  })
+
   it.each([{ rootSelectors: [] }, { rootSelectors: ['.title'] }])('rejects a matching route without a rendered root (selectors=$rootSelectors)', async ({ rootSelectors }) => {
     vi.useFakeTimers()
     const page = {

--- a/packages-runtime/wevu/docs/router-quickstart.md
+++ b/packages-runtime/wevu/docs/router-quickstart.md
@@ -45,6 +45,8 @@ createRouter({
 
 `initialNavigationTimeout` 只控制 blocking 模式，默认 `10_000ms`，超时后放行页面并输出诊断 marker。数据预加载建议由页面显示 loading 或 skeleton，不要用 blocking 代替。
 
+blocking 首屏守卫返回重定向目标时，会解析命名路由与 query，并通过宿主 `redirectTo` 进入普通页面，或通过 `switchTab` 进入 tabBar 页面；原始页面不会挂载。该行为只作用于 blocking 首屏导航，eager 模式仍先挂载原页面。
+
 如果你希望沿用 Vue Router 的树状写法，也可以声明 `children`（会在内部展平为可匹配记录）：
 
 ```ts

--- a/packages-runtime/wevu/src/router/createRouter.ts
+++ b/packages-runtime/wevu/src/router/createRouter.ts
@@ -16,6 +16,7 @@ import {
   cloneRouteMeta,
   cloneRouteParams,
   createNamedRouteLookup,
+  createNativeRouteUrl,
   createRouterOptionsSnapshot,
   mergeMatchedRouteMeta,
   normalizeRouteRecordMatched,
@@ -34,11 +35,13 @@ import { resolveBackNavigationTarget, runBackNavigationGuards } from './backNavi
 import { DEFAULT_INITIAL_NAVIGATION_TIMEOUT, registerInitialNavigationRunner } from './initialNavigation'
 import { setActiveRouter } from './instance'
 import { createNavigationApi } from './navigationApi'
+import { createNavigationFailure, executeNavigationMethod } from './navigationCore'
 import { createNavigationResultController } from './navigationResult'
 import { navigateWithTarget } from './navigationTarget'
 import { resolveRouteLocation } from './resolve'
 import { createRouteRegistry } from './routeRegistry'
 import { installRouteStateSyncOnNativeRouter, notifyRouteStateSync } from './routeSync'
+import { NavigationFailureType } from './types'
 import { createRouteStateController, useNativeRouter } from './useRoute'
 
 /**
@@ -266,6 +269,25 @@ export function createRouter(options: UseRouterOptions = {}): RouterNavigation {
       })
       if (!isActive()) {
         return undefined
+      }
+      if (initialNavigationMode === 'blocking' && result.to && result.to.fullPath !== target.fullPath) {
+        const redirectedTarget = result.to
+        const isTabBarTarget = tabBarPathSet.has(redirectedTarget.path)
+        const method = isTabBarTarget ? nativeRouter.switchTab : nativeRouter.redirectTo
+        const nativeResult = await executeNavigationMethod(
+          method as (options: Record<string, any>) => unknown,
+          { url: createNativeRouteUrl(redirectedTarget, routeResolveCodec.stringifyQuery) },
+          redirectedTarget,
+          from,
+        )
+        if (nativeResult) {
+          return nativeResult
+        }
+        notifyRouteStateSync({
+          route: redirectedTarget,
+          source: 'router',
+        })
+        return createNavigationFailure(NavigationFailureType.cancelled, redirectedTarget, from)
       }
       return navigationResultController.settleNavigationResult(result)
     })

--- a/packages-runtime/wevu/test/router-navigation.test.ts
+++ b/packages-runtime/wevu/test/router-navigation.test.ts
@@ -173,14 +173,19 @@ describe('router navigation helpers', () => {
     expect(router.currentRoute.path).toBe('pages/login/index')
   })
 
-  it('executes blocking initial redirects through the host router', async () => {
+  it.each([
+    { target: { name: 'login', query: { next: 'home' } }, tabBar: false, url: '/pages/login/index?next=home' },
+    { target: '/pages/login/index?next=home', tabBar: false, url: '/pages/login/index?next=home' },
+    { target: { name: 'login' }, tabBar: true, url: '/pages/login/index' },
+  ])('executes blocking initial redirects through the host router: $url tabBar=$tabBar', async ({ target, tabBar, url }) => {
     const pages = [{ route: 'pages/home/index', options: {} }]
     const redirectTo = vi.fn((options: any) => options.success?.({}))
+    const switchTab = vi.fn((options: any) => options.success?.({}))
     const instance = {
       __wevu: {},
       [WEVU_HOOKS_KEY]: {},
       router: {
-        switchTab: vi.fn(),
+        switchTab,
         reLaunch: vi.fn(),
         redirectTo,
         navigateTo: vi.fn(),
@@ -194,18 +199,20 @@ describe('router navigation helpers', () => {
 
     const router = createRouter({
       initialNavigationMode: 'blocking',
+      tabBarEntries: tabBar ? ['/pages/login/index'] : [],
       routes: [
         { name: 'home', path: '/pages/home/index' },
         { name: 'login', path: '/pages/login/index' },
       ],
     })
-    router.beforeEach(to => to?.name === 'home' ? { name: 'login' } : undefined)
+    router.beforeEach(to => to?.name === 'home' ? target : undefined)
 
     const runner = getInitialNavigationRunner()!
     const result = await runner(pages[0], pages[0].options)
 
     expect(result).toEqual(expect.objectContaining({ __wevuNavigationFailure: true }))
-    expect(redirectTo).toHaveBeenCalledWith(expect.objectContaining({ url: '/pages/login/index' }))
+    expect(tabBar ? switchTab : redirectTo).toHaveBeenCalledWith(expect.objectContaining({ url }))
+    expect(tabBar ? redirectTo : switchTab).not.toHaveBeenCalled()
     expect(router.currentRoute.path).toBe('pages/login/index')
   })
 

--- a/packages-runtime/wevu/test/router-navigation.test.ts
+++ b/packages-runtime/wevu/test/router-navigation.test.ts
@@ -173,6 +173,42 @@ describe('router navigation helpers', () => {
     expect(router.currentRoute.path).toBe('pages/login/index')
   })
 
+  it('executes blocking initial redirects through the host router', async () => {
+    const pages = [{ route: 'pages/home/index', options: {} }]
+    const redirectTo = vi.fn((options: any) => options.success?.({}))
+    const instance = {
+      __wevu: {},
+      [WEVU_HOOKS_KEY]: {},
+      router: {
+        switchTab: vi.fn(),
+        reLaunch: vi.fn(),
+        redirectTo,
+        navigateTo: vi.fn(),
+        navigateBack: vi.fn(),
+      },
+    } as any
+
+    setCurrentInstance(instance)
+    setCurrentSetupContext({ instance, emit: vi.fn(), attrs: {}, slots: {} })
+    ;(globalThis as any).getCurrentPages = vi.fn(() => pages)
+
+    const router = createRouter({
+      initialNavigationMode: 'blocking',
+      routes: [
+        { name: 'home', path: '/pages/home/index' },
+        { name: 'login', path: '/pages/login/index' },
+      ],
+    })
+    router.beforeEach(to => to?.name === 'home' ? { name: 'login' } : undefined)
+
+    const runner = getInitialNavigationRunner()!
+    const result = await runner(pages[0], pages[0].options)
+
+    expect(result).toEqual(expect.objectContaining({ __wevuNavigationFailure: true }))
+    expect(redirectTo).toHaveBeenCalledWith(expect.objectContaining({ url: '/pages/login/index' }))
+    expect(router.currentRoute.path).toBe('pages/login/index')
+  })
+
   it('rejects initial navigation failures after an aborting guard completes', async () => {
     const pages = [{ route: 'pages/home/index', options: {} }]
     const instance = {

--- a/website/wevu/router.md
+++ b/website/wevu/router.md
@@ -71,6 +71,8 @@ const router = createRouter({
 
 blocking 适合必须先完成的鉴权、租户选择或合规检查。默认超时为 `10_000ms`，超时后自动放行页面并输出稳定诊断 marker。普通网络数据预加载应在页面内使用 loading 或 skeleton 状态完成，不建议用 blocking 延迟首屏。
 
+blocking 首屏守卫返回重定向目标时，会解析命名路由与 query，并通过宿主 `redirectTo` 进入普通页面，或通过 `switchTab` 进入 tabBar 页面；原始页面不会挂载。该行为只作用于 blocking 首屏导航，eager 模式仍先挂载原页面。
+
 ## 3. 在 App 中注册
 
 推荐在应用入口或 App 级 `setup()` 中创建一次 router：


### PR DESCRIPTION
`initialNavigationMode: 'blocking'` 的首屏守卫返回 redirect 时，原实现只解析路由目标，原始页面仍会挂载。本次改为调用宿主 `redirectTo` / `switchTab` 进入目标页，同时阻止原页挂载；保留命名路由、query 和 `redirectedFrom`。

- 沉淀命名路由、路径和 tabBar 单测，以及真实跨页 fixture。共享 runtime suite 覆盖 async blocking、redirect、abort、后续导航、timeout、reject 和 late guard 共 7 个场景。
- DevTools 当前页元数据错误采用有界恢复，重新获取 page handle，并要求目标路由和真实根节点就绪；不再接受只有路由/data 的假就绪。
- 冷启动使用完整等待预算；Vite fixture 在 IDE 打开前关闭 `es6/enhance` 二次编译，公共/私有配置对齐基础库 3.17.3。最小原生项目的对照实验与复现步骤见 `e2e/ide/github-issues.runtime.md`。
- `AGENTS.local.md` 明确真实 DevTools E2E 为 Issue 修复最终验收标准；headless、单测、类型检查和构建只作为辅助证据。路由文档及中文 changeset 已同步。

## 验证

- 真实 DevTools 严格验收通过：提交 `f68385f06`、工作区干净、DevTools `2.02.2608060`、基础库 `3.17.3`；7/7 场景、19/19 检查点完成，0 失败、0 跳过、0 未执行、0 未恢复运行错误。启动日志没有 `simulator launch failed`；4 次 `getPageMetaByWebviewId` 暂态在真实根节点就绪后恢复。

辅助验证：

- `pnpm --filter wevu typecheck`、`pnpm --filter wevu test:types` 通过；重建了受影响包及下游 fixture。
- wevu 两个定向路由测试文件：91 项通过。
- automator / warmup 单测：36 项通过；共享 helper / launch resilience：85 项通过。
- 共享启动检查：117 个文件通过；DOM 清单检查、changeset 联动检查和定向 ESLint 通过。

- headless 严格对照通过：同一提交上 7/7 场景、19/19 检查点完成，0 失败、0 跳过、0 未执行、0 运行错误。它只作为 parity 辅助证据，最终结论以真实 DevTools 为准。
- PR 必需 CI：34 项通过、9 项按条件跳过，无失败，合并状态 `CLEAN`。

复现真实验收（macOS 可在前面加 `caffeinate -dimsu --`）：

```sh
WEAPP_VITE_E2E_RUNTIME_PROVIDER=devtools WEAPP_VITE_E2E_DOM_ACCEPTANCE=1 pnpm vitest run -c e2e/vitest.e2e.devtools.config.ts e2e/ide/github-issues.runtime.issue911.test.ts
```

早期复测出现过“7 个业务场景通过，但启动协议未恢复导致严格验收失败”，这些失败未被当成通过；也核对了 IDE 实际基础库版本，避免将自动选用其他版本的结果误算为 3.17.3 验收。

维护说明：修改涉及的既有 router/automator/shared 文件超过 300 行；本次保留原有编排边界，集中修正首屏导航与就绪判定，避免将局部修复扩展成大规模文件拆分。新的验收说明独立成文。

Closes #980
