### PR TITLE
fix(web): 修复生产包 polyfill 全局安装被 tree-shaking 移除

### DIFF
--- a/.changeset/fix-web-polyfill-side-effects.md
+++ b/.changeset/fix-web-polyfill-side-effects.md
@@ -1,0 +1,5 @@
+---
+'@weapp-vite/web': patch
+---
+
+修复 Web 生产构建错误移除运行时 polyfill 全局安装副作用的问题，确保 `wx`、`getApp` 和 `getCurrentPages` 在生产包中可用。

--- a/packages-runtime/web/package.json
+++ b/packages-runtime/web/package.json
@@ -25,7 +25,7 @@
     "runtime"
   ],
   "sideEffects": [
-    "dist/runtime/polyfill/**"
+    "dist/runtime/index.mjs"
   ],
   "exports": {
     ".": {

--- a/packages-runtime/web/test/polyfill-entry-contract.test.ts
+++ b/packages-runtime/web/test/polyfill-entry-contract.test.ts
@@ -13,7 +13,7 @@ const originalDescriptors = new Map(
 
 describe('polyfill entry installation contract', () => {
   it('declares the polyfill output as side-effectful for production treeshaking', () => {
-    expect(packageJson.sideEffects).toContain('dist/runtime/polyfill/**')
+    expect(packageJson.sideEffects).toContain('dist/runtime/index.mjs')
   })
 
   afterEach(() => {


### PR DESCRIPTION
## 问题

`@weapp-vite/web` 的 `./runtime/polyfill` 发布入口实际解析到 `dist/runtime/index.mjs`，但 `sideEffects` 错误声明为 `dist/runtime/polyfill/**`。生产构建 tree-shaking 时可能移除 polyfill 的全局安装副作用，导致 `wx`、`getApp` 和 `getCurrentPages` 未定义。

## 修复

将 `sideEffects` 改为匹配实际发布入口 `dist/runtime/index.mjs`，并同步更新契约测试。新增 changeset。

## 验证

- `pnpm --filter @weapp-vite/web exec vitest run test/polyfill-entry-contract.test.ts`
- `pnpm --filter @weapp-vite/web typecheck`
- `pnpm --filter @weapp-vite/web build`
- `git diff --check`

关联 issue：#984
