### PR TITLE
fix(wevu): 修复 App setup 创建路由器失败与 tabBar 误走 redirectTo

### DIFF
--- a/.changeset/wevu-app-router-tabbar.md
+++ b/.changeset/wevu-app-router-tabbar.md
@@ -1,0 +1,6 @@
+---
+'wevu': patch
+'create-weapp-vite': patch
+---
+
+修复 `wevu/router` 在 App setup 中创建实例失败，以及未传入 `tabBarEntries` 时把 tabBar 页走成 `redirectTo` 的问题。

--- a/packages-runtime/wevu/docs/router-quickstart.md
+++ b/packages-runtime/wevu/docs/router-quickstart.md
@@ -32,6 +32,10 @@ createRouter({
 const router = useRouter()
 ```
 
+推荐在 `app.vue` 的 `<script setup>` 同步阶段调用一次 `createRouter()`。App 实例没有页面级 `this.router` 时，会回退到宿主全局路由方法（`wx` / `my` / `tt`）。不要放到 `onLaunch` 回调里：那时 setup 上下文已经结束。
+
+未传入 `tabBarEntries` 时，会读取宿主 `__wxConfig.tabBar.list`。`push` / `replace` 到这些路径会走 `switchTab`，避免 `redirectTo:fail can not redirectTo a tabbar page`。显式传入的 `tabBarEntries` 仍优先。
+
 ### 首屏导航模式
 
 `initialNavigationMode` 默认值为 `'eager'`。页面会先挂载并渲染，首屏守卫异步运行，不会因鉴权请求或其他慢操作造成白屏。若业务必须在页面挂载前完成鉴权、租户选择等判断，显式配置 `initialNavigationMode: 'blocking'`：

--- a/packages-runtime/wevu/docs/router-quickstart.md
+++ b/packages-runtime/wevu/docs/router-quickstart.md
@@ -32,9 +32,7 @@ createRouter({
 const router = useRouter()
 ```
 
-推荐在 `app.vue` 的 `<script setup>` 同步阶段调用一次 `createRouter()`。App 实例没有页面级 `this.router` 时，会回退到宿主全局路由方法（`wx` / `my` / `tt`）。不要放到 `onLaunch` 回调里：那时 setup 上下文已经结束。
-
-未传入 `tabBarEntries` 时，会读取宿主 `__wxConfig.tabBar.list`。`push` / `replace` 到这些路径会走 `switchTab`，避免 `redirectTo:fail can not redirectTo a tabbar page`。显式传入的 `tabBarEntries` 仍优先。
+在 `app.vue` 的 `<script setup>` 里调用一次 `createRouter()`，不要放进 `onLaunch`。App 没有页面级 `this.router` 时会用 `wx` / `my` / `tt`。未传 `tabBarEntries` 时读取宿主 tabBar，这些路径走 `switchTab`。
 
 ### 首屏导航模式
 

--- a/packages-runtime/wevu/src/router/createRouter.ts
+++ b/packages-runtime/wevu/src/router/createRouter.ts
@@ -30,7 +30,7 @@ import {
   stringifyQuery,
   warnDuplicateRouteEntries,
 } from '../routerInternal/shared'
-import { getMiniProgramGlobalObject } from '../runtime/platform'
+import { getCurrentMiniProgramTabBarPagePaths, getMiniProgramGlobalObject } from '../runtime/platform'
 import { resolveBackNavigationTarget, runBackNavigationGuards } from './backNavigation'
 import { DEFAULT_INITIAL_NAVIGATION_TIMEOUT, registerInitialNavigationRunner } from './initialNavigation'
 import { setActiveRouter } from './instance'
@@ -69,7 +69,8 @@ export function createRouter(options: UseRouterOptions = {}): RouterNavigation {
   const routeEntries = resolveRouteOptionEntries(options)
   warnDuplicateRouteEntries(routeEntries)
   const namedRouteLookup = createNamedRouteLookup(routeEntries)
-  const normalizedTabBarEntries = (options.tabBarEntries ?? [])
+  const tabBarEntrySource = options.tabBarEntries ?? getCurrentMiniProgramTabBarPagePaths()
+  const normalizedTabBarEntries = tabBarEntrySource
     .map(path => resolvePath(path, ''))
     .filter(Boolean)
   const tabBarPathSet = new Set(normalizedTabBarEntries)

--- a/packages-runtime/wevu/src/router/useRoute.ts
+++ b/packages-runtime/wevu/src/router/useRoute.ts
@@ -1,6 +1,6 @@
+import type { MiniProgramPageLike } from '../routerInternal/types'
 import type { MiniProgramPageLifetime } from '../runtime/types'
 import type { SetupContextRouter } from '../runtime/types/props'
-import type { MiniProgramPageLike } from '../routerInternal/types'
 import type { RouteStateSyncPayload } from './routeSync'
 import type { LocationQueryRaw, RouteLocationNormalizedLoaded } from './types'
 import { WEVU_NATIVE_INSTANCE_KEY } from '@weapp-core/constants'

--- a/packages-runtime/wevu/src/router/useRoute.ts
+++ b/packages-runtime/wevu/src/router/useRoute.ts
@@ -1,5 +1,6 @@
 import type { MiniProgramPageLifetime } from '../runtime/types'
 import type { SetupContextRouter } from '../runtime/types/props'
+import type { MiniProgramPageLike } from '../routerInternal/types'
 import type { RouteStateSyncPayload } from './routeSync'
 import type { LocationQueryRaw, RouteLocationNormalizedLoaded } from './types'
 import { WEVU_NATIVE_INSTANCE_KEY } from '@weapp-core/constants'
@@ -107,18 +108,13 @@ function applyRouteState(
 }
 
 export function createRouteStateController(options: RouteStateControllerOptions = {}): RouteStateController {
-  const setupContext = getCurrentSetupContext()
-  if (!setupContext) {
-    throw new Error('useRoute() 必须在 setup() 的同步阶段调用')
-  }
-
-  const fallbackPage = setupContext.instance
-  const initialRouteControllerInstance = resolveRouteControllerInstance(fallbackPage)
+  const setupContext = getCurrentSetupContext<{ instance?: unknown }>()
+  const fallbackPage = setupContext?.instance && typeof setupContext.instance === 'object'
+    ? setupContext.instance as MiniProgramPageLike & Record<string, unknown>
+    : undefined
   const resolveRoute = options.resolveRoute
     ?? ((route: RouteLocationNormalizedLoaded) => getActiveRouter()?.resolve(route) ?? route)
   const currentRoute = resolveRoute(resolveCurrentRoute(undefined, fallbackPage))
-  const isPageController = isPageLikeInstance(initialRouteControllerInstance)
-    || getCurrentMiniProgramPages().includes(initialRouteControllerInstance)
   const routeState = reactive<RouteLocationNormalizedLoaded>({
     path: currentRoute.path,
     fullPath: currentRoute.fullPath,
@@ -142,6 +138,33 @@ export function createRouteStateController(options: RouteStateControllerOptions 
     applyRouteState(routeState, nextRoute)
   }
 
+  if (!fallbackPage) {
+    const unregisterRouteStateSync = registerRouteStateSyncHandler((payload) => {
+      if (payload?.route) {
+        syncRoute(undefined, payload.route, payload)
+        return
+      }
+      if (payload?.url) {
+        syncRoute(undefined, resolveRouteLocation(payload.url, routeState.path), payload)
+        return
+      }
+      if (payload?.page) {
+        syncRoute(undefined, resolvePageRoute(payload.page), payload)
+        return
+      }
+      syncRoute(undefined, undefined, payload)
+    })
+    void unregisterRouteStateSync
+    return {
+      route: readonly(routeState) as Readonly<RouteLocationNormalizedLoaded>,
+    }
+  }
+
+  const pageInstance = fallbackPage
+  const initialRouteControllerInstance = resolveRouteControllerInstance(pageInstance)
+  const isPageController = isPageLikeInstance(initialRouteControllerInstance)
+    || getCurrentMiniProgramPages().includes(initialRouteControllerInstance)
+
   onLoad((query: Parameters<NonNullable<MiniProgramPageLifetime['onLoad']>>[0]) => {
     syncRoute(query as unknown as LocationQueryRaw)
   })
@@ -155,7 +178,7 @@ export function createRouteStateController(options: RouteStateControllerOptions 
     syncRoute()
   })
   const unregisterRouteStateSync = registerRouteStateSyncHandler((payload) => {
-    if (!shouldSyncRouteStateForInstance(fallbackPage, isPageController, payload)) {
+    if (!shouldSyncRouteStateForInstance(pageInstance, isPageController, payload)) {
       return
     }
     if (payload?.route) {

--- a/packages-runtime/wevu/src/runtime/platform.test.ts
+++ b/packages-runtime/wevu/src/runtime/platform.test.ts
@@ -91,6 +91,25 @@ describe('runtime platform', () => {
     })
   })
 
+  it('reads tabBar page paths from host app config', async () => {
+    ;(globalThis as Record<string, unknown>).wx = { name: 'wx-runtime' }
+    ;(globalThis as Record<string, unknown>)[getMiniProgramRuntimeHostConfigKey('weapp')] = {
+      tabBar: {
+        list: [
+          { pagePath: 'pages/index/index', text: '首页' },
+          { pagePath: '/pages/mine/index', text: '我的' },
+          { text: 'missing' },
+        ],
+      },
+    }
+
+    const { getCurrentMiniProgramTabBarPagePaths } = await loadPlatformModule()
+    expect(getCurrentMiniProgramTabBarPagePaths()).toEqual([
+      'pages/index/index',
+      '/pages/mine/index',
+    ])
+  })
+
   it('creates current global router wrapper from runtime global object', async () => {
     const calls: Array<{ method: string, context: any, args: any[] }> = []
     ;(globalThis as any).wx = {

--- a/packages-runtime/wevu/src/runtime/platform.ts
+++ b/packages-runtime/wevu/src/runtime/platform.ts
@@ -138,9 +138,35 @@ export function getCurrentMiniProgramGlobalRouter(): MiniProgramGlobalRouter | u
     if (typeof handler !== 'function') {
       return undefined
     }
-    routerMethods[methodName] = (...args: any[]) => handler.apply(miniProgramGlobal, args)
+    routerMethods[methodName] = (...args: unknown[]) => handler.apply(miniProgramGlobal, args)
   }
   return routerMethods as MiniProgramGlobalRouter
+}
+
+/**
+ * @description 读取宿主 app 配置中的 tabBar 页面路径（未带前导 `/`）。
+ */
+export function getCurrentMiniProgramTabBarPagePaths(): string[] {
+  const hostConfig = getCurrentMiniProgramHostConfig()
+  const tabBar = hostConfig?.tabBar
+  if (!tabBar || typeof tabBar !== 'object') {
+    return []
+  }
+  if (!('list' in tabBar) || !Array.isArray(tabBar.list)) {
+    return []
+  }
+  const paths: string[] = []
+  for (const item of tabBar.list) {
+    if (!item || typeof item !== 'object' || !('pagePath' in item)) {
+      continue
+    }
+    const pagePath = item.pagePath
+    if (typeof pagePath !== 'string' || !pagePath) {
+      continue
+    }
+    paths.push(pagePath)
+  }
+  return paths
 }
 
 export function getScopedSlotHostGlobalObject(): MiniProgramGlobal | undefined {

--- a/packages-runtime/wevu/src/runtime/vueCompat/router.ts
+++ b/packages-runtime/wevu/src/runtime/vueCompat/router.ts
@@ -34,7 +34,7 @@ function resolveBasePathCandidate(candidate: unknown): string | undefined {
 }
 
 function resolveRouterBasePath(
-  nativeInstance: Record<string, any>,
+  nativeInstance: Record<string, unknown>,
   accessor: RuntimeRouterAccessor,
 ): string | undefined {
   const candidates = accessor === 'pageRouter'
@@ -113,37 +113,46 @@ function useRuntimeRouterByAccessor(
   fallbackAccessor: RuntimeRouterAccessor,
   helperName: 'useNativeRouter' | 'useNativePageRouter',
 ): RuntimeRouter {
-  const ctx = getCurrentSetupContext<any>()
-  if (!ctx?.instance) {
-    throw new Error(`${helperName}() 必须在 setup() 的同步阶段调用`)
-  }
+  const ctx = getCurrentSetupContext<Record<string, unknown>>()
+  const nativeInstance = ctx?.instance && typeof ctx.instance === 'object'
+    ? ctx.instance as Record<string, unknown>
+    : undefined
 
-  const nativeInstance = ctx.instance as Record<string, any>
-  const basePath = resolveRouterBasePath(nativeInstance, primaryAccessor)
-  const primaryRouter = nativeInstance[primaryAccessor]
-  if (isRuntimeRouter(primaryRouter)) {
-    return createScopedRuntimeRouter(primaryRouter, basePath)
-  }
+  if (nativeInstance) {
+    const basePath = resolveRouterBasePath(nativeInstance, primaryAccessor)
+    const primaryRouter = nativeInstance[primaryAccessor]
+    if (isRuntimeRouter(primaryRouter)) {
+      return createScopedRuntimeRouter(primaryRouter, basePath)
+    }
 
-  const fallbackRouter = nativeInstance[fallbackAccessor]
-  if (isRuntimeRouter(fallbackRouter)) {
-    return createScopedRuntimeRouter(fallbackRouter, basePath)
+    const fallbackRouter = nativeInstance[fallbackAccessor]
+    if (isRuntimeRouter(fallbackRouter)) {
+      return createScopedRuntimeRouter(fallbackRouter, basePath)
+    }
+
+    const globalFallbackRouter = createGlobalRouterFallback()
+    if (globalFallbackRouter) {
+      return createScopedRuntimeRouter(globalFallbackRouter, basePath)
+    }
+
+    throw new Error('当前运行环境不支持 Router，请升级宿主基础库或检查平台路由能力')
   }
 
   const globalFallbackRouter = createGlobalRouterFallback()
   if (globalFallbackRouter) {
-    return createScopedRuntimeRouter(globalFallbackRouter, basePath)
+    return createScopedRuntimeRouter(globalFallbackRouter)
   }
 
-  throw new Error('当前运行环境不支持 Router，请升级宿主基础库或检查平台路由能力')
+  throw new Error(`${helperName}() 必须在 setup() 的同步阶段调用`)
 }
 
 /**
- * 在 setup 中获取与当前组件路径语义一致的原生 Router 对象。
+ * 获取与当前组件路径语义一致的原生 Router 对象。
  *
  * - 优先使用实例上的 `this.router`（组件路径语义）。
  * - 不可用时回退到 `this.pageRouter`。
- * - 低版本基础库再回退到宿主全局路由方法。
+ * - App setup 或低版本基础库再回退到宿主全局路由方法。
+ * - 无 setup 上下文且宿主全局路由可用时，仍可创建应用级路由器。
  *
  * 如需更贴近 Vue Router 的高阶能力（导航守卫、失败类型、统一解析），
  * 推荐改用 `wevu/router` 子入口的 `useRouter()`。
@@ -153,11 +162,11 @@ export function useNativeRouter(): RuntimeRouter {
 }
 
 /**
- * 在 setup 中获取与当前页面路径语义一致的原生 Router 对象。
+ * 获取与当前页面路径语义一致的原生 Router 对象。
  *
  * - 优先使用实例上的 `this.pageRouter`（页面路径语义）。
  * - 不可用时回退到 `this.router`。
- * - 低版本基础库再回退到宿主全局路由方法。
+ * - App setup 或低版本基础库再回退到宿主全局路由方法。
  *
  * 如需更贴近 Vue Router 的高阶能力（导航守卫、失败类型、统一解析），
  * 推荐改用 `wevu/router` 子入口的 `useRouter()`。

--- a/packages-runtime/wevu/test/router-api.test.ts
+++ b/packages-runtime/wevu/test/router-api.test.ts
@@ -15,6 +15,8 @@ describe('router api', () => {
     clearActiveRouter()
     bindCurrentPageInstance(undefined as any)
     delete (globalThis as any).getCurrentPages
+    delete (globalThis as any).wx
+    delete (globalThis as any).__wxConfig
   })
 
   it('parseQuery parses repeated keys, empty value, and flags', () => {
@@ -95,10 +97,17 @@ describe('router api', () => {
     })
   })
 
-  it('useRoute requires setup context', () => {
+  it('useRoute can initialize from the current page stack without setup context', () => {
     setCurrentInstance({ __wevu: {}, [WEVU_HOOKS_KEY]: {} } as any)
     setCurrentSetupContext(undefined)
-    expect(() => useRoute()).toThrow('useRoute() 必须在 setup() 的同步阶段调用')
+    ;(globalThis as any).getCurrentPages = vi.fn(() => [
+      {
+        route: 'pages/login/index',
+        options: {},
+      },
+    ])
+
+    expect(useRoute().path).toBe('pages/login/index')
   })
 
   it('useRouter requires an existing router instance when called without options', () => {
@@ -127,6 +136,52 @@ describe('router api', () => {
     ;(globalThis as any).getCurrentPages = vi.fn(() => [
       {
         route: 'pages/home/index',
+        options: {},
+      },
+    ])
+
+    const createdRouter = createRouter()
+
+    expect(useRouter()).toBe(createdRouter)
+  })
+
+  it('createRouter uses the host global router when App setup has no native router', () => {
+    const wx = {
+      switchTab: vi.fn(),
+      reLaunch: vi.fn(),
+      redirectTo: vi.fn(),
+      navigateTo: vi.fn(),
+      navigateBack: vi.fn(),
+    }
+    ;(globalThis as any).wx = wx
+    const instance = { __wevu: {}, [WEVU_HOOKS_KEY]: {} } as any
+    setCurrentInstance(instance)
+    setCurrentSetupContext({ instance, emit: vi.fn(), attrs: {}, slots: {} })
+    ;(globalThis as any).getCurrentPages = vi.fn(() => [
+      {
+        route: 'pages/login/index',
+        options: {},
+      },
+    ])
+
+    const createdRouter = createRouter()
+
+    expect(useRouter()).toBe(createdRouter)
+    expect(createdRouter.nativeRouter.navigateTo).toBeTypeOf('function')
+  })
+
+  it('createRouter uses the host global router when called without a page setup context', () => {
+    const wx = {
+      switchTab: vi.fn(),
+      reLaunch: vi.fn(),
+      redirectTo: vi.fn(),
+      navigateTo: vi.fn(),
+      navigateBack: vi.fn(),
+    }
+    ;(globalThis as any).wx = wx
+    ;(globalThis as any).getCurrentPages = vi.fn(() => [
+      {
+        route: 'pages/login/index',
         options: {},
       },
     ])

--- a/packages-runtime/wevu/test/router-navigation.test.ts
+++ b/packages-runtime/wevu/test/router-navigation.test.ts
@@ -19,6 +19,7 @@ describe('router navigation helpers', () => {
     clearActiveRouter()
     delete (globalThis as any).getCurrentPages
     delete (globalThis as any).wx
+    delete (globalThis as any).__wxConfig
   })
 
   it('creates and detects navigation failure', () => {
@@ -3180,6 +3181,52 @@ describe('router navigation helpers', () => {
     expect(switchTab).toHaveBeenCalledWith(expect.objectContaining({
       url: '/pages/home/index',
     }))
+    expect(navigateTo).not.toHaveBeenCalled()
+  })
+
+  it('push auto-switches to tabBar pages from host app config when tabBarEntries is omitted', async () => {
+    const switchTab = vi.fn((options: any) => {
+      options.success?.({})
+    })
+    const navigateTo = vi.fn()
+    const redirectTo = vi.fn()
+    const instance = {
+      __wevu: {},
+      [WEVU_HOOKS_KEY]: {},
+      router: {
+        switchTab,
+        reLaunch: vi.fn(),
+        redirectTo,
+        navigateTo,
+        navigateBack: vi.fn(),
+      },
+    } as any
+
+    setCurrentInstance(instance)
+    setCurrentSetupContext({ instance, emit: vi.fn(), attrs: {}, slots: {} })
+    ;(globalThis as any).__wxConfig = {
+      tabBar: {
+        list: [
+          { pagePath: 'pages/index/index', text: '首页' },
+          { pagePath: '/pages/mine/index', text: '我的' },
+        ],
+      },
+    }
+    ;(globalThis as any).getCurrentPages = vi.fn(() => [
+      {
+        route: 'pages/login/index',
+        options: {},
+      },
+    ])
+
+    const router = createRouter()
+    const result = await router.replace('/pages/index/index')
+
+    expect(result).toBeUndefined()
+    expect(switchTab).toHaveBeenCalledWith(expect.objectContaining({
+      url: '/pages/index/index',
+    }))
+    expect(redirectTo).not.toHaveBeenCalled()
     expect(navigateTo).not.toHaveBeenCalled()
   })
 

--- a/packages-runtime/wevu/test/runtime-vue-compat.test.ts
+++ b/packages-runtime/wevu/test/runtime-vue-compat.test.ts
@@ -1366,6 +1366,29 @@ describe('runtime: vue compat helpers', () => {
     expectRouteOption(wxRedirectTo.mock.calls[0], '/pages/b/index')
   })
 
+  it('useNativeRouter/useNativePageRouter fallback to global route methods without setup context', () => {
+    const wxNavigateTo = vi.fn()
+    const wxRedirectTo = vi.fn()
+    const wxSwitchTab = vi.fn()
+    const wxReLaunch = vi.fn()
+    const wxNavigateBack = vi.fn()
+    ;(globalThis as any).wx = {
+      switchTab: wxSwitchTab,
+      reLaunch: wxReLaunch,
+      redirectTo: wxRedirectTo,
+      navigateTo: wxNavigateTo,
+      navigateBack: wxNavigateBack,
+    }
+
+    const router = useNativeRouter()
+    const pageRouter = useNativePageRouter()
+    router.navigateTo({ url: '/pages/a/index' })
+    pageRouter.redirectTo({ url: '/pages/b/index' })
+
+    expectRouteOption(wxNavigateTo.mock.calls[0], '/pages/a/index')
+    expectRouteOption(wxRedirectTo.mock.calls[0], '/pages/b/index')
+  })
+
   it('useNativeRouter/useNativePageRouter fallback to complementary instance accessor before global fallback', () => {
     const pageRouterOnly = {
       switchTab: vi.fn(),


### PR DESCRIPTION
## Problem / Goal

在 `app.vue` 的 `<script setup>` 中调用 `createRouter()` 时，App 实例没有页面级 `this.router`，路由器创建失败。未传入 `tabBarEntries` 时，`push` / `replace` 会把 tabBar 页走成 `redirectTo`，触发 `redirectTo:fail can not redirectTo a tabbar page`。

## Reproduction / Baseline

1. 在 App setup 中调用 `createRouter()`，实例上没有 `router` / `pageRouter`。
2. 不传 `tabBarEntries`，导航到宿主 `__wxConfig.tabBar.list` 中的页面。

修复前：创建失败，或 tabBar 页走 `redirectTo`。

## Root cause / Design

页面级 `this.router` 与宿主全局路由方法（`wx` / `my` / `tt`）不是同一条路径。App setup 和无 setup 的应用级创建都应回退全局路由。tabBar 路径应来自显式 `tabBarEntries`，缺省时读取宿主 app 配置。

## Control

单 Loop。失败短返回 wevu router 切片。

## Bug class / Variant sweep

Predicate：创建/使用路由器时没有页面级 router 实例，或导航目标是宿主 tabBar 页但未传入 `tabBarEntries`。

Invariant：存在宿主全局路由方法时，App setup / 无 setup 可以创建路由器；tabBar 页走 `switchTab`，不走 `redirectTo`。

搜索边界：`packages-runtime/wevu` 的 `createRouter`、`useNativeRouter`、`useNativePageRouter`、`useRoute`、tabBar 路径读取。

命中：
- `current-fix`：App setup 无 `this.router`；无 setup 时创建路由器；`useRoute()` 无 setup 时从页面栈初始化；未传 `tabBarEntries` 时读宿主 tabBar 并 `switchTab`；`useNativeRouter` / `useNativePageRouter` 无 setup 时回退全局方法。
- `excluded`：显式传入的 `tabBarEntries` 仍优先；无宿主全局路由时仍抛错。

## Change

- `useNativeRouter` / `useNativePageRouter` 在实例 router 不可用时回退宿主全局路由方法。
- `createRouter()` 未传 `tabBarEntries` 时读取宿主 tabBar 页面路径。
- `useRoute()` 无 setup 时从当前页面栈初始化。
- 补充文档与回归测试。

## Non-goals

不扩大公开 API，不改 DevTools e2e，不改其他运行时包。

## Verification

| Acceptance | Surface | Evidence | Result |
| --- | --- | --- | --- |
| App setup 无页面 router 时可创建实例 | wevu vitest | `createRouter uses the host global router when App setup has no native router` | pass |
| 无 setup 时可创建实例 | wevu vitest | `createRouter uses the host global router when called without a page setup context` | pass |
| `useRoute()` 无 setup 时从页面栈初始化 | wevu vitest | `useRoute can initialize from the current page stack without setup context` | pass |
| 未传 `tabBarEntries` 时 tabBar 页走 `switchTab` | wevu vitest | `push auto-switches to tabBar pages from host app config when tabBarEntries is omitted` | pass |
| 无 setup 时 native router 回退 `wx` | wevu vitest | `useNativeRouter/useNativePageRouter fallback to global route methods without setup context` | pass |
| 独立验收 | github-verifier | 4 files / 166 tests pass | accept |

命令（仓库相对路径）：

```bash
./node_modules/.bin/vitest run --config packages-runtime/wevu/vitest.config.ts --dir packages-runtime/wevu test/router-api.test.ts test/router-navigation.test.ts src/runtime/platform.test.ts test/runtime-vue-compat.test.ts
```

## Risks

- Compatibility: 无宿主全局路由时仍抛错；显式 `tabBarEntries` 仍优先。
- Security/privacy: 无。
- Performance/resources: 启动时读取一次宿主 tabBar 配置。
- Platform/runtime: 依赖 `__wxConfig.tabBar.list` 或等价宿主配置。

## Rollback

还原该 PR。无数据迁移。

## Related

Closes #988
Closes #989

