### PR TITLE
fix(wevu): 将 setup 返回函数写入 setupState

### DIFF
--- a/.changeset/fix-986-setup-state-functions.md
+++ b/.changeset/fix-986-setup-state-functions.md
@@ -1,0 +1,6 @@
+---
+'wevu': patch
+'create-weapp-vite': patch
+---
+
+修复 setup 返回函数未写入 `setupState` 的问题，使 public proxy 与 `bindModel` 能读到同一份绑定。

--- a/packages-runtime/wevu/src/runtime/register/runtimeInstance/setupPhase.ts
+++ b/packages-runtime/wevu/src/runtime/register/runtimeInstance/setupPhase.ts
@@ -230,8 +230,10 @@ export function runRuntimeSetupPhase<D extends object, C extends ComputedDefinit
       Object.keys(result).forEach((key) => {
         const val = (result as any)[key]
         if (typeof val === 'function') {
-          ;(runtime.methods as any)[key] = (...args: any[]) => (val as any).apply((runtime as any).proxy, args)
-          ;(runtime.state as any)[key] = (...args: any[]) => (val as any).apply((runtime as any).proxy, args)
+          const bound = (...args: any[]) => (val as any).apply((runtime as any).proxy, args)
+          ;(runtime.methods as any)[key] = bound
+          ;(runtime.state as any)[key] = bound
+          ;(runtimeSetupState as any)[key] = bound
           methodsChanged = true
         }
         else {

--- a/packages-runtime/wevu/test/runtime-component.test.ts
+++ b/packages-runtime/wevu/test/runtime-component.test.ts
@@ -785,4 +785,31 @@ describe('runtime: component lifetimes/pageLifetimes mapping', () => {
 
     expect(triggerEvent).toHaveBeenCalledWith('change', { source: 'runtime-instance-fallback' })
   })
+
+  it('writes setup-returned functions into setupState for proxy and bindModel', () => {
+    defineComponent({
+      data: () => ({}),
+      setup() {
+        const count = { value: 0 }
+        function increment() {
+          count.value += 1
+        }
+        return {
+          count,
+          increment,
+        }
+      },
+    })
+
+    const opts = registeredComponents[0]
+    const inst: any = { setData() {} }
+    opts.lifetimes.created.call(inst)
+    opts.lifetimes.attached.call(inst)
+
+    expect(typeof inst.__wevu.setupState.increment).toBe('function')
+    expect(inst.__wevu.proxy.increment).toBe(inst.__wevu.setupState.increment)
+    inst.__wevu.proxy.increment()
+    expect(inst.__wevu.setupState.count.value).toBe(1)
+  })
+
 })

--- a/packages-runtime/wevu/test/runtime-component.test.ts
+++ b/packages-runtime/wevu/test/runtime-component.test.ts
@@ -811,5 +811,4 @@ describe('runtime: component lifetimes/pageLifetimes mapping', () => {
     inst.__wevu.proxy.increment()
     expect(inst.__wevu.setupState.count.value).toBe(1)
   })
-
 })


### PR DESCRIPTION
## Problem / Goal

`<script setup>` 返回的函数只进了 `methods` / `state`，没有写入 `setupState`。public proxy 先查 `setupState`，`bindModel` 也优先写 `setupState`，所以实例上看不到同一份函数绑定。

## Reproduction / Baseline

```ts
setup() {
  const count = { value: 0 }
  function increment() {
    count.value += 1
  }
  return { count, increment }
}
```

修复前：`runtime.setupState.increment` 为 `undefined`。

## Root cause / Design

`runRuntimeSetupPhase()` 的函数分支写 `methods` 和 `state`，不写 `setupState`。`applySetupResult()` 在需要时会写。两条 setup 结果路径不一致。

## Control

单 Loop。失败短返回 setupPhase。

## Bug class / Variant sweep

Predicate：setup 返回对象里的函数键进入 methods/state，但不进入 setupState。

Invariant：会进入 `runtime.state` 的 setup 返回函数，也应进入 `setupState`。

搜索边界：`packages-runtime/wevu/src/runtime/register/runtimeInstance/setupPhase.ts`、`define/setupResult.ts`。

命中：
- `current-fix`：`runRuntimeSetupPhase()` 函数分支。
- `excluded`：`applySetupResult()` 已按 `includeFunctionsInState` / `functionPropPaths` 写入；store `setupStyle` 是另一套实例字段，不是组件 setupState。

## Change

函数分支把同一个 bound 函数写入 `methods`、`state`、`setupState`。

## Non-goals

不改 `allowFunctionProps` 的 setData 策略，不改 store。

## Verification

| Acceptance | Surface | Evidence | Result |
| --- | --- | --- | --- |
| setup 返回函数进入 setupState | wevu vitest | `writes setup-returned functions into setupState for proxy and bindModel` | pass |
| proxy 读到同一函数 | wevu vitest | `proxy.increment === setupState.increment` | pass |
| 调用会改 setup 状态 | wevu vitest | `count.value === 1` | pass |

```bash
./node_modules/.bin/vitest run --config packages-runtime/wevu/vitest.config.ts --dir packages-runtime/wevu test/runtime-component.test.ts
```

## Risks

- Compatibility: setup 返回函数现在对 proxy/`in`/`getOwnPropertyDescriptor` 可见。
- Security/privacy: 无。
- Performance/resources: 每个 setup 函数多一次 setupState 写入。
- Platform/runtime: wevu 组件 runtime。

## Rollback

还原该 PR。

## Related

Closes #986。
