### PR TITLE
fix(weapp-vite): 停止把 Wevu jsx-runtime 写入 compilerOptions.types

### DIFF
--- a/.changeset/fix-wevu-jsx-runtime-types.md
+++ b/.changeset/fix-wevu-jsx-runtime-types.md
@@ -1,0 +1,6 @@
+---
+'weapp-vite': patch
+'create-weapp-vite': patch
+---
+
+修复受管 `.weapp-vite/tsconfig.app.json` 把 `wevu/weapp/jsx-runtime` 写入 `compilerOptions.types` 导致 TS2688 的问题。JSX 类型改由 `jsxImportSource` 解析。

--- a/packages/weapp-vite/src/runtime/tsconfigSupport.test.ts
+++ b/packages/weapp-vite/src/runtime/tsconfigSupport.test.ts
@@ -80,7 +80,8 @@ describe('tsconfig support', () => {
     }))
     const app = JSON.parse(files.find(file => file.path.endsWith('tsconfig.app.json'))!.content)
 
-    expect(app.compilerOptions.types).toEqual(expect.arrayContaining(['miniprogram-api-typings', 'weapp-vite/client', 'wevu/weapp/jsx-runtime']))
+    expect(app.compilerOptions.types).toEqual(expect.arrayContaining(['miniprogram-api-typings', 'weapp-vite/client']))
+    expect(app.compilerOptions.types).not.toContain('wevu/weapp/jsx-runtime')
     expect(app.compilerOptions.types).not.toContain('vite/client')
     expect(app.compilerOptions.paths['weapp-vite/typed-components']).toEqual(['./typed-components.d.ts'])
     expect(app.compilerOptions.jsx).toBe('preserve')
@@ -114,7 +115,7 @@ describe('tsconfig support', () => {
 
     expect(app.compilerOptions.jsx).toBe('preserve')
     expect(app.compilerOptions.jsxImportSource).toBe(jsxImportSource)
-    expect(app.compilerOptions.types).toContain(`${jsxImportSource}/jsx-runtime`)
+    expect(app.compilerOptions.types).not.toContain(`${jsxImportSource}/jsx-runtime`)
     if (jsxImportSource === 'wevu') {
       expect(platformBridge).toBe('export {}\n')
     }
@@ -148,7 +149,7 @@ describe('tsconfig support', () => {
 
     expect(app.compilerOptions.jsx).toBe('preserve')
     expect(app.compilerOptions.jsxImportSource).toBe('wevu/miniprogram')
-    expect(app.compilerOptions.types).toContain('wevu/miniprogram/jsx-runtime')
+    expect(app.compilerOptions.types).not.toContain('wevu/miniprogram/jsx-runtime')
     expect(platformBridge).toContain('wevu/miniprogram/jsx-runtime')
   })
 
@@ -176,6 +177,30 @@ describe('tsconfig support', () => {
     expect(app.compilerOptions.jsxImportSource).toBe('react')
     expect(app.compilerOptions.types).not.toContain('react/jsx-runtime')
     expect(platformBridge).toBe('export {}\n')
+  })
+
+  it('keeps Wevu JSX types on jsxImportSource instead of compilerOptions.types', async () => {
+    const files = await createManagedTsconfigFiles(createCtx({
+      packageJson: {
+        dependencies: {
+          wevu: '^1.0.0',
+        },
+      },
+      weappViteConfig: {
+        typescript: {
+          app: {
+            compilerOptions: {
+              types: ['custom-env', 'wevu/weapp/jsx-runtime'],
+            },
+          },
+        },
+      },
+    }))
+    const app = JSON.parse(files.find(file => file.path.endsWith('tsconfig.app.json'))!.content)
+
+    expect(app.compilerOptions.jsxImportSource).toBe('wevu/weapp')
+    expect(app.compilerOptions.types).toEqual(expect.arrayContaining(['miniprogram-api-typings', 'weapp-vite/client', 'custom-env']))
+    expect(app.compilerOptions.types).not.toContain('wevu/weapp/jsx-runtime')
   })
 
   it('does not inject a JSX type source without a wevu dependency', async () => {

--- a/packages/weapp-vite/src/runtime/tsconfigSupport/configs.ts
+++ b/packages/weapp-vite/src/runtime/tsconfigSupport/configs.ts
@@ -9,7 +9,7 @@ import {
   DEFAULT_NODE_INCLUDE,
   getManagedTypeScriptConfig,
   hasDependency,
-  isWevuJsxImportSource,
+  isWevuJsxRuntimeTypePackage,
   mergePaths,
   normalizeSrcRoot,
   rebaseManagedPaths,
@@ -55,10 +55,6 @@ function getAppTypes(ctx: MutableCompilerContext, legacyConfig?: LegacyManagedTy
     'weapp-vite/client',
   ]
 
-  const jsxImportSource = resolveAppWevuJsxImportSource(ctx, legacyConfig)
-  if (isWevuJsxImportSource(jsxImportSource)) {
-    types.push(`${jsxImportSource}/jsx-runtime`)
-  }
   if (Array.isArray(legacyTypes) && legacyTypes.length > 0) {
     types.push(...legacyTypes)
   }
@@ -67,7 +63,7 @@ function getAppTypes(ctx: MutableCompilerContext, legacyConfig?: LegacyManagedTy
     types.push(...userTypes)
   }
 
-  return unique(types)
+  return unique(types).filter(type => !isWevuJsxRuntimeTypePackage(type))
 }
 
 function getAppPaths(ctx: MutableCompilerContext, legacyConfig?: LegacyManagedTypeScriptConfig) {

--- a/packages/weapp-vite/src/runtime/tsconfigSupport/jsxRuntimeTypes.test.ts
+++ b/packages/weapp-vite/src/runtime/tsconfigSupport/jsxRuntimeTypes.test.ts
@@ -1,0 +1,66 @@
+import { spawnSync } from 'node:child_process'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { isWevuJsxRuntimeTypePackage } from './jsxSources'
+
+const tsc = createRequire(import.meta.url).resolve('typescript/bin/tsc')
+
+describe('Wevu jsx-runtime type packages', () => {
+  it('treats Wevu JSX subpaths as invalid compilerOptions.types entries', () => {
+    expect(isWevuJsxRuntimeTypePackage('wevu/weapp/jsx-runtime')).toBe(true)
+    expect(isWevuJsxRuntimeTypePackage('wevu/alipay/jsx-runtime')).toBe(true)
+    expect(isWevuJsxRuntimeTypePackage('wevu/tt/jsx-runtime')).toBe(true)
+    expect(isWevuJsxRuntimeTypePackage('wevu/miniprogram/jsx-runtime')).toBe(true)
+    expect(isWevuJsxRuntimeTypePackage('wevu/jsx-runtime')).toBe(true)
+    expect(isWevuJsxRuntimeTypePackage('weapp-vite/client')).toBe(false)
+    expect(isWevuJsxRuntimeTypePackage('miniprogram-api-typings')).toBe(false)
+    expect(isWevuJsxRuntimeTypePackage('react/jsx-runtime')).toBe(false)
+  })
+
+  it('reports TS2688 when compilerOptions.types points at a Wevu JSX subpath', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'wevu-jsx-runtime-types-'))
+    await mkdir(path.join(root, 'src'), { recursive: true })
+    await writeFile(path.join(root, 'src/app.tsx'), 'export const n = <view class="x" />\n')
+    await writeFile(path.join(root, 'tsconfig.json'), JSON.stringify({
+      compilerOptions: {
+        jsx: 'preserve',
+        jsxImportSource: 'wevu/weapp',
+        module: 'ESNext',
+        moduleResolution: 'bundler',
+        noEmit: true,
+        strict: true,
+        types: ['wevu/weapp/jsx-runtime'],
+      },
+      include: ['src/app.tsx'],
+    }, null, 2))
+
+    const withTypes = spawnSync(process.execPath, [tsc, '-p', 'tsconfig.json', '--pretty', 'false'], {
+      encoding: 'utf8',
+      cwd: root,
+    })
+    expect(withTypes.status).not.toBe(0)
+    expect(`${withTypes.stdout}${withTypes.stderr}`).toContain('Cannot find type definition file for \'wevu/weapp/jsx-runtime\'')
+
+    await writeFile(path.join(root, 'tsconfig.json'), JSON.stringify({
+      compilerOptions: {
+        jsx: 'preserve',
+        jsxImportSource: 'wevu/weapp',
+        module: 'ESNext',
+        moduleResolution: 'bundler',
+        noEmit: true,
+        strict: true,
+        types: [],
+      },
+      include: ['src/app.tsx'],
+    }, null, 2))
+
+    const withoutTypes = spawnSync(process.execPath, [tsc, '-p', 'tsconfig.json', '--pretty', 'false'], {
+      encoding: 'utf8',
+      cwd: root,
+    })
+    expect(`${withoutTypes.stdout}${withoutTypes.stderr}`).not.toContain('Cannot find type definition file for \'wevu/weapp/jsx-runtime\'')
+  })
+})

--- a/packages/weapp-vite/src/runtime/tsconfigSupport/jsxSources.ts
+++ b/packages/weapp-vite/src/runtime/tsconfigSupport/jsxSources.ts
@@ -1,0 +1,39 @@
+type WevuJsxPlatform = 'weapp' | 'alipay' | 'tt' | string
+
+const WEVU_JSX_IMPORT_SOURCES = new Set([
+  'wevu',
+  'wevu/alipay',
+  'wevu/miniprogram',
+  'wevu/tt',
+  'wevu/weapp',
+])
+
+const JSX_RUNTIME_SUFFIX = '/jsx-runtime'
+
+export function resolveWevuJsxImportSource(platform: WevuJsxPlatform | undefined) {
+  switch (platform) {
+    case undefined:
+    case 'weapp':
+      return 'wevu/weapp'
+    case 'alipay':
+      return 'wevu/alipay'
+    case 'tt':
+      return 'wevu/tt'
+    default:
+      return 'wevu'
+  }
+}
+
+export function isWevuJsxImportSource(value: string | undefined): value is string {
+  return Boolean(value && WEVU_JSX_IMPORT_SOURCES.has(value))
+}
+
+/**
+ * `compilerOptions.types` 只按类型包目录解析，不能指向 Wevu JSX 子路径。
+ */
+export function isWevuJsxRuntimeTypePackage(value: string | undefined) {
+  return Boolean(
+    value?.endsWith(JSX_RUNTIME_SUFFIX)
+    && isWevuJsxImportSource(value.slice(0, -JSX_RUNTIME_SUFFIX.length)),
+  )
+}

--- a/packages/weapp-vite/src/runtime/tsconfigSupport/shared.ts
+++ b/packages/weapp-vite/src/runtime/tsconfigSupport/shared.ts
@@ -1,19 +1,10 @@
 import type { MutableCompilerContext } from '../../context'
-import type { MpPlatform } from '../../types'
 import type { LegacyManagedTsconfigFile, LegacyManagedTypeScriptConfig, ManagedTypeScriptConfig } from './types'
 import { fs } from '@weapp-core/shared/fs'
 import { parse as parseJson } from 'comment-json'
 import path from 'pathe'
 import { resolveBaseDir, WEAPP_VITE_INTERNAL_DIRNAME } from '../autoImport/config/base'
 import { requireConfigService } from '../utils/requireConfigService'
-
-const WEVU_JSX_IMPORT_SOURCES = new Set([
-  'wevu',
-  'wevu/alipay',
-  'wevu/miniprogram',
-  'wevu/tt',
-  'wevu/weapp',
-])
 
 export const DEFAULT_APP_EXTRA_INCLUDE = [
   '../types/**/*.d.ts',
@@ -50,23 +41,7 @@ export function hasDependency(packageJson: Record<string, any> | undefined, name
   )
 }
 
-export function resolveWevuJsxImportSource(platform: MpPlatform | undefined) {
-  switch (platform) {
-    case undefined:
-    case 'weapp':
-      return 'wevu/weapp'
-    case 'alipay':
-      return 'wevu/alipay'
-    case 'tt':
-      return 'wevu/tt'
-    default:
-      return 'wevu'
-  }
-}
-
-export function isWevuJsxImportSource(value: string | undefined): value is string {
-  return Boolean(value && WEVU_JSX_IMPORT_SOURCES.has(value))
-}
+export { isWevuJsxImportSource, isWevuJsxRuntimeTypePackage, resolveWevuJsxImportSource } from './jsxSources'
 
 export function unique(values: string[]) {
   return [...new Set(values)]

--- a/website/wevu/jsx-runtime.md
+++ b/website/wevu/jsx-runtime.md
@@ -41,6 +41,8 @@ Weapp-vite 生成受管 TypeScript 配置时，会保持 `jsx: "preserve"`。只
 
 用户显式配置的 `weapp.typescript.app.compilerOptions.jsxImportSource` 优先级更高。需要三端可移植约束时，应明确覆盖为 `wevu/miniprogram`，它不会被自动当作未知平台的后备类型。
 
+不要把这些入口写进 `compilerOptions.types`。TypeScript 会把 `types` 当成类型包目录查找，`wevu/weapp/jsx-runtime` 这类子路径会报 `TS2688`（找不到类型定义文件）。受管 `tsconfig.app.json` 只设置 `jsxImportSource`，JSX 命名空间由 `${jsxImportSource}/jsx-runtime` 模块解析。
+
 ### 微信小程序
 
 ```json


### PR DESCRIPTION
## Problem / Goal

受管 `.weapp-vite/tsconfig.app.json` 把 `wevu/weapp/jsx-runtime` 写入 `compilerOptions.types`，IDE / `tsc` / `vue-tsc` 报 TS2688：找不到类型定义文件。

## Reproduction / Baseline

项目声明 `wevu` 后运行 `wv prepare`，生成的 `.weapp-vite/tsconfig.app.json` 含：

```json
{
  "compilerOptions": {
    "jsx": "preserve",
    "jsxImportSource": "wevu/weapp",
    "types": ["miniprogram-api-typings", "weapp-vite/client", "wevu/weapp/jsx-runtime"]
  }
}
```

`origin/main` 注入点：`packages/weapp-vite/src/runtime/tsconfigSupport/configs.ts` 的 `getAppTypes()`。

独立 `tsc` 复现：

```json
{
  "compilerOptions": {
    "jsx": "preserve",
    "jsxImportSource": "wevu/weapp",
    "module": "ESNext",
    "moduleResolution": "bundler",
    "noEmit": true,
    "strict": true,
    "types": ["wevu/weapp/jsx-runtime"]
  }
}
```

wevu 未安装、`dist` 缺失、或 `package.json` 没有对应 `exports` 时都会报：

```text
error TS2688: Cannot find type definition file for 'wevu/weapp/jsx-runtime'.
```

## Root cause / Design

`compilerOptions.types` 按类型包目录解析（`node_modules/<name>` / `@types/<name>`），不走 package `exports` 子路径。`wevu/weapp/jsx-runtime` 是合法的 JSX 类型模块入口，应由 `jsxImportSource` 解析，不该写进 `types`。

## Control

单 Loop。失败短返回 `packages/weapp-vite/src/runtime/tsconfigSupport`。

## Bug class / Variant sweep

- Predicate：受管/用户/legacy `compilerOptions.types` 含 `wevu` JSX 子路径（`wevu/jsx-runtime` 或 `wevu/{weapp,alipay,tt,miniprogram}/jsx-runtime`）。
- Invariant：`types` 只列真正的类型包；Wevu JSX 命名空间由 `jsxImportSource` 解析。
- 搜索：`packages/weapp-vite/src/runtime/tsconfigSupport`、模板生成的 `.weapp-vite/tsconfig.app.json`、`compilerOptions.types` 字面量。
- `current-fix`：`getAppTypes()` 不再注入这些子路径，并过滤用户/legacy 误写项。
- `excluded`：`import type { ... } from 'wevu/weapp/jsx-runtime'` 与 `jsxImportSource` 模块解析。

## Change

- `getAppTypes()` 不再把 `${jsxImportSource}/jsx-runtime` 写入 `types`。
- 过滤用户/legacy `types` 中的 Wevu JSX 子路径。
- `jsxImportSource` 和平台 bridge 保持不变。
- 文档说明不要把这些入口写进 `compilerOptions.types`。

## Non-goals

不改变 Wevu JSX 类型入口本身，不新增 runtime 行为。

## Verification

| Acceptance | Surface | Evidence | Result |
| --- | --- | --- | --- |
| `types` 含 `wevu/weapp/jsx-runtime` 时报 TS2688 | `tsc -p` | `jsxRuntimeTypes.test.ts` | 通过 |
| 去掉该 `types` 项后不再报 TS2688 | `tsc -p` | 同测试 | 通过 |
| 受管 tsconfig 不再注入该 `types` 项 | `createManagedTsconfigFiles` | `tsconfigSupport.test.ts` | 已更新断言 |

## Risks

- Compatibility：已有项目重新 `wv prepare` 后，受管 `tsconfig.app.json` 不再含该 `types` 项；JSX 类型仍由 `jsxImportSource` 提供。
- Security/privacy：无。
- Performance/resources：无。
- Platform/runtime：仅 TypeScript 配置。

## Rollback

还原 `getAppTypes()` 注入即可。

## Related

Closes #995